### PR TITLE
refactor: fix all SIM (flake8-simplify) rule violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,12 +102,6 @@ ignore = [
     "B904",    # raise-without-from - fix incrementally
     "RUF012",  # Mutable class default - fix incrementally
     "E402",    # Module level import not at top of file - needed for CLI command loading
-    "SIM102",  # Use single if statement instead of nested - fix incrementally
-    "SIM105",  # Use contextlib.suppress instead of try-except-pass - fix incrementally
-    "SIM114",  # Combine if branches using logical or - fix incrementally
-    "SIM117",  # Use single with statement with multiple contexts - fix incrementally
-    "SIM118",  # Use `key in dict` instead of `key in dict.keys()` - fix incrementally
-    "SIM300",  # Yoda conditions - fix incrementally
 ]
 
 [tool.ruff.format]

--- a/src/infrafoundry/providers/proxmox/validator.py
+++ b/src/infrafoundry/providers/proxmox/validator.py
@@ -226,19 +226,24 @@ class ProxmoxValidator:
                 nodes.add(target_node)
 
             # Collect storage pools
-            if disk_config := config.get("disk"):
-                if isinstance(disk_config, dict) and (storage := disk_config.get("storage")):
-                    if target_node:
-                        storage_pools.add((target_node, storage))
-            if storage := config.get("storage"):
-                if target_node:
-                    storage_pools.add((target_node, storage))
+            if (
+                (disk_config := config.get("disk"))
+                and isinstance(disk_config, dict)
+                and (storage := disk_config.get("storage"))
+                and target_node
+            ):
+                storage_pools.add((target_node, storage))
+            if (storage := config.get("storage")) and target_node:
+                storage_pools.add((target_node, storage))
 
             # Collect network bridges
-            if network_config := config.get("network"):
-                if isinstance(network_config, dict) and (bridge := network_config.get("bridge")):
-                    if target_node:
-                        bridges.add((target_node, bridge))
+            if (
+                (network_config := config.get("network"))
+                and isinstance(network_config, dict)
+                and (bridge := network_config.get("bridge"))
+                and target_node
+            ):
+                bridges.add((target_node, bridge))
 
             # Collect template references (for VMs that clone)
             if resource.type == "vm" and (clone_ref := config.get("clone")):
@@ -260,20 +265,23 @@ class ProxmoxValidator:
                 vmids[vmid] = resource_name
 
             # Collect MAC addresses and check for conflicts
-            if network_config := config.get("network"):
-                if isinstance(network_config, dict) and (mac := network_config.get("macaddr")):
-                    mac_upper = mac.upper()
-                    if mac_upper in mac_addresses:
-                        self.report.add_check(
-                            check_name=f"proxmox_mac_{mac}_duplicate",
-                            passed=False,
-                            message=(
-                                f"MAC address {mac} used by multiple resources: "
-                                f"{mac_addresses[mac_upper]} and {resource_name}"
-                            ),
-                            level=ValidationLevel.ERROR,
-                        )
-                    mac_addresses[mac_upper] = resource_name
+            if (
+                (network_config := config.get("network"))
+                and isinstance(network_config, dict)
+                and (mac := network_config.get("macaddr"))
+            ):
+                mac_upper = mac.upper()
+                if mac_upper in mac_addresses:
+                    self.report.add_check(
+                        check_name=f"proxmox_mac_{mac}_duplicate",
+                        passed=False,
+                        message=(
+                            f"MAC address {mac} used by multiple resources: "
+                            f"{mac_addresses[mac_upper]} and {resource_name}"
+                        ),
+                        level=ValidationLevel.ERROR,
+                    )
+                mac_addresses[mac_upper] = resource_name
 
         return ProxmoxResourceReferences(
             nodes=nodes,

--- a/tests/integration/test_advanced_workflows.py
+++ b/tests/integration/test_advanced_workflows.py
@@ -125,14 +125,16 @@ class TestPolicyEnforcement:
         provider.terraform_dir.mkdir(parents=True, exist_ok=True)
         (provider.terraform_dir / ".terraform").mkdir(exist_ok=True)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch.object(provider, "generate_terraform"),
+        ):
             mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
 
-            with patch.object(provider, "generate_terraform"):
-                # Should accept enforce_policies parameter
-                orchestrator.plan("dev", enforce_policies=True)
+            # Should accept enforce_policies parameter
+            orchestrator.plan("dev", enforce_policies=True)
 
-                provider.generate_terraform.assert_called()
+            provider.generate_terraform.assert_called()
 
 
 @pytest.mark.integration
@@ -144,49 +146,53 @@ class TestDriftDetection:
         orchestrator, provider = advanced_orchestrator
 
         # Mock terraform plan and drift detection
-        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
-            with patch(
+        with (
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch(
                 "infrafoundry.core.runners.terraform_runner.TerraformRunner.parse_plan_for_drift"
-            ) as mock_drift:
-                mock_plan.return_value = {
-                    "success": True,
-                    "output": "No changes. Infrastructure is up-to-date.",
-                }
-                mock_drift.return_value = {
-                    "has_changes": False,
-                    "summary": "No changes detected",
-                }
+            ) as mock_drift,
+            patch.object(provider, "generate_terraform"),
+        ):
+            mock_plan.return_value = {
+                "success": True,
+                "output": "No changes. Infrastructure is up-to-date.",
+            }
+            mock_drift.return_value = {
+                "has_changes": False,
+                "summary": "No changes detected",
+            }
 
-                with patch.object(provider, "generate_terraform"):
-                    drift_results = orchestrator.detect_drift("dev")
+            drift_results = orchestrator.detect_drift("dev")
 
-                    assert drift_results is not None
-                    mock_plan.assert_called()
+            assert drift_results is not None
+            mock_plan.assert_called()
 
     def test_detect_drift_with_changes(self, advanced_orchestrator):
         """Test drift detection when infrastructure has drifted."""
         orchestrator, provider = advanced_orchestrator
 
         # Mock terraform plan and drift detection to show changes
-        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
-            with patch(
+        with (
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch(
                 "infrafoundry.core.runners.terraform_runner.TerraformRunner.parse_plan_for_drift"
-            ) as mock_drift:
-                mock_plan.return_value = {
-                    "success": True,
-                    "output": "Plan: 0 to add, 2 to change, 0 to destroy.",
-                }
-                mock_drift.return_value = {
-                    "has_changes": True,
-                    "summary": "2 to change",
-                    "changed": 2,
-                }
+            ) as mock_drift,
+            patch.object(provider, "generate_terraform"),
+        ):
+            mock_plan.return_value = {
+                "success": True,
+                "output": "Plan: 0 to add, 2 to change, 0 to destroy.",
+            }
+            mock_drift.return_value = {
+                "has_changes": True,
+                "summary": "2 to change",
+                "changed": 2,
+            }
 
-                with patch.object(provider, "generate_terraform"):
-                    drift_results = orchestrator.detect_drift("dev")
+            drift_results = orchestrator.detect_drift("dev")
 
-                    assert drift_results is not None
-                    mock_plan.assert_called()
+            assert drift_results is not None
+            mock_plan.assert_called()
 
     def test_detect_drift_multiple_providers(self, advanced_orchestrator):
         """Test drift detection across multiple providers."""
@@ -205,19 +211,21 @@ class TestDriftDetection:
 
         orchestrator.register_provider(opnsense_provider)
 
-        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
-            with patch(
+        with (
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch(
                 "infrafoundry.core.runners.terraform_runner.TerraformRunner.parse_plan_for_drift"
-            ) as mock_drift:
-                mock_plan.return_value = {"success": True, "output": "No changes."}
-                mock_drift.return_value = {"has_changes": False, "summary": "No changes"}
+            ) as mock_drift,
+            patch.object(provider, "generate_terraform"),
+            patch.object(opnsense_provider, "generate_terraform"),
+        ):
+            mock_plan.return_value = {"success": True, "output": "No changes."}
+            mock_drift.return_value = {"has_changes": False, "summary": "No changes"}
 
-                with patch.object(provider, "generate_terraform"):
-                    with patch.object(opnsense_provider, "generate_terraform"):
-                        drift_results = orchestrator.detect_drift("dev")
+            drift_results = orchestrator.detect_drift("dev")
 
-                        # Should check both providers
-                        assert drift_results is not None
+            # Should check both providers
+            assert drift_results is not None
 
 
 @pytest.mark.integration
@@ -269,23 +277,22 @@ class TestRollbackScenarios:
         provider.terraform_dir.mkdir(parents=True, exist_ok=True)
         (provider.terraform_dir / ".terraform").mkdir(exist_ok=True)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+            patch(
+                "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
+            ) as mock_ids,
+        ):
             mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+            mock_apply.return_value = {"exit_code": 0, "success": True}
+            mock_ids.return_value = {}
 
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-            ) as mock_apply:
-                with patch(
-                    "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
-                ) as mock_ids:
-                    mock_apply.return_value = {"exit_code": 0, "success": True}
-                    mock_ids.return_value = {}
+            # Perform rollback
+            result = orchestrator.rollback(deployment_id, auto_approve=True)
 
-                    # Perform rollback
-                    result = orchestrator.rollback(deployment_id, auto_approve=True)
-
-                    assert result is not None
-                    mock_apply.assert_called()
+            assert result is not None
+            mock_apply.assert_called()
 
     def test_rollback_with_terraform_failure(self, advanced_orchestrator):
         """Test rollback behavior when terraform fails."""
@@ -302,9 +309,8 @@ class TestRollbackScenarios:
             # Simulate terraform failure
             mock_apply.return_value = {"exit_code": 1, "success": False}
 
-            with patch.object(provider, "generate_terraform"):
-                with suppress(Exception):
-                    orchestrator.rollback(deployment_id, auto_approve=True)
+            with patch.object(provider, "generate_terraform"), suppress(Exception):
+                orchestrator.rollback(deployment_id, auto_approve=True)
 
     def test_rollback_nonexistent_deployment(self, advanced_orchestrator):
         """Test rollback with invalid deployment ID."""
@@ -362,32 +368,27 @@ firewall_rules:
         opnsense_provider.terraform_dir.mkdir(parents=True, exist_ok=True)
         (opnsense_provider.terraform_dir / ".terraform").mkdir(exist_ok=True)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+            patch(
+                "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
+            ) as mock_ids,
+            patch("infrafoundry.core.runners.ansible_runner.AnsibleRunner.apply") as mock_ansible,
+        ):
             mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+            mock_plan.return_value = {"success": True}
+            mock_apply.return_value = {"exit_code": 0, "success": True}
+            mock_ids.return_value = {}
+            mock_ansible.return_value = {"exit_code": 0, "success": True}
 
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.plan"
-            ) as mock_plan:
-                with patch(
-                    "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-                ) as mock_apply:
-                    with patch(
-                        "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
-                    ) as mock_ids:
-                        with patch(
-                            "infrafoundry.core.runners.ansible_runner.AnsibleRunner.apply"
-                        ) as mock_ansible:
-                            mock_plan.return_value = {"success": True}
-                            mock_apply.return_value = {"exit_code": 0, "success": True}
-                            mock_ids.return_value = {}
-                            mock_ansible.return_value = {"exit_code": 0, "success": True}
+            # Apply should handle provider ordering
+            orchestrator.apply("dev", auto_approve=True)
 
-                            # Apply should handle provider ordering
-                            orchestrator.apply("dev", auto_approve=True)
-
-                            # Both providers should have been called
-                            proxmox_provider.generate_terraform.assert_called()
-                            opnsense_provider.generate_terraform.assert_called()
+            # Both providers should have been called
+            proxmox_provider.generate_terraform.assert_called()
+            opnsense_provider.generate_terraform.assert_called()
 
     def test_parallel_provider_execution(self, advanced_orchestrator, tmp_path):
         """Test parallel execution of independent providers."""
@@ -431,46 +432,43 @@ deployments:
         k8s_provider.terraform_dir.mkdir(parents=True, exist_ok=True)
         (k8s_provider.terraform_dir / ".terraform").mkdir(exist_ok=True)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+            patch(
+                "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
+            ) as mock_ids,
+        ):
             mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+            mock_plan.return_value = {"success": True}
+            mock_apply.return_value = {"exit_code": 0, "success": True}
+            mock_ids.return_value = {}
 
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.plan"
-            ) as mock_plan:
-                with patch(
-                    "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-                ) as mock_apply:
-                    with patch(
-                        "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
-                    ) as mock_ids:
-                        mock_plan.return_value = {"success": True}
-                        mock_apply.return_value = {"exit_code": 0, "success": True}
-                        mock_ids.return_value = {}
+            # Apply with parallel execution
+            orchestrator.apply("dev", auto_approve=True, parallel=True)
 
-                        # Apply with parallel execution
-                        orchestrator.apply("dev", auto_approve=True, parallel=True)
-
-                        # Both providers should have been executed
-                        proxmox_provider.generate_terraform.assert_called()
-                        k8s_provider.generate_terraform.assert_called()
+            # Both providers should have been executed
+            proxmox_provider.generate_terraform.assert_called()
+            k8s_provider.generate_terraform.assert_called()
 
     def test_provider_failure_handling(self, advanced_orchestrator):
         """Test handling when one provider fails during apply."""
         orchestrator, provider = advanced_orchestrator
 
-        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-            ) as mock_apply:
-                # Simulate failure
-                mock_plan.return_value = {"success": True}
-                mock_apply.return_value = {"exit_code": 1, "success": False}
+        with (
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+            patch.object(provider, "generate_terraform"),
+        ):
+            # Simulate failure
+            mock_plan.return_value = {"success": True}
+            mock_apply.return_value = {"exit_code": 1, "success": False}
 
-                with patch.object(provider, "generate_terraform"):
-                    try:
-                        orchestrator.apply("dev", auto_approve=True)
-                    except Exception as e:
-                        assert "error" in str(e).lower() or "fail" in str(e).lower()
+            try:
+                orchestrator.apply("dev", auto_approve=True)
+            except Exception as e:
+                assert "error" in str(e).lower() or "fail" in str(e).lower()
 
 
 @pytest.mark.integration
@@ -495,16 +493,16 @@ class TestErrorRecoveryAndCleanup:
         """Test cleanup after apply failure."""
         orchestrator, provider = advanced_orchestrator
 
-        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-            ) as mock_apply:
-                mock_plan.return_value = {"success": True}
-                mock_apply.side_effect = Exception("Terraform crashed")
+        with (
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+            patch.object(provider, "generate_terraform"),
+            suppress(Exception),
+        ):
+            mock_plan.return_value = {"success": True}
+            mock_apply.side_effect = Exception("Terraform crashed")
 
-                with patch.object(provider, "generate_terraform"):
-                    with suppress(Exception):
-                        orchestrator.apply("dev", auto_approve=True)
+            orchestrator.apply("dev", auto_approve=True)
 
     def test_state_consistency_after_errors(self, advanced_orchestrator):
         """Test that state remains consistent after errors."""
@@ -513,16 +511,16 @@ class TestErrorRecoveryAndCleanup:
         initial_deployments = orchestrator.state_manager.get_deployment_history("dev", limit=10)
         initial_count = len(initial_deployments)
 
-        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-            ) as mock_apply:
-                mock_plan.return_value = {"success": True}
-                mock_apply.side_effect = Exception("Infrastructure error")
+        with (
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+            patch.object(provider, "generate_terraform"),
+            suppress(Exception),
+        ):
+            mock_plan.return_value = {"success": True}
+            mock_apply.side_effect = Exception("Infrastructure error")
 
-                with patch.object(provider, "generate_terraform"):
-                    with suppress(Exception):
-                        orchestrator.apply("dev", auto_approve=True)
+            orchestrator.apply("dev", auto_approve=True)
 
         # State should still be queryable
         final_deployments = orchestrator.state_manager.get_deployment_history("dev", limit=10)
@@ -537,28 +535,23 @@ class TestErrorRecoveryAndCleanup:
         provider.terraform_dir.mkdir(parents=True, exist_ok=True)
         (provider.terraform_dir / ".terraform").mkdir(exist_ok=True)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with (
+            patch("subprocess.run") as mock_subprocess,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+            patch(
+                "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
+            ) as mock_ids,
+            patch.object(provider, "generate_terraform"),
+        ):
             mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+            mock_plan.return_value = {"success": True}
+            mock_apply.return_value = {"exit_code": 0, "success": True}
+            mock_ids.return_value = {}
 
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.plan"
-            ) as mock_plan:
-                with patch(
-                    "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-                ) as mock_apply:
-                    with patch(
-                        "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids"
-                    ) as mock_ids:
-                        mock_plan.return_value = {"success": True}
-                        mock_apply.return_value = {"exit_code": 0, "success": True}
-                        mock_ids.return_value = {}
+            # First operation
+            orchestrator.apply("dev", auto_approve=True)
 
-                        with patch.object(provider, "generate_terraform"):
-                            # First operation
-                            orchestrator.apply("dev", auto_approve=True)
-
-                            # State should reflect the operation
-                            deployments = orchestrator.state_manager.get_deployment_history(
-                                "dev", limit=1
-                            )
-                            assert len(deployments) > 0
+            # State should reflect the operation
+            deployments = orchestrator.state_manager.get_deployment_history("dev", limit=1)
+            assert len(deployments) > 0

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -43,15 +43,17 @@ class TestCLICommands:
 
     def test_envs_command(self, cli_runner, cli_environment):
         """Test listing environments."""
-        with patch(
-            "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-        ):
-            with patch(
+        with (
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                result = cli_runner.invoke(cli, ["envs"], env=cli_environment)
-                # Command should run (may need config setup)
-                assert result.exit_code in [0, 1, 2]  # Success or expected error
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
+            ),
+        ):
+            result = cli_runner.invoke(cli, ["envs"], env=cli_environment)
+            # Command should run (may need config setup)
+            assert result.exit_code in [0, 1, 2]  # Success or expected error
 
     def test_list_command_requires_env(self, cli_runner):
         """Test that list command requires --env flag."""

--- a/tests/integration/test_cli_credentials.py
+++ b/tests/integration/test_cli_credentials.py
@@ -80,110 +80,118 @@ class TestCLICredentialLoading:
             "PROXMOX_API_TOKEN_SECRET": "prod-secret",
         }
 
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
-        ) as mock_load:
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
+            ) as mock_load,
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
+        ):
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                _result = cli_runner.invoke(
-                    cli,
-                    [
-                        "--config-dir",
-                        str(mock_credentials_setup),
-                        "infra",
-                        "apply",
-                        "--env",
-                        "prod",
-                        "--auto-approve",
-                    ],
-                )
+            _result = cli_runner.invoke(
+                cli,
+                [
+                    "--config-dir",
+                    str(mock_credentials_setup),
+                    "infra",
+                    "apply",
+                    "--env",
+                    "prod",
+                    "--auto-approve",
+                ],
+            )
 
-                # Verify credential loading was called with prod environment
-                assert mock_load.call_count == 1
-                assert mock_load.call_args[0][0] == "prod"
+            # Verify credential loading was called with prod environment
+            assert mock_load.call_count == 1
+            assert mock_load.call_args[0][0] == "prod"
 
     def test_destroy_command_loads_credentials(self, cli_runner, mock_credentials_setup):
         """Test that destroy command loads credentials automatically."""
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
-        ) as mock_load:
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
+            ) as mock_load,
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
+        ):
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                _result = cli_runner.invoke(
-                    cli,
-                    [
-                        "--config-dir",
-                        str(mock_credentials_setup),
-                        "infra",
-                        "destroy",
-                        "--env",
-                        "staging",
-                        "--auto-approve",
-                    ],
-                )
+            _result = cli_runner.invoke(
+                cli,
+                [
+                    "--config-dir",
+                    str(mock_credentials_setup),
+                    "infra",
+                    "destroy",
+                    "--env",
+                    "staging",
+                    "--auto-approve",
+                ],
+            )
 
-                # Verify credential loading was called with staging
-                # Verify called with correct environment (path type may vary)
-                assert mock_load.call_count == 1
-                assert mock_load.call_args[0][0] == "staging"
+            # Verify credential loading was called with staging
+            # Verify called with correct environment (path type may vary)
+            assert mock_load.call_count == 1
+            assert mock_load.call_args[0][0] == "staging"
 
     def test_status_command_loads_credentials(self, cli_runner, mock_credentials_setup):
         """Test that status command loads credentials automatically."""
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
-        ) as mock_load:
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
+            ) as mock_load,
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
+        ):
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                _result = cli_runner.invoke(
-                    cli,
-                    [
-                        "--config-dir",
-                        str(mock_credentials_setup),
-                        "infra",
-                        "status",
-                        "--env",
-                        "dev",
-                    ],
-                )
+            _result = cli_runner.invoke(
+                cli,
+                [
+                    "--config-dir",
+                    str(mock_credentials_setup),
+                    "infra",
+                    "status",
+                    "--env",
+                    "dev",
+                ],
+            )
 
-                # Verify credential loading was called
-                # Verify called with correct environment (path type may vary)
-                assert mock_load.call_count == 1
-                assert mock_load.call_args[0][0] == "dev"
+            # Verify credential loading was called
+            # Verify called with correct environment (path type may vary)
+            assert mock_load.call_count == 1
+            assert mock_load.call_args[0][0] == "dev"
 
     def test_drift_command_loads_credentials(self, cli_runner, mock_credentials_setup):
         """Test that drift command loads credentials automatically."""
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
-        ) as mock_load:
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orch.detect_drift.return_value = {}
-                mock_orchestrator.return_value = mock_orch
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
+            ) as mock_load,
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
+        ):
+            mock_orch = MagicMock()
+            mock_orch.detect_drift.return_value = {}
+            mock_orchestrator.return_value = mock_orch
 
-                _result = cli_runner.invoke(
-                    cli,
-                    [
-                        "--config-dir",
-                        str(mock_credentials_setup),
-                        "infra",
-                        "drift",
-                        "detect",
-                        "--env",
-                        "prod",
-                    ],
-                )
+            _result = cli_runner.invoke(
+                cli,
+                [
+                    "--config-dir",
+                    str(mock_credentials_setup),
+                    "infra",
+                    "drift",
+                    "detect",
+                    "--env",
+                    "prod",
+                ],
+            )
 
-                # Verify credential loading was called
-                # Verify called with correct environment (path type may vary)
-                assert mock_load.call_count == 1
-                assert mock_load.call_args[0][0] == "prod"
+            # Verify credential loading was called
+            # Verify called with correct environment (path type may vary)
+            assert mock_load.call_count == 1
+            assert mock_load.call_args[0][0] == "prod"
 
     def test_credentials_set_in_environment(self, cli_runner, mock_credentials_setup):
         """Test that loaded credentials are set in os.environ."""
@@ -202,29 +210,31 @@ class TestCLICredentialLoading:
             return mock_creds
 
         try:
-            with patch(
-                "infrafoundry.core.credential_loader.CredentialLoader",
-                side_effect=mock_load_creds,
+            with (
+                patch(
+                    "infrafoundry.core.credential_loader.CredentialLoader",
+                    side_effect=mock_load_creds,
+                ),
+                patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
             ):
-                with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                    mock_orch = MagicMock()
-                    mock_orchestrator.return_value = mock_orch
+                mock_orch = MagicMock()
+                mock_orchestrator.return_value = mock_orch
 
-                    _result = cli_runner.invoke(
-                        cli,
-                        [
-                            "--config-dir",
-                            str(mock_credentials_setup),
-                            "infra",
-                            "plan",
-                            "--env",
-                            "test",
-                        ],
-                    )
+                _result = cli_runner.invoke(
+                    cli,
+                    [
+                        "--config-dir",
+                        str(mock_credentials_setup),
+                        "infra",
+                        "plan",
+                        "--env",
+                        "test",
+                    ],
+                )
 
-                    # After invocation, credentials should have been set
-                    # (Note: Click's CliRunner isolates env vars, so we check the mock was called)
-                    assert mock_orch is not None
+                # After invocation, credentials should have been set
+                # (Note: Click's CliRunner isolates env vars, so we check the mock was called)
+                assert mock_orch is not None
 
         finally:
             # Restore original environment
@@ -234,22 +244,24 @@ class TestCLICredentialLoading:
     def test_credential_loading_failure_doesnt_crash(self, cli_runner, mock_credentials_setup):
         """Test that credential loading failures don't crash the CLI."""
         # Mock credential loading to raise an exception
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader",
-            side_effect=Exception("SOPS failed"),
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader",
+                side_effect=Exception("SOPS failed"),
+            ),
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
         ):
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                result = cli_runner.invoke(
-                    cli,
-                    ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
-                )
+            result = cli_runner.invoke(
+                cli,
+                ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
+            )
 
-                # Command should still run (credentials may be in env vars)
-                # The _load_env_credentials wrapper handles exceptions gracefully
-                assert result.exit_code in [0, 1]  # Success or expected error, not crash
+            # Command should still run (credentials may be in env vars)
+            # The _load_env_credentials wrapper handles exceptions gracefully
+            assert result.exit_code in [0, 1]  # Success or expected error, not crash
 
     def test_multiple_commands_with_different_environments(
         self, cli_runner, mock_credentials_setup
@@ -276,32 +288,34 @@ class TestCLICredentialLoading:
                 return prod_creds
             return {}
 
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply",
-            side_effect=mock_load_env,
-        ) as mock_load:
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply",
+                side_effect=mock_load_env,
+            ) as mock_load,
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
+        ):
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                # Run plan for dev
-                _result_dev = cli_runner.invoke(
-                    cli,
-                    ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
-                )
+            # Run plan for dev
+            _result_dev = cli_runner.invoke(
+                cli,
+                ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
+            )
 
-                # Run plan for prod
-                _result_prod = cli_runner.invoke(
-                    cli,
-                    ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "prod"],
-                )
+            # Run plan for prod
+            _result_prod = cli_runner.invoke(
+                cli,
+                ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "prod"],
+            )
 
-                # Verify both environments were loaded
-                assert mock_load.call_count == 2
-                calls = mock_load.call_args_list
-                # Check positional args
-                assert calls[0].args[0] == "dev"
-                assert calls[1].args[0] == "prod"
+            # Verify both environments were loaded
+            assert mock_load.call_count == 2
+            calls = mock_load.call_args_list
+            # Check positional args
+            assert calls[0].args[0] == "dev"
+            assert calls[1].args[0] == "prod"
 
     def test_config_dir_flag_passed_to_credential_loader(self, cli_runner, tmp_path):
         """Test that --config-dir flag is passed to credential loader."""
@@ -312,39 +326,43 @@ class TestCLICredentialLoading:
         secrets_dir.mkdir(parents=True)
         (secrets_dir / "proxmox.yaml").write_text("encrypted")
 
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
-        ) as mock_load:
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
+            ) as mock_load,
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
+        ):
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                _result = cli_runner.invoke(
-                    cli,
-                    ["--config-dir", str(custom_config_dir), "infra", "plan", "--env", "dev"],
-                )
+            _result = cli_runner.invoke(
+                cli,
+                ["--config-dir", str(custom_config_dir), "infra", "plan", "--env", "dev"],
+            )
 
-                # Verify the custom config dir was passed
-                # Verify called with correct environment (path type may vary)
-                assert mock_load.call_count == 1
-                assert mock_load.call_args[0][0] == "dev"
+            # Verify the custom config dir was passed
+            # Verify called with correct environment (path type may vary)
+            assert mock_load.call_count == 1
+            assert mock_load.call_args[0][0] == "dev"
 
     def test_no_config_dir_uses_default(self, cli_runner, mock_credentials_setup):
         """Test that not specifying --config-dir uses default behavior."""
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
-        ) as mock_load:
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader.load_and_apply"
+            ) as mock_load,
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
+        ):
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                # Don't pass --config-dir
-                _result = cli_runner.invoke(cli, ["infra", "plan", "--env", "dev"])
+            # Don't pass --config-dir
+            _result = cli_runner.invoke(cli, ["infra", "plan", "--env", "dev"])
 
-                # Should still call credential loader (with None or default path)
-                mock_load.assert_called_once()
-                # First argument should be 'dev'
-                assert mock_load.call_args[0][0] == "dev"
+            # Should still call credential loader (with None or default path)
+            mock_load.assert_called_once()
+            # First argument should be 'dev'
+            assert mock_load.call_args[0][0] == "dev"
 
 
 @pytest.mark.integration
@@ -355,40 +373,44 @@ class TestCredentialLoadingDebugLogging:
         """Test that debug logging shows credential loading when enabled."""
         mock_creds = {"PROXMOX_API_URL": "https://proxmox.example.com:8006"}
 
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader",
-            return_value=mock_creds,
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader",
+                return_value=mock_creds,
+            ),
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
         ):
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                # Enable debug logging
-                result = cli_runner.invoke(
-                    cli,
-                    ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
-                    env={"INFRAFOUNDRY_LOG_LEVEL": "DEBUG"},
-                )
+            # Enable debug logging
+            result = cli_runner.invoke(
+                cli,
+                ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
+                env={"INFRAFOUNDRY_LOG_LEVEL": "DEBUG"},
+            )
 
-                # Command should run
-                assert result.exit_code in [0, 1]
+            # Command should run
+            assert result.exit_code in [0, 1]
 
     def test_no_debug_logging_by_default(self, cli_runner, mock_credentials_setup):
         """Test that credential loading is silent by default."""
         mock_creds = {"PROXMOX_API_URL": "https://proxmox.example.com:8006"}
 
-        with patch(
-            "infrafoundry.core.credential_loader.CredentialLoader",
-            return_value=mock_creds,
+        with (
+            patch(
+                "infrafoundry.core.credential_loader.CredentialLoader",
+                return_value=mock_creds,
+            ),
+            patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator,
         ):
-            with patch("infrafoundry.cli.main._get_orchestrator") as mock_orchestrator:
-                mock_orch = MagicMock()
-                mock_orchestrator.return_value = mock_orch
+            mock_orch = MagicMock()
+            mock_orchestrator.return_value = mock_orch
 
-                result = cli_runner.invoke(
-                    cli,
-                    ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
-                )
+            result = cli_runner.invoke(
+                cli,
+                ["--config-dir", str(mock_credentials_setup), "infra", "plan", "--env", "dev"],
+            )
 
-                # Command should run without debug output
-                assert result.exit_code in [0, 1]
+            # Command should run without debug output
+            assert result.exit_code in [0, 1]

--- a/tests/integration/test_cli_execution.py
+++ b/tests/integration/test_cli_execution.py
@@ -60,73 +60,81 @@ class TestCLIPlan:
 
     def test_plan_basic(self, cli_runner, test_env, mock_orchestrator):
         """Test basic plan execution."""
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(cli, ["infra", "plan", "--env", "dev"], env=test_env)
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(cli, ["infra", "plan", "--env", "dev"], env=test_env)
 
-                    assert result.exit_code == 0
-                    mock_orchestrator.plan.assert_called_once()
-                    args = mock_orchestrator.plan.call_args
-                    assert args[0][0] == "dev"
-                    assert "Plan generated successfully" in result.output
+            assert result.exit_code == 0
+            mock_orchestrator.plan.assert_called_once()
+            args = mock_orchestrator.plan.call_args
+            assert args[0][0] == "dev"
+            assert "Plan generated successfully" in result.output
 
     def test_plan_dry_run(self, cli_runner, test_env, mock_orchestrator):
         """Test plan with --dry-run."""
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(
-                        cli, ["infra", "plan", "--env", "dev", "--dry-run"], env=test_env
-                    )
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(
+                cli, ["infra", "plan", "--env", "dev", "--dry-run"], env=test_env
+            )
 
-                    assert result.exit_code == 0
-                    assert mock_orchestrator.plan.call_args[1]["dry_run"] is True
-                    assert "Dry run complete" in result.output
+            assert result.exit_code == 0
+            assert mock_orchestrator.plan.call_args[1]["dry_run"] is True
+            assert "Dry run complete" in result.output
 
     def test_plan_with_policies(self, cli_runner, test_env, mock_orchestrator):
         """Test plan with --enforce-policies."""
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(
-                        cli, ["infra", "plan", "--env", "dev", "--enforce-policies"], env=test_env
-                    )
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(
+                cli, ["infra", "plan", "--env", "dev", "--enforce-policies"], env=test_env
+            )
 
-                    assert result.exit_code == 0
-                    assert mock_orchestrator.plan.call_args[1]["enforce_policies"] is True
+            assert result.exit_code == 0
+            assert mock_orchestrator.plan.call_args[1]["enforce_policies"] is True
 
     def test_plan_error(self, cli_runner, test_env, mock_orchestrator):
         """Test plan error handling."""
         mock_orchestrator.plan.side_effect = Exception("Plan failed")
 
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(cli, ["infra", "plan", "--env", "dev"], env=test_env)
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(cli, ["infra", "plan", "--env", "dev"], env=test_env)
 
-                    assert result.exit_code == 1
-                    assert "Plan failed" in result.output
+            assert result.exit_code == 1
+            assert "Plan failed" in result.output
 
 
 @pytest.mark.integration
@@ -135,59 +143,65 @@ class TestCLIApply:
 
     def test_apply_auto_approve(self, cli_runner, test_env, mock_orchestrator):
         """Test apply with --auto-approve."""
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(
-                        cli, ["infra", "apply", "--env", "dev", "--auto-approve"], env=test_env
-                    )
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(
+                cli, ["infra", "apply", "--env", "dev", "--auto-approve"], env=test_env
+            )
 
-                    assert result.exit_code == 0
-                    mock_orchestrator.apply.assert_called_once()
-                    assert "Apply complete" in result.output
+            assert result.exit_code == 0
+            mock_orchestrator.apply.assert_called_once()
+            assert "Apply complete" in result.output
 
     def test_apply_parallel(self, cli_runner, test_env, mock_orchestrator):
         """Test apply with --parallel."""
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(
-                        cli,
-                        ["infra", "apply", "--env", "dev", "--auto-approve", "--parallel"],
-                        env=test_env,
-                    )
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(
+                cli,
+                ["infra", "apply", "--env", "dev", "--auto-approve", "--parallel"],
+                env=test_env,
+            )
 
-                    assert result.exit_code == 0
-                    assert mock_orchestrator.apply.call_args[1]["parallel"] is True
+            assert result.exit_code == 0
+            assert mock_orchestrator.apply.call_args[1]["parallel"] is True
 
     def test_apply_error(self, cli_runner, test_env, mock_orchestrator):
         """Test apply error handling."""
         mock_orchestrator.apply.side_effect = Exception("Apply failed")
 
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(
-                        cli, ["infra", "apply", "--env", "dev", "--auto-approve"], env=test_env
-                    )
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(
+                cli, ["infra", "apply", "--env", "dev", "--auto-approve"], env=test_env
+            )
 
-                    assert result.exit_code == 1
-                    assert "Apply failed" in result.output
+            assert result.exit_code == 1
+            assert "Apply failed" in result.output
 
 
 @pytest.mark.integration
@@ -196,39 +210,43 @@ class TestCLIDestroy:
 
     def test_destroy_auto_approve(self, cli_runner, test_env, mock_orchestrator):
         """Test destroy with --auto-approve."""
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(
-                        cli, ["infra", "destroy", "--env", "dev", "--auto-approve"], env=test_env
-                    )
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(
+                cli, ["infra", "destroy", "--env", "dev", "--auto-approve"], env=test_env
+            )
 
-                    assert result.exit_code == 0
-                    mock_orchestrator.destroy.assert_called_once()
-                    assert "Destroy complete" in result.output
+            assert result.exit_code == 0
+            mock_orchestrator.destroy.assert_called_once()
+            assert "Destroy complete" in result.output
 
     def test_destroy_error(self, cli_runner, test_env, mock_orchestrator):
         """Test destroy error handling."""
         mock_orchestrator.destroy.side_effect = Exception("Destroy failed")
 
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch(
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                with patch(
-                    "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
-                    return_value=None,
-                ):
-                    result = cli_runner.invoke(
-                        cli, ["infra", "destroy", "--env", "dev", "--auto-approve"], env=test_env
-                    )
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__",
+                return_value=None,
+            ),
+        ):
+            result = cli_runner.invoke(
+                cli, ["infra", "destroy", "--env", "dev", "--auto-approve"], env=test_env
+            )
 
-                    assert result.exit_code == 1
+            assert result.exit_code == 1
 
 
 @pytest.mark.integration
@@ -237,13 +255,15 @@ class TestCLIEnvs:
 
     def test_envs_list(self, cli_runner, test_env):
         """Test listing environments."""
-        with patch(
-            "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-        ):
-            with patch(
+        with (
+            patch(
                 "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-            ):
-                result = cli_runner.invoke(cli, ["config", "envs"], env=test_env)
+            ),
+            patch(
+                "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
+            ),
+        ):
+            result = cli_runner.invoke(cli, ["config", "envs"], env=test_env)
 
-                # Command should execute (exit codes may vary based on implementation)
-                assert "dev" in result.output or result.exit_code in [0, 1]
+            # Command should execute (exit codes may vary based on implementation)
+            assert "dev" in result.output or result.exit_code in [0, 1]

--- a/tests/integration/test_orchestrator_workflow.py
+++ b/tests/integration/test_orchestrator_workflow.py
@@ -14,16 +14,14 @@ from infrafoundry.core.state import StateManager
 @pytest.fixture
 def mock_secret_manager(mock_secrets_dir):
     """Create a mock SecretManager."""
-    with patch(
-        "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
+    with (
+        patch("infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None),
+        patch("infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None),
     ):
-        with patch(
-            "infrafoundry.core.secrets.secret_manager.SecretManager.__init__", return_value=None
-        ):
-            manager = SecretManager(env_name="dev", secrets_dir=mock_secrets_dir)
-            # Mock decrypt to return simple data
-            manager.decrypt_file = MagicMock(return_value={"api_token": "test-token"})
-            return manager
+        manager = SecretManager(env_name="dev", secrets_dir=mock_secrets_dir)
+        # Mock decrypt to return simple data
+        manager.decrypt_file = MagicMock(return_value={"api_token": "test-token"})
+        return manager
 
 
 @pytest.mark.integration

--- a/tests/integration/test_orchestrator_workflows.py
+++ b/tests/integration/test_orchestrator_workflows.py
@@ -91,19 +91,21 @@ def orchestrator(tmp_path, mock_config, mock_providers):
 
 def mock_apply_methods(orchestrator):
     """Helper to mock methods needed for apply workflow."""
-    with patch(
-        "infrafoundry.core.runners.terraform_runner.TerraformRunner.run",
-        return_value={"success": True},
-    ):
-        with patch(
+    with (
+        patch(
+            "infrafoundry.core.runners.terraform_runner.TerraformRunner.run",
+            return_value={"success": True},
+        ),
+        patch(
             "infrafoundry.core.runners.terraform_runner.TerraformRunner.get_resource_ids",
             return_value={},
-        ):
-            with patch(
-                "infrafoundry.core.runners.ansible_runner.AnsibleRunner.run",
-                return_value={"success": True},
-            ):
-                yield
+        ),
+        patch(
+            "infrafoundry.core.runners.ansible_runner.AnsibleRunner.run",
+            return_value={"success": True},
+        ),
+    ):
+        yield
 
 
 class TestPlanOrchestrator:
@@ -398,20 +400,20 @@ class TestApplyOrchestrator:
 
     def test_apply_failure_updates_deployment_status(self, orchestrator):
         """Test that apply failure marks deployment as failed."""
-        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
-            with patch(
-                "infrafoundry.core.runners.terraform_runner.TerraformRunner.apply"
-            ) as mock_apply:
-                mock_plan.return_value = {"success": True}
-                mock_apply.side_effect = RuntimeError("Apply failed")
+        with (
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan,
+            patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.apply") as mock_apply,
+        ):
+            mock_plan.return_value = {"success": True}
+            mock_apply.side_effect = RuntimeError("Apply failed")
 
-                with pytest.raises(RuntimeError):
-                    orchestrator.apply(env_name="dev", auto_approve=True)
+            with pytest.raises(RuntimeError):
+                orchestrator.apply(env_name="dev", auto_approve=True)
 
-                # Check deployment was marked as failed
-                deployments = orchestrator.state_manager.get_deployment_history(environment="dev")
-                failed_deployments = [d for d in deployments if d.status == DeploymentStatus.FAILED]
-                assert failed_deployments
+            # Check deployment was marked as failed
+            deployments = orchestrator.state_manager.get_deployment_history(environment="dev")
+            failed_deployments = [d for d in deployments if d.status == DeploymentStatus.FAILED]
+            assert failed_deployments
 
     def test_apply_emits_failure_event(self, orchestrator):
         """Test that apply failure emits failure event."""

--- a/tests/unit/test_cli_secrets.py
+++ b/tests/unit/test_cli_secrets.py
@@ -23,13 +23,15 @@ def test_secrets_init_basic(cli_runner, tmp_path):
     mock_result.returncode = 0
     mock_result.stderr = "# public key: age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
-    with patch("subprocess.run", return_value=mock_result):
-        with patch("infrafoundry.cli.commands.secrets.secrets.create_sops_config"):
-            result = cli_runner.invoke(main, ["secrets", "init", "--key-file", str(key_file)])
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("infrafoundry.cli.commands.secrets.secrets.create_sops_config"),
+    ):
+        result = cli_runner.invoke(main, ["secrets", "init", "--key-file", str(key_file)])
 
-            assert result.exit_code == 0
-            assert "Created age key:" in result.output
-            assert "Created .sops.yaml" in result.output
+        assert result.exit_code == 0
+        assert "Created age key:" in result.output
+        assert "Created .sops.yaml" in result.output
 
 
 def test_secrets_init_key_exists(cli_runner, tmp_path):

--- a/tests/unit/test_cli_state.py
+++ b/tests/unit/test_cli_state.py
@@ -39,18 +39,20 @@ def mock_orchestrator(tmp_path):
 def test_state_backup_basic(cli_runner, mock_orchestrator, tmp_path):
     """Test basic state backup without generated directory."""
     # Patch the _get_orchestrator function to return our mock orchestrator
-    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-        with patch("shutil.copy2") as mock_copy2:
-            result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path)])
+    with (
+        patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+        patch("shutil.copy2") as mock_copy2,
+    ):
+        result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path)])
 
-            assert result.exit_code == 0
-            assert "State database backed up to:" in result.output
-            mock_copy2.assert_called_once()
-            # Compare Path objects directly or their string representations
-            assert Path(mock_orchestrator.state_manager.engine.url.database) == Path(
-                mock_copy2.call_args[0][0]
-            )
-            assert tmp_path.joinpath("infrafoundry_state_").stem in str(mock_copy2.call_args[0][1])
+        assert result.exit_code == 0
+        assert "State database backed up to:" in result.output
+        mock_copy2.assert_called_once()
+        # Compare Path objects directly or their string representations
+        assert Path(mock_orchestrator.state_manager.engine.url.database) == Path(
+            mock_copy2.call_args[0][0]
+        )
+        assert tmp_path.joinpath("infrafoundry_state_").stem in str(mock_copy2.call_args[0][1])
 
 
 def test_state_backup_with_generated(cli_runner, mock_orchestrator, tmp_path):
@@ -61,21 +63,23 @@ def test_state_backup_with_generated(cli_runner, mock_orchestrator, tmp_path):
         (cwd / "generated").mkdir()
         (cwd / "generated" / "file.txt").touch()
 
-        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-            with patch("shutil.copy2") as mock_copy2:
-                with patch("shutil.make_archive") as mock_make_archive:
-                    # Use tmp_path for output to keep it separate, or use cwd
-                    result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path), "-g"])
+        with (
+            patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+            patch("shutil.copy2") as mock_copy2,
+            patch("shutil.make_archive") as mock_make_archive,
+        ):
+            # Use tmp_path for output to keep it separate, or use cwd
+            result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path), "-g"])
 
-                    assert result.exit_code == 0
-                    assert "State database backed up to:" in result.output
-                    assert "'generated/' directory archived to:" in result.output
-                    mock_copy2.assert_called_once()
-                    mock_make_archive.assert_called_once()
-                    # Check root_dir and base_dir arguments for make_archive
-                    # Path.cwd() inside the command will match cwd here
-                    assert str(cwd) == mock_make_archive.call_args[1]["root_dir"]
-                    assert "generated" == mock_make_archive.call_args[1]["base_dir"]
+            assert result.exit_code == 0
+            assert "State database backed up to:" in result.output
+            assert "'generated/' directory archived to:" in result.output
+            mock_copy2.assert_called_once()
+            mock_make_archive.assert_called_once()
+            # Check root_dir and base_dir arguments for make_archive
+            # Path.cwd() inside the command will match cwd here
+            assert str(cwd) == mock_make_archive.call_args[1]["root_dir"]
+            assert mock_make_archive.call_args[1]["base_dir"] == "generated"
 
 
 def test_state_backup_state_db_not_found(cli_runner, mock_orchestrator, tmp_path):
@@ -95,22 +99,26 @@ def test_state_backup_output_dir_creation(cli_runner, mock_orchestrator, tmp_pat
     non_existent_dir = tmp_path / "non_existent_backup_dir"
     assert not non_existent_dir.exists()
 
-    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-        with patch("shutil.copy2"):
-            result = cli_runner.invoke(main, ["state", "backup", "-o", str(non_existent_dir)])
+    with (
+        patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+        patch("shutil.copy2"),
+    ):
+        result = cli_runner.invoke(main, ["state", "backup", "-o", str(non_existent_dir)])
 
-            assert result.exit_code == 0
-            assert non_existent_dir.is_dir()  # Assert directory was created
+        assert result.exit_code == 0
+        assert non_existent_dir.is_dir()  # Assert directory was created
 
 
 def test_state_backup_failure(cli_runner, mock_orchestrator, tmp_path):
     """Test state backup handles copy failure gracefully."""
-    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-        with patch("shutil.copy2", side_effect=OSError("Permission denied")):
-            result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path)])
+    with (
+        patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator),
+        patch("shutil.copy2", side_effect=OSError("Permission denied")),
+    ):
+        result = cli_runner.invoke(main, ["state", "backup", "-o", str(tmp_path)])
 
-            assert result.exit_code == 1  # Expect failure
-            assert "State backup failed: Permission denied" in result.output
+        assert result.exit_code == 1  # Expect failure
+        assert "State backup failed: Permission denied" in result.output
 
 
 def test_state_backup_non_sqlite(cli_runner, mock_orchestrator, tmp_path):

--- a/tests/unit/test_provider_validation.py
+++ b/tests/unit/test_provider_validation.py
@@ -162,9 +162,7 @@ class TestProxmoxValidation:
 
             if "/nodes/pve01/status" in url:
                 mock_response.json.return_value = {"data": {"uptime": 12345}}
-            elif "/nodes/pve01/storage" in url:
-                mock_response.json.return_value = {"data": []}
-            elif "/nodes/pve01/network" in url:
+            elif "/nodes/pve01/storage" in url or "/nodes/pve01/network" in url:
                 mock_response.json.return_value = {"data": []}
             elif "/cluster/resources" in url:
                 # Only ubuntu template, missing centos
@@ -230,9 +228,7 @@ class TestProxmoxValidation:
 
             if "/nodes/pve01/status" in url:
                 mock_response.json.return_value = {"data": {"uptime": 12345}}
-            elif "/nodes/pve01/storage" in url:
-                mock_response.json.return_value = {"data": []}
-            elif "/nodes/pve01/network" in url:
+            elif "/nodes/pve01/storage" in url or "/nodes/pve01/network" in url:
                 mock_response.json.return_value = {"data": []}
             elif "/cluster/resources" in url:
                 mock_response.json.return_value = {

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -81,25 +81,29 @@ class TestSecretManager:
 
     def test_init_no_age_key_env(self, mock_sops_age, temp_secrets_dir):
         """Test initialization fails when SOPS_AGE_KEY_FILE is not set."""
-        with patch.dict(
-            "os.environ",
-            {"INFRAFOUNDRY_CONFIG_REPO": str(temp_secrets_dir)},
-            clear=True,
+        with (
+            patch.dict(
+                "os.environ",
+                {"INFRAFOUNDRY_CONFIG_REPO": str(temp_secrets_dir)},
+                clear=True,
+            ),
+            pytest.raises(ValueError, match="SOPS_AGE_KEY_FILE not set"),
         ):
-            with pytest.raises(ValueError, match="SOPS_AGE_KEY_FILE not set"):
-                SecretManager(env_name="dev")
+            SecretManager(env_name="dev")
 
     def test_init_age_key_file_missing(self, mock_sops_age):
         """Test initialization fails when age key file doesn't exist."""
-        with patch.dict(
-            "os.environ",
-            {
-                "SOPS_AGE_KEY_FILE": "/nonexistent/age.key",
-                "INFRAFOUNDRY_FORCE_SOPS_CHECK": "1",
-            },
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "SOPS_AGE_KEY_FILE": "/nonexistent/age.key",
+                    "INFRAFOUNDRY_FORCE_SOPS_CHECK": "1",
+                },
+            ),
+            pytest.raises(FileNotFoundError, match="Age key file not found"),
         ):
-            with pytest.raises(FileNotFoundError, match="Age key file not found"):
-                SecretManager(env_name="dev")
+            SecretManager(env_name="dev")
 
     def test_decrypt_file(self, temp_secrets_dir, mock_provider):
         """Test decrypting a file using injected provider."""

--- a/tests/unit/test_secrets_rotation.py
+++ b/tests/unit/test_secrets_rotation.py
@@ -376,9 +376,11 @@ class TestSecretsRotator:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = Mock(stdout="age1newkey", returncode=0)
 
-            with patch.dict("os.environ", {"SOPS_AGE_KEY_FILE": "/tmp/old_key"}):
-                with pytest.raises(SecretError, match="Secrets rotation failed"):
-                    rotator.rotate(new_key_file=new_key_file, verify=False)
+            with (
+                patch.dict("os.environ", {"SOPS_AGE_KEY_FILE": "/tmp/old_key"}),
+                pytest.raises(SecretError, match="Secrets rotation failed"),
+            ):
+                rotator.rotate(new_key_file=new_key_file, verify=False)
 
         # Verify backup was created
         assert rotator.current_backup is not None

--- a/tests/unit/test_validation_helpers.py
+++ b/tests/unit/test_validation_helpers.py
@@ -199,10 +199,12 @@ class TestBaseProviderValidator:
 
     def test_check_api_connectivity_no_requests_library(self, validator, report):
         """Test API connectivity when requests library is not installed."""
-        with patch.dict("sys.modules", {"requests": None}):
+        with (
+            patch.dict("sys.modules", {"requests": None}),
             # Import error will be raised when trying to import requests
-            with patch("builtins.__import__", side_effect=ImportError):
-                result = validator.check_api_connectivity(url="https://api.example.com/status")
+            patch("builtins.__import__", side_effect=ImportError),
+        ):
+            result = validator.check_api_connectivity(url="https://api.example.com/status")
 
         assert result is False
         call_args = report.add_check.call_args[1]


### PR DESCRIPTION
## Summary

Fixes all remaining SIM (flake8-simplify) rule violations and removes all SIM rules from the pyproject.toml ignore list.

### Rules fixed in this PR:
- **SIM102** (6 violations): Combined nested `if` statements in `proxmox/validator.py`
- **SIM114** (2 violations): Combined `if` branches using logical `or` in `test_provider_validation.py`
- **SIM117** (48 violations): Combined nested `with` statements across 11 test files
- **SIM300** (1 violation): Fixed Yoda condition in `test_cli_state.py`

### Previously fixed (ignore entries removed):
- **SIM105**: Fixed in PR #114
- **SIM118**: Fixed in PR #113

All 6 SIM rules removed from `pyproject.toml` ignore list.

Fixes #108

## Test plan
- [x] `doit check` passes (all 970 tests, linting, formatting, type checking)
- [x] No new ruff violations introduced
- [x] All SIM rules enforced going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)