### PR TITLE
fix: tests: Use isolated filesystem for state backup

### DIFF
--- a/tests/unit/test_cli_state.py
+++ b/tests/unit/test_cli_state.py
@@ -55,23 +55,27 @@ def test_state_backup_basic(cli_runner, mock_orchestrator, tmp_path):
 
 def test_state_backup_with_generated(cli_runner, mock_orchestrator, tmp_path):
     """Test state backup including generated directory."""
-    # Create a mock generated directory
-    (tmp_path / "generated").mkdir()
-    (tmp_path / "generated" / "file.txt").touch()
+    with cli_runner.isolated_filesystem() as td:
+        cwd = Path(td)
+        # Create a mock generated directory in the current working directory (isolated)
+        (cwd / "generated").mkdir()
+        (cwd / "generated" / "file.txt").touch()
 
-    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-        with patch("shutil.copy2") as mock_copy2:
-            with patch("shutil.make_archive") as mock_make_archive:
-                result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path), "-g"])
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            with patch("shutil.copy2") as mock_copy2:
+                with patch("shutil.make_archive") as mock_make_archive:
+                    # Use tmp_path for output to keep it separate, or use cwd
+                    result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path), "-g"])
 
-                assert result.exit_code == 0
-                assert "State database backed up to:" in result.output
-                assert "'generated/' directory archived to:" in result.output
-                mock_copy2.assert_called_once()
-                mock_make_archive.assert_called_once()
-                # Check root_dir and base_dir arguments for make_archive
-                assert str(Path.cwd()) == mock_make_archive.call_args[1]["root_dir"]
-                assert "generated" == mock_make_archive.call_args[1]["base_dir"]
+                    assert result.exit_code == 0
+                    assert "State database backed up to:" in result.output
+                    assert "'generated/' directory archived to:" in result.output
+                    mock_copy2.assert_called_once()
+                    mock_make_archive.assert_called_once()
+                    # Check root_dir and base_dir arguments for make_archive
+                    # Path.cwd() inside the command will match cwd here
+                    assert str(cwd) == mock_make_archive.call_args[1]["root_dir"]
+                    assert "generated" == mock_make_archive.call_args[1]["base_dir"]
 
 
 def test_state_backup_state_db_not_found(cli_runner, mock_orchestrator, tmp_path):


### PR DESCRIPTION
Fixes a test failure in CI where 'generated/' directory was not found because the test was not running in an isolated filesystem.