### PR TITLE
feat(oci): add NAT gateway support for private subnets

### DIFF
--- a/src/infrafoundry/cli/main.py
+++ b/src/infrafoundry/cli/main.py
@@ -97,6 +97,18 @@ def _get_orchestrator(
         pass
 
     try:
+        from infrafoundry.providers.oci import OCIProvider
+
+        orchestrator.register_provider(
+            OCIProvider(
+                config_dir=config_manager.base_dir,
+                output_dir=Path(os.getenv("INFRAFOUNDRY_OUTPUT_DIR", "generated")),
+            )
+        )
+    except ImportError:
+        pass
+
+    try:
         from infrafoundry.providers.opnsense import OPNsenseProvider
 
         orchestrator.register_provider(

--- a/src/infrafoundry/providers/oci/templates/oci/vcn.tf.j2
+++ b/src/infrafoundry/providers/oci/templates/oci/vcn.tf.j2
@@ -29,6 +29,25 @@ resource "oci_core_route_table" "{{ vcn.name | to_terraform_name }}_public_rt" {
 }
 {% endif %}
 
+{% if vcn.config.get('nat_gateway', false) %}
+resource "oci_core_nat_gateway" "{{ vcn.name | to_terraform_name }}_nat" {
+  compartment_id = var.oci_compartment_ocid
+  vcn_id         = oci_core_vcn.{{ vcn.name | to_terraform_name }}.id
+  display_name   = "{{ vcn.name }}-nat-gw"
+}
+
+resource "oci_core_route_table" "{{ vcn.name | to_terraform_name }}_private_rt" {
+  compartment_id = var.oci_compartment_ocid
+  vcn_id         = oci_core_vcn.{{ vcn.name | to_terraform_name }}.id
+  display_name   = "{{ vcn.name }}-private-rt"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    network_entity_id = oci_core_nat_gateway.{{ vcn.name | to_terraform_name }}_nat.id
+  }
+}
+{% endif %}
+
 {% if vcn.config.get('security_list') %}
 resource "oci_core_security_list" "{{ vcn.name | to_terraform_name }}_sl" {
   compartment_id = var.oci_compartment_ocid
@@ -89,6 +108,12 @@ resource "oci_core_subnet" "{{ subnet.name | to_terraform_name }}" {
   {% set vcn_name = subnet.config.vcn | to_terraform_name %}
   {% if subnet.config.get('public', false) %}
   route_table_id = oci_core_route_table.{{ vcn_name }}_public_rt.id
+  {% else %}
+  {% for vcn in vcns %}
+  {% if vcn.name == subnet.config.vcn and vcn.config.get('nat_gateway', false) %}
+  route_table_id = oci_core_route_table.{{ vcn_name }}_private_rt.id
+  {% endif %}
+  {% endfor %}
   {% endif %}
   {% if subnet.config.get('security_list_id') %}
   security_list_ids = [{{ subnet.config.security_list_id }}]

--- a/tests/unit/providers/oci/test_provider.py
+++ b/tests/unit/providers/oci/test_provider.py
@@ -378,6 +378,61 @@ def test_generate_terraform_only_instances(provider, tmp_dirs):
     assert not (terraform_dir / "vcn.tf").exists()
 
 
+def test_generate_terraform_with_nat_gateway(provider, tmp_dirs):
+    """Test full terraform generation with NAT gateway produces correct vcn.tf."""
+    _config_dir, output_dir = tmp_dirs
+    provider.set_environment("test")
+
+    resources = [
+        ResourceConfig(
+            name="k3s-vcn",
+            type="vcn",
+            provider="oci",
+            config={
+                "cidr_block": "10.0.0.0/16",
+                "internet_gateway": True,
+                "nat_gateway": True,
+            },
+        ),
+        ResourceConfig(
+            name="public-subnet",
+            type="subnet",
+            provider="oci",
+            config={
+                "vcn": "k3s-vcn",
+                "cidr_block": "10.0.0.0/24",
+                "public": True,
+            },
+        ),
+        ResourceConfig(
+            name="private-subnet",
+            type="subnet",
+            provider="oci",
+            config={
+                "vcn": "k3s-vcn",
+                "cidr_block": "10.0.1.0/24",
+                "public": False,
+            },
+        ),
+    ]
+
+    provider.generate_terraform(resources)
+
+    terraform_dir = output_dir / "test" / "terraform" / "oci"
+    vcn_content = (terraform_dir / "vcn.tf").read_text()
+
+    # NAT gateway and private route table present
+    assert "oci_core_nat_gateway" in vcn_content
+    assert "k3s_vcn_private_rt" in vcn_content
+    assert "k3s_vcn_nat" in vcn_content
+
+    # Public subnet uses public_rt
+    assert "oci_core_route_table.k3s_vcn_public_rt.id" in vcn_content
+
+    # Private subnet uses private_rt
+    assert "oci_core_route_table.k3s_vcn_private_rt.id" in vcn_content
+
+
 def test_generate_ansible_with_ansible_host_override(provider, tmp_dirs):
     """Test ansible inventory uses ansible_host override when set."""
     _config_dir, output_dir = tmp_dirs

--- a/tests/unit/providers/oci/test_templates.py
+++ b/tests/unit/providers/oci/test_templates.py
@@ -132,6 +132,82 @@ class TestVCNTemplate:
         content = provider.render_template("oci/vcn.tf.j2", {"vcns": [], "subnets": subnets})
         assert "prohibit_public_ip_on_vnic = true" in content
 
+    def test_renders_nat_gateway(self, provider):
+        """Test VCN with nat_gateway creates NAT gateway and private route table."""
+        vcns = [
+            ResourceConfig(
+                name="nat-vcn",
+                type="vcn",
+                provider="oci",
+                config={
+                    "cidr_block": "10.0.0.0/16",
+                    "nat_gateway": True,
+                },
+            )
+        ]
+        content = provider.render_template("oci/vcn.tf.j2", {"vcns": vcns, "subnets": []})
+        assert "oci_core_nat_gateway" in content
+        assert 'display_name   = "nat-vcn-nat-gw"' in content
+        assert "nat_vcn_private_rt" in content
+        assert "oci_core_nat_gateway.nat_vcn_nat.id" in content
+
+    def test_private_subnet_with_nat_gets_private_rt(self, provider):
+        """Test private subnet gets private_rt when VCN has NAT gateway."""
+        vcns = [
+            ResourceConfig(
+                name="my-vcn",
+                type="vcn",
+                provider="oci",
+                config={
+                    "cidr_block": "10.0.0.0/16",
+                    "internet_gateway": True,
+                    "nat_gateway": True,
+                },
+            )
+        ]
+        subnets = [
+            ResourceConfig(
+                name="private-sub",
+                type="subnet",
+                provider="oci",
+                config={
+                    "vcn": "my-vcn",
+                    "cidr_block": "10.0.1.0/24",
+                    "public": False,
+                },
+            )
+        ]
+        content = provider.render_template("oci/vcn.tf.j2", {"vcns": vcns, "subnets": subnets})
+        assert "oci_core_route_table.my_vcn_private_rt.id" in content
+
+    def test_private_subnet_without_nat_no_route_table(self, provider):
+        """Test private subnet without NAT gateway gets no route table."""
+        vcns = [
+            ResourceConfig(
+                name="my-vcn",
+                type="vcn",
+                provider="oci",
+                config={
+                    "cidr_block": "10.0.0.0/16",
+                    "internet_gateway": True,
+                },
+            )
+        ]
+        subnets = [
+            ResourceConfig(
+                name="private-sub",
+                type="subnet",
+                provider="oci",
+                config={
+                    "vcn": "my-vcn",
+                    "cidr_block": "10.0.1.0/24",
+                    "public": False,
+                },
+            )
+        ]
+        content = provider.render_template("oci/vcn.tf.j2", {"vcns": vcns, "subnets": subnets})
+        assert "private_rt" not in content
+
     def test_vcn_with_security_list(self, provider):
         """Test VCN with security list configuration."""
         vcns = [


### PR DESCRIPTION
## Summary
- Adds `oci_core_nat_gateway` resource to `vcn.tf.j2` (conditional on `vcn.config.nat_gateway`)
- Adds private route table (`private_rt`) routing `0.0.0.0/0` through the NAT gateway
- Private subnets automatically get `private_rt` when their parent VCN has `nat_gateway: true`
- Enables outbound internet access for private instances without public IPs

Closes #160

## Test plan
- [x] Template test: NAT gateway + private_rt rendered correctly
- [x] Template test: private subnet with NAT gets private_rt
- [x] Template test: private subnet without NAT gets no route table
- [x] Provider test: full generation with NAT produces correct vcn.tf
- [x] `doit check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)