### PR TITLE
fix: operation ordering bugs - destroy order, parallel apply, provider order

### DIFF
--- a/src/infrafoundry/core/config/models.py
+++ b/src/infrafoundry/core/config/models.py
@@ -62,6 +62,10 @@ class EnvironmentConfig(BaseModel):
     provider_settings: dict[str, dict[str, Any]] = Field(default_factory=dict)
     # Override runner execution order: { "pyinfra": 40, "ansible": 60 }
     runner_priorities: dict[str, int] = Field(default_factory=dict)
+    # Override provider execution order: ["opnsense", "proxmox", "oci", "kubernetes"]
+    # Providers earlier in the list are applied first. Unlisted providers run last.
+    # For destroy operations, the order is automatically reversed.
+    provider_order: list[str] = Field(default_factory=list)
     # Terraform backend configuration for state management and locking
     backend: BackendConfig | None = None
     # Drift remediation configuration for automated drift detection and remediation

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -7,6 +7,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from infrafoundry.core.events import EventManager, EventType
 from infrafoundry.core.exceptions import InfraFoundryError
+from infrafoundry.core.execution_planner import ExecutionPlanner
 from infrafoundry.core.protocols import Applyable, StateAware
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.runners import RunnerRegistry
@@ -26,6 +27,7 @@ class DeploymentExecutor:
         providers: dict[str, ProviderBase],
         console: Console | None = None,
         runner_priorities: dict[str, int] | None = None,
+        provider_order: list[str] | None = None,
     ) -> None:
         """Initialize deployment executor.
 
@@ -36,6 +38,8 @@ class DeploymentExecutor:
             providers: Dict of registered provider instances
             console: Rich console for output (creates default if None)
             runner_priorities: Optional dict mapping runner names to priorities
+            provider_order: Optional list defining provider execution order.
+                           Providers earlier in the list are executed first.
         """
         self.runner_registry = runner_registry
         self.state_manager = state_manager
@@ -43,6 +47,10 @@ class DeploymentExecutor:
         self.providers = providers
         self.console = console or Console()
         self.runner_priorities = runner_priorities or {}
+        self.provider_order = provider_order
+
+        # Create execution planner with configured provider order
+        self.execution_planner = ExecutionPlanner(provider_order=provider_order)
 
         # Dynamically create all registered runners
         self.runners: dict[str, BaseRunner] = {}
@@ -95,15 +103,9 @@ class DeploymentExecutor:
         """
         results = {}
 
-        # Define provider execution order
-        # Providers earlier in the list are applied first
-        # Infrastructure providers (network, compute) run before application providers (kubernetes)
-        provider_order = ["opnsense", "proxmox", "oci", "kubernetes"]
-
-        # Sort providers by defined order, putting undefined ones at the end
-        sorted_providers = sorted(
-            resources_by_provider.keys(),
-            key=lambda p: provider_order.index(p) if p in provider_order else len(provider_order),
+        # Sort providers using execution planner (forward order for apply)
+        sorted_providers = self.execution_planner.sort_providers(
+            list(resources_by_provider.keys()), reverse=False
         )
 
         for provider_name in sorted_providers:
@@ -147,7 +149,11 @@ class DeploymentExecutor:
         auto_approve: bool,
         max_workers: int,
     ) -> dict[str, Any]:
-        """Apply providers in parallel.
+        """Apply providers in parallel, respecting provider execution order.
+
+        Providers are processed in batches based on their execution order.
+        Providers within the same batch can run in parallel, but batches
+        are processed sequentially to respect provider dependencies.
 
         Args:
             env_name: Environment name
@@ -160,67 +166,90 @@ class DeploymentExecutor:
         Returns:
             Dict with apply results per provider
         """
-        results = {}
+        results: dict[str, Any] = {}
+
+        # Get execution batches from planner (forward order for apply)
+        batches = self.execution_planner.plan_apply(resources_by_provider)
+
+        total_providers = sum(len(batch.providers) for batch in batches)
         self.console.print(
-            f"\n[bold cyan]Applying {len(resources_by_provider)} providers in parallel "
-            f"(max {max_workers} workers)...[/bold cyan]"
+            f"\n[bold cyan]Applying {total_providers} providers in {len(batches)} batch(es) "
+            f"(max {max_workers} workers per batch)...[/bold cyan]"
         )
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit all provider apply tasks
-            future_to_provider = {}
-            for provider_name, resources in resources_by_provider.items():
+        # Process each batch sequentially
+        for batch_idx, batch in enumerate(batches, 1):
+            batch_providers = []
+
+            # Filter to providers we have registered and have matching resources
+            for provider_name in batch.providers:
                 if provider_name not in self.providers:
                     continue
 
-                provider = self.providers[provider_name]
+                resources = batch.resources_by_provider.get(provider_name, [])
 
-                # Set environment for provider to ensure correct output directory
-                provider.set_environment(env_name)
-
-                # Check if any resources match filter for this provider
+                # Apply resource filter
                 if resource_filter:
                     resources = [r for r in resources if r.name in resource_filter]
                     if not resources:
-                        continue  # Skip provider if no matching resources
+                        continue
 
-                future = executor.submit(
-                    self.apply_single_provider,
-                    env_name=env_name,
-                    deployment_id=deployment_id,
-                    provider_name=provider_name,
-                    provider=provider,
-                    resources=resources,
-                    auto_approve=auto_approve,
-                )
-                future_to_provider[future] = provider_name
+                batch_providers.append((provider_name, resources))
 
-            # Collect results as they complete
-            with Progress(
-                SpinnerColumn(), TextColumn("[progress.description]{task.description}")
-            ) as progress:
-                task = progress.add_task(
-                    "[cyan]Applying providers...", total=len(future_to_provider)
+            if not batch_providers:
+                continue
+
+            if len(batches) > 1:
+                self.console.print(
+                    f"\n[dim]Batch {batch_idx}/{len(batches)}: "
+                    f"{', '.join(p[0] for p in batch_providers)}[/dim]"
                 )
 
-                for future in as_completed(future_to_provider):
-                    provider_name = future_to_provider[future]
-                    try:
-                        result = future.result()
-                        results[provider_name] = result
-                        self.console.print(f"[green]✓ {provider_name} completed[/green]")
-                    except InfraFoundryError as e:
-                        self.console.print(f"[red]✗ {provider_name} failed: {e.message}[/red]")
-                        if e.context:
-                            self.console.print(f"  Context: {e.context}", style="dim red")
-                        results[provider_name] = {"error": str(e)}
-                    except Exception as e:
-                        self.console.print(f"[red]✗ {provider_name} failed (unexpected): {e}[/red]")
-                        self.console.print(
-                            traceback.format_exc(), style="dim red"
-                        )  # Log full traceback
-                        results[provider_name] = {"error": str(e)}
-                    progress.update(task, advance=1)
+            # Run providers in this batch in parallel
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_to_provider: dict[Any, str] = {}
+
+                for provider_name, resources in batch_providers:
+                    provider = self.providers[provider_name]
+                    provider.set_environment(env_name)
+
+                    future = executor.submit(
+                        self.apply_single_provider,
+                        env_name=env_name,
+                        deployment_id=deployment_id,
+                        provider_name=provider_name,
+                        provider=provider,
+                        resources=resources,
+                        auto_approve=auto_approve,
+                    )
+                    future_to_provider[future] = provider_name
+
+                # Collect results as they complete
+                with Progress(
+                    SpinnerColumn(), TextColumn("[progress.description]{task.description}")
+                ) as progress:
+                    task = progress.add_task(
+                        "[cyan]Applying providers...", total=len(future_to_provider)
+                    )
+
+                    for future in as_completed(future_to_provider):
+                        provider_name = future_to_provider[future]
+                        try:
+                            result = future.result()
+                            results[provider_name] = result
+                            self.console.print(f"[green]✓ {provider_name} completed[/green]")
+                        except InfraFoundryError as e:
+                            self.console.print(f"[red]✗ {provider_name} failed: {e.message}[/red]")
+                            if e.context:
+                                self.console.print(f"  Context: {e.context}", style="dim red")
+                            results[provider_name] = {"error": str(e)}
+                        except Exception as e:
+                            self.console.print(
+                                f"[red]✗ {provider_name} failed (unexpected): {e}[/red]"
+                            )
+                            self.console.print(traceback.format_exc(), style="dim red")
+                            results[provider_name] = {"error": str(e)}
+                        progress.update(task, advance=1)
 
         return results
 

--- a/src/infrafoundry/core/execution_planner.py
+++ b/src/infrafoundry/core/execution_planner.py
@@ -1,0 +1,260 @@
+"""Execution planner for infrastructure operations.
+
+This module bridges the dependency graph to actual execution order,
+ensuring providers and resources are processed in the correct order
+for create, apply, and destroy operations.
+"""
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from infrafoundry.core.dependencies import DependencyGraph
+from infrafoundry.core.provider import ResourceConfig
+
+
+@dataclass
+class ProviderBatch:
+    """A batch of providers that can be processed together.
+
+    Providers in the same batch have no dependencies between them
+    and can be executed in parallel.
+    """
+
+    providers: list[str]
+    resources_by_provider: dict[str, list[ResourceConfig]]
+
+    def __len__(self) -> int:
+        return len(self.providers)
+
+
+class ExecutionPlanner:
+    """Plans execution order for infrastructure operations.
+
+    Bridges the dependency graph to actual execution by:
+    - Computing provider batches for create/apply operations
+    - Computing reverse batches for destroy operations
+    - Respecting cross-provider dependencies
+    - Falling back to configured or default provider order
+    """
+
+    # Default provider execution order when not configured
+    DEFAULT_PROVIDER_ORDER: ClassVar[list[str]] = ["opnsense", "proxmox", "oci", "kubernetes"]
+
+    def __init__(
+        self,
+        provider_order: list[str] | None = None,
+        dependency_graph: DependencyGraph | None = None,
+    ) -> None:
+        """Initialize execution planner.
+
+        Args:
+            provider_order: Optional list defining provider execution order.
+                           Providers earlier in the list are executed first.
+                           Unlisted providers run after listed ones.
+            dependency_graph: Optional dependency graph for cross-provider deps.
+        """
+        self.provider_order = provider_order or self.DEFAULT_PROVIDER_ORDER
+        self.dependency_graph = dependency_graph
+
+    def get_provider_order_key(self, provider: str) -> int:
+        """Get sort key for a provider based on configured order.
+
+        Args:
+            provider: Provider name
+
+        Returns:
+            Integer sort key (lower = earlier in execution)
+        """
+        if provider in self.provider_order:
+            return self.provider_order.index(provider)
+        # Unlisted providers go after listed ones
+        return len(self.provider_order)
+
+    def sort_providers(self, providers: list[str], reverse: bool = False) -> list[str]:
+        """Sort providers by configured execution order.
+
+        Args:
+            providers: List of provider names to sort
+            reverse: If True, sort in reverse order (for destroy)
+
+        Returns:
+            Sorted list of provider names
+        """
+        return sorted(providers, key=self.get_provider_order_key, reverse=reverse)
+
+    def plan_apply(
+        self,
+        resources_by_provider: dict[str, list[ResourceConfig]],
+    ) -> list[ProviderBatch]:
+        """Plan execution batches for apply operation.
+
+        For apply, providers are processed in forward order:
+        infrastructure providers (opnsense, proxmox) before
+        application providers (kubernetes).
+
+        Args:
+            resources_by_provider: Dict mapping provider names to resources
+
+        Returns:
+            List of ProviderBatch objects in execution order.
+            Each batch contains providers that can run in parallel.
+        """
+        return self._plan_batches(resources_by_provider, reverse=False)
+
+    def plan_destroy(
+        self,
+        resources_by_provider: dict[str, list[ResourceConfig]],
+    ) -> list[ProviderBatch]:
+        """Plan execution batches for destroy operation.
+
+        For destroy, providers are processed in REVERSE order:
+        application providers (kubernetes) before
+        infrastructure providers (proxmox, opnsense).
+
+        Args:
+            resources_by_provider: Dict mapping provider names to resources
+
+        Returns:
+            List of ProviderBatch objects in execution order.
+            Each batch contains providers that can run in parallel.
+        """
+        return self._plan_batches(resources_by_provider, reverse=True)
+
+    def _plan_batches(
+        self,
+        resources_by_provider: dict[str, list[ResourceConfig]],
+        reverse: bool = False,
+    ) -> list[ProviderBatch]:
+        """Plan execution batches with optional reverse ordering.
+
+        Args:
+            resources_by_provider: Dict mapping provider names to resources
+            reverse: If True, use reverse order (for destroy)
+
+        Returns:
+            List of ProviderBatch objects in execution order.
+        """
+        if not resources_by_provider:
+            return []
+
+        # If we have a dependency graph with cross-provider deps, use it
+        if self.dependency_graph and self._has_cross_provider_deps():
+            return self._plan_batches_from_graph(resources_by_provider, reverse)
+
+        # Otherwise, process providers one at a time in order
+        sorted_providers = self.sort_providers(list(resources_by_provider.keys()), reverse=reverse)
+
+        batches = []
+        for provider in sorted_providers:
+            resources = resources_by_provider.get(provider, [])
+            if resources:
+                batches.append(
+                    ProviderBatch(
+                        providers=[provider],
+                        resources_by_provider={provider: resources},
+                    )
+                )
+
+        return batches
+
+    def _has_cross_provider_deps(self) -> bool:
+        """Check if dependency graph has cross-provider dependencies.
+
+        Returns:
+            True if any resources depend on resources from other providers.
+        """
+        if not self.dependency_graph:
+            return False
+
+        for full_name, deps in self.dependency_graph._adjacency.items():
+            source_provider = full_name.split(":")[0]
+            for dep in deps:
+                dep_provider = dep.split(":")[0]
+                if source_provider != dep_provider:
+                    return True
+        return False
+
+    def _plan_batches_from_graph(
+        self,
+        resources_by_provider: dict[str, list[ResourceConfig]],
+        reverse: bool = False,
+    ) -> list[ProviderBatch]:
+        """Plan batches using dependency graph for cross-provider deps.
+
+        Args:
+            resources_by_provider: Dict mapping provider names to resources
+            reverse: If True, reverse the batch order (for destroy)
+
+        Returns:
+            List of ProviderBatch objects respecting cross-provider deps.
+        """
+        if not self.dependency_graph:
+            return self._plan_batches(resources_by_provider, reverse)
+
+        # Get resource batches from topological sort
+        resource_batches = self.dependency_graph.topological_sort()
+
+        if reverse:
+            resource_batches = list(reversed(resource_batches))
+
+        # Convert resource batches to provider batches
+        provider_batches: list[ProviderBatch] = []
+
+        for resource_batch in resource_batches:
+            # Group resources in this batch by provider
+            batch_by_provider: dict[str, list[ResourceConfig]] = {}
+
+            for full_name in resource_batch:
+                provider, resource_name = full_name.split(":", 1)
+
+                # Find the matching resource config
+                provider_resources = resources_by_provider.get(provider, [])
+                for resource in provider_resources:
+                    if resource.name == resource_name:
+                        if provider not in batch_by_provider:
+                            batch_by_provider[provider] = []
+                        batch_by_provider[provider].append(resource)
+                        break
+
+            if batch_by_provider:
+                provider_batches.append(
+                    ProviderBatch(
+                        providers=list(batch_by_provider.keys()),
+                        resources_by_provider=batch_by_provider,
+                    )
+                )
+
+        return provider_batches
+
+    def get_execution_summary(
+        self,
+        batches: list[ProviderBatch],
+    ) -> dict[str, Any]:
+        """Get a summary of the execution plan.
+
+        Args:
+            batches: List of provider batches
+
+        Returns:
+            Dict with execution plan summary
+        """
+        total_providers = set()
+        total_resources = 0
+
+        for batch in batches:
+            total_providers.update(batch.providers)
+            for resources in batch.resources_by_provider.values():
+                total_resources += len(resources)
+
+        return {
+            "total_batches": len(batches),
+            "total_providers": len(total_providers),
+            "total_resources": total_resources,
+            "batches": [
+                {
+                    "providers": batch.providers,
+                    "resources": sum(len(r) for r in batch.resources_by_provider.values()),
+                }
+                for batch in batches
+            ],
+        }

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -13,6 +13,7 @@ from infrafoundry.core.dependencies import DependencyGraph
 from infrafoundry.core.deployment_executor import DeploymentExecutor
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import Event, EventManager, EventType
+from infrafoundry.core.execution_planner import ExecutionPlanner
 from infrafoundry.core.hooks import HookManager
 from infrafoundry.core.notifications import NotificationManager
 from infrafoundry.core.orchestrator_workflows import (
@@ -255,14 +256,57 @@ class Orchestrator:
             resources_by_provider.setdefault(resource.provider, []).append(resource)
         return all_resources, resources_by_provider
 
+    def _create_execution_planner(self, env_name: str) -> ExecutionPlanner:
+        """Create an execution planner for an environment.
+
+        Args:
+            env_name: Environment name
+
+        Returns:
+            ExecutionPlanner configured with environment's provider order
+        """
+        env_config = self.config_manager.load_environment(env_name)
+        provider_order = None
+        if env_config and env_config.provider_order:
+            provider_order = env_config.provider_order
+
+        # Optionally include dependency graph for cross-provider deps
+        dependency_graph = self.build_dependency_graph(env_name)
+
+        return ExecutionPlanner(
+            provider_order=provider_order,
+            dependency_graph=dependency_graph,
+        )
+
     def _iter_provider_batches(
         self,
         resources_by_provider: dict[str, list[ResourceConfig]],
         resource_filter: list[str] | None,
+        reverse: bool = False,
+        env_name: str | None = None,
     ) -> list[ProviderResourceBatch]:
-        """Yield provider batches applying an optional resource name filter."""
+        """Yield provider batches applying an optional resource name filter.
+
+        Args:
+            resources_by_provider: Dict mapping provider names to resources
+            resource_filter: Optional list of resource names to filter by
+            reverse: If True, return batches in reverse order (for destroy)
+            env_name: Optional environment name for loading provider order config
+
+        Returns:
+            List of ProviderResourceBatch in execution order
+        """
+        # Create execution planner with environment config
+        planner = self._create_execution_planner(env_name) if env_name else ExecutionPlanner()
+
+        # Get sorted provider order
+        sorted_providers = planner.sort_providers(
+            list(resources_by_provider.keys()), reverse=reverse
+        )
+
         batches: list[ProviderResourceBatch] = []
-        for provider_name, resources in resources_by_provider.items():
+        for provider_name in sorted_providers:
+            resources = resources_by_provider.get(provider_name, [])
             original_count = len(resources)
             filtered_resources = resources
             if resource_filter:
@@ -483,10 +527,15 @@ class Orchestrator:
         auto_approve: bool,
     ) -> dict[str, Any]:
         """Apply providers sequentially."""
-        # Load runner priorities from environment config
+        # Load runner priorities and provider order from environment config
         env_config = self.config_manager.load_environment(env_name)
         if env_config:
             self.deployment_executor.runner_priorities = env_config.runner_priorities
+            # Update execution planner with environment-specific provider order
+            self.deployment_executor.provider_order = env_config.provider_order or None
+            self.deployment_executor.execution_planner = ExecutionPlanner(
+                provider_order=env_config.provider_order or None
+            )
 
         return self.deployment_executor.apply_serial(
             env_name, deployment_id, resources_by_provider, resource_filter, auto_approve
@@ -502,10 +551,15 @@ class Orchestrator:
         max_workers: int,
     ) -> dict[str, Any]:
         """Apply providers in parallel."""
-        # Load runner priorities from environment config
+        # Load runner priorities and provider order from environment config
         env_config = self.config_manager.load_environment(env_name)
         if env_config:
             self.deployment_executor.runner_priorities = env_config.runner_priorities
+            # Update execution planner with environment-specific provider order
+            self.deployment_executor.provider_order = env_config.provider_order or None
+            self.deployment_executor.execution_planner = ExecutionPlanner(
+                provider_order=env_config.provider_order or None
+            )
 
         return self.deployment_executor.apply_parallel(
             env_name,

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -113,7 +113,8 @@ class ValidationOrchestrator:
             [str], tuple[list[ResourceConfig], dict[str, list[ResourceConfig]]]
         ],
         iter_provider_batches: Callable[
-            [dict[str, list[ResourceConfig]], list[str] | None], list[ProviderResourceBatch]
+            [dict[str, list[ResourceConfig]], list[str] | None, bool, str | None],
+            list[ProviderResourceBatch],
         ],
     ) -> None:
         self.config_manager = config_manager
@@ -149,7 +150,10 @@ class ValidationOrchestrator:
         results: dict[str, Any] = {}
 
         providers = self._get_providers()
-        for batch in self._iter_provider_batches(resources_by_provider, resource_filter):
+        # Use forward order for validation (same as apply)
+        for batch in self._iter_provider_batches(
+            resources_by_provider, resource_filter, False, env_name
+        ):
             provider_name = batch.name
             resources = batch.resources
             provider = providers.get(provider_name)
@@ -268,7 +272,8 @@ class PlanOrchestrator:
             [str], tuple[list[ResourceConfig], dict[str, list[ResourceConfig]]]
         ],
         iter_provider_batches: Callable[
-            [dict[str, list[ResourceConfig]], list[str] | None], list[ProviderResourceBatch]
+            [dict[str, list[ResourceConfig]], list[str] | None, bool, str | None],
+            list[ProviderResourceBatch],
         ],
         validate_resources: Callable[[list[ResourceConfig]], None],
         has_policies: Callable[[], bool],
@@ -352,7 +357,10 @@ class PlanOrchestrator:
             self._execute_env_hooks(env_name, "before_plan", env_config)
 
             providers = self._get_providers()
-            for batch in self._iter_provider_batches(resources_by_provider, resource_filter):
+            # Use forward order for plan (same as apply)
+            for batch in self._iter_provider_batches(
+                resources_by_provider, resource_filter, False, env_name
+            ):
                 provider_name = batch.name
                 provider_resources = batch.resources
                 provider = providers.get(provider_name)
@@ -869,7 +877,8 @@ class DestroyOrchestrator:
             [str], tuple[list[ResourceConfig], dict[str, list[ResourceConfig]]]
         ],
         iter_provider_batches: Callable[
-            [dict[str, list[ResourceConfig]], list[str] | None], list[ProviderResourceBatch]
+            [dict[str, list[ResourceConfig]], list[str] | None, bool, str | None],
+            list[ProviderResourceBatch],
         ],
         get_current_user: Callable[[], str],
         hook_manager: HookManager | None = None,
@@ -955,7 +964,11 @@ class DestroyOrchestrator:
             # Execute environment-level before_destroy hooks
             self._execute_env_hooks(env_name, "before_destroy", env_config)
 
-            for batch in self._iter_provider_batches(resources_by_provider, resource_filter):
+            # Use REVERSE order for destroy - application providers (kubernetes) before
+            # infrastructure providers (proxmox, opnsense)
+            for batch in self._iter_provider_batches(
+                resources_by_provider, resource_filter, True, env_name
+            ):
                 provider_name = batch.name
                 resources = batch.resources
                 provider = providers.get(provider_name)

--- a/tests/integration/test_orchestrator_workflows.py
+++ b/tests/integration/test_orchestrator_workflows.py
@@ -26,6 +26,7 @@ def mock_providers(tmp_path):
     proxmox.generate_ansible = Mock()
     proxmox.validate_config = Mock()
     proxmox.get_resource_types = Mock(return_value=["vm", "network", "template"])
+    proxmox.get_dependencies = Mock(return_value={})  # No dependencies defined
 
     return {"proxmox": proxmox}
 
@@ -53,6 +54,7 @@ def orchestrator(tmp_path, mock_config, mock_providers):
     env_config_mock = Mock()
     env_config_mock.runner_priorities = {}
     env_config_mock.hooks = None  # No lifecycle hooks configured
+    env_config_mock.provider_order = []  # Use default provider order
     env_config_mock.model_dump.return_value = mock_config["environment"]
 
     config_manager.load_environment = Mock(return_value=env_config_mock)
@@ -577,6 +579,7 @@ class TestMultiProviderWorkflow:
         kubernetes.generate_terraform = Mock()
         kubernetes.generate_ansible = Mock()
         kubernetes.get_resource_types = Mock(return_value=["deployment", "service"])
+        kubernetes.get_dependencies = Mock(return_value={})
         mock_providers["kubernetes"] = kubernetes
         orchestrator.providers = mock_providers
 
@@ -611,6 +614,7 @@ class TestMultiProviderWorkflow:
         kubernetes.generate_terraform = Mock()
         kubernetes.generate_ansible = Mock()
         kubernetes.get_resource_types = Mock(return_value=["deployment", "service"])
+        kubernetes.get_dependencies = Mock(return_value={})
         mock_providers["kubernetes"] = kubernetes
         orchestrator.providers = mock_providers
 
@@ -658,6 +662,8 @@ class TestMultiProviderWorkflow:
         opnsense.ensure_directories = Mock()
         opnsense.generate_terraform = Mock()
         opnsense.generate_ansible = Mock()
+        opnsense.get_resource_types = Mock(return_value=["rule", "alias"])
+        opnsense.get_dependencies = Mock(return_value={})
         mock_providers["opnsense"] = opnsense
         orchestrator.providers = mock_providers
 

--- a/tests/unit/test_execution_planner.py
+++ b/tests/unit/test_execution_planner.py
@@ -1,0 +1,182 @@
+"""Tests for the ExecutionPlanner service."""
+
+from infrafoundry.core.dependencies import DependencyGraph
+from infrafoundry.core.execution_planner import ExecutionPlanner, ProviderBatch
+from infrafoundry.core.provider import ResourceConfig
+
+
+def make_resource(provider: str, name: str, rtype: str = "vm") -> ResourceConfig:
+    """Create a test ResourceConfig."""
+    return ResourceConfig(
+        provider=provider,
+        type=rtype,
+        name=name,
+        config={},
+    )
+
+
+class TestExecutionPlannerInit:
+    """Test ExecutionPlanner initialization."""
+
+    def test_default_provider_order(self) -> None:
+        """Test that default provider order is set correctly."""
+        planner = ExecutionPlanner()
+        assert planner.provider_order == ["opnsense", "proxmox", "oci", "kubernetes"]
+
+    def test_custom_provider_order(self) -> None:
+        """Test custom provider order is used."""
+        order = ["kubernetes", "oci", "proxmox"]
+        planner = ExecutionPlanner(provider_order=order)
+        assert planner.provider_order == order
+
+    def test_with_dependency_graph(self) -> None:
+        """Test initialization with dependency graph."""
+        graph = DependencyGraph()
+        planner = ExecutionPlanner(dependency_graph=graph)
+        assert planner.dependency_graph is graph
+
+
+class TestExecutionPlannerSorting:
+    """Test provider sorting functionality."""
+
+    def test_sort_providers_forward(self) -> None:
+        """Test forward sorting respects provider order."""
+        planner = ExecutionPlanner(provider_order=["a", "b", "c"])
+        providers = ["c", "a", "b"]
+        sorted_providers = planner.sort_providers(providers, reverse=False)
+        assert sorted_providers == ["a", "b", "c"]
+
+    def test_sort_providers_reverse(self) -> None:
+        """Test reverse sorting for destroy operations."""
+        planner = ExecutionPlanner(provider_order=["a", "b", "c"])
+        providers = ["a", "c", "b"]
+        sorted_providers = planner.sort_providers(providers, reverse=True)
+        assert sorted_providers == ["c", "b", "a"]
+
+    def test_sort_providers_unlisted_go_last(self) -> None:
+        """Test that unlisted providers are placed at the end."""
+        planner = ExecutionPlanner(provider_order=["a", "b"])
+        providers = ["z", "a", "y", "b"]
+        sorted_providers = planner.sort_providers(providers, reverse=False)
+        # a, b first (in order), then z, y (unlisted, in original order due to stable sort)
+        assert sorted_providers[:2] == ["a", "b"]
+        assert set(sorted_providers[2:]) == {"y", "z"}
+
+    def test_sort_providers_unlisted_reverse(self) -> None:
+        """Test reverse sorting with unlisted providers."""
+        planner = ExecutionPlanner(provider_order=["a", "b"])
+        providers = ["z", "a", "b"]
+        sorted_providers = planner.sort_providers(providers, reverse=True)
+        # In reverse: unlisted (z) first, then b, a
+        assert sorted_providers == ["z", "b", "a"]
+
+
+class TestExecutionPlannerPlanApply:
+    """Test plan_apply functionality."""
+
+    def test_plan_apply_empty(self) -> None:
+        """Test plan_apply with empty resources."""
+        planner = ExecutionPlanner()
+        batches = planner.plan_apply({})
+        assert batches == []
+
+    def test_plan_apply_single_provider(self) -> None:
+        """Test plan_apply with single provider."""
+        planner = ExecutionPlanner()
+        resources = {"proxmox": [make_resource("proxmox", "vm1")]}
+        batches = planner.plan_apply(resources)
+
+        assert len(batches) == 1
+        assert batches[0].providers == ["proxmox"]
+        assert "proxmox" in batches[0].resources_by_provider
+
+    def test_plan_apply_multiple_providers(self) -> None:
+        """Test plan_apply with multiple providers in correct order."""
+        planner = ExecutionPlanner(provider_order=["opnsense", "proxmox", "kubernetes"])
+        resources = {
+            "kubernetes": [make_resource("kubernetes", "deploy1")],
+            "opnsense": [make_resource("opnsense", "rule1")],
+            "proxmox": [make_resource("proxmox", "vm1")],
+        }
+        batches = planner.plan_apply(resources)
+
+        # Each provider should be in its own batch, in order
+        assert len(batches) == 3
+        assert batches[0].providers == ["opnsense"]
+        assert batches[1].providers == ["proxmox"]
+        assert batches[2].providers == ["kubernetes"]
+
+
+class TestExecutionPlannerPlanDestroy:
+    """Test plan_destroy functionality."""
+
+    def test_plan_destroy_reverse_order(self) -> None:
+        """Test plan_destroy uses reverse provider order."""
+        planner = ExecutionPlanner(provider_order=["opnsense", "proxmox", "kubernetes"])
+        resources = {
+            "kubernetes": [make_resource("kubernetes", "deploy1")],
+            "opnsense": [make_resource("opnsense", "rule1")],
+            "proxmox": [make_resource("proxmox", "vm1")],
+        }
+        batches = planner.plan_destroy(resources)
+
+        # Destroy should be in REVERSE order
+        assert len(batches) == 3
+        assert batches[0].providers == ["kubernetes"]
+        assert batches[1].providers == ["proxmox"]
+        assert batches[2].providers == ["opnsense"]
+
+
+class TestExecutionPlannerWithGraph:
+    """Test ExecutionPlanner with dependency graph for cross-provider deps."""
+
+    def test_cross_provider_deps_detected(self) -> None:
+        """Test that cross-provider dependencies are detected."""
+        graph = DependencyGraph()
+        # kubernetes depends on proxmox VM
+        graph.add_resource("proxmox", "vm", "vm1")
+        # Manually add cross-provider dependency
+        graph._adjacency["kubernetes:deploy1"].add("proxmox:vm1")
+        graph._reverse_adjacency["proxmox:vm1"].add("kubernetes:deploy1")
+
+        planner = ExecutionPlanner(dependency_graph=graph)
+        assert planner._has_cross_provider_deps()
+
+    def test_no_cross_provider_deps(self) -> None:
+        """Test when there are no cross-provider dependencies."""
+        graph = DependencyGraph()
+        graph.add_resource("proxmox", "vm", "vm1")
+        graph.add_resource("proxmox", "vm", "vm2", dependencies=["vm1"])
+
+        planner = ExecutionPlanner(dependency_graph=graph)
+        assert not planner._has_cross_provider_deps()
+
+
+class TestExecutionPlannerSummary:
+    """Test execution summary functionality."""
+
+    def test_execution_summary(self) -> None:
+        """Test get_execution_summary returns correct data."""
+        planner = ExecutionPlanner()
+        resources = {
+            "proxmox": [make_resource("proxmox", "vm1"), make_resource("proxmox", "vm2")],
+            "kubernetes": [make_resource("kubernetes", "deploy1")],
+        }
+        batches = planner.plan_apply(resources)
+        summary = planner.get_execution_summary(batches)
+
+        assert summary["total_batches"] == 2
+        assert summary["total_providers"] == 2
+        assert summary["total_resources"] == 3
+
+
+class TestProviderBatch:
+    """Test ProviderBatch dataclass."""
+
+    def test_provider_batch_len(self) -> None:
+        """Test ProviderBatch length."""
+        batch = ProviderBatch(
+            providers=["a", "b", "c"],
+            resources_by_provider={},
+        )
+        assert len(batch) == 3

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -53,7 +53,7 @@ def test_plan_orchestrator_dry_run_skips_generation(console):
         runner_registry,
         get_providers=lambda: providers,
         load_resources=load_resources,
-        iter_provider_batches=lambda resources_by_provider, filt: [
+        iter_provider_batches=lambda resources_by_provider, filt, reverse, env_name: [
             ProviderResourceBatch("proxmox", resources_by_provider["proxmox"], 1)
         ],
         validate_resources=MagicMock(),
@@ -120,7 +120,7 @@ def test_plan_orchestrator_runs_runners_in_priority_order(console):
         runner_registry,
         get_providers=lambda: providers,
         load_resources=load_resources,
-        iter_provider_batches=lambda resources_by_provider, filt: [
+        iter_provider_batches=lambda resources_by_provider, filt, reverse, env_name: [
             ProviderResourceBatch("proxmox", resources_by_provider["proxmox"], 1)
         ],
         validate_resources=MagicMock(),
@@ -196,7 +196,7 @@ def test_destroy_orchestrator_requires_confirmation(console):
         runner_registry,
         get_providers=lambda: providers,
         load_resources=lambda env: ([], {"proxmox": []}),
-        iter_provider_batches=lambda resources_by_provider, filt: [
+        iter_provider_batches=lambda resources_by_provider, filt, reverse, env_name: [
             ProviderResourceBatch("proxmox", [], 0)
         ],
         get_current_user=lambda: "tester",
@@ -227,7 +227,7 @@ def test_validation_orchestrator_warns_on_missing_provider(console):
         console,
         get_providers=lambda: {},  # Missing provider
         load_resources=lambda env: (env_resources, {"proxmox": env_resources}),
-        iter_provider_batches=lambda resources_by_provider, filt: [
+        iter_provider_batches=lambda resources_by_provider, filt, reverse, env_name: [
             ProviderResourceBatch("proxmox", env_resources, 1)
         ],
     )


### PR DESCRIPTION
## Description

This PR fixes critical operation ordering bugs in InfraFoundry by introducing an ExecutionPlanner service that properly orders provider execution for all operations.

## Related Issue

Closes #197

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Add ExecutionPlanner service to bridge dependency graph to execution ordering
- Fix destroy to use REVERSE provider order (kubernetes before proxmox before opnsense)
- Fix parallel apply to process batches sequentially while parallelizing within batches
- Add configurable `provider_order` field to EnvironmentConfig
- Add 15 tests for ExecutionPlanner functionality

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

**Key files changed:**

| File | Change |
|------|--------|
| `core/execution_planner.py` | NEW - ExecutionPlanner service |
| `core/config/models.py` | Add `provider_order` field |
| `core/orchestrator.py` | Integrate ExecutionPlanner |
| `core/orchestrator_workflows.py` | Use ordered batches |
| `core/deployment_executor.py` | Batch-based parallel apply |
| `tests/unit/test_execution_planner.py` | NEW - 15 tests |

**Configuration example:**
```yaml
# In settings.yaml
provider_order: ["opnsense", "proxmox", "oci", "kubernetes"]
```
