### PR TITLE
feat: Load policies from INFRAFOUNDRY_CONFIG_REPO

### DIFF
--- a/src/infrafoundry/cli/main.py
+++ b/src/infrafoundry/cli/main.py
@@ -77,7 +77,11 @@ def _get_orchestrator(
         config_manager = ConfigManager()
 
     # Create orchestrator (SecretManager is created per-operation now)
-    orchestrator = Orchestrator(config_manager, strict_config=strict_config)
+    orchestrator = Orchestrator(
+        config_manager,
+        strict_config=strict_config,
+        policy_dir=config_repo / "policies" if config_repo else None,
+    )
 
     # Dynamically register available providers
     try:


### PR DESCRIPTION
Updated CLI to load policies from the configuration repository instead of the framework root. Removed root policies directory.