### PR TITLE
test: fix flaky test_initialize_skips_when_already_initialized

### DIFF
--- a/tests/unit/test_runner_terraform.py
+++ b/tests/unit/test_runner_terraform.py
@@ -41,7 +41,8 @@ def test_initialize_skips_when_already_initialized(
 ) -> None:
     """Initialization short-circuits when .terraform exists."""
     (provider.terraform_dir / ".terraform").mkdir()
-    result = runner.initialize(provider.terraform_dir)
+    with patch("shutil.which", return_value="/usr/bin/terraform"):
+        result = runner.initialize(provider.terraform_dir)
     assert result["success"]
     assert "Already initialized" in result["message"]
 


### PR DESCRIPTION
## Problem

Test `test_initialize_skips_when_already_initialized` failed in CI (workflow run #20560806799, action #261) with:
```
tests/unit/test_runner_terraform.py:45: in test_initialize_skips_when_already_initialized
    assert result["success"]
E   assert False
```

The test passed locally but failed in CI, indicating environment-dependent behavior (a "flaky test").

## Root Cause

The test called `runner.initialize()` without mocking `shutil.which("terraform")`. The `initialize()` method checks `is_available()` which calls `shutil.which("terraform")`. Without mocking:
- **Local environment**: terraform installed → `is_available()` returns `True` → test passes
- **CI environment**: terraform not installed → `is_available()` returns `False` → returns error → test fails

## Solution

Added `patch("shutil.which", return_value="/usr/bin/terraform")` context manager to ensure consistent behavior across all test environments. This matches the pattern used in other tests in the same file:
- Line 33-36: `test_is_available` 
- Line 51: `test_initialize_missing_binary`

## Changes

- `tests/unit/test_runner_terraform.py`: Added mock to make test environment-independent

## Testing

- Verified all 8 terraform runner tests pass locally
- Test is now deterministic and won't flake in CI

Fixes workflow failure #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)