### PR TITLE
feat: add ansible_host override to OCI and Proxmox inventory templates

### DIFF
--- a/src/infrafoundry/providers/oci/templates/oci/inventory.yml.j2
+++ b/src/infrafoundry/providers/oci/templates/oci/inventory.yml.j2
@@ -6,7 +6,11 @@ all:
       hosts:
 {% for instance in instances %}
         {{ instance.name }}:
+{% if instance.config.get('ansible_host') %}
+          ansible_host: "{{ instance.config.ansible_host }}"
+{% else %}
           ansible_host: "{{ '${oci_core_instance.' ~ (instance.name | to_terraform_name) ~ '.public_ip}' }}"
+{% endif %}
           ansible_user: "{{ instance.config.get('ssh_user', 'ubuntu') }}"
 {% if instance.config.get('ansible_vars') %}
 {% for key, value in instance.config.ansible_vars.items() %}

--- a/src/infrafoundry/providers/proxmox/templates/proxmox/inventory.yml.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/inventory.yml.j2
@@ -7,7 +7,11 @@ all:
 {% for resource in resources %}
 {% if resource.type == 'vms' %}
         {{ resource.config.name }}:
+{% if resource.config.ansible_host is defined %}
+          ansible_host: "{{ resource.config.ansible_host }}"
+{% else %}
           ansible_host: "{{ resource.config.ipconfig.split('=')[1].split('/')[0] if resource.config.ipconfig is defined else 'CHANGEME' }}"
+{% endif %}
           ansible_user: "{{ resource.config.ssh_user | default('root') }}"
 {% endif %}
 {% endfor %}

--- a/tests/unit/providers/oci/test_provider.py
+++ b/tests/unit/providers/oci/test_provider.py
@@ -378,6 +378,34 @@ def test_generate_terraform_only_instances(provider, tmp_dirs):
     assert not (terraform_dir / "vcn.tf").exists()
 
 
+def test_generate_ansible_with_ansible_host_override(provider, tmp_dirs):
+    """Test ansible inventory uses ansible_host override when set."""
+    _config_dir, output_dir = tmp_dirs
+    provider.set_environment("test")
+
+    custom_host = "custom-ansible-host-override"
+    resources = [
+        ResourceConfig(
+            name="ts-node",
+            type="instance",
+            provider="oci",
+            config={
+                "shape": "VM.Standard.A1.Flex",
+                "subnet": "public-subnet",
+                "image": "ocid1.image.oc1.iad.example",
+                "ansible_host": custom_host,
+            },
+        ),
+    ]
+
+    provider.generate_ansible(resources)
+
+    ansible_dir = output_dir / "test" / "ansible" / "oci"
+    content = (ansible_dir / "inventory.yml").read_text()
+    assert custom_host in content
+    assert "oci_core_instance" not in content
+
+
 def test_generate_ansible_filters_non_instances(provider, tmp_dirs):
     """Test that generate_ansible only includes instance resources."""
     _config_dir, output_dir = tmp_dirs

--- a/tests/unit/providers/oci/test_templates.py
+++ b/tests/unit/providers/oci/test_templates.py
@@ -419,6 +419,43 @@ class TestInventoryTemplate:
         assert "opc" in content
         assert "oci_instances" in content
 
+    def test_ansible_host_override(self, provider):
+        """Test ansible_host config override takes priority over Terraform output."""
+        custom_host = "custom-ansible-host-override"
+        instances = [
+            ResourceConfig(
+                name="ts-host",
+                type="instance",
+                provider="oci",
+                config={
+                    "shape": "VM.Standard.A1.Flex",
+                    "subnet": "s",
+                    "image": "img",
+                    "ansible_host": custom_host,
+                },
+            )
+        ]
+        content = provider.render_template("oci/inventory.yml.j2", {"instances": instances})
+        assert custom_host in content
+        assert "oci_core_instance" not in content
+
+    def test_ansible_host_default(self, provider):
+        """Test ansible_host falls back to Terraform output when not set."""
+        instances = [
+            ResourceConfig(
+                name="pub-host",
+                type="instance",
+                provider="oci",
+                config={
+                    "shape": "VM.Standard.A1.Flex",
+                    "subnet": "s",
+                    "image": "img",
+                },
+            )
+        ]
+        content = provider.render_template("oci/inventory.yml.j2", {"instances": instances})
+        assert "oci_core_instance.pub_host.public_ip" in content
+
     def test_default_ssh_user(self, provider):
         """Test inventory uses ubuntu as default ssh user."""
         instances = [

--- a/tests/unit/providers/proxmox/test_inventory_template.py
+++ b/tests/unit/providers/proxmox/test_inventory_template.py
@@ -1,0 +1,72 @@
+"""Unit tests for Proxmox inventory template rendering."""
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.proxmox import ProxmoxProvider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    """Create a ProxmoxProvider for template testing."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    p = ProxmoxProvider(config_dir, output_dir)
+    p.set_environment("test")
+    return p
+
+
+class TestInventoryTemplate:
+    """Tests for proxmox/inventory.yml.j2 template."""
+
+    def test_ansible_host_override(self, provider):
+        """Test ansible_host config override takes priority over ipconfig parsing."""
+        custom_host = "custom-ansible-host-override"
+        resources = [
+            ResourceConfig(
+                name="ts-vm",
+                type="vms",
+                provider="proxmox",
+                config={
+                    "name": "ts-vm",
+                    "ipconfig": "ip=192.168.1.100/24",
+                    "ansible_host": custom_host,
+                },
+            )
+        ]
+        content = provider.render_template("proxmox/inventory.yml.j2", {"resources": resources})
+        assert custom_host in content
+        assert "192.168.1.100" not in content
+
+    def test_ansible_host_falls_back_to_ipconfig(self, provider):
+        """Test ansible_host falls back to ipconfig when not overridden."""
+        resources = [
+            ResourceConfig(
+                name="regular-vm",
+                type="vms",
+                provider="proxmox",
+                config={
+                    "name": "regular-vm",
+                    "ipconfig": "ip=10.0.0.50/24",
+                },
+            )
+        ]
+        content = provider.render_template("proxmox/inventory.yml.j2", {"resources": resources})
+        assert "10.0.0.50" in content
+
+    def test_ansible_host_no_ipconfig_no_override(self, provider):
+        """Test CHANGEME fallback when no ansible_host and no ipconfig."""
+        resources = [
+            ResourceConfig(
+                name="bare-vm",
+                type="vms",
+                provider="proxmox",
+                config={
+                    "name": "bare-vm",
+                },
+            )
+        ]
+        content = provider.render_template("proxmox/inventory.yml.j2", {"resources": resources})
+        assert "CHANGEME" in content


### PR DESCRIPTION
## Summary
- Both OCI and Proxmox `inventory.yml.j2` templates now support an explicit `ansible_host` config field
- When set, it takes priority over provider-specific defaults (Terraform `public_ip` for OCI, `ipconfig` parsing for Proxmox)
- Enables managing instances via overlay networks (e.g. Tailscale FQDNs)

Closes #161

## Test plan
- [x] Unit tests for OCI template: override and default fallback
- [x] Integration test for OCI provider `generate_ansible`
- [x] Unit tests for Proxmox template: override, ipconfig fallback, CHANGEME fallback
- [x] `doit check` passes (format, lint, type check, security, spelling, all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)