### PR TITLE
feat: add configurable provider execution order per environment

### DIFF
--- a/src/infrafoundry/core/config/models.py
+++ b/src/infrafoundry/core/config/models.py
@@ -62,6 +62,9 @@ class EnvironmentConfig(BaseModel):
     provider_settings: dict[str, dict[str, Any]] = Field(default_factory=dict)
     # Override runner execution order: { "pyinfra": 40, "ansible": 60 }
     runner_priorities: dict[str, int] = Field(default_factory=dict)
+    # Override provider execution order: ["opnsense", "proxmox", "oci", "kubernetes"]
+    # Providers earlier in the list are applied first. Unlisted providers run last.
+    provider_order: list[str] = Field(default_factory=list)
     # Terraform backend configuration for state management and locking
     backend: BackendConfig | None = None
     # Drift remediation configuration for automated drift detection and remediation

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -1,6 +1,6 @@
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -18,6 +18,9 @@ from infrafoundry.core.types import ResourceEventData
 class DeploymentExecutor:
     """Executes infrastructure deployments across providers."""
 
+    # Default provider execution order when not configured
+    DEFAULT_PROVIDER_ORDER: ClassVar[list[str]] = ["opnsense", "proxmox", "oci", "kubernetes"]
+
     def __init__(
         self,
         runner_registry: RunnerRegistry,
@@ -26,6 +29,7 @@ class DeploymentExecutor:
         providers: dict[str, ProviderBase],
         console: Console | None = None,
         runner_priorities: dict[str, int] | None = None,
+        provider_order: list[str] | None = None,
     ) -> None:
         """Initialize deployment executor.
 
@@ -36,6 +40,7 @@ class DeploymentExecutor:
             providers: Dict of registered provider instances
             console: Rich console for output (creates default if None)
             runner_priorities: Optional dict mapping runner names to priorities
+            provider_order: Optional list defining provider execution order
         """
         self.runner_registry = runner_registry
         self.state_manager = state_manager
@@ -43,6 +48,7 @@ class DeploymentExecutor:
         self.providers = providers
         self.console = console or Console()
         self.runner_priorities = runner_priorities or {}
+        self.provider_order = provider_order or self.DEFAULT_PROVIDER_ORDER
 
         # Dynamically create all registered runners
         self.runners: dict[str, BaseRunner] = {}
@@ -73,6 +79,29 @@ class DeploymentExecutor:
 
         return sorted(self.runners.items(), key=get_priority)
 
+    def _get_sorted_providers(
+        self, resources_by_provider: dict[str, list[ResourceConfig]]
+    ) -> list[str]:
+        """Get providers sorted by configured execution order.
+
+        Providers are sorted by their position in provider_order.
+        Providers not in the order list are placed at the end.
+
+        Args:
+            resources_by_provider: Dict mapping provider names to resources
+
+        Returns:
+            List of provider names sorted by execution order.
+        """
+        order = self.provider_order
+
+        def get_order(provider: str) -> int:
+            if provider in order:
+                return order.index(provider)
+            return len(order)
+
+        return sorted(resources_by_provider.keys(), key=get_order)
+
     def apply_serial(
         self,
         env_name: str,
@@ -95,16 +124,8 @@ class DeploymentExecutor:
         """
         results = {}
 
-        # Define provider execution order
-        # Providers earlier in the list are applied first
-        # Infrastructure providers (network, compute) run before application providers (kubernetes)
-        provider_order = ["opnsense", "proxmox", "oci", "kubernetes"]
-
-        # Sort providers by defined order, putting undefined ones at the end
-        sorted_providers = sorted(
-            resources_by_provider.keys(),
-            key=lambda p: provider_order.index(p) if p in provider_order else len(provider_order),
-        )
+        # Sort providers by configured execution order
+        sorted_providers = self._get_sorted_providers(resources_by_provider)
 
         for provider_name in sorted_providers:
             if provider_name not in self.providers:

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -483,10 +483,12 @@ class Orchestrator:
         auto_approve: bool,
     ) -> dict[str, Any]:
         """Apply providers sequentially."""
-        # Load runner priorities from environment config
+        # Load runner/provider priorities from environment config
         env_config = self.config_manager.load_environment(env_name)
         if env_config:
             self.deployment_executor.runner_priorities = env_config.runner_priorities
+            if env_config.provider_order and isinstance(env_config.provider_order, list):
+                self.deployment_executor.provider_order = env_config.provider_order
 
         return self.deployment_executor.apply_serial(
             env_name, deployment_id, resources_by_provider, resource_filter, auto_approve
@@ -502,10 +504,12 @@ class Orchestrator:
         max_workers: int,
     ) -> dict[str, Any]:
         """Apply providers in parallel."""
-        # Load runner priorities from environment config
+        # Load runner/provider priorities from environment config
         env_config = self.config_manager.load_environment(env_name)
         if env_config:
             self.deployment_executor.runner_priorities = env_config.runner_priorities
+            if env_config.provider_order and isinstance(env_config.provider_order, list):
+                self.deployment_executor.provider_order = env_config.provider_order
 
         return self.deployment_executor.apply_parallel(
             env_name,

--- a/tests/unit/test_deployment_executor.py
+++ b/tests/unit/test_deployment_executor.py
@@ -491,3 +491,141 @@ def test_apply_single_provider_handles_multiple_resources():
     assert state_manager.track_resource.call_count == 3
     assert state_manager.update_resource_state.call_count == 3
     assert results["terraform"]["success"] is True
+
+
+def test_get_sorted_providers_uses_default_order():
+    """Provider sorting uses default order when not configured."""
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = []
+    state_manager = MagicMock()
+    event_manager = MagicMock()
+    providers = {}
+
+    executor = DeploymentExecutor(
+        runner_registry=runner_registry,
+        state_manager=state_manager,
+        event_manager=event_manager,
+        providers=providers,
+    )
+
+    # Verify default order is used
+    assert executor.provider_order == ["opnsense", "proxmox", "oci", "kubernetes"]
+
+    # Test sorting with default order
+    resources_by_provider = {
+        "kubernetes": [_resource("app", provider="kubernetes")],
+        "proxmox": [_resource("vm1", provider="proxmox")],
+        "opnsense": [_resource("fw1", provider="opnsense")],
+    }
+
+    sorted_providers = executor._get_sorted_providers(resources_by_provider)
+    assert sorted_providers == ["opnsense", "proxmox", "kubernetes"]
+
+
+def test_get_sorted_providers_uses_custom_order():
+    """Provider sorting respects custom order from config."""
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = []
+    state_manager = MagicMock()
+    event_manager = MagicMock()
+    providers = {}
+
+    # Custom order: proxmox first, then kubernetes, then opnsense
+    custom_order = ["proxmox", "kubernetes", "opnsense"]
+
+    executor = DeploymentExecutor(
+        runner_registry=runner_registry,
+        state_manager=state_manager,
+        event_manager=event_manager,
+        providers=providers,
+        provider_order=custom_order,
+    )
+
+    resources_by_provider = {
+        "kubernetes": [_resource("app", provider="kubernetes")],
+        "proxmox": [_resource("vm1", provider="proxmox")],
+        "opnsense": [_resource("fw1", provider="opnsense")],
+    }
+
+    sorted_providers = executor._get_sorted_providers(resources_by_provider)
+    assert sorted_providers == ["proxmox", "kubernetes", "opnsense"]
+
+
+def test_get_sorted_providers_puts_unknown_providers_last():
+    """Providers not in order list are placed at the end."""
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = []
+    state_manager = MagicMock()
+    event_manager = MagicMock()
+    providers = {}
+
+    # Custom order that doesn't include "cloudflare"
+    custom_order = ["opnsense", "proxmox"]
+
+    executor = DeploymentExecutor(
+        runner_registry=runner_registry,
+        state_manager=state_manager,
+        event_manager=event_manager,
+        providers=providers,
+        provider_order=custom_order,
+    )
+
+    resources_by_provider = {
+        "cloudflare": [_resource("dns", provider="cloudflare")],
+        "proxmox": [_resource("vm1", provider="proxmox")],
+        "opnsense": [_resource("fw1", provider="opnsense")],
+    }
+
+    sorted_providers = executor._get_sorted_providers(resources_by_provider)
+    # cloudflare should be last since it's not in the order list
+    assert sorted_providers == ["opnsense", "proxmox", "cloudflare"]
+
+
+def test_apply_serial_uses_custom_provider_order():
+    """Serial apply honors custom provider order from config."""
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = ["terraform"]
+    tf_runner = MagicMock()
+    tf_runner.priority = 0
+    tf_runner.apply = MagicMock(return_value={"success": True})
+    tf_runner.plan = MagicMock()
+    tf_runner.destroy = MagicMock()
+    tf_runner.get_resource_ids = MagicMock(return_value={})
+    runner_registry.create_runner.return_value = tf_runner
+
+    state_manager = MagicMock()
+    state_manager.track_resource.side_effect = [
+        MagicMock(id=1, terraform_id=None),
+        MagicMock(id=2, terraform_id=None),
+    ]
+    event_manager = MagicMock()
+
+    providers = {
+        "opnsense": MagicMock(),
+        "proxmox": MagicMock(),
+    }
+
+    resources_by_provider = {
+        "opnsense": [_resource("fw", provider="opnsense")],
+        "proxmox": [_resource("vm1", provider="proxmox")],
+    }
+
+    # Custom order: proxmox first, then opnsense (reversed from default)
+    executor = DeploymentExecutor(
+        runner_registry=runner_registry,
+        state_manager=state_manager,
+        event_manager=event_manager,
+        providers=providers,
+        provider_order=["proxmox", "opnsense"],
+    )
+
+    results = executor.apply_serial(
+        env_name="dev",
+        deployment_id=10,
+        resources_by_provider=resources_by_provider,
+        resource_filter=None,
+        auto_approve=True,
+    )
+
+    # Provider order should be proxmox first, then opnsense
+    assert list(results.keys()) == ["proxmox", "opnsense"]


### PR DESCRIPTION
## Description

Allow provider execution order to be configured per environment in settings.yaml via the `provider_order` field. This replaces the hardcoded order in deployment_executor.py with a configurable list that falls back to a sensible default when not specified.

## Related Issue

Closes #193

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `provider_order: list[str]` field to `EnvironmentConfig` model
- Add `DEFAULT_PROVIDER_ORDER` class constant to `DeploymentExecutor`
- Add `_get_sorted_providers()` method following the existing `_get_sorted_runners()` pattern
- Update orchestrator to pass `provider_order` from environment config
- Providers not in the configured order are placed at the end

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Added 4 new tests:
- `test_get_sorted_providers_uses_default_order`
- `test_get_sorted_providers_uses_custom_order`
- `test_get_sorted_providers_puts_unknown_providers_last`
- `test_apply_serial_uses_custom_provider_order`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Usage in `settings.yaml`:
```yaml
name: prod
provider_order:
  - opnsense
  - proxmox
  - oci
  - kubernetes
```