### PR TITLE
docs: fix MkDocs broken links and missing files

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,532 @@
+# InfraFoundry – AI Agent Unified Instructions
+
+## Overview
+InfraFoundry generates Terraform `.tf` files and Ansible playbooks from YAML configurations, then optionally orchestrates their execution. It uses a strict separation between the framework repository and user configuration repositories. Providers, runners, validators, and policies are fully pluggable. State and secret management are robust and event-driven orchestration is used throughout.
+
+## Repository & Architecture
+- **Framework Repo:** Core code, provider plugins, templates
+- **Config Repo:** User infrastructure configs, secrets (separate)
+- **Managers:** Inherit from `BaseManager` or `PathBasedManager` for logging, error handling, and path utilities
+- **Provider Mixins:** Use `TemplateRendererMixin`, `ResourceGrouperMixin` for Jinja2 templating and resource grouping
+- **Provider 3-Layer Stack:** Provider → Component Manager → Service Layer for complex API workflows
+- **Pluggable Runners:** Terraform, Ansible, etc., extend `BaseRunner`
+- **Event System:** Pub/sub hooks for orchestration lifecycle (e.g., DRIFT_*, POLICY_*, PLAN/APPLY events)
+
+## State, Data Flow, and Artifacts
+- **Terraform State:** `generated/{env}/terraform/{provider}/.terraform/terraform.tfstate` (local by default; remote backends configurable)
+- **InfraFoundry State DB:** `~/.infrafoundry/state.db` (SQLite) or PostgreSQL via `INFRAFOUNDRY_STATE_BACKEND` / `INFRAFOUNDRY_STATE_CONNECTION`, tracking deployments, resources, dependencies, and events
+- **Generated Configs:** `generated/{env}/{terraform|ansible}/{provider}/` (reproducible, git-ignored)
+- **Data Flow:** YAML configs → ConfigManager → Orchestrator → Providers/Templates → generated files → optional execution
+
+## Configuration & Secrets
+- Two-repo approach: framework repo (this) + configuration repo set via `INFRAFOUNDRY_CONFIG_REPO` or `infra --config-dir`. CLI precedence: explicit flag > env var > local `./envs`.
+- **Config Formats:**
+  - Provider-centric: `envs/{env}/{provider}/{resource_type}.yaml`
+  - Resource-centric: `envs/{env}/resources/*.yaml` (recommended for multi-provider)
+  - Both formats may coexist; providers are auto-discovered
+- **Secrets:** Managed with SOPS + age, per-environment keys; decrypted data shared with Terraform `.tfvars` and Ansible vars
+- **Environment Variables:** Use `INFRAFOUNDRY_*` for framework, standard names for providers
+
+## Development & Testing
+- **Use `uv` for Python package management**
+- **Run tests:** `doit test` or `uv run pytest`
+- **Format/lint:** `doit format`, `doit lint`
+- **Coverage:** `doit coverage`
+- **Add dependencies:** `uv pip install <package>`
+- **Temporary files:** Use `tmp/` (git-ignored); keep root directory clean
+
+## CLI & Operations
+- Key commands (`infra` via `uv run infra …` or equivalent):
+  - `infra envs` – list configured environments.
+  - `infra plan --env <name>` – generate files only (use `--dry-run` when applicable).
+  - `infra apply --env <name>` – generate and execute Terraform/Ansible.
+  - `infra destroy --env <name>` – tear down infrastructure.
+  - `infra drift --env <name>` – detect drift.
+  - `infra history --env <name>` – inspect past deployments.
+  - `infra secrets <init|encrypt|decrypt>` – manage SOPS secrets.
+- Generated artifacts should be reviewed (and optionally validated with native Terraform/Ansible tools) from the `generated/` directory hierarchy.
+
+## Code Style & Conventions
+
+### Python Style
+- Python 3.12+ type hints with modern syntax: `list[str]`, `dict[str, Any]`, `X | None`
+- `@override` decorator on all abstract method implementations
+- Black formatting, ruff linting, max line length 100
+- Snake_case for Python, kebab-case for YAML resource names
+- Use singular resource type names
+
+### Import Organization
+Organize imports in this order (separated by blank lines):
+1. **Standard library imports** (alphabetical)
+2. **Third-party imports** (alphabetical)
+3. **Local application imports** (alphabetical)
+
+```python
+# Standard library
+import os
+from pathlib import Path
+from typing import Any
+
+# Third-party
+import click
+from jinja2 import Environment
+
+# Local
+from infrafoundry.core.base_manager import BaseManager
+from infrafoundry.providers.base_provider import BaseProvider
+```
+
+### Docstring Requirements
+- **Public APIs** (classes, functions, methods): Required
+- **Private functions/methods** (prefixed with `_`): Optional, use when complex
+- **Module-level docstrings**: Required for all modules
+- **Format**: Google-style docstrings
+- **Content**: Brief description, Args, Returns, Raises (when applicable)
+
+```python
+def generate_terraform(self, resources: list[dict[str, Any]]) -> Path:
+    """Generate Terraform configuration from resource definitions.
+
+    Args:
+        resources: List of resource definitions to convert
+
+    Returns:
+        Path to the generated Terraform file
+
+    Raises:
+        ValidationError: If resource validation fails
+        TemplateError: If template rendering fails
+    """
+```
+
+## Coding Standards & Best Practices
+- **Read-before-edit**: inspect files before modifying; maintain backward-compatible public APIs.
+- Follow BaseManager/PathBasedManager, provider mixins, and 3-layer architecture conventions—new managers/providers must integrate cleanly.
+- Python style: full type hints with modern syntax (`list[str]`, `X | None`), `@override` on abstract implementations, max line 100, Google-style docstrings.
+- Error handling: raise specific exceptions with contextual logging; never catch `KeyboardInterrupt`/`SystemExit`. Prefer early returns over deep nesting.
+- Avoid duplication in validators/templates; consider mixins or helpers before copying logic.
+- Do not modify public CLI signatures, BaseManager APIs, provider plugin contracts, state schema (introduce migrations instead), or event enums except additive changes.
+
+## Common Patterns
+
+### Manager Pattern
+- **BaseManager**: Base class for all managers; provides logging, error handling
+- **PathBasedManager**: Extends BaseManager with path utilities for file operations
+- Use managers for orchestration logic, not business logic
+
+### Provider Pattern
+- **TemplateRendererMixin**: Jinja2 template rendering for providers
+- **ResourceGrouperMixin**: Group resources by type or dependency
+- **3-Layer Architecture**: Provider → Component Manager → Service Layer
+  - Provider: High-level interface, config parsing
+  - Component Manager: Resource-specific logic
+  - Service Layer: API/direct interaction
+
+### Pluggable Runners
+- Extend `BaseRunner` for new execution engines (Terraform, Ansible, PyInfra)
+- Implement required methods: `plan()`, `apply()`, `destroy()`
+- Use dependency injection for testability
+
+### Event-Driven Orchestration
+- Subscribe to events: `DRIFT_DETECTED`, `POLICY_VIOLATED`, `PLAN_COMPLETE`, `APPLY_COMPLETE`
+- Publish events when state changes
+- Keep event handlers focused and side-effect free
+
+## Common Pitfalls
+
+### Anti-Patterns to Avoid
+- **God Classes**: Don't put all logic in Orchestrator; use managers and providers
+- **Tight Coupling**: Always use dependency injection, avoid importing concrete implementations
+- **Silent Failures**: Always log errors and raise exceptions with context
+- **Mutable Defaults**: Never use mutable default arguments (`def foo(items=[])` ❌)
+- **String Concatenation for Paths**: Use `Path` objects, not string concatenation
+- **Blocking I/O in Loops**: Batch operations when possible
+- **Ignoring Type Hints**: Type hints are enforced by mypy in CI
+
+### Security Pitfalls
+- **Never log secrets**: Scrub sensitive data before logging
+- **Command Injection**: Always use subprocess with list args, not shell=True
+- **Path Traversal**: Validate all user-provided paths
+- **YAML Unsafe Loading**: Always use `yaml.safe_load()`, never `yaml.load()`
+
+### State Management Pitfalls
+- **Race Conditions**: Use state locking for concurrent operations
+- **Stale State**: Always refresh state before operations
+- **Lost State**: Never delete generated configs without destroy first
+
+## Development Workflow
+
+**Rule:** All *code* changes must originate from a GitHub Issue. Documentation updates are exempt from this rule.
+
+### Issue-Driven Development Flow
+
+1. **Issue:** Ensure a GitHub Issue exists for the code task (e.g., "Add PyInfra runner support").
+   - Use YAML issue forms to create structured, validated issues
+   - Required fields ensure all necessary information is captured
+   - Auto-labeling helps with project management and triage
+
+2. **Branch:** Create a branch linked to the issue
+   - Format: `issue/<number>-<short-desc>`, `feat/<number>-<desc>`, or `fix/<number>-<desc>`
+   - Examples:
+     - `issue/42-add-cloudflare-provider`
+     - `feat/42-cloudflare-provider`
+     - `fix/123-handle-null-values`
+   - Branch naming is enforced by pre-commit hooks
+
+3. **Commit:** Use Conventional Commits format for all commits
+   - Format: `<type>: <subject>`
+   - Enforced by pre-commit hooks locally and PR checks in CI
+   - Use `uv run cz commit` for interactive commit message creation (if commitizen is installed)
+
+4. **Pull Request:** Submit a PR from your branch to `main` (or `develop` if active)
+   - Reference the issue in PR description (e.g., "Closes #42")
+   - PR title must follow conventional commit format
+   - Automated checks validate:
+     - PR title format
+     - Issue link presence (except docs-only PRs)
+     - PR description completeness
+     - Breaking change documentation
+
+5. **PR Merge:** When merging, ensure the merge commit follows the format:
+   - `<type>: <subject> (merges PR #XX, closes #YY)` - when PR has associated issue
+   - `<type>: <subject> (merges PR #XX)` - when PR has no issue (docs-only)
+
+**Examples - Correct Merge Commit Format:**
+```
+feat: add PyInfra runner support and configurable execution order (merges PR #18, closes #42)
+fix: handle None values in OPNsense provider (merges PR #23, closes #19)
+docs: update provider implementation guide (merges PR #29)
+refactor: extract common validation logic (merges PR #31, closes #28)
+```
+
+**Examples - Incorrect Format:**
+```
+❌ Merge pull request #18 from endavis/feat/pyinfra-support
+❌ feat: Add PyInfra Support (capitalized subject)
+❌ added pyinfra support (missing type)
+❌ feat: add pyinfra support (missing PR reference)
+```
+
+### Why Issue-Driven Development?
+
+- **Traceability:** Every code change is linked to a documented need
+- **Context:** Issues capture the "why" behind changes
+- **Planning:** Better project management and prioritization
+- **History:** Searchable record of decisions and rationale
+- **Collaboration:** Clear communication about work in progress
+
+## Commit Guidelines
+
+### Commit Message Format
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>: <subject>
+
+[optional body]
+
+[optional footer]
+```
+
+**Commit Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `refactor`: Code restructuring without behavior change
+- `docs`: Documentation updates
+- `test`: Adding or updating tests
+- `chore`: Dependency updates, tooling changes
+- `ci`: CI/CD configuration changes
+- `perf`: Performance improvements
+
+**Rules:**
+- Subject must be lowercase, concise (no period at end)
+- Use imperative mood ("add feature" not "added feature")
+- Separate concerns: one commit per logical change
+- Write clear, descriptive messages
+
+**Examples:**
+```
+feat: add support for CloudFlare DNS provider
+
+fix: handle None values in OPNsense interface parsing
+
+refactor: extract common provider validation logic
+
+docs: update provider implementation guide with new patterns
+
+test: add tests for edge cases in state manager
+
+chore: update dependencies to latest versions
+```
+
+### Breaking Changes Policy
+
+**What Constitutes a Breaking Change:**
+- Changes to public function/method signatures
+- Removal of public functions, classes, or modules
+- Changes to CLI command syntax or options
+- Changes to configuration file formats
+- Changes to default behavior that affects existing code
+- Changes to exception types or error handling
+- Removal of deprecated features
+
+**How to Handle Breaking Changes:**
+
+1. **Document in Commit Message:**
+   ```
+   refactor: change provider API to use async/await
+
+   Migrate to async for better concurrency handling.
+
+   BREAKING CHANGE: All provider methods are now async and must be awaited.
+   Update custom providers to use async def for generate(), validate(), etc.
+   See docs/migration.md for detailed migration guide.
+   ```
+
+2. **Document in PR Description:**
+   - Add "BREAKING CHANGE" section to PR description
+   - Explain what changed and why
+   - Provide migration guide with before/after examples
+   - List affected APIs or features
+
+3. **Update CHANGELOG.md:**
+   - Add breaking changes to "Breaking Changes" section
+   - Include migration instructions
+   - Provide code examples showing the change
+
+4. **Version Bump:**
+   - Breaking changes require a major version bump (e.g., 1.x.x → 2.0.0)
+   - Follow semantic versioning principles
+
+5. **Consider Deprecation Period:**
+   - For widely-used features, consider deprecating first (with warnings)
+   - Remove in next major version
+   - Gives users time to migrate
+
+**Automated Detection:**
+- PR checks will scan for potential breaking changes
+- Comments will be added to PRs highlighting concerns
+- CI will fail if breaking changes are not documented
+
+## Issue Creation Guidelines
+
+### Issue Title Format
+Use clear, actionable titles with type prefix matching conventional commits:
+
+```
+<type>: <brief description>
+```
+
+**Examples:**
+- `feat: add support for CloudFlare DNS provider`
+- `bug: infrafoundry crashes when processing OPNsense config`
+- `refactor: extract duplicate provider validation logic`
+- `docs: add examples for custom provider implementation`
+
+### Issue Templates
+
+The project uses GitHub YAML issue forms with required fields:
+
+**Bug Reports (bug_report.yml):**
+- Required: title, description, steps to reproduce, expected/actual behavior
+- Dropdowns: Python version, OS, priority (CRITICAL/HIGH/MEDIUM/LOW)
+- Optional: error output, additional context, possible solution
+- Auto-labels: `bug`, `needs-triage`
+
+**Feature Requests (feature_request.yml):**
+- Required: title, problem statement, proposed solution, use cases
+- Dropdowns: complexity (1-10 scale), priority
+- Optional: alternatives, implementation ideas, benefits
+- Checkbox: breaking changes flag
+- Auto-labels: `enhancement`, `needs-triage`
+
+**Refactor Requests (refactor.yml):**
+- Required: title, current situation, proposed improvement, technical debt impact
+- Dropdowns: complexity, priority
+- Optional: affected areas, benefits
+- Checkboxes: breaking changes, test updates, doc updates, API impact
+- Auto-labels: `refactor`, `needs-triage`
+
+### When to Create an Issue
+
+**Always create an issue for:**
+- New features or enhancements
+- Bug fixes
+- Refactoring work
+- Performance improvements
+- Security updates
+
+**Optional for:**
+- Documentation-only changes (can PR directly)
+- Typo fixes in comments
+- Minor README updates
+
+**Before starting work:**
+- Check if an issue already exists
+- Create the issue first, then the branch
+- Link the branch to the issue number
+
+### Issue Best Practices
+
+- **Be specific:** Clear, concise descriptions
+- **Be complete:** Fill all required fields
+- **Add context:** Include examples, screenshots, or code snippets
+- **Estimate complexity:** Helps with prioritization and planning
+- **Set priority:** CRITICAL for blockers, HIGH for important work, MEDIUM/LOW otherwise
+- **Link related issues:** Reference related issues or PRs
+- **Update as needed:** Add information as you learn more
+
+## Pull Request Guidelines
+
+### PR Title Format
+Same as commit messages: `<type>: <subject>`
+
+**The PR title becomes the merge commit message, so make it clear and descriptive.**
+
+**Examples:**
+- ✅ `feat: add CloudFlare DNS provider`
+- ✅ `fix: handle None values in OPNsense interface parsing`
+- ✅ `docs: update provider implementation guide`
+- ❌ `Add CloudFlare provider` (missing type)
+- ❌ `Feat: Add CloudFlare Provider` (capitalization wrong)
+
+### PR Description Requirements
+
+**Minimum requirements (enforced by CI):**
+- At least 50 characters
+- Include reference to related issue (except docs-only PRs)
+- Describe what changed and why
+- Include testing information
+
+**Complete PR template includes:**
+- **Summary:** 2-3 sentence overview of changes
+- **Changes:** Bullet list of specific changes with file paths
+- **Related Issues:** "Closes #123" or "Fixes #123"
+- **Testing:** How changes were tested
+- **Breaking Changes:** Document any breaking changes
+- **Documentation:** List doc updates
+
+### Automated PR Checks
+
+All PRs are automatically validated for:
+
+✅ **PR Title Format** - Must follow conventional commits
+✅ **Issue Link** - Must reference an issue (code changes only)
+✅ **Description Length** - Minimum 50 characters
+✅ **Breaking Changes** - Detects and requires documentation
+✅ **Tests** - All tests must pass
+✅ **Coverage** - Must maintain ≥69% coverage
+✅ **Linting** - Ruff checks must pass
+✅ **Type Checking** - Mypy must pass
+✅ **Format** - Code must be formatted with ruff
+
+**Docs-only PRs are exempt from issue linking requirement.**
+
+### Code Review Checklist
+
+**Before submitting:**
+- [ ] Created and linked GitHub Issue (for code changes)
+- [ ] Branch name follows convention (`feat/123-description`)
+- [ ] Self-reviewed code
+- [ ] All CI checks passing locally (`doit check coverage`)
+- [ ] Tests added/updated with ≥69% coverage
+- [ ] Documentation updated (README, docstrings, guides)
+- [ ] CHANGELOG.md updated (for notable changes)
+- [ ] Breaking changes documented (if applicable)
+
+**Reviewers verify:**
+- [ ] Code follows project conventions (style, patterns, architecture)
+- [ ] Tests adequate and passing
+- [ ] No security vulnerabilities (injection, secrets, path traversal)
+- [ ] Error handling appropriate with clear messages
+- [ ] Documentation clear and accurate
+- [ ] Breaking changes properly documented
+- [ ] Issue is fully addressed
+
+### Merge Process
+
+1. **All CI checks must pass** - No exceptions
+2. **At least one approval required** - From code owner or maintainer
+3. **Merge commit format** - Must include PR and issue numbers:
+   - `<type>: <subject> (merges PR #XX, closes #YY)`
+   - PR title is automatically used as merge commit message
+4. **Squash and merge** - Preferred for clean history (multiple commits → one)
+5. **Delete branch** - After successful merge
+
+## CI/CD Requirements
+
+### Required Checks (must pass before merge)
+- **Tests**: All pytest tests pass, ≥69% coverage maintained
+- **Lint**: ruff checks pass with no errors
+- **Type checking**: mypy passes with no type errors
+- **Format**: ruff formatting applied
+- **Pre-commit hooks**: All hooks pass
+
+### Running CI Checks Locally
+```bash
+# Run all checks
+doit check coverage
+
+# Individual checks
+doit lint
+doit format
+doit coverage
+```
+
+### CI Workflow
+1. Push to branch triggers GitHub Actions
+2. All checks must pass (tests, lint, type checking)
+3. Coverage report posted to PR
+4. Reviewer approval required
+5. Merge to main triggers deployment (if applicable)
+
+## AI Agent Guidelines
+
+### When to Ask for User Input
+AI agents (like Claude) should ask the user when:
+- **Ambiguous requirements**: Multiple valid implementation approaches exist
+- **Architectural decisions**: Choosing between patterns or libraries
+- **Breaking changes**: User impact needs to be understood
+- **Missing information**: Config values, credentials, or preferences needed
+- **Trade-offs**: Performance vs. simplicity, etc.
+- **Scope clarification**: Feature boundaries unclear
+
+### When to Proceed Autonomously
+Agents can proceed without asking when:
+- **Clear conventions exist**: Follow existing patterns in codebase
+- **Obvious fixes**: Clear bugs with single correct solution
+- **Documentation tasks**: Adding docstrings, comments, README updates
+- **Refactoring**: Improving code structure without behavior change
+- **Tests**: Adding missing test coverage for existing code
+
+### Best Practices for AI Agents
+- **Read before editing**: Always read files before modifying them
+- **Follow patterns**: Match existing code style and patterns
+- **Run tests**: Execute tests after changes to verify correctness
+- **Commit incrementally**: Make focused commits, not large batch changes
+- **Explain changes**: Provide clear commit messages and PR descriptions
+- **Check CI**: Ensure all CI checks pass before considering work complete
+- **Link issues**: Always reference related issue numbers
+
+## Testing Expectations
+- Maintain ≥69% coverage
+- Add/update tests when refactoring or adding features; use fixtures and mocks
+- Typical commands:
+  - `uv run pytest`
+  - `uv run pytest --cov=src/infrafoundry/<module>.py tests/`
+
+## Troubleshooting
+- Use CLI commands to check config loading, state, and secrets
+- Inspect files with `cat -pp` or `batcat -pp` for consistent output
+
+## Help & Resources
+- **Documentation Index:** [Table of Contents](index.md)
+- **Getting Started:** `getting-started/`
+- **Configuration:** `configuration/`
+- **Architecture:** `architecture/`
+- **Development:** `development/`
+- **Example Configs:** `../example-config/`
+- **Roadmap & TODOs:** [TODO.md](TODO.md)
+
+---
+This file unifies essential agent instructions for InfraFoundry. For coding/development specifics, see dedicated documentation files.

--- a/docs/architecture/events.md
+++ b/docs/architecture/events.md
@@ -1,0 +1,385 @@
+# Event System Architecture
+
+## Overview
+
+InfraFoundry implements a synchronous publish-subscribe event system for orchestration lifecycle management, enabling decoupled notifications, auditing, and extensibility throughout the infrastructure automation workflow.
+
+## Design Goals
+
+1. **Decoupling**: Separate event producers from consumers
+2. **Extensibility**: Allow plugins and integrations to hook into workflows
+3. **Observability**: Provide visibility into orchestration lifecycle
+4. **Simplicity**: Lightweight, synchronous design for predictable execution
+
+## Architecture
+
+### Event Flow
+
+```
+┌─────────────┐
+│  Provider   │
+│ / Runner    │──┐
+└─────────────┘  │
+                 │ emit_event()
+┌─────────────┐  │
+│Orchestrator │──┤
+└─────────────┘  │
+                 │
+┌─────────────┐  │        ┌──────────────┐
+│CLI Commands │──┴───────>│EventManager  │
+└─────────────┘           │ (singleton)  │
+                          └──────┬───────┘
+                                 │ dispatch
+                                 │
+                    ┌────────────┼────────────┐
+                    │            │            │
+                    v            v            v
+              ┌──────────┐ ┌──────────┐ ┌──────────┐
+              │Notification│State     │ Audit    │
+              │Manager   │ │Manager   │ │Logger   │
+              └──────────┘ └──────────┘ └──────────┘
+```
+
+### Core Components
+
+#### EventManager
+
+Central event dispatcher implementing pub-sub pattern.
+
+**Responsibilities:**
+- Register event subscribers
+- Dispatch events to registered handlers
+- Maintain subscription registry
+- Ensure synchronous execution
+
+**Key Methods:**
+```python
+def subscribe(event_type: EventType, handler: Callable[[Event], None]) -> None
+def subscribe_all(handler: Callable[[Event], None]) -> None
+def emit_event(event_type: EventType, environment: str, data: dict) -> None
+```
+
+#### Event
+
+Data structure representing a single event occurrence.
+
+**Structure:**
+```python
+@dataclass
+class Event:
+    event_type: EventType           # Type of event
+    environment: str                # Environment context
+    data: dict[str, Any]           # Event-specific payload
+    timestamp: datetime             # When event occurred
+```
+
+#### EventType Enum
+
+Categorized event types for different lifecycle phases and operations.
+
+**Categories:**
+
+1. **Lifecycle Events** - Orchestration workflow phases
+   - `BEFORE_PLAN`, `AFTER_PLAN`, `PLAN_FAILED`
+   - `BEFORE_APPLY`, `AFTER_APPLY`, `APPLY_FAILED`
+   - `BEFORE_DESTROY`, `AFTER_DESTROY`, `DESTROY_FAILED`
+
+2. **Resource Events** - Individual resource lifecycle
+   - `RESOURCE_CREATED`
+   - `RESOURCE_UPDATED`
+   - `RESOURCE_DELETED`
+   - `RESOURCE_FAILED`
+
+3. **Drift Events** - Configuration drift detection
+   - `DRIFT_DETECTED`
+   - `DRIFT_REMEDIATION_STARTED`
+   - `DRIFT_REMEDIATION_COMPLETED`
+   - `DRIFT_REMEDIATION_FAILED`
+
+4. **Policy Events** - Governance validation
+   - `POLICY_CHECK_STARTED`
+   - `POLICY_VIOLATION`
+   - `POLICY_CHECK_PASSED`
+
+5. **Validation Events** - Configuration validation
+   - `VALIDATION_STARTED`
+   - `VALIDATION_COMPLETED`
+   - `VALIDATION_FAILED`
+
+## Event Consumers
+
+### Built-in Consumers
+
+#### NotificationManager
+
+Forwards events to configured notification channels (email, Slack, webhooks).
+
+**Subscription:**
+- Subscribes to all events via `subscribe_all()`
+- Filters based on notification configuration
+- Routes to appropriate channels
+
+#### StateManager
+
+Tracks state changes and resource lifecycle.
+
+**Subscriptions:**
+- `RESOURCE_CREATED`, `RESOURCE_UPDATED`, `RESOURCE_DELETED`
+- `AFTER_APPLY`, `AFTER_DESTROY`
+
+#### AuditLogger
+
+Logs all events for compliance and debugging.
+
+**Subscription:**
+- `subscribe_all()` - Captures complete event history
+
+### Custom Consumers
+
+Plugins and extensions can subscribe to events:
+
+```python
+from infrafoundry.core.events import EventManager, EventType, Event
+
+class CustomIntegration:
+    def __init__(self, event_manager: EventManager):
+        event_manager.subscribe(EventType.AFTER_APPLY, self.on_apply_complete)
+        event_manager.subscribe(EventType.DRIFT_DETECTED, self.on_drift)
+
+    def on_apply_complete(self, event: Event) -> None:
+        # Custom logic after successful apply
+        pass
+
+    def on_drift(self, event: Event) -> None:
+        # Custom drift handling
+        pass
+```
+
+## Event Data Conventions
+
+Each event type includes specific data fields:
+
+### Lifecycle Events
+
+```python
+{
+    "provider_name": "proxmox-homelab",
+    "runner": "terraform",
+    "deployment_id": "abc123",
+    "duration_seconds": 45.2
+}
+```
+
+### Resource Events
+
+```python
+{
+    "resource_type": "vm",
+    "resource_name": "web-01",
+    "resource_id": "vm-101",
+    "provider": "proxmox"
+}
+```
+
+### Drift Events
+
+```python
+{
+    "provider": "opnsense-gateway",
+    "has_changes": true,
+    "resources_added": 0,
+    "resources_changed": 2,
+    "resources_destroyed": 0,
+    "summary": "2 resources drifted"
+}
+```
+
+### Policy Events
+
+```python
+{
+    "policy_name": "strict-naming",
+    "violation_count": 3,
+    "resources": ["vm-01", "vm-02", "vm-03"],
+    "severity": "ERROR"
+}
+```
+
+## Design Patterns
+
+### Synchronous Execution
+
+Events are dispatched synchronously to maintain predictable execution order:
+
+```python
+# Events execute in order, blocking until handlers complete
+emit_event(EventType.BEFORE_APPLY, env="prod", data={...})
+# ... apply operation ...
+emit_event(EventType.AFTER_APPLY, env="prod", data={...})
+```
+
+**Benefits:**
+- Predictable execution order
+- Simple debugging and tracing
+- No race conditions
+- Easy testing
+
+**Trade-offs:**
+- Slow handlers block emission
+- Not suitable for long-running operations
+
+**Best Practice:** Keep handlers lightweight; offload heavy work to async tasks or queues.
+
+### Error Handling
+
+Event handlers should not raise exceptions:
+
+```python
+def safe_handler(event: Event) -> None:
+    try:
+        # Handler logic
+        pass
+    except Exception as e:
+        logger.error(f"Handler failed: {e}")
+        # Don't re-raise; don't block other handlers
+```
+
+### Event Bubbling
+
+Events bubble up through architectural layers:
+
+```
+Runner (emit) → Provider (emit) → Orchestrator (emit) → EventManager
+```
+
+Each layer can emit its own events, enriching context as it goes.
+
+## Integration Points
+
+### CLI Commands
+
+Commands emit events at key points:
+
+```python
+# infra apply command
+event_manager.emit_event(EventType.BEFORE_APPLY, environment=env, data={...})
+orchestrator.apply(environment=env)
+event_manager.emit_event(EventType.AFTER_APPLY, environment=env, data={...})
+```
+
+### Runners
+
+Runners emit resource-level events:
+
+```python
+class TerraformRunner:
+    def apply(self, provider, auto_approve=True):
+        # Parse terraform output
+        for resource in created_resources:
+            self.event_manager.emit_event(
+                EventType.RESOURCE_CREATED,
+                environment=provider.environment,
+                data={"resource_name": resource.name}
+            )
+```
+
+### Providers
+
+Providers emit validation and configuration events:
+
+```python
+class ProxmoxProvider:
+    def validate(self):
+        self.event_manager.emit_event(
+            EventType.VALIDATION_STARTED,
+            environment=self.environment,
+            data={"provider": self.name}
+        )
+```
+
+## Testing
+
+Event system supports testing via subscription inspection:
+
+```python
+def test_apply_emits_events():
+    events_received = []
+
+    def capture(event: Event):
+        events_received.append(event)
+
+    event_manager.subscribe_all(capture)
+    orchestrator.apply(environment="test")
+
+    assert any(e.event_type == EventType.BEFORE_APPLY for e in events_received)
+    assert any(e.event_type == EventType.AFTER_APPLY for e in events_received)
+```
+
+## Performance Considerations
+
+### Event Volume
+
+Typical event counts per operation:
+
+- **Plan**: 5-10 events (lifecycle + validation)
+- **Apply**: 10-50 events (lifecycle + resources)
+- **Drift Detection**: 3-15 events (detection + summary)
+
+### Handler Performance
+
+Recommended handler execution times:
+
+- **Logging**: < 1ms
+- **State updates**: < 10ms
+- **Notifications**: < 100ms
+- **Heavy operations**: Offload to background tasks
+
+## Security Considerations
+
+### Event Data Sanitization
+
+Never include secrets in event data:
+
+```python
+# ❌ Bad
+emit_event(EventType.RESOURCE_CREATED, data={
+    "password": "secret123"  # Don't do this!
+})
+
+# ✅ Good
+emit_event(EventType.RESOURCE_CREATED, data={
+    "resource_name": "database",
+    "has_credentials": True  # Indicate presence without exposing
+})
+```
+
+### Handler Trust
+
+All handlers run in-process with full access. Only register trusted handlers.
+
+## Future Enhancements
+
+Potential improvements:
+
+1. **Async Events**: Support for asynchronous event processing
+2. **Event Filtering**: More granular subscription filters
+3. **Event Replay**: Replay historical events for debugging
+4. **Event Persistence**: Durable event log for audit compliance
+5. **Priority Handlers**: Execute critical handlers first
+6. **Event Batching**: Group related events for efficiency
+
+## Related Documentation
+
+- [Event System Guide](../development/event-system.md) - Developer guide for using events
+- [Orchestrator Architecture](orchestrator-architecture.md) - How orchestrator uses events
+- [Notifications Configuration](../configuration/notifications.md) - Configuring event-driven notifications
+- [State Management](state-management.md) - How state manager consumes events
+
+## See Also
+
+- [Design Principles](principles.md) - Guiding principles for event system design
+- [Architectural Patterns](architectural-patterns.md) - Pub-sub and observer patterns
+
+---
+
+**Last Updated:** 2025-12-29

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,37 @@
+# Development Guides
+
+This section provides comprehensive guides for developing and extending InfraFoundry.
+
+## Getting Started with Development
+
+- **[Coding Standards](coding-standards.md)** - Style guides, conventions, and best practices for contributing code
+- **[CI/CD Testing](ci-cd-testing.md)** - Continuous integration setup, testing strategies, and workflows
+- **[Release & Automation](release-and-automation.md)** - Automated versioning, release management, and governance validation
+
+## Extending InfraFoundry
+
+### Core Extension Points
+
+- **[Implementing Providers](implementing-providers.md)** - Guide for creating new infrastructure providers (Proxmox, OPNsense, etc.)
+- **[Implementing Runners](implementing-runners.md)** - Comprehensive guide for creating custom infrastructure tool runners (Terraform, Ansible, etc.)
+- **[Implementing Secret Providers](implementing-secret-providers.md)** - Guide to adding new secret storage backends (Vaultwarden, AWS, Azure, etc.)
+
+### Quick References
+
+- **[Runner Protocol Quick Reference](runner-protocol-quick-reference.md)** - Quick reference for protocol-based runner system implementation
+
+## Architecture Patterns
+
+- **[Manager Patterns](manager-patterns.md)** - Implementation patterns for Manager classes in the codebase
+- **[Event System](event-system.md)** - Documentation of the internal event system for orchestration
+- **[Credential Loader System](credential-loader-system.md)** - How the credential loading system works
+
+## See Also
+
+- [Architecture Overview](../architecture/overview.md) - High-level system architecture
+- [AGENTS.md](../AGENTS.md) - Issue-driven development workflow
+- [Examples](../examples/) - Working examples and tutorials
+
+---
+
+**Last Updated:** 2025-12-29

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -5,7 +5,7 @@ This guide covers the automated versioning, release management, governance valid
 ## Table of Contents
 - [Automated Versioning](#automated-versioning)
 - [Release Management](#release-management)
-- [Security & Quality Tasks](#security--quality-tasks)
+- [Security & Quality Tasks](#security-quality-tasks)
 - [Governance Validation](#governance-validation)
 - [Environment Configuration](#environment-configuration)
 
@@ -226,7 +226,7 @@ uv run doit fmt_pyproject
 - **Example**:
   ```bash
   $ uv run doit spell_check
-  docs/README.md:42: recieve ==> receive
+  docs/README.md:42: receive ==> receive
   ```
 
 #### `doit fmt_pyproject`
@@ -576,5 +576,4 @@ ignore-words-list = "crate,kubernetes,terraform"
 
 - [Coding Standards](coding-standards.md) - Code style guidelines
 - [CI/CD Testing](ci-cd-testing.md) - Continuous integration setup
-- [Contributing](../../CONTRIBUTING.md) - Contribution guidelines (if exists)
-- [AGENTS.md](../../AGENTS.md) - Issue-driven development workflow
+- [AGENTS.md](../AGENTS.md) - Issue-driven development workflow

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,32 @@
+# Examples
+
+Practical examples and reference configurations for InfraFoundry.
+
+## Quick Links
+
+- **[Overview](overview.md)** - Introduction to the examples and how to use them
+
+## Configuration Examples
+
+- **[Environment Example](ENV_EXAMPLE.md)** - Annotated example of environment configuration
+- **[Envrc Local](ENVRC_LOCAL.md)** - Example usage of local environment variables
+
+## Integration Examples
+
+- **[GitLab CI Example](GITLAB_CI_EXAMPLE.md)** - Example GitLab CI workflow configuration
+
+## Extension Examples
+
+- **[Custom Runner Example](custom-runner-example.md)** - Complete example of implementing a CloudFormation runner
+
+## Getting Help
+
+For more detailed documentation, see:
+
+- [Configuration Documentation](../configuration/) - Complete configuration reference
+- [Development Guides](../development/) - Guides for extending InfraFoundry
+- [Architecture Documentation](../architecture/) - System design and patterns
+
+---
+
+**Last Updated:** 2025-12-29

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -1,0 +1,57 @@
+# Examples Overview
+
+This section provides practical examples and reference configurations for InfraFoundry.
+
+## What You'll Find Here
+
+The examples in this section demonstrate real-world usage patterns and provide templates you can adapt for your own infrastructure needs.
+
+## Available Examples
+
+### Configuration Examples
+
+- **[Environment Example](ENV_EXAMPLE.md)** - Annotated example of a complete environment configuration file showing all available options
+- **[Envrc Local](ENVRC_LOCAL.md)** - Example usage of local environment variables with direnv for development
+
+### Integration Examples
+
+- **[GitLab CI Example](GITLAB_CI_EXAMPLE.md)** - Complete GitLab CI workflow configuration for automated infrastructure deployment
+
+### Extension Examples
+
+- **[Custom Runner Example](custom-runner-example.md)** - Complete walkthrough of implementing a custom runner (CloudFormation example)
+
+## How to Use These Examples
+
+1. **Review the example** - Read through to understand the pattern and options
+2. **Copy and adapt** - Use the example as a template for your own configuration
+3. **Test incrementally** - Start with a minimal configuration and add complexity gradually
+4. **Refer to docs** - Link to detailed documentation for each feature used
+
+## Example Structure
+
+Each example follows this structure:
+
+- **Overview** - What the example demonstrates
+- **Prerequisites** - Required setup and dependencies
+- **Configuration** - Complete configuration with annotations
+- **Usage** - How to run and test the example
+- **Customization** - How to adapt for your needs
+
+## Getting Started
+
+If you're new to InfraFoundry, start with these examples in order:
+
+1. **[Environment Example](ENV_EXAMPLE.md)** - Understand the configuration structure
+2. **[Envrc Local](ENVRC_LOCAL.md)** - Set up your development environment
+3. **[Custom Runner Example](custom-runner-example.md)** - Learn how to extend InfraFoundry
+
+## See Also
+
+- [Configuration Overview](../configuration/overview.md) - Detailed configuration documentation
+- [Getting Started Guide](../getting-started/setup-guide.md) - Initial setup instructions
+- [Development Guides](../development/) - Guides for extending InfraFoundry
+
+---
+
+**Last Updated:** 2025-12-29

--- a/docs/guides/drift-detection.md
+++ b/docs/guides/drift-detection.md
@@ -1,0 +1,322 @@
+# Drift Detection Guide
+
+## Overview
+
+Drift detection identifies discrepancies between your declared infrastructure configuration and the actual state of deployed resources. InfraFoundry provides automated drift detection to help maintain infrastructure consistency.
+
+## Audience and Prerequisites
+
+- **Audience:** DevOps engineers, platform teams, and infrastructure operators
+- **Prerequisites:**
+  - Familiarity with infrastructure as code concepts
+  - Understanding of state management
+  - A deployed environment to check for drift
+
+## What is Infrastructure Drift?
+
+Infrastructure drift occurs when the actual state of resources diverges from the declared configuration. Common causes include:
+
+- **Manual Changes:** Direct modifications via web console or CLI
+- **Auto-Scaling:** Dynamic resource creation/deletion
+- **External Updates:** OS patches, security updates
+- **Configuration Management:** Changes by other automation tools
+- **Resource Dependencies:** Cascading changes from related resources
+
+## Drift Detection Capabilities
+
+InfraFoundry drift detection supports runners that implement the `DriftDetectable` protocol:
+
+- ✅ **Terraform** - Full drift detection support via plan output parsing
+- ✅ **Pulumi** - Drift detection via preview/refresh operations
+- ❌ **Ansible** - Not supported (Ansible is idempotent but doesn't track state)
+- ❌ **PyInfra** - Not supported
+
+## CLI Commands
+
+### Detect Drift
+
+```bash
+# Detect drift in all providers for an environment
+infra drift detect --env dev
+
+# Detect drift for a specific provider
+infra drift detect --env dev --provider proxmox
+
+# Verbose output showing detailed changes
+infra drift detect --env dev --verbose
+
+# Output results as JSON
+infra drift detect --env dev --format json
+```
+
+### View Drift Information
+
+```bash
+# Show drift summary for environment
+infra drift status --env dev
+
+# Show drift for specific provider
+infra drift status --env dev --provider opnsense
+
+# Show historical drift detection results
+infra drift history --env dev --limit 10
+```
+
+## Understanding Drift Results
+
+### Drift Summary
+
+When drift is detected, you'll see a summary like this:
+
+```
+Drift Detection Results for 'dev' environment:
+
+Provider: proxmox-homelab (terraform)
+  Status: DRIFT DETECTED
+  Resources Added: 0
+  Resources Changed: 2
+  Resources Destroyed: 0
+  Details:
+    - vm-web-01: configuration changed (CPU count: 2 → 4)
+    - vm-db-01: configuration changed (Memory: 4096MB → 8192MB)
+
+Provider: opnsense-gateway (terraform)
+  Status: NO DRIFT
+  Resources: 12 unchanged
+```
+
+### Drift Types
+
+1. **Added Resources**: Resources exist in deployed state but not in configuration
+   - Usually indicates manual creation or missing config
+
+2. **Changed Resources**: Resources exist but with different properties
+   - Most common type of drift
+   - Can be intentional (manual scaling) or unintentional (configuration errors)
+
+3. **Destroyed Resources**: Resources in configuration but not in deployed state
+   - May indicate manual deletion or provisioning failures
+
+## Configuration
+
+### Enable Drift Detection
+
+Configure drift detection in your environment settings:
+
+```yaml
+# envs/dev/settings.yaml
+drift_detection:
+  enabled: true
+  check_on_plan: true          # Auto-detect drift during plan operations
+  fail_on_drift: false          # Whether to fail if drift is detected
+  ignore_resources: []          # Resources to exclude from drift checking
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable drift detection |
+| `check_on_plan` | bool | `true` | Automatically check for drift during plan operations |
+| `fail_on_drift` | bool | `false` | Exit with error if drift is detected |
+| `ignore_resources` | list | `[]` | Resource patterns to ignore (regex) |
+
+### Ignoring Expected Drift
+
+Some drift is expected and can be safely ignored:
+
+```yaml
+# envs/prod/settings.yaml
+drift_detection:
+  enabled: true
+  ignore_resources:
+    - "aws_autoscaling_group.*"      # Ignore auto-scaling changes
+    - ".*_security_patch"             # Ignore automatic security patches
+    - "aws_instance.*\.tags"          # Ignore tag changes
+```
+
+## Common Workflows
+
+### Daily Drift Monitoring
+
+Run drift detection on a schedule:
+
+```bash
+# Cron entry (daily at 9 AM)
+0 9 * * * cd /path/to/infra && infra drift detect --env prod --notify
+```
+
+### Pre-Apply Drift Check
+
+Always check for drift before applying changes:
+
+```bash
+# Check for drift
+infra drift detect --env prod
+
+# If no drift, apply changes
+infra apply --env prod
+
+# If drift exists, review and decide:
+# Option 1: Accept drift and apply anyway
+infra apply --env prod --accept-drift
+
+# Option 2: Remediate drift first
+infra drift remediate --env prod --auto-approve
+infra apply --env prod
+```
+
+### CI/CD Integration
+
+Add drift detection to your CI/CD pipeline:
+
+```yaml
+# .gitlab-ci.yml
+drift-check:
+  stage: validate
+  script:
+    - infra drift detect --env $CI_ENVIRONMENT_NAME
+    - infra drift status --env $CI_ENVIRONMENT_NAME --format json > drift-report.json
+  artifacts:
+    reports:
+      drift: drift-report.json
+  only:
+    - schedules
+```
+
+## Troubleshooting
+
+### Issue: "Provider does not support drift detection"
+
+**Symptoms:**
+- Error message when running drift detect
+- Provider skipped during drift detection
+
+**Cause:** Provider's runner doesn't implement the `DriftDetectable` protocol
+
+**Solutions:**
+1. Only Terraform and Pulumi runners support drift detection
+2. For Ansible/PyInfra, use manual comparison or state tracking
+3. Consider implementing drift detection for custom runners
+
+### Issue: "State file not found"
+
+**Symptoms:**
+- Error: "Cannot detect drift: no state file"
+- Drift detection fails immediately
+
+**Cause:** Provider has never been applied or state file is missing
+
+**Solutions:**
+1. Run `infra apply --env <env>` first to create state
+2. Verify state file exists in `generated/{env}/{runner}/{provider}/`
+3. Check state backend configuration if using remote state
+
+### Issue: False positive drift detected
+
+**Symptoms:**
+- Drift reported but configuration hasn't changed
+- Same drift detected repeatedly
+
+**Causes:**
+- Dynamic resource properties (timestamps, auto-generated values)
+- Computed fields that change on every read
+- Time-based resources (expiration dates, etc.)
+
+**Solutions:**
+1. Add resources to `ignore_resources` list
+2. Use lifecycle rules in provider configuration
+3. Update configuration to match actual deployed state
+
+### Issue: Drift not detected for manual changes
+
+**Symptoms:**
+- Manual changes made but drift detection shows no drift
+- State seems out of sync
+
+**Cause:** State hasn't been refreshed
+
+**Solutions:**
+```bash
+# Force state refresh before drift detection
+infra drift detect --env dev --refresh
+
+# Or manually refresh state first
+infra state refresh --env dev
+infra drift detect --env dev
+```
+
+## Best Practices
+
+### 1. Regular Drift Checks
+
+Run drift detection on a schedule:
+- **Development:** Daily or before deployments
+- **Staging:** Daily
+- **Production:** Multiple times per day
+
+### 2. Drift Alerts
+
+Configure notifications for drift detection:
+
+```yaml
+# notifications.yaml
+notifications:
+  - type: slack
+    events:
+      - drift_detected
+    webhook_url: https://hooks.slack.com/services/...
+    channels:
+      - "#infrastructure-alerts"
+```
+
+### 3. Drift Categories
+
+Classify drift to prioritize response:
+- **Critical:** Security groups, IAM policies, encryption settings
+- **High:** Resource configurations, networking changes
+- **Medium:** Tags, metadata, non-critical attributes
+- **Low:** Expected drift (auto-scaling, patches)
+
+### 4. Drift Review Process
+
+1. **Detect** drift regularly
+2. **Classify** drift by severity and impact
+3. **Investigate** unexpected drift
+4. **Remediate** or accept drift based on classification
+5. **Document** accepted drift in `ignore_resources`
+
+### 5. Prevent Drift
+
+- Use IAM policies to restrict manual changes
+- Enable CloudTrail/audit logging for tracking
+- Use read-only credentials for drift detection
+- Implement approval workflows for manual changes
+
+## Integration with Drift Remediation
+
+Drift detection is the first step in drift remediation:
+
+```bash
+# Step 1: Detect drift
+infra drift detect --env dev
+
+# Step 2: Review drift
+infra drift status --env dev
+
+# Step 3: Remediate if within thresholds
+infra drift remediate --env dev --auto-approve
+```
+
+See [Drift Remediation Guide](drift-remediation.md) for automated remediation.
+
+## Related Documentation
+
+- [Drift Remediation](drift-remediation.md) - Automated drift remediation
+- [State Management](../architecture/state-management.md) - Understanding state tracking
+- [Notifications](../configuration/notifications.md) - Setting up drift alerts
+- [Runner Protocols](../development/runner-protocol-quick-reference.md) - DriftDetectable protocol
+
+---
+
+**Last Updated:** 2025-12-29


### PR DESCRIPTION
## Summary

Fixes all remaining MkDocs documentation warnings after renaming TABLE_OF_CONTENTS.md to index.md in PR #119.

## Changes

### Files Added
- **docs/AGENTS.md**: Copied from root and updated relative links
- **docs/development/README.md**: Index for development guides
- **docs/examples/README.md**: Index for examples section
- **docs/examples/overview.md**: Overview of examples
- **docs/guides/drift-detection.md**: Comprehensive drift detection guide
- **docs/architecture/events.md**: Event system architecture documentation

### Files Modified
- **docs/development/release-and-automation.md**: 
  - Removed link to non-existent CONTRIBUTING.md
  - Fixed AGENTS.md link to use relative path
  - Fixed broken anchor link (#security-quality-tasks → #security-quality-tasks)
  - Fixed typo (recieve → receive)

## Testing

✅ Documentation builds without warnings:
```bash
uv run doit docs_build
# Result: INFO - Building documentation to directory: /nfs/data/src/infrafoundry/site
# No warnings or errors
```

## Related Issues

Closes #120

## Documentation

All changes are documentation additions/fixes. No code changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)