### PR TITLE
fix: add oci to provider execution order before kubernetes

### DIFF
--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -97,8 +97,8 @@ class DeploymentExecutor:
 
         # Define provider execution order
         # Providers earlier in the list are applied first
-        # This ensures network/DHCP config is ready before VMs
-        provider_order = ["opnsense", "proxmox", "kubernetes"]
+        # Infrastructure providers (network, compute) run before application providers (kubernetes)
+        provider_order = ["opnsense", "proxmox", "oci", "kubernetes"]
 
         # Sort providers by defined order, putting undefined ones at the end
         sorted_providers = sorted(


### PR DESCRIPTION
## Description

OCI provider was not in the `provider_order` list, causing it to run AFTER kubernetes. This meant kubernetes terraform tried to deploy resources before the k3s cluster was created by OCI ansible.

## Related Issue

Closes #189

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

Added `oci` to the provider execution order in `deployment_executor.py`:

```python
# Before
provider_order = ["opnsense", "proxmox", "kubernetes"]

# After
provider_order = ["opnsense", "proxmox", "oci", "kubernetes"]
```

This ensures infrastructure providers (network, compute) run before application providers (kubernetes).

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually verified provider ordering logic

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

---
Generated with [Claude Code](https://claude.com/claude-code)
