### PR TITLE
feat: add environment lifecycle hooks for custom scripts

### DIFF
--- a/docs/architecture/decisions/0005-environment-lifecycle-hooks.md
+++ b/docs/architecture/decisions/0005-environment-lifecycle-hooks.md
@@ -1,0 +1,100 @@
+# 5. Environment Lifecycle Hooks
+
+**Date:** 2025-01-26
+**Status:** Accepted
+
+## Context
+
+Users need the ability to execute custom scripts at specific points during infrastructure operations. Common use cases include:
+
+- **Before destroy:** Remove a Tailscale device before the VM is destroyed
+- **After apply:** Notify Slack about successful deployments
+- **Before plan:** Run pre-flight validation scripts
+- **After destroy:** Clean up external resources not managed by Terraform
+
+The current event system (ADR-0003) provides internal observability but doesn't support user-defined script execution with proper environment injection, secret access, and error handling.
+
+## Decision
+
+We will implement a **two-level hook system**:
+
+1. **Environment-level hooks** in `settings.yaml` - run for all operations in that environment
+2. **Resource-level hooks** in resource configs - run only for that specific resource
+
+### Execution Order
+
+```
+Environment before_X → Resource before_X → [Operation] → Resource after_X → Environment after_X
+```
+
+### Hook Configuration Model
+
+```yaml
+# settings.yaml (environment-level)
+hooks:
+  before_destroy:
+    - script: scripts/backup-state.sh
+      description: "Backup Terraform state"
+      timeout: 300
+      continue_on_error: false
+      env:
+        BACKUP_BUCKET: "{{ secrets.backup_bucket }}"
+
+# resource config (resource-level)
+- name: k3s-control
+  type: instance
+  hooks:
+    before_destroy:
+      - script: scripts/cleanup-tailscale.sh
+        env:
+          TAILSCALE_API_KEY: "{{ secrets.tailscale_api_key }}"
+```
+
+### HookManager Responsibilities
+
+1. **Script execution** via subprocess with:
+   - Working directory = environment config directory
+   - Timeout handling (default 300s, max 3600s)
+   - stdout/stderr capture and logging
+
+2. **Environment variable injection:**
+   - `INFRAFOUNDRY_ENV` - environment name
+   - `INFRAFOUNDRY_CONFIG_DIR` - path to env config
+   - `INFRAFOUNDRY_EVENT` - event type (e.g., "before_destroy")
+   - `INFRAFOUNDRY_RESOURCE` - resource name (for resource-level hooks)
+   - `INFRAFOUNDRY_PROVIDER` - provider name
+   - Custom env vars from hook config
+
+3. **Secret template resolution:** `{{ secrets.xxx }}` in env values resolved via SecretManager
+
+4. **Error handling:**
+   - Non-zero exit or timeout = failure
+   - `continue_on_error: true` allows operation to proceed despite hook failure
+   - Missing script = immediate failure with clear error message
+
+## Consequences
+
+**Positive:**
+
+- **Flexibility:** Users can integrate with any external system (Tailscale, Slack, backup services)
+- **Separation of concerns:** Scripts live in user's config repo, not framework code
+- **Secret access:** Scripts receive secrets via environment variables, no hardcoding
+- **Granularity:** Resource-level hooks enable per-resource customization
+- **Safety:** `continue_on_error: false` (default) ensures operations fail fast on hook errors
+
+**Negative:**
+
+- **Complexity:** Two-level execution order requires careful documentation
+- **Debugging:** Script failures may be harder to debug than native integrations
+- **Security surface:** Scripts run with access to secrets; users must secure their config repos
+- **Platform dependency:** Scripts must be POSIX-compatible (or users must handle Windows separately)
+
+## Alternatives Considered
+
+1. **Plugin system with Python modules:** Rejected because it requires users to write Python code and understand the InfraFoundry internals. Shell scripts are more accessible.
+
+2. **Event webhooks only:** Rejected because webhooks require an external HTTP server, adding infrastructure overhead. Local scripts are simpler for most use cases.
+
+3. **Single-level hooks (environment only):** Rejected because per-resource hooks are essential for use cases like per-VM Tailscale cleanup where each resource has different parameters.
+
+4. **Inline script content in YAML:** Rejected because external script files are easier to test, version, and maintain. Also avoids YAML escaping issues.

--- a/docs/configuration/lifecycle-hooks.md
+++ b/docs/configuration/lifecycle-hooks.md
@@ -1,0 +1,280 @@
+# Lifecycle Hooks
+
+## Overview
+
+Lifecycle hooks allow you to run custom scripts at specific points during infrastructure operations (plan, apply, destroy). Common use cases include:
+
+- Removing cloud resources not managed by Terraform (e.g., Tailscale devices)
+- Sending notifications to Slack/Teams on deployment
+- Running smoke tests after apply
+- Backing up state before destroy
+- Pre-flight validation checks
+
+## Audience and Prerequisites
+
+- **Audience:** Operators who need custom automation around infrastructure lifecycle events
+- **Prerequisites:** Basic shell scripting knowledge, access to the config repo
+
+## When to Use This
+
+- You need to run external cleanup scripts before destroying infrastructure
+- You want to integrate with external systems (Tailscale, DNS providers, monitoring)
+- You need custom validation or notification beyond built-in features
+- You want per-resource customization of lifecycle behavior
+
+## Hook Levels
+
+Hooks can be defined at two levels:
+
+1. **Environment-level:** In `settings.yaml`, runs for all operations in that environment
+2. **Resource-level:** In resource configs, runs only for that specific resource
+
+### Execution Order
+
+```
+Environment before_X → Resource before_X → [Operation] → Resource after_X → Environment after_X
+```
+
+## Quick Start
+
+### Environment-Level Hooks
+
+Add hooks to your environment's `settings.yaml`:
+
+```yaml
+# envs/prod/settings.yaml
+name: prod
+
+hooks:
+  after_apply:
+    - script: scripts/notify-slack.sh
+      description: "Notify team of deployment"
+      env:
+        SLACK_WEBHOOK: "{{ secrets.slack.webhook }}"
+      continue_on_error: true
+
+  before_destroy:
+    - script: scripts/backup-state.sh
+      description: "Backup Terraform state before destroy"
+```
+
+### Resource-Level Hooks
+
+Add hooks to specific resources:
+
+```yaml
+# envs/prod/oci/instances.yaml
+instance:
+  - name: k3s-control
+    shape: VM.Standard.A1.Flex
+    hooks:
+      before_destroy:
+        - script: scripts/cleanup-tailscale.sh
+          description: "Remove Tailscale device"
+          env:
+            TAILSCALE_API_KEY: "{{ secrets.tailscale.api_key }}"
+            HOSTNAME: k3s-control
+    # ... rest of config
+```
+
+## Configuration Reference
+
+### Hook Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `script` | string | required | Path to script, relative to environment directory |
+| `description` | string | null | Human-readable description shown during execution |
+| `env` | dict | {} | Environment variables to pass to the script |
+| `continue_on_error` | bool | false | Whether to continue if script fails |
+| `timeout` | int | 300 | Script timeout in seconds (1-3600) |
+
+### Supported Lifecycle Stages
+
+| Stage | When it runs |
+|-------|--------------|
+| `before_plan` | Before generating Terraform/Ansible configs |
+| `after_plan` | After successful plan operation |
+| `before_apply` | Before applying infrastructure changes |
+| `after_apply` | After successful apply operation |
+| `before_destroy` | Before destroying infrastructure |
+| `after_destroy` | After successful destroy operation |
+
+### Environment Variables
+
+Scripts receive these environment variables automatically:
+
+| Variable | Description |
+|----------|-------------|
+| `INFRAFOUNDRY_ENV` | Environment name (e.g., "prod") |
+| `INFRAFOUNDRY_CONFIG_DIR` | Path to environment config directory |
+| `INFRAFOUNDRY_EVENT` | Lifecycle stage (e.g., "before_destroy") |
+| `INFRAFOUNDRY_RESOURCE` | Resource name (resource-level hooks only) |
+| `INFRAFOUNDRY_PROVIDER` | Provider name (resource-level hooks only) |
+
+Plus any custom variables defined in the hook's `env` section.
+
+### Secret Templating
+
+Use `{{ secrets.file.key }}` syntax to inject secrets:
+
+```yaml
+hooks:
+  after_apply:
+    - script: scripts/notify.sh
+      env:
+        API_KEY: "{{ secrets.notifications.api_key }}"
+        WEBHOOK: "{{ secrets.slack.webhook_url }}"
+```
+
+The secret path maps to `envs/{env}/secrets/{file}.yaml` and the specified key.
+
+## Examples
+
+### Tailscale Cleanup Before Destroy
+
+```yaml
+# envs/prod/settings.yaml
+hooks:
+  before_destroy:
+    - script: scripts/cleanup-tailscale.sh
+      description: "Remove Tailscale devices from admin console"
+      env:
+        TAILSCALE_API_KEY: "{{ secrets.tailscale.api_key }}"
+      timeout: 60
+```
+
+```bash
+#!/bin/bash
+# scripts/cleanup-tailscale.sh
+# Remove Tailscale device when destroying VM
+
+set -e
+
+# INFRAFOUNDRY_RESOURCE is set for resource-level hooks
+if [ -n "$INFRAFOUNDRY_RESOURCE" ]; then
+    DEVICE_NAME="$INFRAFOUNDRY_RESOURCE"
+else
+    # For environment-level hooks, remove all devices in this environment
+    DEVICE_NAME="*-${INFRAFOUNDRY_ENV}"
+fi
+
+echo "Removing Tailscale device: $DEVICE_NAME"
+
+# Use Tailscale API to remove device
+curl -s -X DELETE \
+    -H "Authorization: Bearer $TAILSCALE_API_KEY" \
+    "https://api.tailscale.com/api/v2/device/${DEVICE_NAME}"
+
+echo "Device removed successfully"
+```
+
+### Slack Notification After Apply
+
+```yaml
+hooks:
+  after_apply:
+    - script: scripts/notify-slack.sh
+      description: "Notify deployment channel"
+      env:
+        SLACK_WEBHOOK: "{{ secrets.slack.webhook }}"
+        CHANNEL: "#deployments"
+      continue_on_error: true  # Don't fail deploy if notification fails
+```
+
+```bash
+#!/bin/bash
+# scripts/notify-slack.sh
+
+curl -s -X POST "$SLACK_WEBHOOK" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"channel\": \"$CHANNEL\",
+        \"text\": \"Deployment completed for $INFRAFOUNDRY_ENV\",
+        \"username\": \"InfraFoundry\",
+        \"icon_emoji\": \":rocket:\"
+    }"
+```
+
+### Pre-Destroy State Backup
+
+```yaml
+hooks:
+  before_destroy:
+    - script: scripts/backup-state.sh
+      description: "Backup Terraform state to S3"
+      env:
+        BACKUP_BUCKET: "{{ secrets.aws.backup_bucket }}"
+      timeout: 120
+```
+
+### Per-Resource Hooks
+
+For resources that need individual cleanup:
+
+```yaml
+# envs/prod/oci/instances.yaml
+instance:
+  - name: monitoring-server
+    hooks:
+      before_destroy:
+        - script: scripts/deregister-monitoring.sh
+          env:
+            DATADOG_API_KEY: "{{ secrets.datadog.api_key }}"
+            HOST_TAG: monitoring-server
+      after_apply:
+        - script: scripts/register-monitoring.sh
+          env:
+            DATADOG_API_KEY: "{{ secrets.datadog.api_key }}"
+    # ... rest of instance config
+```
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Script not found | Operation fails with clear error message |
+| Script not executable | Operation fails with clear error message |
+| Script exits non-zero | Operation fails (unless `continue_on_error: true`) |
+| Script times out | Operation fails (unless `continue_on_error: true`) |
+| Secret not found | Warning logged, empty string used |
+
+## Validation
+
+Test your hooks with a dry run:
+
+```bash
+# See what hooks would be executed
+infra plan --env prod --dry-run
+```
+
+Check script permissions:
+
+```bash
+# Ensure scripts are executable
+chmod +x envs/prod/scripts/*.sh
+```
+
+## Related Documentation
+
+- [Notifications Configuration](notifications.md) - Built-in event notifications
+- [Secrets Management](per-environment-credentials.md) - Managing secrets for hooks
+- [Architecture: Event System](../development/event-system.md) - Understanding lifecycle events
+- [ADR-0005: Environment Lifecycle Hooks](../architecture/decisions/0005-environment-lifecycle-hooks.md)
+
+## Troubleshooting
+
+- **Symptom:** Hook not running. **Fix:** Verify script path is relative to environment directory, script is executable, and hook is defined for the correct lifecycle stage.
+
+- **Symptom:** Secret not resolved. **Fix:** Check secret file exists at `envs/{env}/secrets/{file}.yaml` and key path is correct. Missing secrets become empty strings with a warning.
+
+- **Symptom:** Script times out. **Fix:** Increase `timeout` value or optimize script. Default is 300 seconds, maximum is 3600.
+
+- **Symptom:** Hook fails but operation continues. **Fix:** Remove `continue_on_error: true` if you want failures to stop the operation.
+
+---
+
+Last updated: 2025-01-26
+
+---
+[Back to Table of Contents](../index.md)

--- a/example-config/envs/oci-k3s/oci/instances.yaml
+++ b/example-config/envs/oci-k3s/oci/instances.yaml
@@ -55,6 +55,15 @@ instance:
     ansible_vars:
       kubeconfig_local_path: "~/.kube/oci-k3s.yaml"
     ssh_user: ubuntu
+    # Resource-level lifecycle hooks
+    # These run only for this specific instance
+    hooks:
+      before_destroy:
+        - script: scripts/cleanup-tailscale-device.sh
+          description: "Remove k3s-control from Tailscale"
+          env:
+            TAILSCALE_API_KEY: "{{ secrets.tailscale.api_key }}"
+            # INFRAFOUNDRY_RESOURCE is automatically set to "k3s-control"
 
   # K3s Worker Node 0
   # - Private subnet (no public IP)

--- a/example-config/envs/oci-k3s/scripts/cleanup-tailscale-device.sh
+++ b/example-config/envs/oci-k3s/scripts/cleanup-tailscale-device.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# cleanup-tailscale-device.sh
+#
+# Remove a single Tailscale device when destroying an instance.
+# This script is called as a resource-level hook with INFRAFOUNDRY_RESOURCE
+# set to the instance name.
+#
+# Required environment variables:
+#   TAILSCALE_API_KEY - Tailscale API access token
+#   INFRAFOUNDRY_RESOURCE - Instance name (set automatically)
+#
+# See: https://tailscale.com/kb/1101/api/
+
+set -euo pipefail
+
+# Validate required variables
+if [ -z "${TAILSCALE_API_KEY:-}" ]; then
+    echo "ERROR: TAILSCALE_API_KEY not set"
+    exit 1
+fi
+
+if [ -z "${INFRAFOUNDRY_RESOURCE:-}" ]; then
+    echo "ERROR: INFRAFOUNDRY_RESOURCE not set (this should be set automatically)"
+    exit 1
+fi
+
+DEVICE_NAME="$INFRAFOUNDRY_RESOURCE"
+echo "Looking up Tailscale device: $DEVICE_NAME"
+
+# Get device ID from Tailscale API
+DEVICE_ID=$(curl -s \
+    -H "Authorization: Bearer $TAILSCALE_API_KEY" \
+    "https://api.tailscale.com/api/v2/tailnet/-/devices" | \
+    jq -r ".devices[] | select(.hostname == \"$DEVICE_NAME\") | .id" | head -1)
+
+if [ -z "$DEVICE_ID" ] || [ "$DEVICE_ID" = "null" ]; then
+    echo "Device '$DEVICE_NAME' not found in Tailscale - may already be removed"
+    exit 0
+fi
+
+echo "Found device ID: $DEVICE_ID"
+echo "Removing device from Tailscale..."
+
+# Delete the device
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X DELETE \
+    -H "Authorization: Bearer $TAILSCALE_API_KEY" \
+    "https://api.tailscale.com/api/v2/device/$DEVICE_ID")
+
+if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+    echo "Successfully removed $DEVICE_NAME from Tailscale"
+else
+    echo "Warning: Unexpected response code $HTTP_CODE when removing device"
+    # Don't fail - the device might already be gone
+fi

--- a/example-config/envs/oci-k3s/scripts/cleanup-tailscale-devices.sh
+++ b/example-config/envs/oci-k3s/scripts/cleanup-tailscale-devices.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# cleanup-tailscale-devices.sh
+#
+# Remove ALL Tailscale devices for this environment before destroy.
+# This is an environment-level hook that runs before any resources are destroyed.
+#
+# Required environment variables:
+#   TAILSCALE_API_KEY - Tailscale API access token
+#   INFRAFOUNDRY_ENV - Environment name (set automatically)
+#
+# See: https://tailscale.com/kb/1101/api/
+
+set -euo pipefail
+
+# Validate required variables
+if [ -z "${TAILSCALE_API_KEY:-}" ]; then
+    echo "ERROR: TAILSCALE_API_KEY not set"
+    exit 1
+fi
+
+ENV_NAME="${INFRAFOUNDRY_ENV:-unknown}"
+echo "Cleaning up Tailscale devices for environment: $ENV_NAME"
+
+# Get all devices from Tailscale
+DEVICES=$(curl -s \
+    -H "Authorization: Bearer $TAILSCALE_API_KEY" \
+    "https://api.tailscale.com/api/v2/tailnet/-/devices")
+
+# Filter devices that match our k3s cluster naming pattern
+# Adjust the pattern based on your naming convention
+DEVICE_IDS=$(echo "$DEVICES" | jq -r '.devices[] | select(.hostname | test("^k3s-")) | .id')
+
+if [ -z "$DEVICE_IDS" ]; then
+    echo "No matching Tailscale devices found for cleanup"
+    exit 0
+fi
+
+REMOVED=0
+FAILED=0
+
+for DEVICE_ID in $DEVICE_IDS; do
+    HOSTNAME=$(echo "$DEVICES" | jq -r ".devices[] | select(.id == \"$DEVICE_ID\") | .hostname")
+    echo "Removing device: $HOSTNAME ($DEVICE_ID)"
+
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X DELETE \
+        -H "Authorization: Bearer $TAILSCALE_API_KEY" \
+        "https://api.tailscale.com/api/v2/device/$DEVICE_ID")
+
+    if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "204" ]; then
+        echo "  Removed successfully"
+        ((REMOVED++))
+    else
+        echo "  Warning: Unexpected response code $HTTP_CODE"
+        ((FAILED++))
+    fi
+done
+
+echo ""
+echo "Cleanup complete: $REMOVED removed, $FAILED failed"
+
+# Only fail if all removals failed
+if [ "$REMOVED" -eq 0 ] && [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/example-config/envs/oci-k3s/scripts/verify-cluster.sh
+++ b/example-config/envs/oci-k3s/scripts/verify-cluster.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# verify-cluster.sh
+#
+# Verify K3s cluster health after apply.
+# This is an environment-level hook that runs after successful apply.
+#
+# Required environment variables:
+#   INFRAFOUNDRY_ENV - Environment name (set automatically)
+#   INFRAFOUNDRY_CONFIG_DIR - Config directory path (set automatically)
+#
+# Optional:
+#   KUBECONFIG - Path to kubeconfig (defaults to ~/.kube/oci-k3s.yaml)
+
+set -euo pipefail
+
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/oci-k3s.yaml}"
+
+echo "Verifying K3s cluster health for environment: ${INFRAFOUNDRY_ENV:-unknown}"
+echo "Using kubeconfig: $KUBECONFIG"
+
+# Check if kubeconfig exists
+if [ ! -f "$KUBECONFIG" ]; then
+    echo "Warning: Kubeconfig not found at $KUBECONFIG"
+    echo "This is normal on first deploy - Ansible will create it"
+    exit 0
+fi
+
+# Check if kubectl is available
+if ! command -v kubectl &> /dev/null; then
+    echo "Warning: kubectl not found in PATH"
+    echo "Install kubectl to enable cluster verification"
+    exit 0
+fi
+
+export KUBECONFIG
+
+echo ""
+echo "=== Node Status ==="
+if ! kubectl get nodes -o wide; then
+    echo "Warning: Failed to get node status"
+    exit 1
+fi
+
+echo ""
+echo "=== System Pods ==="
+if ! kubectl get pods -n kube-system; then
+    echo "Warning: Failed to get system pods"
+    exit 1
+fi
+
+echo ""
+echo "=== Cluster Info ==="
+kubectl cluster-info
+
+# Check node readiness
+NOT_READY=$(kubectl get nodes --no-headers | grep -v " Ready " | wc -l)
+if [ "$NOT_READY" -gt 0 ]; then
+    echo ""
+    echo "Warning: $NOT_READY node(s) not in Ready state"
+    echo "This may be normal if nodes are still initializing"
+fi
+
+echo ""
+echo "Cluster verification complete"

--- a/example-config/envs/oci-k3s/settings.yaml
+++ b/example-config/envs/oci-k3s/settings.yaml
@@ -36,3 +36,23 @@ secrets:
     # Generate an auth key at https://login.tailscale.com/admin/settings/keys
     # Use a reusable, ephemeral key for best security
     auth_key: "tskey-auth-XXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    # API key for device management (Settings -> Keys -> API access tokens)
+    api_key: "tskey-api-XXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+# Lifecycle hooks for custom automation
+# See: https://infrafoundry.dev/docs/configuration/lifecycle-hooks/
+hooks:
+  # Run before destroying any resources in this environment
+  before_destroy:
+    - script: scripts/cleanup-tailscale-devices.sh
+      description: "Remove all Tailscale devices for this environment"
+      env:
+        TAILSCALE_API_KEY: "{{ secrets.tailscale.api_key }}"
+      timeout: 60
+
+  # Run after successful apply
+  after_apply:
+    - script: scripts/verify-cluster.sh
+      description: "Verify K3s cluster is healthy"
+      continue_on_error: true  # Don't fail if verification fails
+      timeout: 120

--- a/src/infrafoundry/core/config/models.py
+++ b/src/infrafoundry/core/config/models.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from infrafoundry.core.config.backend_config import BackendConfig
+from infrafoundry.core.hooks.models import HooksConfig
 
 
 class DriftRemediationConfig(BaseModel):
@@ -65,6 +66,8 @@ class EnvironmentConfig(BaseModel):
     backend: BackendConfig | None = None
     # Drift remediation configuration for automated drift detection and remediation
     drift_remediation: DriftRemediationConfig | None = None
+    # Lifecycle hooks for environment-level script execution
+    hooks: HooksConfig | None = None
 
     def get_ssh_config(self, provider_name: str) -> SSHConfig | None:
         """Get SSH config for a specific provider.

--- a/src/infrafoundry/core/hooks/__init__.py
+++ b/src/infrafoundry/core/hooks/__init__.py
@@ -1,0 +1,16 @@
+"""Lifecycle hooks for infrastructure operations.
+
+This module provides user-defined script execution at specific points
+during plan, apply, and destroy operations.
+"""
+
+from infrafoundry.core.hooks.manager import HookExecutionError, HookManager
+from infrafoundry.core.hooks.models import HookConfig, HookResult, HooksConfig
+
+__all__ = [
+    "HookConfig",
+    "HookExecutionError",
+    "HookManager",
+    "HookResult",
+    "HooksConfig",
+]

--- a/src/infrafoundry/core/hooks/manager.py
+++ b/src/infrafoundry/core/hooks/manager.py
@@ -1,0 +1,396 @@
+"""Hook manager for executing lifecycle hooks."""
+
+import os
+import re
+import subprocess  # nosec B404 - required for running user scripts
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from infrafoundry.core.base_manager import PathBasedManager
+from infrafoundry.core.hooks.models import HookConfig, HookResult, HooksConfig
+from infrafoundry.core.secrets.secret_manager import SecretManager
+
+
+class HookExecutionError(Exception):
+    """Raised when a hook execution fails and continue_on_error is False."""
+
+    def __init__(self, message: str, result: HookResult) -> None:
+        """Initialize hook execution error.
+
+        Args:
+            message: Error description
+            result: The HookResult containing execution details
+        """
+        super().__init__(message)
+        self.result = result
+
+
+class HookManager(PathBasedManager):
+    """Manages execution of lifecycle hooks.
+
+    Hooks are user-defined scripts that run at specific points during
+    infrastructure operations. The manager handles:
+    - Script path resolution relative to environment directory
+    - Environment variable injection (INFRAFOUNDRY_*, custom vars)
+    - Secret template resolution ({{ secrets.xxx }})
+    - Timeout enforcement
+    - stdout/stderr capture and logging
+    """
+
+    # Pattern to match {{ secrets.key }} or {{ secrets.key.subkey }}
+    SECRET_PATTERN = re.compile(r"\{\{\s*secrets\.([a-zA-Z0-9_.]+)\s*\}\}")
+
+    def __init__(
+        self,
+        config_base_dir: Path,
+        secret_manager_factory: Callable[[str], SecretManager],
+    ) -> None:
+        """Initialize hook manager.
+
+        Args:
+            config_base_dir: Base directory for configuration (contains envs/)
+            secret_manager_factory: Factory function to create SecretManager for an environment
+        """
+        super().__init__()
+        self.config_base_dir = config_base_dir
+        self._secret_manager_factory = secret_manager_factory
+
+    def execute_environment_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        hooks_config: HooksConfig | None,
+    ) -> list[HookResult]:
+        """Execute environment-level hooks for a lifecycle stage.
+
+        Args:
+            env_name: Environment name
+            stage: Lifecycle stage (e.g., "before_plan", "after_destroy")
+            hooks_config: Hooks configuration from environment settings
+
+        Returns:
+            List of HookResult objects for each executed hook
+
+        Raises:
+            HookExecutionError: If a hook fails and continue_on_error is False
+        """
+        if not hooks_config:
+            return []
+
+        hooks = getattr(hooks_config, stage, [])
+        if not hooks:
+            return []
+
+        env_dir = self.config_base_dir / "envs" / env_name
+        self._log_info(f"Executing {len(hooks)} environment hook(s) for {stage}")
+
+        return self._execute_hooks(
+            hooks=hooks,
+            env_name=env_name,
+            stage=stage,
+            working_dir=env_dir,
+            resource_name=None,
+            provider_name=None,
+        )
+
+    def execute_resource_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        resource_name: str,
+        provider_name: str,
+        hooks_config: HooksConfig | None,
+    ) -> list[HookResult]:
+        """Execute resource-level hooks for a lifecycle stage.
+
+        Args:
+            env_name: Environment name
+            stage: Lifecycle stage (e.g., "before_plan", "after_destroy")
+            resource_name: Name of the resource
+            provider_name: Name of the provider
+            hooks_config: Hooks configuration from resource config
+
+        Returns:
+            List of HookResult objects for each executed hook
+
+        Raises:
+            HookExecutionError: If a hook fails and continue_on_error is False
+        """
+        if not hooks_config:
+            return []
+
+        hooks = getattr(hooks_config, stage, [])
+        if not hooks:
+            return []
+
+        env_dir = self.config_base_dir / "envs" / env_name
+        self._log_info(f"Executing {len(hooks)} resource hook(s) for {stage} on {resource_name}")
+
+        return self._execute_hooks(
+            hooks=hooks,
+            env_name=env_name,
+            stage=stage,
+            working_dir=env_dir,
+            resource_name=resource_name,
+            provider_name=provider_name,
+        )
+
+    def _execute_hooks(
+        self,
+        hooks: list[HookConfig],
+        env_name: str,
+        stage: str,
+        working_dir: Path,
+        resource_name: str | None,
+        provider_name: str | None,
+    ) -> list[HookResult]:
+        """Execute a list of hooks.
+
+        Args:
+            hooks: List of hook configurations to execute
+            env_name: Environment name
+            stage: Lifecycle stage
+            working_dir: Working directory for script execution
+            resource_name: Resource name (None for environment-level hooks)
+            provider_name: Provider name (None for environment-level hooks)
+
+        Returns:
+            List of HookResult objects
+
+        Raises:
+            HookExecutionError: If a hook fails and continue_on_error is False
+        """
+        results: list[HookResult] = []
+
+        for hook in hooks:
+            result = self._execute_single_hook(
+                hook=hook,
+                env_name=env_name,
+                stage=stage,
+                working_dir=working_dir,
+                resource_name=resource_name,
+                provider_name=provider_name,
+            )
+            results.append(result)
+
+            if not result.success and not hook.continue_on_error:
+                error_msg = f"Hook '{hook.script}' failed: {result.error_message or result.stderr}"
+                self._log_error(error_msg)
+                raise HookExecutionError(error_msg, result)
+
+        return results
+
+    def _execute_single_hook(
+        self,
+        hook: HookConfig,
+        env_name: str,
+        stage: str,
+        working_dir: Path,
+        resource_name: str | None,
+        provider_name: str | None,
+    ) -> HookResult:
+        """Execute a single hook script.
+
+        Args:
+            hook: Hook configuration
+            env_name: Environment name
+            stage: Lifecycle stage
+            working_dir: Working directory for script execution
+            resource_name: Resource name (None for environment-level hooks)
+            provider_name: Provider name (None for environment-level hooks)
+
+        Returns:
+            HookResult with execution details
+        """
+        script_path = working_dir / hook.script
+
+        # Validate script exists
+        if not script_path.exists():
+            return HookResult(
+                script=hook.script,
+                success=False,
+                exit_code=-1,
+                stdout="",
+                stderr="",
+                duration_seconds=0.0,
+                timed_out=False,
+                error_message=f"Script not found: {script_path}",
+            )
+
+        # Validate script is executable
+        if not os.access(script_path, os.X_OK):
+            return HookResult(
+                script=hook.script,
+                success=False,
+                exit_code=-1,
+                stdout="",
+                stderr="",
+                duration_seconds=0.0,
+                timed_out=False,
+                error_message=f"Script not executable: {script_path}",
+            )
+
+        # Prepare environment variables
+        env = self._prepare_environment(
+            hook=hook,
+            env_name=env_name,
+            stage=stage,
+            working_dir=working_dir,
+            resource_name=resource_name,
+            provider_name=provider_name,
+        )
+
+        # Log execution
+        desc = hook.description or hook.script
+        if resource_name:
+            self._log_info(f"Running hook: {desc} (resource: {resource_name})")
+        else:
+            self._log_info(f"Running hook: {desc}")
+
+        # Execute script
+        start_time = time.monotonic()
+        try:
+            result = subprocess.run(  # nosec B603 - user-controlled scripts
+                [str(script_path)],
+                cwd=working_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=hook.timeout,
+            )
+            duration = time.monotonic() - start_time
+
+            return HookResult(
+                script=hook.script,
+                success=result.returncode == 0,
+                exit_code=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                duration_seconds=duration,
+                timed_out=False,
+                error_message=None if result.returncode == 0 else f"Exit code: {result.returncode}",
+            )
+
+        except subprocess.TimeoutExpired as e:
+            duration = time.monotonic() - start_time
+            return HookResult(
+                script=hook.script,
+                success=False,
+                exit_code=-1,
+                stdout=e.stdout.decode() if e.stdout else "",
+                stderr=e.stderr.decode() if e.stderr else "",
+                duration_seconds=duration,
+                timed_out=True,
+                error_message=f"Timeout after {hook.timeout} seconds",
+            )
+
+        except PermissionError:
+            duration = time.monotonic() - start_time
+            return HookResult(
+                script=hook.script,
+                success=False,
+                exit_code=-1,
+                stdout="",
+                stderr="",
+                duration_seconds=duration,
+                timed_out=False,
+                error_message=f"Permission denied: {script_path}",
+            )
+
+        except OSError as e:
+            duration = time.monotonic() - start_time
+            return HookResult(
+                script=hook.script,
+                success=False,
+                exit_code=-1,
+                stdout="",
+                stderr="",
+                duration_seconds=duration,
+                timed_out=False,
+                error_message=f"OS error: {e}",
+            )
+
+    def _prepare_environment(
+        self,
+        hook: HookConfig,
+        env_name: str,
+        stage: str,
+        working_dir: Path,
+        resource_name: str | None,
+        provider_name: str | None,
+    ) -> dict[str, str]:
+        """Prepare environment variables for hook execution.
+
+        Injects INFRAFOUNDRY_* variables and resolves secret templates
+        in custom environment variables.
+
+        Args:
+            hook: Hook configuration
+            env_name: Environment name
+            stage: Lifecycle stage
+            working_dir: Working directory
+            resource_name: Resource name (None for environment-level hooks)
+            provider_name: Provider name (None for environment-level hooks)
+
+        Returns:
+            Complete environment variable dictionary
+        """
+        # Start with current environment
+        env = os.environ.copy()
+
+        # Add InfraFoundry-specific variables
+        env["INFRAFOUNDRY_ENV"] = env_name
+        env["INFRAFOUNDRY_CONFIG_DIR"] = str(working_dir)
+        env["INFRAFOUNDRY_EVENT"] = stage
+
+        if resource_name:
+            env["INFRAFOUNDRY_RESOURCE"] = resource_name
+
+        if provider_name:
+            env["INFRAFOUNDRY_PROVIDER"] = provider_name
+
+        # Resolve custom environment variables with secret templates
+        for key, value in hook.env.items():
+            resolved_value = self._resolve_secret_templates(value, env_name)
+            env[key] = resolved_value
+
+        return env
+
+    def _resolve_secret_templates(self, value: str, env_name: str) -> str:
+        """Resolve {{ secrets.xxx }} templates in a value.
+
+        Args:
+            value: String that may contain secret templates
+            env_name: Environment name for secret lookup
+
+        Returns:
+            Value with secrets resolved, or original value if no templates
+        """
+        if "{{" not in value:
+            return value
+
+        def replace_secret(match: re.Match[str]) -> str:
+            secret_path = match.group(1)
+            try:
+                secret_manager = self._secret_manager_factory(env_name)
+                # Split path into file and key
+                # e.g., "tailscale.api_key" -> "tailscale.yaml", "api_key"
+                parts = secret_path.split(".", 1)
+                if len(parts) == 1:
+                    # Just a filename, return the whole file as string (unlikely use case)
+                    self._log_warning(f"Secret path '{secret_path}' has no key, returning empty")
+                    return ""
+
+                filename = f"{parts[0]}.yaml"
+                key = parts[1]
+                return str(secret_manager.get_secret(filename, key))
+            except (FileNotFoundError, KeyError) as e:
+                self._log_warning(f"Secret '{secret_path}' not found: {e}")
+                return ""
+
+        return self.SECRET_PATTERN.sub(replace_secret, value)
+
+    def cleanup(self) -> None:
+        """Clean up resources (required by BaseManager)."""
+        self._log_debug("HookManager cleanup complete")

--- a/src/infrafoundry/core/hooks/models.py
+++ b/src/infrafoundry/core/hooks/models.py
@@ -1,0 +1,76 @@
+"""Pydantic models for lifecycle hooks."""
+
+from pydantic import BaseModel, Field
+
+
+class HookConfig(BaseModel):
+    """Configuration for a single lifecycle hook.
+
+    Hooks are user-defined scripts that run at specific points during
+    infrastructure operations (plan, apply, destroy).
+
+    Attributes:
+        script: Path to script file, relative to environment directory
+        description: Optional human-readable description of what the hook does
+        env: Environment variables to pass to the script
+        continue_on_error: If True, operation continues even if hook fails
+        timeout: Maximum execution time in seconds (1-3600)
+    """
+
+    script: str
+    description: str | None = None
+    env: dict[str, str] = Field(default_factory=dict)
+    continue_on_error: bool = False
+    timeout: int = Field(default=300, ge=1, le=3600)
+
+
+class HooksConfig(BaseModel):
+    """Collection of hooks organized by lifecycle stage.
+
+    Hooks can be defined at two levels:
+    - Environment-level: In settings.yaml, runs for all operations
+    - Resource-level: In resource configs, runs only for that resource
+
+    Execution order:
+        Environment before_X -> Resource before_X -> [Operation] ->
+        Resource after_X -> Environment after_X
+
+    Attributes:
+        before_plan: Hooks to run before plan operation
+        after_plan: Hooks to run after successful plan
+        before_apply: Hooks to run before apply operation
+        after_apply: Hooks to run after successful apply
+        before_destroy: Hooks to run before destroy operation
+        after_destroy: Hooks to run after successful destroy
+    """
+
+    before_plan: list[HookConfig] = Field(default_factory=list)
+    after_plan: list[HookConfig] = Field(default_factory=list)
+    before_apply: list[HookConfig] = Field(default_factory=list)
+    after_apply: list[HookConfig] = Field(default_factory=list)
+    before_destroy: list[HookConfig] = Field(default_factory=list)
+    after_destroy: list[HookConfig] = Field(default_factory=list)
+
+
+class HookResult(BaseModel):
+    """Result of a hook execution.
+
+    Attributes:
+        script: Path to the executed script
+        success: Whether the hook completed successfully
+        exit_code: Process exit code
+        stdout: Captured standard output
+        stderr: Captured standard error
+        duration_seconds: Execution time in seconds
+        timed_out: Whether the hook was terminated due to timeout
+        error_message: Human-readable error description if failed
+    """
+
+    script: str
+    success: bool
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_seconds: float
+    timed_out: bool = False
+    error_message: str | None = None

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -13,6 +13,7 @@ from infrafoundry.core.dependencies import DependencyGraph
 from infrafoundry.core.deployment_executor import DeploymentExecutor
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import Event, EventManager, EventType
+from infrafoundry.core.hooks import HookManager
 from infrafoundry.core.notifications import NotificationManager
 from infrafoundry.core.orchestrator_workflows import (
     ApplyOrchestrator,
@@ -93,6 +94,12 @@ class Orchestrator:
         self._providers = self.provider_registry.providers
         self.runner_registry = self.provider_registry.runner_registry
 
+        # Hook manager for lifecycle hooks
+        self.hook_manager = HookManager(
+            config_base_dir=self.config_manager.base_dir,
+            secret_manager_factory=self._create_secret_manager,
+        )
+
         # Initialize helper classes for orchestration tasks
         self.policy_checker = PolicyChecker(self.policy_engine, self.event_manager, self.console)
         self.drift_detector = DriftDetector(
@@ -131,6 +138,8 @@ class Orchestrator:
             get_current_user=self._get_current_user,
             fail_on_missing_secrets=self.strict_config.fail_on_missing_secrets,
             get_runner_priorities=self.provider_registry.get_runner_priorities,
+            hook_manager=self.hook_manager,
+            load_environment=self.config_manager.load_environment,
         )
         self.apply_orchestrator = ApplyOrchestrator(
             console=self.console,
@@ -140,6 +149,8 @@ class Orchestrator:
             apply_serial=self._apply_providers_serial,
             apply_parallel=self._apply_providers_parallel,
             get_current_user=self._get_current_user,
+            hook_manager=self.hook_manager,
+            load_environment=self.config_manager.load_environment,
         )
         self.destroy_orchestrator = DestroyOrchestrator(
             console=self.console,
@@ -150,6 +161,8 @@ class Orchestrator:
             load_resources=self._load_resources,
             iter_provider_batches=self._iter_provider_batches,
             get_current_user=self._get_current_user,
+            hook_manager=self.hook_manager,
+            load_environment=self.config_manager.load_environment,
         )
         self.rollback_orchestrator = RollbackOrchestrator(
             console=self.console,

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -12,8 +12,10 @@ from rich.console import Console
 from rich.table import Table
 
 from infrafoundry.core.config import ConfigManager
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import EventManager, EventType
+from infrafoundry.core.hooks import HookExecutionError, HookManager
 from infrafoundry.core.protocols import Destroyable, Plannable
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.runners import RunnerRegistry
@@ -275,6 +277,8 @@ class PlanOrchestrator:
         get_current_user: Callable[[], str],
         fail_on_missing_secrets: bool,
         get_runner_priorities: Callable[[str], dict[str, int]],
+        hook_manager: HookManager | None = None,
+        load_environment: Callable[[str], EnvironmentConfig | None] | None = None,
     ) -> None:
         self.console = console
         self.state_manager = state_manager
@@ -290,6 +294,8 @@ class PlanOrchestrator:
         self._get_current_user = get_current_user
         self._fail_on_missing_secrets = fail_on_missing_secrets
         self._get_runner_priorities = get_runner_priorities
+        self._hook_manager = hook_manager
+        self._load_environment = load_environment
 
         # Dynamically create all registered runners
         self.runners: dict[str, BaseRunner] = {}
@@ -332,12 +338,18 @@ class PlanOrchestrator:
         results: dict[str, Any] = {}
         runner_priorities = self._get_runner_priorities(env_name)
 
+        # Load environment config for hooks
+        env_config = self._load_environment(env_name) if self._load_environment else None
+
         try:
             self._print_header("Planning", env_name, resource_filter, style="bold cyan")
             all_resources, resources_by_provider = self._load_resources(env_name)
 
             if self._has_policies():
                 self._check_policies(env_name, all_resources, enforce_policies)
+
+            # Execute environment-level before_plan hooks
+            self._execute_env_hooks(env_name, "before_plan", env_config)
 
             providers = self._get_providers()
             for batch in self._iter_provider_batches(resources_by_provider, resource_filter):
@@ -359,6 +371,10 @@ class PlanOrchestrator:
                 )
 
                 provider_results: dict[str, Any] = {"resources": len(provider_resources)}
+
+                # Execute resource-level before_plan hooks
+                for resource in provider_resources:
+                    self._execute_resource_hooks(env_name, "before_plan", resource, provider_name)
 
                 if dry_run:
                     self.console.print("  [dim]Would generate configurations and run plans[/dim]")
@@ -390,7 +406,14 @@ class PlanOrchestrator:
                                 f"no generate_{tool_name} method[/dim]"
                             )
 
+                # Execute resource-level after_plan hooks
+                for resource in provider_resources:
+                    self._execute_resource_hooks(env_name, "after_plan", resource, provider_name)
+
                 results[provider_name] = provider_results
+
+            # Execute environment-level after_plan hooks
+            self._execute_env_hooks(env_name, "after_plan", env_config)
 
             self.state_manager.update_deployment_status(deployment_id, DeploymentStatus.COMPLETED)
             self.event_manager.emit_event(
@@ -483,6 +506,49 @@ class PlanOrchestrator:
             if self._fail_on_missing_secrets:
                 raise
             self.console.print(f"[dim]Skipping secrets export: {exc}[/dim]")
+
+    def _execute_env_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        env_config: EnvironmentConfig | None,
+    ) -> None:
+        """Execute environment-level hooks for a lifecycle stage."""
+        if not self._hook_manager or not env_config or not env_config.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_environment_hooks(
+                env_name=env_name,
+                stage=stage,
+                hooks_config=env_config.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed: {e}[/red]")
+            raise
+
+    def _execute_resource_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        resource: ResourceConfig,
+        provider_name: str,
+    ) -> None:
+        """Execute resource-level hooks for a lifecycle stage."""
+        if not self._hook_manager or not resource.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_resource_hooks(
+                env_name=env_name,
+                stage=stage,
+                resource_name=resource.name,
+                provider_name=provider_name,
+                hooks_config=resource.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed for {resource.name}: {e}[/red]")
+            raise
 
 
 class RollbackOrchestrator:
@@ -607,6 +673,8 @@ class ApplyOrchestrator:
             dict[str, Any],
         ],
         get_current_user: Callable[[], str],
+        hook_manager: HookManager | None = None,
+        load_environment: Callable[[str], EnvironmentConfig | None] | None = None,
     ) -> None:
         self.console = console
         self.state_manager = state_manager
@@ -615,6 +683,8 @@ class ApplyOrchestrator:
         self._apply_serial = apply_serial
         self._apply_parallel = apply_parallel
         self._get_current_user = get_current_user
+        self._hook_manager = hook_manager
+        self._load_environment = load_environment
 
     def apply(
         self,
@@ -644,10 +714,24 @@ class ApplyOrchestrator:
 
         results: dict[str, Any] = {}
 
+        # Load environment config for hooks
+        env_config = self._load_environment(env_name) if self._load_environment else None
+
         try:
             self._print_header("Applying", env_name, resource_filter, "bold green")
             all_resources, resources_by_provider = self._load_resources(env_name)
             self._store_rollback_snapshot(deployment_id, env_name, all_resources)
+
+            # Execute environment-level before_apply hooks
+            self._execute_env_hooks(env_name, "before_apply", env_config)
+
+            # Execute resource-level before_apply hooks
+            for resources in resources_by_provider.values():
+                for resource in resources:
+                    if not resource_filter or resource.name in resource_filter:
+                        self._execute_resource_hooks(
+                            env_name, "before_apply", resource, resource.provider
+                        )
 
             if parallel and len(resources_by_provider) > 1:
                 results = self._apply_parallel(
@@ -666,6 +750,17 @@ class ApplyOrchestrator:
                     resource_filter,
                     auto_approve,
                 )
+
+            # Execute resource-level after_apply hooks
+            for resources in resources_by_provider.values():
+                for resource in resources:
+                    if not resource_filter or resource.name in resource_filter:
+                        self._execute_resource_hooks(
+                            env_name, "after_apply", resource, resource.provider
+                        )
+
+            # Execute environment-level after_apply hooks
+            self._execute_env_hooks(env_name, "after_apply", env_config)
 
             self.state_manager.update_deployment_status(deployment_id, DeploymentStatus.COMPLETED)
             self.event_manager.emit_event(
@@ -716,6 +811,49 @@ class ApplyOrchestrator:
         else:
             self.console.print(f"\n[{style}]{label} infrastructure for: {env_name}[/{style}]")
 
+    def _execute_env_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        env_config: EnvironmentConfig | None,
+    ) -> None:
+        """Execute environment-level hooks for a lifecycle stage."""
+        if not self._hook_manager or not env_config or not env_config.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_environment_hooks(
+                env_name=env_name,
+                stage=stage,
+                hooks_config=env_config.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed: {e}[/red]")
+            raise
+
+    def _execute_resource_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        resource: ResourceConfig,
+        provider_name: str,
+    ) -> None:
+        """Execute resource-level hooks for a lifecycle stage."""
+        if not self._hook_manager or not resource.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_resource_hooks(
+                env_name=env_name,
+                stage=stage,
+                resource_name=resource.name,
+                provider_name=provider_name,
+                hooks_config=resource.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed for {resource.name}: {e}[/red]")
+            raise
+
 
 class DestroyOrchestrator:
     """Handle destroy operations with consistent tracking."""
@@ -734,6 +872,8 @@ class DestroyOrchestrator:
             [dict[str, list[ResourceConfig]], list[str] | None], list[ProviderResourceBatch]
         ],
         get_current_user: Callable[[], str],
+        hook_manager: HookManager | None = None,
+        load_environment: Callable[[str], EnvironmentConfig | None] | None = None,
     ) -> None:
         self.console = console
         self.state_manager = state_manager
@@ -743,6 +883,8 @@ class DestroyOrchestrator:
         self._load_resources = load_resources
         self._iter_provider_batches = iter_provider_batches
         self._get_current_user = get_current_user
+        self._hook_manager = hook_manager
+        self._load_environment = load_environment
 
         # Dynamically create all registered runners
         self.runners: dict[str, BaseRunner] = {}
@@ -778,6 +920,9 @@ class DestroyOrchestrator:
 
         results: dict[str, Any] = {}
 
+        # Load environment config for hooks
+        env_config = self._load_environment(env_name) if self._load_environment else None
+
         try:
             self._print_header("Destroying", env_name, resource_filter, "bold red")
 
@@ -807,6 +952,9 @@ class DestroyOrchestrator:
             _, resources_by_provider = self._load_resources(env_name)
             providers = self._get_providers()
 
+            # Execute environment-level before_destroy hooks
+            self._execute_env_hooks(env_name, "before_destroy", env_config)
+
             for batch in self._iter_provider_batches(resources_by_provider, resource_filter):
                 provider_name = batch.name
                 resources = batch.resources
@@ -816,6 +964,13 @@ class DestroyOrchestrator:
 
                 self.console.print(f"\n[bold]Destroying {provider_name}...[/bold]")
                 provider.set_environment(env_name)
+
+                # Execute resource-level before_destroy hooks
+                for resource in resources:
+                    self._execute_resource_hooks(
+                        env_name, "before_destroy", resource, provider_name
+                    )
+
                 resource_ids = self._track_destroying_resources(
                     deployment_id, env_name, provider_name, resources
                 )
@@ -833,7 +988,15 @@ class DestroyOrchestrator:
                     provider_results[tool_name] = runner_result
 
                 self._finalize_destroyed_resources(env_name, provider_name, resource_ids)
+
+                # Execute resource-level after_destroy hooks
+                for resource in resources:
+                    self._execute_resource_hooks(env_name, "after_destroy", resource, provider_name)
+
                 results[provider_name] = provider_results
+
+            # Execute environment-level after_destroy hooks
+            self._execute_env_hooks(env_name, "after_destroy", env_config)
 
             self.state_manager.update_deployment_status(deployment_id, DeploymentStatus.COMPLETED)
             self.event_manager.emit_event(
@@ -913,3 +1076,46 @@ class DestroyOrchestrator:
             )
         else:
             self.console.print(f"\n[{style}]{label} infrastructure for: {env_name}[/{style}]")
+
+    def _execute_env_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        env_config: EnvironmentConfig | None,
+    ) -> None:
+        """Execute environment-level hooks for a lifecycle stage."""
+        if not self._hook_manager or not env_config or not env_config.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_environment_hooks(
+                env_name=env_name,
+                stage=stage,
+                hooks_config=env_config.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed: {e}[/red]")
+            raise
+
+    def _execute_resource_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        resource: ResourceConfig,
+        provider_name: str,
+    ) -> None:
+        """Execute resource-level hooks for a lifecycle stage."""
+        if not self._hook_manager or not resource.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_resource_hooks(
+                env_name=env_name,
+                stage=stage,
+                resource_name=resource.name,
+                provider_name=provider_name,
+                hooks_config=resource.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed for {resource.name}: {e}[/red]")
+            raise

--- a/src/infrafoundry/core/provider.py
+++ b/src/infrafoundry/core/provider.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from infrafoundry.core.hooks.models import HooksConfig
 from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
 
@@ -17,6 +18,7 @@ class ResourceConfig(BaseModel):
     type: str
     provider: str
     config: dict[str, Any]
+    hooks: HooksConfig | None = None
 
 
 class ProviderBase(ABC):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 import yaml
+
+from infrafoundry.core.config import ConfigManager
 
 
 @pytest.fixture
@@ -12,6 +15,15 @@ def temp_dir():
     """Create a temporary directory for test files."""
     with tempfile.TemporaryDirectory() as tmpdir:
         yield Path(tmpdir)
+
+
+@pytest.fixture
+def mock_config_manager(temp_dir):
+    """Create a mock ConfigManager with required attributes for Orchestrator tests."""
+    config_manager = Mock(spec=ConfigManager)
+    config_manager.base_dir = temp_dir
+    config_manager.load_environment.return_value = None
+    return config_manager
 
 
 @pytest.fixture
@@ -161,6 +173,7 @@ def mock_config():
         resource.type = "vm"
         resource.name = f"web-0{i + 1}"
         resource.config = {"cores": 2, "memory": 4096}
+        resource.hooks = None  # No lifecycle hooks configured
         resources.append(resource)
 
     return {"environment": environment, "resources": resources}

--- a/tests/integration/test_orchestrator_workflows.py
+++ b/tests/integration/test_orchestrator_workflows.py
@@ -52,6 +52,7 @@ def orchestrator(tmp_path, mock_config, mock_providers):
     # Create a mock environment config object
     env_config_mock = Mock()
     env_config_mock.runner_priorities = {}
+    env_config_mock.hooks = None  # No lifecycle hooks configured
     env_config_mock.model_dump.return_value = mock_config["environment"]
 
     config_manager.load_environment = Mock(return_value=env_config_mock)
@@ -585,6 +586,7 @@ class TestMultiProviderWorkflow:
         k8s_resource.type = "deployment"
         k8s_resource.name = "app-01"
         k8s_resource.config = {}
+        k8s_resource.hooks = None  # No lifecycle hooks configured
         mock_config["resources"].append(k8s_resource)
 
         with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
@@ -618,6 +620,7 @@ class TestMultiProviderWorkflow:
         k8s_resource.type = "deployment"
         k8s_resource.name = "app-01"
         k8s_resource.config = {}
+        k8s_resource.hooks = None  # No lifecycle hooks configured
         mock_config["resources"].append(k8s_resource)
 
         with (
@@ -664,6 +667,7 @@ class TestMultiProviderWorkflow:
         opn_resource.type = "firewall_rule"
         opn_resource.name = "rule-01"
         opn_resource.config = {}
+        opn_resource.hooks = None  # No lifecycle hooks configured
         mock_config["resources"].append(opn_resource)
 
         with patch(

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1,0 +1,558 @@
+"""Unit tests for lifecycle hooks."""
+
+import stat
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.hooks import (
+    HookConfig,
+    HookExecutionError,
+    HookManager,
+    HookResult,
+    HooksConfig,
+)
+from infrafoundry.core.secrets.secret_manager import SecretManager
+
+
+@pytest.fixture
+def temp_config_dir():
+    """Create a temporary config directory with env structure."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_dir = Path(tmpdir)
+        env_dir = config_dir / "envs" / "test-env"
+        scripts_dir = env_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        yield config_dir
+
+
+@pytest.fixture
+def executable_script(temp_config_dir):
+    """Create an executable script that prints environment variables."""
+    env_dir = temp_config_dir / "envs" / "test-env"
+    scripts_dir = env_dir / "scripts"
+    script_path = scripts_dir / "test-hook.sh"
+    script_path.write_text("""#!/bin/bash
+echo "ENV: $INFRAFOUNDRY_ENV"
+echo "CONFIG_DIR: $INFRAFOUNDRY_CONFIG_DIR"
+echo "EVENT: $INFRAFOUNDRY_EVENT"
+echo "CUSTOM_VAR: $CUSTOM_VAR"
+exit 0
+""")
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+    return script_path
+
+
+@pytest.fixture
+def failing_script(temp_config_dir):
+    """Create a script that exits with non-zero."""
+    env_dir = temp_config_dir / "envs" / "test-env"
+    scripts_dir = env_dir / "scripts"
+    script_path = scripts_dir / "failing-hook.sh"
+    script_path.write_text("""#!/bin/bash
+echo "About to fail"
+exit 1
+""")
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+    return script_path
+
+
+@pytest.fixture
+def timeout_script(temp_config_dir):
+    """Create a script that takes too long."""
+    env_dir = temp_config_dir / "envs" / "test-env"
+    scripts_dir = env_dir / "scripts"
+    script_path = scripts_dir / "timeout-hook.sh"
+    script_path.write_text("""#!/bin/bash
+sleep 10
+exit 0
+""")
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+    return script_path
+
+
+@pytest.fixture
+def mock_secret_manager_factory():
+    """Create a mock secret manager factory."""
+
+    def factory(env_name: str) -> SecretManager:
+        mock_manager = MagicMock(spec=SecretManager)
+        mock_manager.get_secret.return_value = "secret-value-from-manager"
+        return mock_manager
+
+    return factory
+
+
+class TestHookConfig:
+    """Tests for HookConfig model."""
+
+    def test_minimal_config(self):
+        """Test creating HookConfig with minimal fields."""
+        config = HookConfig(script="scripts/test.sh")
+        assert config.script == "scripts/test.sh"
+        assert config.description is None
+        assert config.env == {}
+        assert config.continue_on_error is False
+        assert config.timeout == 300
+
+    def test_full_config(self):
+        """Test creating HookConfig with all fields."""
+        config = HookConfig(
+            script="scripts/test.sh",
+            description="Test hook",
+            env={"KEY": "value"},
+            continue_on_error=True,
+            timeout=60,
+        )
+        assert config.script == "scripts/test.sh"
+        assert config.description == "Test hook"
+        assert config.env == {"KEY": "value"}
+        assert config.continue_on_error is True
+        assert config.timeout == 60
+
+    def test_timeout_validation_min(self):
+        """Test timeout minimum validation."""
+        with pytest.raises(ValueError):
+            HookConfig(script="test.sh", timeout=0)
+
+    def test_timeout_validation_max(self):
+        """Test timeout maximum validation."""
+        with pytest.raises(ValueError):
+            HookConfig(script="test.sh", timeout=3601)
+
+
+class TestHooksConfig:
+    """Tests for HooksConfig model."""
+
+    def test_empty_config(self):
+        """Test creating empty HooksConfig."""
+        config = HooksConfig()
+        assert config.before_plan == []
+        assert config.after_plan == []
+        assert config.before_apply == []
+        assert config.after_apply == []
+        assert config.before_destroy == []
+        assert config.after_destroy == []
+
+    def test_config_with_hooks(self):
+        """Test creating HooksConfig with hooks defined."""
+        hook = HookConfig(script="scripts/test.sh")
+        config = HooksConfig(
+            before_destroy=[hook],
+            after_apply=[hook],
+        )
+        assert len(config.before_destroy) == 1
+        assert len(config.after_apply) == 1
+        assert len(config.before_plan) == 0
+
+
+class TestHookResult:
+    """Tests for HookResult model."""
+
+    def test_successful_result(self):
+        """Test creating successful HookResult."""
+        result = HookResult(
+            script="test.sh",
+            success=True,
+            exit_code=0,
+            stdout="output",
+            stderr="",
+            duration_seconds=1.5,
+        )
+        assert result.success is True
+        assert result.exit_code == 0
+        assert result.timed_out is False
+        assert result.error_message is None
+
+    def test_failed_result(self):
+        """Test creating failed HookResult."""
+        result = HookResult(
+            script="test.sh",
+            success=False,
+            exit_code=1,
+            stdout="",
+            stderr="error",
+            duration_seconds=0.5,
+            error_message="Exit code: 1",
+        )
+        assert result.success is False
+        assert result.exit_code == 1
+
+    def test_timeout_result(self):
+        """Test creating timeout HookResult."""
+        result = HookResult(
+            script="test.sh",
+            success=False,
+            exit_code=-1,
+            stdout="",
+            stderr="",
+            duration_seconds=5.0,
+            timed_out=True,
+            error_message="Timeout after 5 seconds",
+        )
+        assert result.timed_out is True
+
+
+class TestHookManager:
+    """Tests for HookManager."""
+
+    def test_init(self, temp_config_dir, mock_secret_manager_factory):
+        """Test HookManager initialization."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        assert manager.config_base_dir == temp_config_dir
+
+    def test_execute_environment_hooks_empty(self, temp_config_dir, mock_secret_manager_factory):
+        """Test executing with no hooks defined."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=None,
+        )
+        assert results == []
+
+    def test_execute_environment_hooks_no_hooks_for_stage(
+        self, temp_config_dir, mock_secret_manager_factory
+    ):
+        """Test executing when no hooks defined for the stage."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hooks_config = HooksConfig(before_destroy=[HookConfig(script="scripts/test.sh")])
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",  # No hooks for this stage
+            hooks_config=hooks_config,
+        )
+        assert results == []
+
+    def test_execute_single_hook_success(
+        self, temp_config_dir, mock_secret_manager_factory, executable_script
+    ):
+        """Test successful hook execution."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(
+            script="scripts/test-hook.sh",
+            env={"CUSTOM_VAR": "custom-value"},
+        )
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].exit_code == 0
+        assert "ENV: test-env" in results[0].stdout
+        assert "CUSTOM_VAR: custom-value" in results[0].stdout
+
+    def test_execute_hook_script_not_found(self, temp_config_dir, mock_secret_manager_factory):
+        """Test hook execution when script doesn't exist."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(script="scripts/nonexistent.sh")
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        with pytest.raises(HookExecutionError) as exc_info:
+            manager.execute_environment_hooks(
+                env_name="test-env",
+                stage="before_plan",
+                hooks_config=hooks_config,
+            )
+
+        assert "Script not found" in str(exc_info.value)
+        assert exc_info.value.result.success is False
+
+    def test_execute_hook_failure_raises_error(
+        self, temp_config_dir, mock_secret_manager_factory, failing_script
+    ):
+        """Test that hook failure raises HookExecutionError."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(script="scripts/failing-hook.sh")
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        with pytest.raises(HookExecutionError) as exc_info:
+            manager.execute_environment_hooks(
+                env_name="test-env",
+                stage="before_plan",
+                hooks_config=hooks_config,
+            )
+
+        assert exc_info.value.result.success is False
+        assert exc_info.value.result.exit_code == 1
+
+    def test_execute_hook_failure_continue_on_error(
+        self, temp_config_dir, mock_secret_manager_factory, failing_script
+    ):
+        """Test that continue_on_error allows execution to proceed."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(
+            script="scripts/failing-hook.sh",
+            continue_on_error=True,
+        )
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        # Should not raise
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        assert len(results) == 1
+        assert results[0].success is False
+        assert results[0].exit_code == 1
+
+    def test_execute_hook_timeout(
+        self, temp_config_dir, mock_secret_manager_factory, timeout_script
+    ):
+        """Test hook timeout handling."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(
+            script="scripts/timeout-hook.sh",
+            timeout=1,  # 1 second timeout
+        )
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        with pytest.raises(HookExecutionError) as exc_info:
+            manager.execute_environment_hooks(
+                env_name="test-env",
+                stage="before_plan",
+                hooks_config=hooks_config,
+            )
+
+        assert exc_info.value.result.timed_out is True
+        assert "Timeout" in exc_info.value.result.error_message
+
+    def test_execute_resource_hooks(
+        self, temp_config_dir, mock_secret_manager_factory, executable_script
+    ):
+        """Test resource-level hook execution."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(script="scripts/test-hook.sh")
+        hooks_config = HooksConfig(before_destroy=[hook])
+
+        results = manager.execute_resource_hooks(
+            env_name="test-env",
+            stage="before_destroy",
+            resource_name="my-resource",
+            provider_name="oci",
+            hooks_config=hooks_config,
+        )
+
+        assert len(results) == 1
+        assert results[0].success is True
+
+    def test_environment_variables_injection(self, temp_config_dir, mock_secret_manager_factory):
+        """Test that environment variables are properly injected."""
+        env_dir = temp_config_dir / "envs" / "test-env" / "scripts"
+        script_path = env_dir / "check-env.sh"
+        script_path.write_text("""#!/bin/bash
+echo "INFRAFOUNDRY_ENV=$INFRAFOUNDRY_ENV"
+echo "INFRAFOUNDRY_CONFIG_DIR=$INFRAFOUNDRY_CONFIG_DIR"
+echo "INFRAFOUNDRY_EVENT=$INFRAFOUNDRY_EVENT"
+echo "INFRAFOUNDRY_RESOURCE=$INFRAFOUNDRY_RESOURCE"
+echo "INFRAFOUNDRY_PROVIDER=$INFRAFOUNDRY_PROVIDER"
+exit 0
+""")
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(script="scripts/check-env.sh")
+        hooks_config = HooksConfig(before_destroy=[hook])
+
+        results = manager.execute_resource_hooks(
+            env_name="test-env",
+            stage="before_destroy",
+            resource_name="my-vm",
+            provider_name="oci",
+            hooks_config=hooks_config,
+        )
+
+        stdout = results[0].stdout
+        assert "INFRAFOUNDRY_ENV=test-env" in stdout
+        assert "INFRAFOUNDRY_EVENT=before_destroy" in stdout
+        assert "INFRAFOUNDRY_RESOURCE=my-vm" in stdout
+        assert "INFRAFOUNDRY_PROVIDER=oci" in stdout
+
+    def test_secret_template_resolution(self, temp_config_dir, mock_secret_manager_factory):
+        """Test that {{ secrets.xxx }} templates are resolved."""
+        env_dir = temp_config_dir / "envs" / "test-env" / "scripts"
+        script_path = env_dir / "check-secret.sh"
+        script_path.write_text("""#!/bin/bash
+echo "SECRET=$MY_SECRET"
+exit 0
+""")
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(
+            script="scripts/check-secret.sh",
+            env={"MY_SECRET": "{{ secrets.myfile.api_key }}"},
+        )
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        assert results[0].success is True
+        assert "SECRET=secret-value-from-manager" in results[0].stdout
+
+    def test_secret_template_not_found(self, temp_config_dir):
+        """Test that missing secrets result in empty string with warning."""
+        env_dir = temp_config_dir / "envs" / "test-env" / "scripts"
+        script_path = env_dir / "check-secret.sh"
+        script_path.write_text("""#!/bin/bash
+echo "SECRET=$MY_SECRET"
+exit 0
+""")
+        script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+
+        def failing_factory(env_name: str) -> SecretManager:
+            mock_manager = MagicMock(spec=SecretManager)
+            mock_manager.get_secret.side_effect = FileNotFoundError("Secret file not found")
+            return mock_manager
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=failing_factory,
+        )
+        hook = HookConfig(
+            script="scripts/check-secret.sh",
+            env={"MY_SECRET": "{{ secrets.missing.key }}"},
+        )
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        # Should not raise - missing secrets become empty strings
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        assert results[0].success is True
+        assert "SECRET=" in results[0].stdout
+
+    def test_multiple_hooks_execution_order(self, temp_config_dir, mock_secret_manager_factory):
+        """Test that multiple hooks are executed in order."""
+        env_dir = temp_config_dir / "envs" / "test-env" / "scripts"
+
+        # Create scripts that append to a file
+        script1 = env_dir / "hook1.sh"
+        script1.write_text("""#!/bin/bash
+echo "hook1"
+exit 0
+""")
+        script1.chmod(script1.stat().st_mode | stat.S_IXUSR)
+
+        script2 = env_dir / "hook2.sh"
+        script2.write_text("""#!/bin/bash
+echo "hook2"
+exit 0
+""")
+        script2.chmod(script2.stat().st_mode | stat.S_IXUSR)
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hooks_config = HooksConfig(
+            before_plan=[
+                HookConfig(script="scripts/hook1.sh"),
+                HookConfig(script="scripts/hook2.sh"),
+            ]
+        )
+
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        assert len(results) == 2
+        assert results[0].success is True
+        assert "hook1" in results[0].stdout
+        assert results[1].success is True
+        assert "hook2" in results[1].stdout
+
+    def test_non_executable_script(self, temp_config_dir, mock_secret_manager_factory):
+        """Test that non-executable script fails properly."""
+        env_dir = temp_config_dir / "envs" / "test-env" / "scripts"
+        script_path = env_dir / "non-exec.sh"
+        script_path.write_text("""#!/bin/bash
+echo "test"
+exit 0
+""")
+        # Don't make it executable
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+        )
+        hook = HookConfig(script="scripts/non-exec.sh")
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        with pytest.raises(HookExecutionError) as exc_info:
+            manager.execute_environment_hooks(
+                env_name="test-env",
+                stage="before_plan",
+                hooks_config=hooks_config,
+            )
+
+        assert "not executable" in str(exc_info.value)
+
+
+class TestHookExecutionError:
+    """Tests for HookExecutionError."""
+
+    def test_error_with_result(self):
+        """Test HookExecutionError contains result."""
+        result = HookResult(
+            script="test.sh",
+            success=False,
+            exit_code=1,
+            stdout="",
+            stderr="error",
+            duration_seconds=0.5,
+        )
+        error = HookExecutionError("Hook failed", result)
+        assert error.result == result
+        assert "Hook failed" in str(error)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -24,6 +24,7 @@ class TestOrchestratorInit:
     def test_init_with_defaults(self, tmp_path):
         """Test initialization with default parameters."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
 
         orchestrator = Orchestrator(
             config_manager=config_manager,
@@ -40,6 +41,7 @@ class TestOrchestratorInit:
     def test_init_with_custom_output_dir(self, tmp_path):
         """Test initialization with custom output directory."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         output_dir = tmp_path / "custom_output"
 
         orchestrator = Orchestrator(
@@ -53,6 +55,7 @@ class TestOrchestratorInit:
     def test_init_with_custom_managers(self, tmp_path):
         """Test initialization with custom manager instances."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         state_manager = Mock(spec=StateManager)
         event_manager = Mock(spec=EventManager)
 
@@ -68,6 +71,7 @@ class TestOrchestratorInit:
     def test_init_creates_output_directory(self, tmp_path):
         """Test that initialization creates output directory if it doesn't exist."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         output_dir = tmp_path / "nested" / "output" / "dir"
 
         assert not output_dir.exists()
@@ -82,6 +86,7 @@ class TestOrchestratorInit:
     def test_init_sets_current_user(self, tmp_path):
         """Test that initialization captures current user from environment."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
 
         with patch.dict(os.environ, {"USER": "testuser"}):
             orchestrator = Orchestrator(
@@ -92,6 +97,7 @@ class TestOrchestratorInit:
     def test_init_fallback_user(self, tmp_path):
         """Test user fallback when USER env var not set."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
 
         # Clear USER and USERNAME
         env = os.environ.copy()
@@ -111,6 +117,7 @@ class TestOrchestratorNotifications:
     def test_setup_notifications_with_channels(self, tmp_path):
         """Test that notifications are set up when channels exist."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         event_manager = Mock(spec=EventManager)
 
         # Mock notification manager with channels
@@ -130,6 +137,7 @@ class TestOrchestratorNotifications:
     def test_setup_notifications_without_channels(self, tmp_path):
         """Test that notifications are skipped when no channels configured."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
 
         orchestrator = Orchestrator(
             config_manager=config_manager,
@@ -145,6 +153,7 @@ class TestOrchestratorProviderManagement:
     def test_register_provider(self, tmp_path):
         """Test registering a provider."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         provider = Mock(spec=ProviderBase)
@@ -158,6 +167,7 @@ class TestOrchestratorProviderManagement:
     def test_register_multiple_providers(self, tmp_path):
         """Test registering multiple providers."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         provider1 = Mock(spec=ProviderBase)
@@ -175,6 +185,7 @@ class TestOrchestratorProviderManagement:
     def test_register_provider_overwrites_existing(self, tmp_path):
         """Test that registering a provider with same name overwrites."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         provider1 = Mock(spec=ProviderBase)
@@ -190,6 +201,7 @@ class TestOrchestratorProviderManagement:
     def test_register_provider_applies_strict_snippet_flag(self, tmp_path):
         """Provider inherits strict snippet config when registered."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(
             config_manager,
             strict_config=OrchestratorStrictConfig(fail_on_missing_snippets=True),
@@ -209,6 +221,7 @@ class TestOrchestratorValidateResources:
     def test_validate_resources_all_valid(self, tmp_path):
         """Test validation succeeds when all resources are valid."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         # Register provider
@@ -234,6 +247,7 @@ class TestOrchestratorValidateResources:
     def test_validate_resources_provider_not_registered(self, tmp_path):
         """Test validation fails when provider not registered."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         resource = Mock()
@@ -247,6 +261,7 @@ class TestOrchestratorValidateResources:
     def test_validate_resources_type_not_supported(self, tmp_path):
         """Test validation fails when resource type not supported."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         provider = Mock(spec=ProviderBase)
@@ -268,6 +283,7 @@ class TestOrchestratorValidateResources:
     def test_validate_resources_empty_list(self, tmp_path):
         """Test validation succeeds with empty resource list."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         # Should not raise
@@ -280,6 +296,7 @@ class TestOrchestratorBuildDependencyGraph:
     def test_build_dependency_graph_basic(self, tmp_path):
         """Test building a basic dependency graph."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         # Register provider with dependencies
@@ -311,6 +328,7 @@ class TestOrchestratorBuildDependencyGraph:
     def test_build_dependency_graph_multi_provider(self, tmp_path):
         """Test building dependency graph with multiple providers."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         orchestrator = Orchestrator(config_manager)
 
         # Register multiple providers
@@ -352,6 +370,7 @@ class TestOrchestratorStatus:
     def test_status_no_resources(self, tmp_path, capsys):
         """Test status when no resources exist."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
         config_manager.get_all_resources_all_providers.return_value = []
 
         orchestrator = Orchestrator(config_manager)
@@ -364,6 +383,7 @@ class TestOrchestratorStatus:
     def test_status_with_resources(self, tmp_path):
         """Test status with resources."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
 
         # Mock resource
         vm = Mock()
@@ -388,6 +408,7 @@ class TestOrchestratorStatus:
     def test_status_with_unregistered_provider(self, tmp_path):
         """Test status with resource from unregistered provider."""
         config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
 
         # Mock resource from unregistered provider
         vm = Mock()


### PR DESCRIPTION
## Description

Add support for user-defined scripts that run at specific points during infrastructure operations (plan, apply, destroy). This enables integration with external systems like Tailscale, Slack, and custom validation tools.

**Key features:**
- **Two-level hooks:** Environment-level (settings.yaml) and resource-level (resource configs)
- **Six lifecycle stages:** before_plan, after_plan, before_apply, after_apply, before_destroy, after_destroy
- **Execution order:** Environment before_X → Resource before_X → [Operation] → Resource after_X → Environment after_X
- **Secret templating:** `{{ secrets.file.key }}` syntax for injecting secrets
- **Environment variables:** INFRAFOUNDRY_ENV, CONFIG_DIR, EVENT, RESOURCE, PROVIDER
- **Error handling:** continue_on_error option, configurable timeout (1-3600s)

## Related Issue

Closes #177

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Add `src/infrafoundry/core/hooks/` package with HookManager and Pydantic models
- Add `hooks` field to EnvironmentConfig for environment-level hooks
- Add `hooks` field to ResourceConfig for resource-level hooks
- Integrate hook execution into PlanOrchestrator, ApplyOrchestrator, DestroyOrchestrator
- Add ADR-0005 documenting the design decisions
- Add user documentation at `docs/configuration/lifecycle-hooks.md`
- Add example hook scripts for Tailscale cleanup and K3s verification
- Add comprehensive unit tests for hooks module

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Configuration Example

```yaml
# settings.yaml (environment-level)
hooks:
  before_destroy:
    - script: scripts/cleanup-tailscale.sh
      env:
        TAILSCALE_API_KEY: "{{ secrets.tailscale.api_key }}"
```

```yaml
# resource config (resource-level)
- name: k3s-control
  hooks:
    before_destroy:
      - script: scripts/cleanup-tailscale-device.sh
```
