### PR TITLE
feat(examples): add OCI K3s cluster example with Tailscale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ env/
 
 # User configuration (use example-config/ as template, or separate repo)
 envs/
+!example-config/envs/
 !src/infrafoundry/core/secrets/
 
 # Secrets and sensitive data

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -11,6 +11,10 @@ Practical examples and reference configurations for InfraFoundry.
 - **[Environment Example](ENV_EXAMPLE.md)** - Annotated example of environment configuration
 - **[Envrc Local](ENVRC_LOCAL.md)** - Example usage of local environment variables
 
+## Infrastructure Examples
+
+- **[OCI K3s Cluster](oci-k3s-cluster.md)** - Complete K3s cluster on OCI free tier with Tailscale
+
 ## Integration Examples
 
 - **[GitLab CI Example](GITLAB_CI_EXAMPLE.md)** - Example GitLab CI workflow configuration
@@ -29,4 +33,4 @@ For more detailed documentation, see:
 
 ---
 
-**Last Updated:** 2025-12-29
+**Last Updated:** 2025-01-25

--- a/docs/examples/oci-k3s-cluster.md
+++ b/docs/examples/oci-k3s-cluster.md
@@ -1,0 +1,309 @@
+# OCI K3s Cluster with Tailscale
+
+A complete example of deploying a K3s Kubernetes cluster on Oracle Cloud Infrastructure (OCI) using Always Free Tier ARM instances with Tailscale for secure management access.
+
+## Overview
+
+This example demonstrates:
+
+- **OCI Free Tier**: Maximizes the Always Free ARM instances (4 OCPUs, 24GB RAM)
+- **Network Isolation**: Workers in private subnet with NAT gateway for image pulls
+- **Secure Access**: Tailscale overlay network for SSH and kubectl access
+- **Full Automation**: Terraform for infrastructure, Ansible for K3s installation
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────────────────────┐
+                    │                    OCI VCN                          │
+                    │                  10.0.0.0/16                        │
+                    │                                                     │
+    Internet        │  ┌─────────────────┐    ┌─────────────────────┐    │
+        │           │  │  Public Subnet  │    │   Private Subnet    │    │
+        │           │  │   10.0.0.0/24   │    │    10.0.1.0/24      │    │
+        ▼           │  │                 │    │                     │    │
+   ┌────────┐       │  │ ┌─────────────┐ │    │ ┌─────────────────┐ │    │
+   │Internet│◄──────┼──┤ │k3s-control  │ │    │ │  k3s-worker-0   │ │    │
+   │Gateway │       │  │ │ 2 OCPU/8GB  │ │    │ │  1 OCPU/8GB     │ │    │
+   └────────┘       │  │ │ Public IP   │ │    │ │  No Public IP   │ │    │
+        │           │  │ └─────────────┘ │    │ └─────────────────┘ │    │
+        │           │  │                 │    │                     │    │
+        │           │  │                 │    │ ┌─────────────────┐ │    │
+   ┌────────┐       │  │                 │    │ │  k3s-worker-1   │ │    │
+   │  NAT   │◄──────┼──┼─────────────────┼────┤ │  1 OCPU/8GB     │ │    │
+   │Gateway │       │  │                 │    │ │  No Public IP   │ │    │
+   └────────┘       │  │                 │    │ └─────────────────┘ │    │
+                    │  └─────────────────┘    └─────────────────────┘    │
+                    └─────────────────────────────────────────────────────┘
+                                            │
+                                            │ Tailscale Overlay
+                                            ▼
+                                    ┌───────────────┐
+                                    │  Your Device  │
+                                    │  (Tailscale)  │
+                                    └───────────────┘
+```
+
+## Prerequisites
+
+1. **OCI Account** with Always Free Tier resources
+2. **OCI CLI** configured (`~/.oci/config`)
+3. **Tailscale Account** with an auth key
+4. **InfraFoundry** installed
+
+## Configuration Files
+
+The example is located in `example-config/envs/oci-k3s/`:
+
+```
+example-config/
+├── envs/oci-k3s/
+│   ├── settings.yaml                    # OCI credentials, Tailscale auth key
+│   ├── README.md                        # Detailed setup instructions
+│   ├── oci/
+│   │   ├── network.yaml                 # VCN, subnets, gateways
+│   │   └── instances.yaml               # Control plane + workers
+│   └── files/cloud-init-snippets/
+│       └── tailscale.yaml               # Tailscale installation script
+└── roles/
+    ├── k3s-server/                      # Control plane installation
+    │   ├── tasks/main.yml
+    │   ├── defaults/main.yml
+    │   └── README.md
+    └── k3s-agent/                       # Worker node installation
+        ├── tasks/main.yml
+        ├── defaults/main.yml
+        └── README.md
+```
+
+## Key Configuration
+
+### Network (`oci/network.yaml`)
+
+```yaml
+vcn:
+  - name: k3s-vcn
+    cidr_block: "10.0.0.0/16"
+    internet_gateway: true
+    nat_gateway: true        # Enables outbound for private subnet
+    security_list:
+      ingress_rules:
+        - source: "0.0.0.0/0"
+          protocol: "6"
+          tcp_options:
+            min: 22
+            max: 22
+
+subnet:
+  - name: k3s-control-subnet
+    cidr_block: "10.0.0.0/24"
+    public: true             # Control plane gets public IP
+
+  - name: k3s-worker-subnet
+    cidr_block: "10.0.1.0/24"
+    public: false            # Workers are private
+```
+
+### Instances (`oci/instances.yaml`)
+
+```yaml
+instance:
+  - name: k3s-control
+    shape: VM.Standard.A1.Flex
+    shape_config:
+      ocpus: 2
+      memory_in_gbs: 8
+    subnet: k3s-control-subnet
+    assign_public_ip: true
+    cloud_init_snippets:
+      - tailscale
+    ansible_host: "k3s-control.${variables.tailnet}"
+    ansible_roles:
+      - k3s-server
+
+  - name: k3s-worker-0
+    subnet: k3s-worker-subnet
+    assign_public_ip: false
+    ansible_roles:
+      - k3s-agent
+    ansible_vars:
+      k3s_control_host: "k3s-control"
+```
+
+### Cloud-Init Tailscale (`files/cloud-init-snippets/tailscale.yaml`)
+
+The cloud-init snippet installs Tailscale on first boot with retry logic for unreliable networks:
+
+```yaml
+#cloud-config
+runcmd:
+  - |
+    # Download and install Tailscale with retries
+    for i in $(seq 1 30); do
+      curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/pool/tailscale_*.deb -o /tmp/tailscale.deb && break
+      sleep 10
+    done
+    dpkg -i /tmp/tailscale.deb
+  - tailscale up --auth-key=${TS_AUTH_KEY} --hostname=${HOSTNAME} --ssh
+```
+
+## Deployment Steps
+
+### 1. Find Your Ubuntu ARM Image OCID
+
+```bash
+oci compute image list \
+  --compartment-id <your-compartment-ocid> \
+  --operating-system "Canonical Ubuntu" \
+  --operating-system-version "22.04" \
+  --shape "VM.Standard.A1.Flex" \
+  --sort-by TIMECREATED --sort-order DESC \
+  --query 'data[0].id' --raw-output
+```
+
+### 2. Update Configuration
+
+Edit `envs/oci-k3s/settings.yaml`:
+```yaml
+provider_settings:
+  oci:
+    tenancy_ocid: "ocid1.tenancy.oc1..your-tenancy"
+    user_ocid: "ocid1.user.oc1..your-user"
+    compartment_ocid: "ocid1.compartment.oc1..your-compartment"
+    # ...
+
+secrets:
+  tailscale:
+    auth_key: "tskey-auth-XXXX-XXXXXXXXXXXX"
+```
+
+Edit `envs/oci-k3s/oci/instances.yaml`:
+- Replace image OCIDs
+- Add your SSH public key
+
+### 3. Encrypt Settings
+
+```bash
+infra secrets init --env oci-k3s
+sops --encrypt --in-place envs/oci-k3s/settings.yaml
+```
+
+### 4. Deploy Infrastructure
+
+```bash
+# Generate and review Terraform
+infra plan --env oci-k3s
+
+# Create infrastructure
+infra apply --env oci-k3s
+```
+
+### 5. Install K3s
+
+After Terraform completes and nodes join Tailscale:
+
+```bash
+# Run Ansible to install K3s
+infra apply --env oci-k3s --ansible-only
+```
+
+### 6. Access Your Cluster
+
+```bash
+# Use the fetched kubeconfig
+export KUBECONFIG=~/.kube/oci-k3s.yaml
+
+# Verify cluster
+kubectl get nodes
+kubectl get pods -A
+```
+
+## Ansible Roles
+
+### k3s-server
+
+Installs K3s control plane:
+- Configures TLS SANs for Tailscale hostname
+- Fetches kubeconfig to local machine
+- Updates server endpoint for remote access
+
+Variables:
+- `kubeconfig_local_path`: Where to save kubeconfig (default: `~/.kube/k3s-cluster.yaml`)
+- `k3s_version`: Specific version (default: latest)
+- `k3s_server_args`: Additional server arguments
+
+### k3s-agent
+
+Installs K3s worker nodes:
+- Fetches join token from control plane
+- Joins existing cluster
+- Verifies successful registration
+
+Variables:
+- `k3s_control_host`: Inventory name of control plane (required)
+- `k3s_version`: Should match server version
+- `k3s_agent_args`: Additional agent arguments
+
+## Resource Usage
+
+| Resource | Free Tier Limit | This Config |
+|----------|-----------------|-------------|
+| ARM OCPUs | 4 | 4 (2+1+1) |
+| RAM | 24 GB | 24 GB (8+8+8) |
+| Boot Volume | 200 GB | 150 GB (50×3) |
+
+## Customization
+
+### Different Region
+
+Update `settings.yaml` region and find new image OCID:
+```yaml
+provider_settings:
+  oci:
+    region: "eu-frankfurt-1"
+```
+
+### Disable Traefik
+
+```yaml
+ansible_vars:
+  k3s_server_args: "--disable traefik"
+```
+
+### Add Node Labels
+
+```yaml
+ansible_vars:
+  k3s_agent_args: "--node-label zone=private"
+```
+
+## Troubleshooting
+
+### Tailscale Not Connecting
+
+```bash
+# Check cloud-init logs
+ssh ubuntu@<public-ip> 'sudo cat /var/log/cloud-init-output.log'
+
+# Check Tailscale status
+ssh ubuntu@<public-ip> 'sudo tailscale status'
+```
+
+### Workers Can't Pull Images
+
+Verify NAT gateway is configured and private subnet routes through it.
+
+### Instance Creation Fails
+
+OCI free tier ARM instances are popular. Try different availability domains or off-peak hours.
+
+## See Also
+
+- [OCI Provider Documentation](../providers/oci.md)
+- [Ansible Runner Documentation](../runners/ansible.md)
+- [Separate Config Repository Guide](../configuration/separate-config-repo.md)
+- [Example Config Repository](../../example-config/)
+
+---
+
+**Last Updated:** 2025-01-25

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -13,6 +13,10 @@ The examples in this section demonstrate real-world usage patterns and provide t
 - **[Environment Example](ENV_EXAMPLE.md)** - Annotated example of a complete environment configuration file showing all available options
 - **[Envrc Local](ENVRC_LOCAL.md)** - Example usage of local environment variables with direnv for development
 
+### Infrastructure Examples
+
+- **[OCI K3s Cluster](oci-k3s-cluster.md)** - Complete example deploying a K3s Kubernetes cluster on OCI Always Free Tier with Tailscale for secure access. Includes Terraform for infrastructure and Ansible roles for K3s installation.
+
 ### Integration Examples
 
 - **[GitLab CI Example](GITLAB_CI_EXAMPLE.md)** - Complete GitLab CI workflow configuration for automated infrastructure deployment
@@ -44,7 +48,8 @@ If you're new to InfraFoundry, start with these examples in order:
 
 1. **[Environment Example](ENV_EXAMPLE.md)** - Understand the configuration structure
 2. **[Envrc Local](ENVRC_LOCAL.md)** - Set up your development environment
-3. **[Custom Runner Example](custom-runner-example.md)** - Learn how to extend InfraFoundry
+3. **[OCI K3s Cluster](oci-k3s-cluster.md)** - See a complete real-world deployment
+4. **[Custom Runner Example](custom-runner-example.md)** - Learn how to extend InfraFoundry
 
 ## See Also
 
@@ -54,4 +59,4 @@ If you're new to InfraFoundry, start with these examples in order:
 
 ---
 
-**Last Updated:** 2025-12-29
+**Last Updated:** 2025-01-25

--- a/example-config/envs/oci-k3s/README.md
+++ b/example-config/envs/oci-k3s/README.md
@@ -1,0 +1,23 @@
+# OCI K3s Cluster with Tailscale
+
+K3s Kubernetes cluster on Oracle Cloud Infrastructure (OCI) Always Free Tier with Tailscale overlay network.
+
+## Documentation
+
+Full documentation: **[docs/examples/oci-k3s-cluster.md](../../../docs/examples/oci-k3s-cluster.md)**
+
+Or view online at: https://endavis.github.io/infrafoundry/examples/oci-k3s-cluster/
+
+## Quick Start
+
+1. Update `settings.yaml` with your OCI credentials and Tailscale auth key
+2. Update `oci/instances.yaml` with your image OCID and SSH key
+3. Encrypt settings: `sops --encrypt --in-place settings.yaml`
+4. Deploy: `infra apply --env oci-k3s`
+
+## Files
+
+- `settings.yaml` - OCI credentials, Tailscale auth key
+- `oci/network.yaml` - VCN, subnets, gateways
+- `oci/instances.yaml` - Control plane + worker instances
+- `files/cloud-init-snippets/tailscale.yaml` - Tailscale installation

--- a/example-config/envs/oci-k3s/files/cloud-init-snippets/tailscale.yaml
+++ b/example-config/envs/oci-k3s/files/cloud-init-snippets/tailscale.yaml
@@ -1,0 +1,61 @@
+#cloud-config
+# Tailscale Installation Cloud-Init Snippet
+#
+# Installs Tailscale and joins your tailnet during first boot.
+# This enables secure access to nodes in private subnets without
+# exposing them to the public internet.
+#
+# Required variables:
+#   TS_AUTH_KEY - Tailscale auth key (get from admin console)
+#   HOSTNAME    - Machine hostname for Tailscale network
+#
+# Generate an auth key at: https://login.tailscale.com/admin/settings/keys
+# Recommended settings:
+#   - Reusable: Yes (for multiple nodes)
+#   - Ephemeral: Yes (auto-removes stale nodes)
+#   - Tags: tag:k3s-cluster (for ACL policies)
+
+# Preserve SSH host keys across reboots
+ssh_deletekeys: false
+ssh_genkeytypes: []
+
+bootcmd:
+  # Generate SSH host keys if missing
+  - ssh-keygen -A
+  # Configure DNS fallback (OCI's DNS can be slow initially)
+  - mkdir -p /etc/systemd/resolved.conf.d
+  - printf "[Resolve]\nFallbackDNS=8.8.8.8 8.8.4.4\n" > /etc/systemd/resolved.conf.d/fallback.conf
+  - systemctl restart systemd-resolved
+  # Force IPv4 for apt (IPv6 can timeout on some networks)
+  - printf 'Acquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99force-ipv4
+
+runcmd:
+  # Install Tailscale with retry logic
+  # Direct .deb download avoids apt repository setup issues
+  - |
+    bash -c '
+      ARCH=$(dpkg --print-architecture)
+      BASEURL="https://pkgs.tailscale.com/stable/ubuntu"
+      for i in $(seq 1 30); do
+        echo "Attempt $i: fetching Tailscale package index..."
+        VER=$(timeout 10 curl -fsSL "$BASEURL/dists/noble/main/binary-$ARCH/Packages" 2>/dev/null | grep "^Version:" | cut -d" " -f2 | sort -V | tail -1)
+        if [ -z "$VER" ]; then
+          echo "  Failed to get version, sleeping 10s..."
+          sleep 10
+          continue
+        fi
+        DEBFILE=$(printf "tailscale_%s_%s.deb" "$VER" "$ARCH")
+        echo "  Downloading Tailscale $VER..."
+        if timeout 30 curl -fsSL "$BASEURL/pool/$DEBFILE" -o /tmp/tailscale.deb; then
+          dpkg -i /tmp/tailscale.deb && \
+            systemctl enable --now tailscaled && \
+            echo "Tailscale installed successfully on attempt $i" && exit 0
+        fi
+        echo "  Download/install failed, sleeping 10s..."
+        sleep 10
+      done
+      echo "ERROR: Failed to install Tailscale after 30 attempts"
+      exit 1
+    '
+  # Join tailnet with SSH enabled (allows SSH via Tailscale)
+  - tailscale up --auth-key=${TS_AUTH_KEY} --hostname=${HOSTNAME} --ssh

--- a/example-config/envs/oci-k3s/oci/instances.yaml
+++ b/example-config/envs/oci-k3s/oci/instances.yaml
@@ -1,0 +1,116 @@
+# OCI K3s Cluster Instances
+#
+# Architecture:
+#   - 1 control plane (2 OCPU, 8GB RAM, public subnet)
+#   - 2 workers (1 OCPU, 8GB RAM each, private subnet)
+#   - All nodes join Tailscale for secure management access
+#   - Workers use NAT gateway for internet (image pulls)
+#
+# OCI Always Free Tier (ARM):
+#   - 4 OCPUs total (Ampere A1)
+#   - 24 GB RAM total
+#   - 200 GB boot volume total
+#   This config uses: 4 OCPUs, 24 GB RAM (maxes out free tier)
+#
+# Finding the Image OCID:
+#   oci compute image list --compartment-id <compartment-ocid> \
+#     --operating-system "Canonical Ubuntu" \
+#     --operating-system-version "22.04" \
+#     --shape "VM.Standard.A1.Flex" \
+#     --sort-by TIMECREATED --sort-order DESC \
+#     --query 'data[0].id' --raw-output
+
+instance:
+  # K3s Control Plane
+  # - Public IP for initial SSH access
+  # - Runs k3s server (control plane components)
+  # - Access via Tailscale after initial setup
+  - name: k3s-control
+    shape: VM.Standard.A1.Flex
+    shape_config:
+      ocpus: 2
+      memory_in_gbs: 8
+    subnet: k3s-control-subnet
+    # Replace with current Ubuntu 22.04 ARM image OCID for your region
+    # See command above to find the latest image
+    image: "ocid1.image.oc1.iad.aaaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    boot_volume_size_in_gbs: 50
+    assign_public_ip: true
+    ssh_authorized_keys:
+      - "ssh-rsa AAAA... your-ssh-public-key"
+    freeform_tags:
+      role: control-plane
+      cluster: k3s
+      managed_by: infrafoundry
+    # Cloud-init for Tailscale installation
+    cloud_init_snippets:
+      - tailscale
+    cloud_init_vars:
+      TS_AUTH_KEY: "${secrets.tailscale.auth_key}"
+      HOSTNAME: k3s-control
+    # Ansible connection via Tailscale hostname
+    ansible_host: "k3s-control.${variables.tailnet}"
+    ansible_roles:
+      - k3s-server
+    ansible_vars:
+      kubeconfig_local_path: "~/.kube/oci-k3s.yaml"
+    ssh_user: ubuntu
+
+  # K3s Worker Node 0
+  # - Private subnet (no public IP)
+  # - Uses NAT gateway for outbound internet
+  # - Accessible only via Tailscale
+  - name: k3s-worker-0
+    shape: VM.Standard.A1.Flex
+    shape_config:
+      ocpus: 1
+      memory_in_gbs: 8
+    subnet: k3s-worker-subnet
+    image: "ocid1.image.oc1.iad.aaaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    boot_volume_size_in_gbs: 50
+    assign_public_ip: false
+    ssh_authorized_keys:
+      - "ssh-rsa AAAA... your-ssh-public-key"
+    freeform_tags:
+      role: worker
+      cluster: k3s
+      managed_by: infrafoundry
+    cloud_init_snippets:
+      - tailscale
+    cloud_init_vars:
+      TS_AUTH_KEY: "${secrets.tailscale.auth_key}"
+      HOSTNAME: k3s-worker-0
+    ansible_host: "k3s-worker-0.${variables.tailnet}"
+    ansible_roles:
+      - k3s-agent
+    ansible_vars:
+      k3s_control_host: "k3s-control"
+    ssh_user: ubuntu
+
+  # K3s Worker Node 1
+  - name: k3s-worker-1
+    shape: VM.Standard.A1.Flex
+    shape_config:
+      ocpus: 1
+      memory_in_gbs: 8
+    subnet: k3s-worker-subnet
+    image: "ocid1.image.oc1.iad.aaaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    boot_volume_size_in_gbs: 50
+    assign_public_ip: false
+    ssh_authorized_keys:
+      - "ssh-rsa AAAA... your-ssh-public-key"
+    freeform_tags:
+      role: worker
+      cluster: k3s
+      managed_by: infrafoundry
+    cloud_init_snippets:
+      - tailscale
+    cloud_init_vars:
+      TS_AUTH_KEY: "${secrets.tailscale.auth_key}"
+      HOSTNAME: k3s-worker-1
+    ansible_host: "k3s-worker-1.${variables.tailnet}"
+    ansible_roles:
+      - k3s-agent
+    ansible_vars:
+      k3s_control_host: "k3s-control"
+    ssh_user: ubuntu

--- a/example-config/envs/oci-k3s/oci/network.yaml
+++ b/example-config/envs/oci-k3s/oci/network.yaml
@@ -1,0 +1,59 @@
+# OCI K3s Network Configuration
+#
+# Architecture:
+#   - VCN with /16 CIDR for cluster networking
+#   - Internet Gateway for public subnet (control plane)
+#   - NAT Gateway for private subnet (workers) to pull images
+#   - Public subnet: Control plane with public IP for initial SSH/Tailscale setup
+#   - Private subnet: Worker nodes accessible only via Tailscale
+#
+# Security:
+#   - Minimal ingress: SSH only from internet
+#   - All intra-cluster traffic allowed within VCN
+#   - Workers have no public IPs - accessed via Tailscale overlay
+
+vcn:
+  - name: k3s-vcn
+    cidr_block: "10.0.0.0/16"
+    dns_label: k3svcn
+    internet_gateway: true
+    nat_gateway: true
+    security_list:
+      egress_rules:
+        # Allow all outbound (for package updates, image pulls, Tailscale)
+        - destination: "0.0.0.0/0"
+          protocol: "all"
+      ingress_rules:
+        # SSH from anywhere (for initial setup, then use Tailscale)
+        - source: "0.0.0.0/0"
+          protocol: "6"  # TCP
+          tcp_options:
+            min: 22
+            max: 22
+        # All traffic within VCN (K3s cluster communication)
+        - source: "10.0.0.0/16"
+          protocol: "all"
+        # Kubernetes API from VCN (for kubectl via Tailscale)
+        - source: "10.0.0.0/16"
+          protocol: "6"
+          tcp_options:
+            min: 6443
+            max: 6443
+
+subnet:
+  # Public subnet for control plane
+  # Uses Internet Gateway for routing
+  - name: k3s-control-subnet
+    vcn: k3s-vcn
+    cidr_block: "10.0.0.0/24"
+    dns_label: ctrl
+    public: true
+
+  # Private subnet for workers
+  # Uses NAT Gateway for outbound traffic (image pulls, updates)
+  # No public IPs - accessed via Tailscale
+  - name: k3s-worker-subnet
+    vcn: k3s-vcn
+    cidr_block: "10.0.1.0/24"
+    dns_label: work
+    public: false

--- a/example-config/envs/oci-k3s/settings.yaml
+++ b/example-config/envs/oci-k3s/settings.yaml
@@ -1,0 +1,38 @@
+# OCI K3s Cluster Environment Settings
+#
+# This example deploys a K3s cluster on Oracle Cloud Infrastructure (OCI)
+# using the Always Free Tier ARM instances with Tailscale for secure access.
+#
+# SECURITY NOTE: Encrypt with SOPS before committing:
+#   sops --encrypt --in-place envs/oci-k3s/settings.yaml
+
+name: oci-k3s
+description: OCI K3s cluster - ARM free tier with Tailscale overlay
+
+variables:
+  environment: oci-k3s
+  managed_by: infrafoundry
+  # Tailscale network name (used in ansible_host)
+  tailnet: your-tailnet.ts.net
+
+ssh:
+  user: ubuntu
+  key_path: ~/.ssh/id_rsa
+
+provider_settings:
+  oci:
+    # Get these from OCI Console -> Identity -> Users -> API Keys
+    tenancy_ocid: "ocid1.tenancy.oc1..aaaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    user_ocid: "ocid1.user.oc1..aaaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    fingerprint: "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99"
+    private_key_path: "~/.oci/oci_api_key.pem"
+    region: "us-ashburn-1"
+    # Create a compartment or use root compartment OCID
+    compartment_ocid: "ocid1.compartment.oc1..aaaaaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Secrets for cloud-init (referenced via ${SECRET_NAME} in snippets)
+secrets:
+  tailscale:
+    # Generate an auth key at https://login.tailscale.com/admin/settings/keys
+    # Use a reusable, ephemeral key for best security
+    auth_key: "tskey-auth-XXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"

--- a/example-config/roles/README.md
+++ b/example-config/roles/README.md
@@ -10,7 +10,8 @@ roles/
 ├── webserver/           # Nginx/Apache web server
 ├── database/            # Database servers (PostgreSQL, MySQL)
 ├── docker/              # Docker installation and configuration
-├── kubernetes/          # Kubernetes node configuration
+├── k3s-server/          # K3s control plane installation
+├── k3s-agent/           # K3s worker node installation
 ├── monitoring/          # Monitoring agents (Prometheus, etc.)
 ├── tailscale-exit-node/ # Tailscale VPN exit node (includes example)
 └── custom/              # Your custom roles
@@ -42,6 +43,43 @@ vms:
 ```
 
 See [tailscale-exit-node/README.md](tailscale-exit-node/README.md) for full documentation or [tailscale-exit-node/QUICKSTART.md](tailscale-exit-node/QUICKSTART.md) for quick deployment guide.
+
+### K3s Cluster (`k3s-server/` and `k3s-agent/`)
+
+Production-ready roles for deploying lightweight Kubernetes (K3s) clusters:
+
+**k3s-server** - Control plane installation:
+- ✅ Installs K3s in server mode
+- ✅ Configures TLS SANs for remote access (Tailscale)
+- ✅ Fetches kubeconfig to local machine
+- ✅ Supports custom cluster/service CIDRs
+
+**k3s-agent** - Worker node installation:
+- ✅ Automatically fetches join token from control plane
+- ✅ Joins existing K3s cluster
+- ✅ Supports node labels and taints
+
+**Quick Usage:**
+```yaml
+instance:
+  # Control plane
+  - name: k3s-control
+    ansible_roles:
+      - k3s-server
+    ansible_vars:
+      kubeconfig_local_path: "~/.kube/my-cluster.yaml"
+
+  # Workers
+  - name: k3s-worker-0
+    ansible_roles:
+      - k3s-agent
+    ansible_vars:
+      k3s_control_host: "k3s-control"
+```
+
+See [k3s-server/README.md](k3s-server/README.md) and [k3s-agent/README.md](k3s-agent/README.md) for full documentation.
+
+For a complete OCI deployment example with Tailscale, see [envs/oci-k3s/](../envs/oci-k3s/).
 
 ## Using Roles in Configuration
 

--- a/example-config/roles/k3s-agent/README.md
+++ b/example-config/roles/k3s-agent/README.md
@@ -1,0 +1,92 @@
+# K3s Agent Role
+
+Installs K3s in agent mode (worker node), joining an existing K3s cluster.
+
+## Features
+
+- Automatically fetches join token from control plane
+- Installs matching K3s version
+- Clean install (removes existing K3s agent if present)
+- Verifies successful cluster join
+- Retry logic for unreliable networks
+
+## Requirements
+
+- Ubuntu 22.04+ or Debian 12+
+- Root/sudo access
+- K3s server must be installed and running first
+- Network connectivity to control plane (port 6443)
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `k3s_version` | `""` (latest) | K3s version (should match server) |
+| `k3s_control_host` | `k3s-control` | Inventory hostname of control plane |
+| `k3s_agent_args` | `""` | Additional agent arguments |
+
+## Example Usage
+
+In your InfraFoundry instance configuration:
+
+```yaml
+instance:
+  - name: k3s-worker-0
+    # ... instance config ...
+    ansible_host: "k3s-worker-0.your-tailnet.ts.net"
+    ansible_roles:
+      - k3s-agent
+    ansible_vars:
+      k3s_control_host: "k3s-control"
+```
+
+## How It Works
+
+1. Connects to `k3s_control_host` to fetch the node join token
+2. Gets the control plane's `ansible_host` for the server URL
+3. Installs K3s agent with the token and server URL
+4. Verifies the node appears in `kubectl get nodes`
+
+## Important Notes
+
+### Execution Order
+
+Workers must be provisioned **after** the control plane. In InfraFoundry, this is handled automatically when you define the control plane before workers in your configuration.
+
+### Control Host Reference
+
+The `k3s_control_host` must match the inventory hostname of your control plane node:
+
+```yaml
+# Control plane
+- name: k3s-control        # This is the inventory hostname
+  ansible_roles:
+    - k3s-server
+
+# Workers reference it
+- name: k3s-worker-0
+  ansible_roles:
+    - k3s-agent
+  ansible_vars:
+    k3s_control_host: "k3s-control"  # Must match above
+```
+
+### Network Requirements
+
+The agent needs to reach the control plane on port 6443. With Tailscale, this works automatically via the overlay network.
+
+## Customization
+
+### Node Labels
+
+```yaml
+ansible_vars:
+  k3s_agent_args: "--node-label role=worker --node-label zone=private"
+```
+
+### Node Taints
+
+```yaml
+ansible_vars:
+  k3s_agent_args: "--node-taint dedicated=worker:NoSchedule"
+```

--- a/example-config/roles/k3s-agent/defaults/main.yml
+++ b/example-config/roles/k3s-agent/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# K3s version to install (empty = latest stable)
+# Should match the server version
+k3s_version: ""
+
+# Hostname of the k3s control plane node (from inventory)
+# This is used to fetch the join token and determine the server URL
+k3s_control_host: "k3s-control"
+
+# Additional k3s agent arguments
+# Example: "--node-label role=worker"
+k3s_agent_args: ""

--- a/example-config/roles/k3s-agent/meta/main.yml
+++ b/example-config/roles/k3s-agent/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: k3s-agent
+  author: InfraFoundry
+  description: Install and configure k3s agent (worker node)
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []

--- a/example-config/roles/k3s-agent/tasks/main.yml
+++ b/example-config/roles/k3s-agent/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+# K3s Agent (Worker Node) Installation
+#
+# This role installs K3s in agent mode, joining an existing cluster.
+# It fetches the join token from the control plane node automatically.
+#
+# Variables:
+#   k3s_version: Specific version to install (empty = latest, should match server)
+#   k3s_control_host: Inventory hostname of the control plane node
+#   k3s_agent_args: Additional agent arguments
+#
+# Requirements:
+#   - Control plane must be installed and running first
+#   - This role delegates to k3s_control_host to fetch the token
+
+- name: Wait for connectivity
+  wait_for_connection:
+    timeout: 300
+
+- name: Gather facts
+  setup:
+
+- name: Check for existing k3s-agent installation
+  stat:
+    path: /usr/local/bin/k3s
+  register: k3s_binary
+
+- name: Stop existing k3s-agent (if present)
+  service:
+    name: k3s-agent
+    state: stopped
+  ignore_errors: true
+  when: k3s_binary.stat.exists
+
+- name: Uninstall existing k3s-agent (if present)
+  shell: /usr/local/bin/k3s-agent-uninstall.sh
+  ignore_errors: true
+  when: k3s_binary.stat.exists
+
+- name: Remove old k3s-agent state
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/rancher
+    - /var/lib/rancher
+    - /etc/systemd/system/k3s-agent.service
+    - /etc/systemd/system/k3s-agent.service.env
+
+- name: Get join token from control node
+  delegate_to: "{{ k3s_control_host }}"
+  shell: cat /var/lib/rancher/k3s/server/node-token
+  register: k3s_token_output
+  changed_when: false
+
+- name: Get control plane ansible_host
+  set_fact:
+    k3s_server_url: "https://{{ hostvars[k3s_control_host]['ansible_host'] }}:6443"
+
+- name: Display join information
+  debug:
+    msg: "Joining cluster at {{ k3s_server_url }}"
+
+- name: Install k3s agent
+  shell: |
+    curl -sfL https://get.k3s.io | sh -s - agent {{ k3s_agent_args }}
+    test -x /usr/local/bin/k3s
+  register: k3s_install
+  retries: 5
+  delay: 15
+  until: k3s_install.rc == 0
+  environment:
+    K3S_URL: "{{ k3s_server_url }}"
+    K3S_TOKEN: "{{ k3s_token_output.stdout }}"
+    INSTALL_K3S_VERSION: "{{ k3s_version | default(omit, true) }}"
+
+- name: Wait for k3s-agent service to be active
+  service:
+    name: k3s-agent
+    state: started
+  register: k3s_agent_service
+  retries: 5
+  delay: 10
+  until: k3s_agent_service is succeeded
+
+- name: Verify node joined cluster (from control plane)
+  delegate_to: "{{ k3s_control_host }}"
+  shell: kubectl get nodes | grep -q "{{ inventory_hostname }}"
+  register: node_joined
+  retries: 30
+  delay: 10
+  until: node_joined.rc == 0
+  changed_when: false

--- a/example-config/roles/k3s-server/README.md
+++ b/example-config/roles/k3s-server/README.md
@@ -1,0 +1,77 @@
+# K3s Server Role
+
+Installs K3s in server mode (control plane) on a target node.
+
+## Features
+
+- Installs latest K3s or specific version
+- Configures TLS SANs for remote access (Tailscale hostnames)
+- Fetches kubeconfig to local machine with updated server endpoint
+- Clean install (removes existing K3s if present)
+- Retry logic for unreliable networks
+
+## Requirements
+
+- Ubuntu 22.04+ or Debian 12+
+- Root/sudo access
+- Network connectivity to download K3s
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `k3s_version` | `""` (latest) | K3s version to install (e.g., `v1.28.5+k3s1`) |
+| `kubeconfig_local_path` | `~/.kube/k3s-cluster.yaml` | Where to save kubeconfig locally |
+| `k3s_server_args` | `""` | Additional server arguments |
+| `k3s_cluster_cidr` | `""` | Pod CIDR (default: 10.42.0.0/16) |
+| `k3s_service_cidr` | `""` | Service CIDR (default: 10.43.0.0/16) |
+
+## Example Usage
+
+In your InfraFoundry instance configuration:
+
+```yaml
+instance:
+  - name: k3s-control
+    # ... instance config ...
+    ansible_host: "k3s-control.your-tailnet.ts.net"
+    ansible_roles:
+      - k3s-server
+    ansible_vars:
+      kubeconfig_local_path: "~/.kube/oci-k3s.yaml"
+      k3s_server_args: "--disable traefik"
+```
+
+## After Installation
+
+```bash
+# Use the fetched kubeconfig
+export KUBECONFIG=~/.kube/k3s-cluster.yaml
+
+# Verify cluster
+kubectl get nodes
+kubectl get pods -A
+```
+
+## Customization
+
+### Disable Default Components
+
+```yaml
+ansible_vars:
+  k3s_server_args: "--disable traefik --disable servicelb"
+```
+
+### Custom Network CIDRs
+
+```yaml
+ansible_vars:
+  k3s_cluster_cidr: "10.100.0.0/16"
+  k3s_service_cidr: "10.101.0.0/16"
+```
+
+## Notes
+
+- The role adds `ansible_host` to TLS SANs, enabling kubectl via Tailscale
+- Existing K3s installations are completely removed before reinstall
+- Kubeconfig `server:` is automatically updated to use `ansible_host`

--- a/example-config/roles/k3s-server/defaults/main.yml
+++ b/example-config/roles/k3s-server/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# K3s version to install (empty = latest stable)
+# Example: "v1.28.5+k3s1"
+k3s_version: ""
+
+# Local path to save kubeconfig after installation
+# The server endpoint will be updated to use ansible_host
+kubeconfig_local_path: "~/.kube/k3s-cluster.yaml"
+
+# Additional k3s server arguments
+# Example: "--disable traefik --disable servicelb"
+k3s_server_args: ""
+
+# Cluster CIDR for pods (default: 10.42.0.0/16)
+k3s_cluster_cidr: ""
+
+# Service CIDR (default: 10.43.0.0/16)
+k3s_service_cidr: ""

--- a/example-config/roles/k3s-server/meta/main.yml
+++ b/example-config/roles/k3s-server/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: k3s-server
+  author: InfraFoundry
+  description: Install and configure k3s server (control plane)
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []

--- a/example-config/roles/k3s-server/tasks/main.yml
+++ b/example-config/roles/k3s-server/tasks/main.yml
@@ -1,0 +1,109 @@
+---
+# K3s Server (Control Plane) Installation
+#
+# This role installs K3s in server mode, creating the control plane.
+# After installation, it fetches the kubeconfig to your local machine.
+#
+# Variables:
+#   k3s_version: Specific version to install (empty = latest)
+#   kubeconfig_local_path: Where to save kubeconfig locally
+#   k3s_server_args: Additional server arguments
+
+- name: Wait for connectivity
+  wait_for_connection:
+    timeout: 300
+
+- name: Gather facts
+  setup:
+
+- name: Check for existing k3s installation
+  stat:
+    path: /usr/local/bin/k3s
+  register: k3s_binary
+
+- name: Uninstall existing k3s (if present)
+  shell: /usr/local/bin/k3s-uninstall.sh
+  ignore_errors: true
+  when: k3s_binary.stat.exists
+
+- name: Remove old k3s directories
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/rancher
+    - /var/lib/rancher
+    - /var/lib/kubelet
+    - /etc/systemd/system/k3s.service
+    - /etc/systemd/system/k3s.service.env
+
+- name: Create k3s config directory
+  file:
+    path: /etc/rancher/k3s
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Write k3s config.yaml
+  copy:
+    dest: /etc/rancher/k3s/config.yaml
+    content: |
+      write-kubeconfig-mode: "0644"
+      tls-san:
+        - {{ ansible_host }}
+        - {{ inventory_hostname }}
+      {% if k3s_cluster_cidr %}
+      cluster-cidr: {{ k3s_cluster_cidr }}
+      {% endif %}
+      {% if k3s_service_cidr %}
+      service-cidr: {{ k3s_service_cidr }}
+      {% endif %}
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Install k3s server
+  shell: |
+    curl -sfL https://get.k3s.io | sh -s - server {{ k3s_server_args }}
+    test -x /usr/local/bin/k3s
+  register: k3s_install
+  retries: 5
+  delay: 15
+  until: k3s_install.rc == 0
+  environment:
+    INSTALL_K3S_VERSION: "{{ k3s_version | default(omit, true) }}"
+
+- name: Wait for k3s to be ready
+  command: kubectl get nodes
+  register: k3s_ready
+  retries: 30
+  delay: 5
+  until: k3s_ready.rc == 0
+  changed_when: false
+
+- name: Wait for node to be Ready
+  shell: kubectl get nodes -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}'
+  register: node_ready
+  retries: 30
+  delay: 10
+  until: node_ready.stdout == "True"
+  changed_when: false
+
+- name: Fetch kubeconfig from control node
+  fetch:
+    src: /etc/rancher/k3s/k3s.yaml
+    dest: "{{ kubeconfig_local_path }}"
+    flat: true
+
+- name: Update server endpoint in fetched kubeconfig
+  delegate_to: localhost
+  become: false
+  replace:
+    path: "{{ kubeconfig_local_path }}"
+    regexp: 'server: https://127.0.0.1:6443'
+    replace: 'server: https://{{ ansible_host }}:6443'
+
+- name: Display kubeconfig location
+  debug:
+    msg: "Kubeconfig saved to {{ kubeconfig_local_path }}. Use: export KUBECONFIG={{ kubeconfig_local_path }}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
   - Examples:
     - Overview: examples/overview.md
     - Quick Start: examples/README.md
+    - OCI K3s Cluster: examples/oci-k3s-cluster.md
     - Environment Example: examples/ENV_EXAMPLE.md
     - Envrc Local: examples/ENVRC_LOCAL.md
     - GitLab CI: examples/GITLAB_CI_EXAMPLE.md


### PR DESCRIPTION
## Summary

Add a complete, production-ready example for deploying a K3s Kubernetes cluster on Oracle Cloud Infrastructure (OCI) Always Free Tier with Tailscale overlay network for secure access.

### New Files

**Environment (`example-config/envs/oci-k3s/`):**
- `settings.yaml` - OCI credentials and Tailscale auth key placeholders
- `oci/network.yaml` - VCN with internet gateway, NAT gateway, public/private subnets
- `oci/instances.yaml` - Control plane + 2 workers using ARM free tier
- `files/cloud-init-snippets/tailscale.yaml` - Tailscale installation with retry logic

**Ansible Roles:**
- `k3s-server` - Installs K3s control plane, configures TLS SANs, fetches kubeconfig
- `k3s-agent` - Joins workers to cluster by fetching token from control plane

**Documentation:**
- `docs/examples/oci-k3s-cluster.md` - Full documentation with architecture diagram, deployment steps, customization options

### Changes to Existing Files
- `.gitignore` - Added exception for `example-config/envs/`
- `mkdocs.yml` - Added OCI K3s Cluster to Examples nav
- `docs/examples/README.md` and `overview.md` - Added links to new example
- `example-config/roles/README.md` - Added K3s roles documentation

## Test Plan

- [ ] Verify mkdocs builds successfully with new documentation
- [ ] Review YAML syntax in example configs
- [ ] Verify all file references and links are correct

Closes #170

🤖 Generated with [Claude Code](https://claude.ai/code)