### PR TITLE
fix: Resolve workflow syntax error in Codecov step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,6 @@ jobs:
                  -v
 
       - name: Upload coverage to Codecov
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml


### PR DESCRIPTION
Removes the deprecated conditional syntax in the Codecov upload step that was causing workflow startup failures.