### PR TITLE
refactor: rename 'drift log' back to 'drift history'

### DIFF
--- a/src/infrafoundry/cli/commands/drift.py
+++ b/src/infrafoundry/cli/commands/drift.py
@@ -215,11 +215,11 @@ def drift_remediate(
         raise_cli_error("Drift remediation failed", exc)
 
 
-@drift.command("log")
+@drift.command("history")
 @click.option("--env", "-e", help="Filter by environment name")
 @click.option("--limit", "-n", type=int, default=10, help="Number of entries to show (default: 10)")
 @with_orchestrator("Failed to retrieve remediation history")
-def drift_log(
+def drift_history(
     _ctx: click.Context,
     orchestrator: Orchestrator,
     env: str | None,


### PR DESCRIPTION
## Summary
Renames the drift subcommand from `log` back to the more intuitive `history` now that the CommandLoader bug is fixed.

## Background
The command was temporarily renamed from `history` to `log` in commit 7c4e151 to work around a CommandLoader bug (#83) where subcommands were incorrectly registered at the top level, causing a conflict with the standalone `history` command.

With PR #84 merged, the CommandLoader now correctly distinguishes between:
- `infra history` (standalone deployment history)
- `infra drift history` (drift remediation history subcommand)

## Changes
- **src/infrafoundry/cli/commands/drift.py**:
  - Changed `@drift.command("log")` → `@drift.command("history")`
  - Renamed function `drift_log()` → `drift_history()`

## Related Issues
Closes #85

## Testing
- [x] Unit tests passing (all 832 tests pass)
- [x] Manual testing completed
  - Verified `infra history` shows deployment history
  - Verified `infra drift history` shows drift remediation history
  - No command conflicts between the two

## Breaking Changes
**Minor breaking change:** Users currently using `infra drift log` will need to use `infra drift history` instead. This restores the original, more intuitive command name.

## Documentation
- [x] Commit message includes detailed explanation
- [x] No additional documentation needed (reverting to original name)