### PR TITLE
Chore: direnv watch local overrides

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -23,6 +23,7 @@ PATH_add generated/bin
 if [ -f .envrc.local ]; then
   source_env .envrc.local
 fi
+watch_file .envrc.local
 
 # Python virtual environment support
 # Use the .venv created by uv


### PR DESCRIPTION
Summary:
- direnv now watches .envrc.local
- Keeps prior changes on dev (SOPS skip/force, terraform plan output capture, coverage workflow tweak, added tests and caches).

- Testing:
- uv run pre-commit run --all-files
- make test