### PR TITLE
refactor: Move tool caches to tmp/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dev:
 	uv pip install -e ".[dev]"
 
 clean:
-	rm -rf build/ dist/ *.egg-info __pycache__ .pytest_cache .mypy_cache .ruff_cache tmp/htmlcov/ tmp/coverage.xml .coverage
+	rm -rf build/ dist/ *.egg-info __pycache__ .pytest_cache .mypy_cache .ruff_cache tmp/htmlcov/ tmp/coverage.xml .coverage tmp/.pytest_cache tmp/.mypy_cache tmp/.ruff_cache
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
+cache-dir = "tmp/.ruff_cache"
 line-length = 100
 target-version = "py312"
 
@@ -67,6 +68,7 @@ ignore = [
 ]
 
 [tool.mypy]
+cache_dir = "tmp/.mypy_cache"
 python_version = "3.12"
 # Strict type checking
 disallow_untyped_defs = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+cache_dir = tmp/.pytest_cache
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*


### PR DESCRIPTION
Configured Ruff, MyPy, and Pytest to use the  directory for their caches (.ruff_cache, .mypy_cache, .pytest_cache) to keep the project root clean. Updated Makefile to clean these locations.