### PR TITLE
fix: resolve test failure and address security findings

### DIFF
--- a/src/infrafoundry/cli/commands/secrets/secrets.py
+++ b/src/infrafoundry/cli/commands/secrets/secrets.py
@@ -7,6 +7,7 @@ import click
 
 from infrafoundry.core.exceptions import InfraFoundryError, SecretError
 from infrafoundry.core.secrets import SecretManager
+from infrafoundry.core.secrets.age_key_manager import create_sops_config
 
 from ...utils import console, raise_cli_error
 
@@ -43,10 +44,10 @@ def secrets_init(ctx: click.Context, key_file: str | None) -> None:
 
     key_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Generate age key
-    import subprocess
+    # Generate age key using subprocess with hardcoded command (not user input)
+    import subprocess  # nosec B404
 
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603, B607
         ["age-keygen", "-o", str(key_path)],
         capture_output=True,
         text=True,
@@ -60,9 +61,8 @@ def secrets_init(ctx: click.Context, key_file: str | None) -> None:
         if line.startswith("# public key:"):
             public_key = line.split(": ")[1]
 
-            # Create .sops.yaml
-            secret_manager = SecretManager(str(key_path.parent))
-            secret_manager.create_sops_config(public_key)
+            # Create .sops.yaml (call directly - SecretManager requires SOPS_AGE_KEY_FILE)
+            create_sops_config(key_path.parent, public_key)
 
             console.success(f"Created age key: {key_path}")
             console.success(f"Created .sops.yaml with public key: {public_key}")
@@ -78,7 +78,7 @@ def secrets_init(ctx: click.Context, key_file: str | None) -> None:
 def secrets_encrypt(file: str) -> None:
     """Encrypt a file with SOPS."""
     try:
-        import subprocess
+        import subprocess  # nosec B404
 
         config_repo = os.getenv("INFRAFOUNDRY_CONFIG_REPO")
         if config_repo and not Path(file).is_absolute():
@@ -91,7 +91,7 @@ def secrets_encrypt(file: str) -> None:
         if not file_path.exists():
             raise click.ClickException(f"File not found: {file_path}")
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603, B607
             ["sops", "--encrypt", "--in-place", str(file_path)],
             capture_output=True,
             text=True,
@@ -117,7 +117,7 @@ def secrets_encrypt(file: str) -> None:
 def secrets_decrypt(file: str) -> None:
     """Decrypt and display a SOPS-encrypted file."""
     try:
-        import subprocess
+        import subprocess  # nosec B404
 
         config_repo = os.getenv("INFRAFOUNDRY_CONFIG_REPO")
         if config_repo and not Path(file).is_absolute():
@@ -128,7 +128,7 @@ def secrets_decrypt(file: str) -> None:
         if not file_path.exists():
             raise click.ClickException(f"File not found: {file_path}")
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603, B607
             ["sops", "--decrypt", str(file_path)],
             capture_output=True,
             text=True,

--- a/src/infrafoundry/core/credential_loader/credential_loader.py
+++ b/src/infrafoundry/core/credential_loader/credential_loader.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import tempfile
 from pathlib import Path
 from types import TracebackType
 
@@ -51,7 +52,8 @@ class CredentialLoader:
         result = {}
         for name, loader_class in self.PROVIDER_LOADERS.items():
             # Create a temporary instance to get properties
-            temp_secrets_dir = Path("/tmp")
+            # Use tempfile.gettempdir() instead of hardcoded /tmp for security
+            temp_secrets_dir = Path(tempfile.gettempdir())
             # Loader classes in registry are concrete implementations, not abstract
             loader = loader_class(temp_secrets_dir, False)  # type: ignore[abstract]
             result[name] = {

--- a/src/infrafoundry/core/drift_remediation.py
+++ b/src/infrafoundry/core/drift_remediation.py
@@ -1,5 +1,6 @@
 """Automated drift remediation for infrastructure management."""
 
+import logging
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +12,8 @@ from infrafoundry.core.config.models import DriftRemediationConfig
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import EventManager, EventType
 from infrafoundry.core.exceptions import InfraFoundryError
+
+logger = logging.getLogger(__name__)
 
 
 class DriftRemediationError(InfraFoundryError):
@@ -252,8 +255,10 @@ class DriftRemediator:
                         history.append(entry)
                         if len(history) >= limit:
                             break
-            except Exception:
-                continue  # Skip corrupted history files
+            except Exception as e:
+                # Skip corrupted history files but log the issue
+                logger.debug("Skipping corrupted history file %s: %s", history_file, e)
+                continue
 
         return history
 
@@ -270,7 +275,6 @@ class DriftRemediator:
         try:
             with open(history_file, "w") as f:
                 yaml.dump(results, f, default_flow_style=False)
-        except Exception:
-            # Don't fail remediation if history save fails
-            # Silently ignore history save errors
-            pass
+        except Exception as e:
+            # Don't fail remediation if history save fails, but log the issue
+            logger.warning("Failed to save remediation history to %s: %s", history_file, e)

--- a/src/infrafoundry/core/provider_mixins.py
+++ b/src/infrafoundry/core/provider_mixins.py
@@ -95,12 +95,15 @@ class TemplateRendererMixin:
         if "jinja2.ext.do" not in extensions:
             extensions.append("jinja2.ext.do")
 
+        # autoescape=False is intentional - we're generating Terraform/Ansible code,
+        # not HTML. HTML escaping would break infrastructure configuration syntax.
         self.jinja_env = Environment(
             loader=FileSystemLoader(str(self.template_dir)),
             trim_blocks=env_kwargs.pop("trim_blocks", True),
             lstrip_blocks=env_kwargs.pop("lstrip_blocks", True),
             keep_trailing_newline=env_kwargs.pop("keep_trailing_newline", True),
             extensions=extensions,
+            autoescape=False,  # nosec B701 - infrastructure code, not HTML
             **env_kwargs,  # Pass through any additional parameters
         )
 
@@ -629,12 +632,14 @@ class TerraformGeneratorMixin:
             from jinja2 import Environment, FileSystemLoader
 
             # Load from common templates directory
+            # autoescape=False is intentional - generating Terraform code, not HTML
             common_templates_dir = Path(__file__).parent.parent / "templates" / "common"
             env = Environment(
                 loader=FileSystemLoader(str(common_templates_dir)),
                 trim_blocks=True,
                 lstrip_blocks=True,
                 keep_trailing_newline=True,
+                autoescape=False,  # nosec B701 - infrastructure code, not HTML
             )
 
             template = env.get_template("backend.tf.j2")

--- a/src/infrafoundry/core/runners/ansible_runner.py
+++ b/src/infrafoundry/core/runners/ansible_runner.py
@@ -1,7 +1,6 @@
 """Ansible runner implementation."""
 
-import shutil
-import subprocess
+import subprocess  # nosec B404 - required for running ansible-playbook
 from pathlib import Path
 from typing import Any, override
 
@@ -16,12 +15,16 @@ class AnsibleRunner(BaseRunner):
     @override
     def tool_name(self) -> str:
         """Return the name of the tool."""
-        return "ansible"
+        return "ansible-playbook"
 
     @override
     def is_available(self) -> bool:
         """Check if Ansible is installed."""
-        return shutil.which("ansible-playbook") is not None
+        try:
+            _ = self.tool_path
+            return True
+        except FileNotFoundError:
+            return False
 
     @override
     def initialize(self, working_dir: Path, **kwargs: Any) -> dict[str, Any]:
@@ -69,8 +72,8 @@ class AnsibleRunner(BaseRunner):
             return None
 
         try:
-            result = subprocess.run(
-                ["ansible-playbook", "--version"],
+            result = subprocess.run(  # nosec B603 - trusted command
+                [self.tool_path, "--version"],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -102,8 +105,8 @@ class AnsibleRunner(BaseRunner):
             return {"valid": True, "message": "No playbook found (optional)"}
 
         try:
-            result = subprocess.run(
-                ["ansible-playbook", "--syntax-check", str(playbook)],
+            result = subprocess.run(  # nosec B603 - trusted command
+                [self.tool_path, "--syntax-check", str(playbook)],
                 cwd=ansible_dir,
                 capture_output=True,
                 text=True,
@@ -140,17 +143,17 @@ class AnsibleRunner(BaseRunner):
             )
             return {"error": "ansible-playbook not found", "success": False}
 
-        # Build command
-        cmd = ["ansible-playbook", "-i", str(inventory), str(playbook)]
+        # Build command using full path to ansible-playbook binary
+        cmd = [self.tool_path, "-i", str(inventory), str(playbook)]
         if check_mode:
             cmd.append("--check")
             self.console.print("[dim]Running Ansible in check mode (dry run)...[/dim]")
         else:
             self.console.print("[dim]Running Ansible playbook...[/dim]")
 
-        # Run command
+        # Run command - nosec B603: trusted command with validated inputs
         try:
-            result = subprocess.run(cmd, cwd=ansible_dir, capture_output=False)
+            result = subprocess.run(cmd, cwd=ansible_dir, capture_output=False)  # nosec B603
             return {"exit_code": result.returncode, "success": result.returncode == 0}
         except FileNotFoundError:
             return {"error": "ansible-playbook not found", "success": False}

--- a/src/infrafoundry/core/runners/base_runner.py
+++ b/src/infrafoundry/core/runners/base_runner.py
@@ -1,5 +1,6 @@
 """Base runner interface for infrastructure tools."""
 
+import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
@@ -48,6 +49,26 @@ class BaseRunner(ABC):
             Tool name (e.g., 'terraform', 'ansible', 'pulumi')
         """
         pass
+
+    @property
+    def tool_path(self) -> str:
+        """Return the full path to the tool executable.
+
+        Uses shutil.which() to resolve the full path, which is more secure
+        than using a partial path that relies on PATH lookup at runtime.
+
+        Returns:
+            Full path to the tool executable, or tool_name if not found
+
+        Raises:
+            FileNotFoundError: If the tool is not found on PATH
+        """
+        path = shutil.which(self.tool_name)
+        if path is None:
+            raise FileNotFoundError(
+                f"{self.tool_name} not found on PATH. Please install {self.tool_name}."
+            )
+        return path
 
     @abstractmethod
     def is_available(self) -> bool:

--- a/src/infrafoundry/core/runners/pulumi_runner.py
+++ b/src/infrafoundry/core/runners/pulumi_runner.py
@@ -1,8 +1,7 @@
 """Pulumi runner implementation (example of pluggable runner)."""
 
 import json
-import shutil
-import subprocess
+import subprocess  # nosec B404 - required for running pulumi
 from pathlib import Path
 from typing import Any, override
 
@@ -38,7 +37,11 @@ class PulumiRunner(BaseRunner):
     @override
     def is_available(self) -> bool:
         """Check if Pulumi is installed."""
-        return shutil.which("pulumi") is not None
+        try:
+            _ = self.tool_path
+            return True
+        except FileNotFoundError:
+            return False
 
     @override
     def initialize(self, working_dir: Path, **kwargs: Any) -> dict[str, Any]:
@@ -58,8 +61,8 @@ class PulumiRunner(BaseRunner):
 
         try:
             # Check if stack exists
-            result = subprocess.run(
-                ["pulumi", "stack", "ls", "--json"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "stack", "ls", "--json"],
                 cwd=working_dir,
                 capture_output=True,
                 text=True,
@@ -72,15 +75,15 @@ class PulumiRunner(BaseRunner):
                 if not stack_exists:
                     # Create stack if it doesn't exist
                     self.console.print(f"[dim]Creating Pulumi stack: {stack}...[/dim]")
-                    subprocess.run(
-                        ["pulumi", "stack", "init", stack],
+                    subprocess.run(  # nosec B603
+                        [self.tool_path, "stack", "init", stack],
                         cwd=working_dir,
                         check=True,
                     )
                 else:
                     # Select existing stack
-                    subprocess.run(
-                        ["pulumi", "stack", "select", stack],
+                    subprocess.run(  # nosec B603
+                        [self.tool_path, "stack", "select", stack],
                         cwd=working_dir,
                         check=True,
                     )
@@ -108,8 +111,8 @@ class PulumiRunner(BaseRunner):
             return {"success": False, "error": "Pulumi directory does not exist"}
 
         try:
-            result = subprocess.run(
-                ["pulumi", "preview", "--non-interactive"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "preview", "--non-interactive"],
                 cwd=pulumi_dir,
                 capture_output=True,
                 text=True,
@@ -140,11 +143,11 @@ class PulumiRunner(BaseRunner):
             return {"success": False, "error": "Pulumi directory does not exist"}
 
         try:
-            cmd = ["pulumi", "up"]
+            cmd = [self.tool_path, "up"]
             if auto_approve:
                 cmd.append("--yes")
 
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 cmd,
                 cwd=pulumi_dir,
                 capture_output=False,
@@ -170,11 +173,11 @@ class PulumiRunner(BaseRunner):
             return {"success": False, "error": "Pulumi directory does not exist"}
 
         try:
-            cmd = ["pulumi", "destroy"]
+            cmd = [self.tool_path, "destroy"]
             if auto_approve:
                 cmd.append("--yes")
 
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 cmd,
                 cwd=pulumi_dir,
                 capture_output=False,
@@ -190,8 +193,8 @@ class PulumiRunner(BaseRunner):
             return None
 
         try:
-            result = subprocess.run(
-                ["pulumi", "version"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "version"],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -230,8 +233,8 @@ class PulumiRunner(BaseRunner):
             return {}
 
         try:
-            result = subprocess.run(
-                ["pulumi", "stack", "export"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "stack", "export"],
                 cwd=pulumi_dir,
                 capture_output=True,
                 text=True,

--- a/src/infrafoundry/core/runners/pyinfra_runner.py
+++ b/src/infrafoundry/core/runners/pyinfra_runner.py
@@ -1,7 +1,7 @@
 """PyInfra runner implementation."""
 
-import shutil
-import subprocess
+import subprocess  # nosec B404 - required for running pyinfra
+import sys
 from pathlib import Path
 from typing import Any, override
 
@@ -21,7 +21,11 @@ class PyInfraRunner(BaseRunner):
     @override
     def is_available(self) -> bool:
         """Check if pyinfra is installed."""
-        return shutil.which("pyinfra") is not None
+        try:
+            _ = self.tool_path
+            return True
+        except FileNotFoundError:
+            return False
 
     @override
     def initialize(self, working_dir: Path, **kwargs: Any) -> dict[str, Any]:
@@ -69,8 +73,8 @@ class PyInfraRunner(BaseRunner):
             return None
 
         try:
-            result = subprocess.run(
-                ["pyinfra", "--version"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "--version"],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -105,13 +109,13 @@ class PyInfraRunner(BaseRunner):
 
         # Basic syntax check using python -m py_compile
         try:
-            subprocess.run(
-                ["python3", "-m", "py_compile", str(deploy_file)],
+            subprocess.run(  # nosec B603
+                [sys.executable, "-m", "py_compile", str(deploy_file)],
                 check=True,
                 capture_output=True,
             )
-            subprocess.run(
-                ["python3", "-m", "py_compile", str(inventory_file)],
+            subprocess.run(  # nosec B603
+                [sys.executable, "-m", "py_compile", str(inventory_file)],
                 check=True,
                 capture_output=True,
             )
@@ -146,9 +150,9 @@ class PyInfraRunner(BaseRunner):
             )
             return {"error": "pyinfra not found", "success": False}
 
-        # Build command
+        # Build command using full path to pyinfra binary
         # pyinfra [options] INVENTORY DEPLOY
-        cmd = ["pyinfra"]
+        cmd = [self.tool_path]
         if dry_run:
             cmd.append("--dry")
             self.console.print("[dim]Running pyinfra in dry-run mode...[/dim]")
@@ -162,7 +166,7 @@ class PyInfraRunner(BaseRunner):
         # Run command
         try:
             # pyinfra outputs to stderr mostly for progress
-            result = subprocess.run(cmd, cwd=pyinfra_dir, capture_output=False)
+            result = subprocess.run(cmd, cwd=pyinfra_dir, capture_output=False)  # nosec B603
             return {"exit_code": result.returncode, "success": result.returncode == 0}
         except FileNotFoundError:
             return {"error": "pyinfra not found", "success": False}

--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -3,8 +3,7 @@
 import json
 import os
 import re
-import shutil
-import subprocess
+import subprocess  # nosec B404 - required for running terraform
 from pathlib import Path
 from typing import Any, cast, override
 
@@ -40,7 +39,11 @@ class TerraformRunner(BaseRunner):
     @override
     def is_available(self) -> bool:
         """Check if Terraform is installed."""
-        return shutil.which("terraform") is not None
+        try:
+            _ = self.tool_path
+            return True
+        except FileNotFoundError:
+            return False
 
     @override
     def initialize(self, working_dir: Path, **kwargs: Any) -> dict[str, Any]:
@@ -100,8 +103,8 @@ class TerraformRunner(BaseRunner):
             if not reconfigure:
                 return {"success": True, "message": "Already initialized"}
 
-        # Build init command
-        cmd = ["terraform", "init"]
+        # Build init command using full path to terraform binary
+        cmd = [self.tool_path, "init"]
         if reconfigure:
             cmd.append("-reconfigure")
         if migrate_state:
@@ -117,7 +120,7 @@ class TerraformRunner(BaseRunner):
                 msg = "Migrating Terraform state..."
             self.console.print(f"[dim]{msg}[/dim]")
 
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 cmd,
                 cwd=working_dir,
                 capture_output=True,
@@ -173,8 +176,8 @@ class TerraformRunner(BaseRunner):
             return None
 
         try:
-            result = subprocess.run(
-                ["terraform", "version", "-json"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "version", "-json"],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -194,8 +197,8 @@ class TerraformRunner(BaseRunner):
 
         try:
             env = self._prepare_environment(provider)
-            result = subprocess.run(
-                ["terraform", "validate"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "validate"],
                 cwd=tf_dir,
                 capture_output=True,
                 text=True,
@@ -232,14 +235,14 @@ class TerraformRunner(BaseRunner):
         if not init_result.get("success"):
             return init_result
 
-        # Build command
-        cmd = ["terraform", command]
+        # Build command using full path to terraform binary
+        cmd = [self.tool_path, command]
         if auto_approve and command in {"apply", "destroy"}:
             cmd.append("-auto-approve")
 
         # Run command with environment variables; capture output for plan so drift parsing works
         capture = command == "plan"
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             cmd,
             cwd=tf_dir,
             capture_output=capture,
@@ -270,8 +273,8 @@ class TerraformRunner(BaseRunner):
 
         try:
             # Run terraform show -json to get state
-            result = subprocess.run(
-                ["terraform", "show", "-json"],
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "show", "-json"],
                 cwd=tf_dir,
                 capture_output=True,
                 text=True,

--- a/src/infrafoundry/core/secrets/providers/sops.py
+++ b/src/infrafoundry/core/secrets/providers/sops.py
@@ -1,5 +1,6 @@
 import logging
-import subprocess
+import shutil
+import subprocess  # nosec B404 - required for running sops
 from pathlib import Path
 from typing import Any, cast
 
@@ -20,20 +21,21 @@ class SopsSecretProvider(SecretProvider):
     Secret provider implementation using Mozilla SOPS.
     """
 
-    def _ensure_sops_installed(self) -> None:
-        """Check if sops is installed."""
-        try:
-            subprocess.run(
-                ["sops", "--version"],
-                capture_output=True,
-                check=True,
-            )
-        except (subprocess.CalledProcessError, FileNotFoundError):
+    @property
+    def _sops_path(self) -> str:
+        """Return the full path to the sops executable."""
+        path = shutil.which("sops")
+        if path is None:
             error_msg = (
                 "sops not found. Install with: brew install sops (macOS) "
                 "or see https://github.com/getsops/sops"
             )
             raise SecretError(error_msg)
+        return path
+
+    def _ensure_sops_installed(self) -> None:
+        """Check if sops is installed."""
+        _ = self._sops_path  # Will raise SecretError if not found
 
     def load_secret(self, location: str | Path) -> dict[str, Any]:
         """
@@ -51,8 +53,8 @@ class SopsSecretProvider(SecretProvider):
             raise SecretNotFoundError(f"Encrypted file not found: {file_path}")
 
         try:
-            result = subprocess.run(
-                ["sops", "--decrypt", str(file_path)],
+            result = subprocess.run(  # nosec B603
+                [self._sops_path, "--decrypt", str(file_path)],
                 capture_output=True,
                 check=True,
                 text=True,
@@ -92,8 +94,8 @@ class SopsSecretProvider(SecretProvider):
                 yaml.dump(data, f)
 
             # Encrypt in place
-            subprocess.run(
-                ["sops", "--encrypt", "--in-place", str(temp_file)],
+            subprocess.run(  # nosec B603
+                [self._sops_path, "--encrypt", "--in-place", str(temp_file)],
                 capture_output=True,
                 check=True,
             )

--- a/src/infrafoundry/core/secrets/providers/vaultwarden.py
+++ b/src/infrafoundry/core/secrets/providers/vaultwarden.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import os
-import subprocess
+import shutil
+import subprocess  # nosec B404 - required for running bitwarden CLI
 from pathlib import Path
 from typing import Any
 
@@ -29,18 +30,19 @@ class VaultwardenProvider(SecretProvider):
         self._ensure_bw_installed()
         self._authenticate_if_needed()
 
-    def _ensure_bw_installed(self) -> None:
-        """Check if bw CLI is installed."""
-        try:
-            subprocess.run(
-                ["bw", "--version"],
-                capture_output=True,
-                check=True,
-            )
-        except (subprocess.CalledProcessError, FileNotFoundError):
+    @property
+    def _bw_path(self) -> str:
+        """Return the full path to the bw executable."""
+        path = shutil.which("bw")
+        if path is None:
             raise SecretError(
                 "Bitwarden CLI (bw) not found. Please install it to use VaultwardenProvider."
             )
+        return path
+
+    def _ensure_bw_installed(self) -> None:
+        """Check if bw CLI is installed."""
+        _ = self._bw_path  # Will raise SecretError if not found
 
     def _run_bw(self, args: list[str], input_data: str | None = None) -> str:
         """Run Bitwarden CLI command."""
@@ -49,8 +51,8 @@ class VaultwardenProvider(SecretProvider):
             env["BW_SESSION"] = self.session_key
 
         try:
-            result = subprocess.run(
-                ["bw", *args, "--nointeraction"],
+            result = subprocess.run(  # nosec B603
+                [self._bw_path, *args, "--nointeraction"],
                 input=input_data,
                 capture_output=True,
                 check=True,
@@ -201,8 +203,8 @@ class VaultwardenProvider(SecretProvider):
             else:
                 item_data["fields"].append({"name": k, "value": str(v), "type": 0})
 
-        encoded_data = subprocess.run(
-            ["bw", "encode"],
+        encoded_data = subprocess.run(  # nosec B603
+            [self._bw_path, "encode"],
             input=json.dumps(item_data),
             text=True,
             capture_output=True,

--- a/src/infrafoundry/core/secrets/rotation.py
+++ b/src/infrafoundry/core/secrets/rotation.py
@@ -1,7 +1,7 @@
 """Secrets rotation utilities for re-encrypting secrets with new keys."""
 
 import shutil
-import subprocess
+import subprocess  # nosec B404 - required for running age-keygen
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -41,6 +41,17 @@ class SecretsRotator:
         self.backup_dir = backup_dir or secrets_dir.parent / ".secrets_backups"
         self.current_backup: Path | None = None
 
+    @property
+    def _age_keygen_path(self) -> str:
+        """Return the full path to the age-keygen executable."""
+        path = shutil.which("age-keygen")
+        if path is None:
+            raise SecretError(
+                "age-keygen not found. Install with: brew install age (macOS) "
+                "or see https://github.com/FiloSottile/age"
+            )
+        return path
+
     def generate_age_key(self, key_file: Path) -> str:
         """Generate a new age key pair.
 
@@ -59,8 +70,8 @@ class SecretsRotator:
         key_file.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            result = subprocess.run(
-                ["age-keygen", "-o", str(key_file)],
+            result = subprocess.run(  # nosec B603
+                [self._age_keygen_path, "-o", str(key_file)],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -75,11 +86,6 @@ class SecretsRotator:
 
         except subprocess.CalledProcessError as e:
             raise SecretError(f"Failed to generate age key: {e.stderr}") from e
-        except FileNotFoundError:
-            raise SecretError(
-                "age-keygen not found. Install with: brew install age (macOS) "
-                "or see https://github.com/FiloSottile/age"
-            ) from None
 
     def create_backup(self) -> Path:
         """Create timestamped backup of encrypted files.
@@ -300,8 +306,8 @@ class SecretsRotator:
             Age public key
         """
         try:
-            result = subprocess.run(
-                ["age-keygen", "-y", str(key_file)],
+            result = subprocess.run(  # nosec B603
+                [self._age_keygen_path, "-y", str(key_file)],
                 capture_output=True,
                 text=True,
                 check=True,

--- a/tests/unit/test_cli_secrets.py
+++ b/tests/unit/test_cli_secrets.py
@@ -24,7 +24,7 @@ def test_secrets_init_basic(cli_runner, tmp_path):
     mock_result.stderr = "# public key: age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
     with patch("subprocess.run", return_value=mock_result):
-        with patch("infrafoundry.core.secrets.SecretManager.create_sops_config"):
+        with patch("infrafoundry.cli.commands.secrets.secrets.create_sops_config"):
             result = cli_runner.invoke(main, ["secrets", "init", "--key-file", str(key_file)])
 
             assert result.exit_code == 0

--- a/tests/unit/test_pyinfra_runner.py
+++ b/tests/unit/test_pyinfra_runner.py
@@ -101,7 +101,8 @@ def test_run_plan(runner: PyInfraRunner, mock_provider: MagicMock) -> None:
 
         assert result["success"]
         args = mock_run.call_args[0][0]
-        assert args[0] == "pyinfra"
+        # Check that the command uses the full path from shutil.which
+        assert args[0].endswith("pyinfra")
         assert "--dry" in args
         assert str(mock_provider.pyinfra_dir / "inventory.py") in args
         assert str(mock_provider.pyinfra_dir / "deploy.py") in args
@@ -119,6 +120,7 @@ def test_run_apply(runner: PyInfraRunner, mock_provider: MagicMock) -> None:
 
         assert result["success"]
         args = mock_run.call_args[0][0]
-        assert args[0] == "pyinfra"
+        # Check that the command uses the full path from shutil.which
+        assert args[0].endswith("pyinfra")
         assert "--yes" in args
         assert "--dry" not in args

--- a/tests/unit/test_secrets_rotation.py
+++ b/tests/unit/test_secrets_rotation.py
@@ -64,8 +64,9 @@ class TestSecretsRotator:
 
         assert rotator.backup_dir == custom_backup
 
+    @patch("shutil.which", return_value="/usr/bin/age-keygen")
     @patch("subprocess.run")
-    def test_generate_age_key_success(self, mock_run, temp_secrets_dir):
+    def test_generate_age_key_success(self, mock_run, mock_which, temp_secrets_dir):
         """Test successful age key generation."""
         mock_run.return_value = Mock(
             stderr="# public key: age1newkey456789",
@@ -78,7 +79,8 @@ class TestSecretsRotator:
 
         assert public_key == "age1newkey456789"
         mock_run.assert_called_once()
-        assert "age-keygen" in mock_run.call_args[0][0]
+        # Check that the command uses the full path
+        assert mock_run.call_args[0][0][0].endswith("age-keygen")
 
     def test_generate_age_key_existing_file(self, temp_secrets_dir):
         """Test that generation fails if key file already exists."""
@@ -90,8 +92,9 @@ class TestSecretsRotator:
         with pytest.raises(SecretError, match="already exists"):
             rotator.generate_age_key(key_file)
 
+    @patch("shutil.which", return_value="/usr/bin/age-keygen")
     @patch("subprocess.run")
-    def test_generate_age_key_command_failure(self, mock_run, temp_secrets_dir):
+    def test_generate_age_key_command_failure(self, mock_run, mock_which, temp_secrets_dir):
         """Test handling of age-keygen command failure."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "age-keygen", stderr="error")
 
@@ -101,11 +104,9 @@ class TestSecretsRotator:
         with pytest.raises(SecretError, match="Failed to generate age key"):
             rotator.generate_age_key(key_file)
 
-    @patch("subprocess.run")
-    def test_generate_age_key_age_not_found(self, mock_run, temp_secrets_dir):
+    @patch("shutil.which", return_value=None)
+    def test_generate_age_key_age_not_found(self, mock_which, temp_secrets_dir):
         """Test handling when age-keygen is not installed."""
-        mock_run.side_effect = FileNotFoundError()
-
         key_file = temp_secrets_dir / "age.key.new"
         rotator = SecretsRotator(secrets_dir=temp_secrets_dir)
 
@@ -245,9 +246,12 @@ class TestSecretsRotator:
         assert result["new_public_key"] == "age1newpublickey789"
         assert len(result["files_rotated"]) > 0
 
+    @patch("shutil.which", return_value="/usr/bin/age-keygen")
     @patch("subprocess.run")
     @patch.dict("os.environ", {}, clear=True)
-    def test_rotate_with_generate_new_key(self, mock_run, temp_secrets_dir, mock_provider):
+    def test_rotate_with_generate_new_key(
+        self, mock_run, mock_which, temp_secrets_dir, mock_provider
+    ):
         """Test rotation with automatic key generation."""
         # Mock age-keygen for key generation
         mock_run.return_value = Mock(
@@ -274,7 +278,8 @@ class TestSecretsRotator:
         assert result["success"] is True
         assert result["new_public_key"] == "age1generatedkey123"
 
-    def test_rotate_no_encrypted_files(self, temp_secrets_dir):
+    @patch("shutil.which", return_value="/usr/bin/age-keygen")
+    def test_rotate_no_encrypted_files(self, mock_which, temp_secrets_dir):
         """Test rotation when no encrypted files exist."""
         # Remove all yaml files
         for yaml_file in temp_secrets_dir.glob("*.yaml"):
@@ -293,8 +298,9 @@ class TestSecretsRotator:
         assert result["success"] is False
         assert "No encrypted files found" in result["errors"][0]
 
+    @patch("shutil.which", return_value="/usr/bin/age-keygen")
     @patch("subprocess.run")
-    def test_extract_public_key(self, mock_run, temp_secrets_dir, tmp_path):
+    def test_extract_public_key(self, mock_run, mock_which, temp_secrets_dir, tmp_path):
         """Test extracting public key from private key file."""
         mock_run.return_value = Mock(stdout="age1extractedkey456\n", returncode=0)
 
@@ -308,8 +314,9 @@ class TestSecretsRotator:
         mock_run.assert_called_once()
         assert "-y" in mock_run.call_args[0][0]
 
+    @patch("shutil.which", return_value="/usr/bin/age-keygen")
     @patch("subprocess.run")
-    def test_extract_public_key_failure(self, mock_run, temp_secrets_dir, tmp_path):
+    def test_extract_public_key_failure(self, mock_run, mock_which, temp_secrets_dir, tmp_path):
         """Test handling of public key extraction failure."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "age-keygen", stderr="error")
 


### PR DESCRIPTION
## Summary
- Fix `secrets init` command that was failing because it used `SecretManager` which requires `SOPS_AGE_KEY_FILE` during initialization
- Address all bandit security findings (B607, B701, B108, B110/B112, B404, B603)

## Changes
- Add `tool_path` property to `BaseRunner` using `shutil.which()` for full executable paths
- Explicitly set `autoescape=False` in Jinja2 environments with explanatory comments
- Use `tempfile.gettempdir()` instead of hardcoded `/tmp`
- Add logging to try/except handlers in drift_remediation
- Add `# nosec` comments to all intentional subprocess usage

## Breaking Change Assessment

**No breaking changes.** The CI detected potential breaking changes but these are all internal implementation details:

- `SopsSecretProvider._ensure_sops_installed()` - Internal method, implementation changed to use new `_sops_path` property
- `VaultwardenProvider._ensure_bw_installed()` - Internal method, implementation changed to use new `_bw_path` property  
- `SecretsRotator` - Added `_age_keygen_path` property, internal exception handling updated

All public APIs remain unchanged:
- `SopsSecretProvider.load_secret()`, `save_secret()` - unchanged
- `VaultwardenProvider.load_secret()`, `save_secret()` - unchanged
- `SecretsRotator.rotate()`, `generate_age_key()` - unchanged signatures and behavior

## Test plan
- [x] All 916 tests pass
- [x] `doit check` passes (format, lint, type_check, security, test)
- [x] No bandit findings remain

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)