### PR TITLE
refactor: Consolidate temporary files in tmp/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dev:
 	uv pip install -e ".[dev]"
 
 clean:
-	rm -rf build/ dist/ *.egg-info __pycache__ .pytest_cache .mypy_cache .ruff_cache tmp/htmlcov/ tmp/coverage.xml .coverage tmp/.pytest_cache tmp/.mypy_cache tmp/.ruff_cache
+	rm -rf build/ dist/ *.egg-info __pycache__ .pytest_cache .mypy_cache .ruff_cache tmp/htmlcov/ tmp/coverage.xml tmp/.coverage tmp/.pytest_cache tmp/.mypy_cache tmp/.ruff_cache
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ markers =
 
 # Coverage settings
 [coverage:run]
+data_file = tmp/.coverage
 source = src/infrafoundry
 omit =
     */tests/*


### PR DESCRIPTION
## Summary
- Completes the consolidation of all temporary files into the `tmp/` directory
- Moves `.coverage` file to `tmp/.coverage` via pytest.ini configuration
- Updates Makefile clean target to reference new location

## Changes
- **pytest.ini**: Added `data_file = tmp/.coverage` to `[coverage:run]` section
- **Makefile**: Updated clean target to remove `tmp/.coverage` instead of `.coverage`

## Context
This PR follows the pattern established in recent commits:
- 3adbd8b: Relocated tool caches to tmp/
- e6d0d71: Moved coverage reports to tmp/

All temporary build artifacts and tool outputs are now centralized in `tmp/` for easier cleanup and gitignore management.

## Test plan
- [x] Changes are configuration-only
- [x] Pre-commit hooks passed
- [x] No functional changes to test behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)