### PR TITLE
fix(ansible): use filenames instead of full paths in runner subprocess

### DIFF
--- a/src/infrafoundry/core/runners/ansible_runner.py
+++ b/src/infrafoundry/core/runners/ansible_runner.py
@@ -106,7 +106,7 @@ class AnsibleRunner(BaseRunner):
 
         try:
             result = subprocess.run(  # nosec B603 - trusted command
-                [self.tool_path, "--syntax-check", str(playbook)],
+                [self.tool_path, "--syntax-check", playbook.name],
                 cwd=ansible_dir,
                 capture_output=True,
                 text=True,
@@ -143,8 +143,8 @@ class AnsibleRunner(BaseRunner):
             )
             return {"error": "ansible-playbook not found", "success": False}
 
-        # Build command using full path to ansible-playbook binary
-        cmd = [self.tool_path, "-i", str(inventory), str(playbook)]
+        # Build command using filenames only since cwd is ansible_dir
+        cmd = [self.tool_path, "-i", inventory.name, playbook.name]
         if check_mode:
             cmd.append("--check")
             self.console.print("[dim]Running Ansible in check mode (dry run)...[/dim]")


### PR DESCRIPTION
## Description

The Ansible runner passed full relative paths (`str(playbook)`, `str(inventory)`) to `ansible-playbook` while also setting `cwd=ansible_dir`. This caused ansible-playbook to interpret the paths relative to cwd, resulting in a doubled path (e.g., `generated/ocik8/ansible/oci/generated/ocik8/ansible/oci/playbook.yml`).

Fix: use `.name` (just the filename) since `cwd` is already set to the ansible directory.

## Related Issue

Closes #166

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Changed `str(inventory)` and `str(playbook)` to `inventory.name` and `playbook.name` in `_run_ansible()`
- Same fix applied to `validate_config()` which had the same issue

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes (`foundry infra plan --env ocik8` now runs ansible check mode successfully)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings