### PR TITLE
Fix regressions from PR feedback

### DIFF
--- a/docs/separate-config-repo.md
+++ b/docs/separate-config-repo.md
@@ -295,7 +295,8 @@ jobs:
         run: |
           cd infrafoundry
           # Install just and use it to install dependencies
-          curl -LsSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+          curl -LsSf https://just.systems/install.sh | bash -s -- --to $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           just install-uv
           just install
 
@@ -369,7 +370,8 @@ variables:
   before_script:
     # Install just and InfraFoundry
     - apt-get update && apt-get install -y git curl wget
-    - curl -LsSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+    - curl -LsSf https://just.systems/install.sh | bash -s -- --to $HOME/.local/bin
+    - export PATH="$HOME/.local/bin:$PATH"
     - git clone --depth 1 --branch $INFRAFOUNDRY_VERSION https://github.com/your-org/infrafoundry.git
     - cd infrafoundry
     - just install-uv

--- a/example-config/README.md
+++ b/example-config/README.md
@@ -280,7 +280,8 @@ jobs:
         working-directory: infrafoundry
         run: |
           # Install just and use it to install dependencies
-          curl -LsSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+          curl -LsSf https://just.systems/install.sh | bash -s -- --to $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           just install-uv
           just install
 

--- a/src/infrafoundry/cli/commands/secrets.py
+++ b/src/infrafoundry/cli/commands/secrets.py
@@ -26,13 +26,18 @@ def secrets() -> None:
     default=None,
     help="Path to age key file (defaults to envs/age.key in config repo)",
 )
-def secrets_init(key_file: str | None) -> None:
+@click.pass_context
+def secrets_init(ctx: click.Context, key_file: str | None) -> None:
     """Initialize secrets with a new age key."""
     if key_file:
         key_path = Path(key_file)
     else:
-        config_repo = os.getenv("INFRAFOUNDRY_CONFIG_REPO")
-        base_dir = Path(config_repo) if config_repo else Path.cwd()
+        ctx_config_dir = ctx.obj.get("config_dir") if ctx and ctx.obj else None
+        base_dir = Path(ctx_config_dir) if ctx_config_dir else None
+        if not base_dir:
+            config_repo = os.getenv("INFRAFOUNDRY_CONFIG_REPO")
+            base_dir = Path(config_repo) if config_repo else Path.cwd()
+
         key_path = base_dir / "envs" / "age.key"
 
     if key_path.exists():

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -763,24 +763,15 @@ class DestroyOrchestrator:
             self._print_header("Destroying", env_name, resource_filter, "bold red")
 
             if not auto_approve:
-                if confirm_callback:
-                    should_continue = confirm_callback()
-                    if not should_continue:
-                        self.console.print("[yellow]Aborted[/yellow]")
-                        self.state_manager.update_deployment_status(
-                            deployment_id, DeploymentStatus.FAILED, "User aborted"
-                        )
-                        return {}
-                else:
-                    # Programmatic use without callback but requiring approval is an error
+                should_continue = (
+                    confirm_callback() if confirm_callback else self._confirm_destroy()
+                )
+                if not should_continue:
+                    self.console.print("[yellow]Aborted[/yellow]")
                     self.state_manager.update_deployment_status(
-                        deployment_id,
-                        DeploymentStatus.FAILED,
-                        "Destroy requires approval but no callback provided",
+                        deployment_id, DeploymentStatus.FAILED, "User aborted"
                     )
-                    raise ValueError(
-                        "Destroy requires approval but no confirmation callback provided"
-                    )
+                    return {}
 
             _, resources_by_provider = self._load_resources(env_name)
             providers = self._get_providers()
@@ -826,6 +817,11 @@ class DestroyOrchestrator:
             raise
 
         return results
+
+    def _confirm_destroy(self) -> bool:
+        """Prompt for destroy confirmation when no callback provided."""
+        response = self.console.input("Are you sure you want to destroy? [y/N]: ")
+        return response.strip().lower() in {"y", "yes"}
 
     def _track_destroying_resources(
         self,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -108,6 +108,29 @@ class TestCLICommands:
             # Command should attempt to run
             assert result.exit_code in [0, 1, 2]
 
+    def test_secrets_init_defaults_to_config_dir(self, cli_runner, temp_dir):
+        """Test secrets init writes key to --config-dir when no key path provided."""
+        config_dir = temp_dir / "config"
+        (config_dir / "envs").mkdir(parents=True)
+        key_path = config_dir / "envs" / "age.key"
+
+        def fake_run(*args, **kwargs):
+            key_path.parent.mkdir(parents=True, exist_ok=True)
+            key_path.write_text("AGE-SECRET-KEY-TEST")
+            stderr = "# public key: age1test\n" if args and "age-keygen" in args[0][0] else ""
+            return MagicMock(returncode=0, stdout="", stderr=stderr)
+
+        env = {"SOPS_AGE_KEY_FILE": str(key_path)}
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = cli_runner.invoke(
+                cli, ["--config-dir", str(config_dir), "secrets", "init"], env=env
+            )
+
+        assert result.exit_code == 0
+        assert key_path.exists()
+        assert (config_dir / "envs" / ".sops.yaml").exists()
+
     def test_secrets_encrypt_requires_file(self, cli_runner):
         """Test that secrets encrypt requires a file argument."""
         result = cli_runner.invoke(cli, ["secrets", "encrypt"])

--- a/tests/integration/test_orchestrator_workflows.py
+++ b/tests/integration/test_orchestrator_workflows.py
@@ -419,17 +419,20 @@ class TestDestroyOrchestrator:
             )
             assert len(deployments) > 0
 
-    def test_destroy_requires_confirmation_without_auto_approve(self, orchestrator):
-        """Test that destroy raises error when confirmation required but no callback provided."""
-        with pytest.raises(
-            ValueError, match="Destroy requires approval but no confirmation callback provided"
+    def test_destroy_prompts_without_callback_and_aborts(self, orchestrator):
+        """Test that destroy prompts when no callback provided and aborts on negative response."""
+        with patch.object(
+            orchestrator.destroy_orchestrator, "_confirm_destroy", return_value=False
         ):
-            orchestrator.destroy(env_name="dev", auto_approve=False, confirm_callback=None)
+            result = orchestrator.destroy(
+                env_name="dev", auto_approve=False, confirm_callback=None
+            )
 
-        # Check deployment was marked as failed
+        assert result == {}
+
         deployments = orchestrator.state_manager.get_deployment_history(environment="dev")
         assert deployments[0].status == DeploymentStatus.FAILED
-        assert "Destroy requires approval" in deployments[0].error_message
+        assert deployments[0].error_message == "User aborted"
 
     def test_destroy_proceeds_with_confirmation(self, orchestrator):
         """Test that destroy proceeds when user confirms."""
@@ -442,6 +445,22 @@ class TestDestroyOrchestrator:
 
             # Should proceed with destroy
             assert "proxmox" in result
+
+    def test_destroy_prompts_without_callback_and_proceeds(self, orchestrator):
+        """Test that destroy proceeds using internal prompt when confirmed."""
+        with patch.object(
+            orchestrator.destroy_orchestrator, "_confirm_destroy", return_value=True
+        ):
+            with patch(
+                "infrafoundry.core.runners.terraform_runner.TerraformRunner.run"
+            ) as mock_tf:
+                mock_tf.return_value = {"success": True}
+
+                result = orchestrator.destroy(
+                    env_name="dev", auto_approve=False, confirm_callback=None
+                )
+
+        assert "proxmox" in result
 
     def test_destroy_with_resource_filter(self, orchestrator):
         """Test destroy with resource filter."""


### PR DESCRIPTION
## Summary
- restore destroy confirmation fallback when auto-approve is false and no callback is provided, with tests
- default secrets init to the config repo when --config-dir is used and add coverage
- adjust CI/docs snippets to install just into a user-writable path

## Testing
- just check
- pytest tests/integration/test_orchestrator_workflows.py::TestDestroyOrchestrator tests/integration/test_cli.py::TestCLICommands::test_secrets_init_defaults_to_config_dir -q
