### PR TITLE
ci: install terraform in code-quality job and remove continue-on-error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,6 +179,7 @@ jobs:
         run: |
           uv run doit install
           uv run doit dev
+          uv run doit install_deps
 
       - name: Check formatting with ruff
         run: |
@@ -187,4 +188,3 @@ jobs:
       - name: Run linting and type checking
         run: |
           uv run doit check
-        continue-on-error: true


### PR DESCRIPTION
## Summary
Fixes hidden test failures in the Code Quality Checks job by installing terraform and removing `continue-on-error: true`.

## Problem
The "Code Quality Checks" job was failing `test_initialize_skips_when_already_initialized` because terraform wasn't installed, but the failure was hidden by `continue-on-error: true`.

**Job comparison:**
- ✅ "Run Tests" job: Installs terraform via `doit install_deps` → tests pass
- ❌ "Code Quality Checks" job: Doesn't install terraform → test fails (hidden)

## Changes
- **.github/workflows/tests.yml**:
  - Added `uv run doit install_deps` to code-quality job (line 182)
  - Removed `continue-on-error: true` from linting/type checking step (line 190)

## Impact
- **Consistent environments**: All CI jobs now have terraform installed
- **Visible failures**: Real test failures will block merges instead of being hidden
- **Better integration testing**: Catches terraform integration issues in CI

## Related Issues
Closes #88

## Testing
- [x] Workflow syntax is valid
- [ ] CI will verify terraform is installed and all tests pass

## Breaking Changes
None - this fixes broken behavior

## Documentation
- [x] Commit message includes detailed explanation
- [x] No additional documentation needed