### PR TITLE
fix(ci): skip breaking change detection for additive-only __all__ changes

### DIFF
--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -57,7 +57,8 @@ jobs:
               {
                 pattern: /__all__.*=/,
                 description: 'Public API exports modified',
-                severity: 'high'
+                severity: 'high',
+                requiresDeletions: true
               },
               {
                 pattern: /^-.*@property/m,
@@ -77,7 +78,8 @@ jobs:
               if (!file.patch) continue;
 
               const matches = [];
-              for (const {pattern, description, severity} of breakingPatterns) {
+              for (const {pattern, description, severity, requiresDeletions} of breakingPatterns) {
+                if (requiresDeletions && file.deletions === 0) continue;
                 if (pattern.test(file.patch)) {
                   matches.push({description, severity});
                 }


### PR DESCRIPTION
## Summary

- Adds `requiresDeletions` flag to the `__all__` breaking change pattern
- Skips the check when the modified file has zero deletions (purely additive exports)
- Correctly continues to flag removals or replacements in `__all__`

## Root Cause

The `__all__` pattern (`/__all__.*=/`) was the only pattern without a `^-` prefix, so it matched context lines and additions in diffs — not just deletions. This caused false positives when adding new provider exports.

## Test Plan

- [ ] PR with additive-only `__all__` changes should pass (e.g., #146)
- [ ] PR removing entries from `__all__` should still be flagged

Closes #147