### PR TITLE
refactor: make PolicyEngine inherit from BaseManager

### DIFF
--- a/src/infrafoundry/core/policy/engine.py
+++ b/src/infrafoundry/core/policy/engine.py
@@ -2,10 +2,11 @@
 
 import traceback
 from pathlib import Path
-from typing import Any
+from typing import Any, override
 
 import yaml
 
+from infrafoundry.core.base_manager import BaseManager
 from infrafoundry.core.exceptions import PolicyError
 
 from .evaluators import (
@@ -18,7 +19,7 @@ from .evaluators import (
 from .models import Policy, PolicyLevel, PolicyType, PolicyViolation
 
 
-class PolicyEngine:
+class PolicyEngine(BaseManager):
     """Evaluates policies against infrastructure configurations.
 
     This engine loads policies from YAML files and evaluates resources
@@ -31,6 +32,7 @@ class PolicyEngine:
         Args:
             policy_dir: Directory containing policy files (defaults to ./policies)
         """
+        super().__init__()
         self.policy_dir = policy_dir or Path("policies")
         self.policies: list[Policy] = []
 
@@ -66,14 +68,14 @@ class PolicyEngine:
                         )
                         self.policies.append(policy)
             except yaml.YAMLError as e:
-                print(f"Warning: Invalid YAML in policy file {policy_file}: {e}")
+                self._log_warning(f"Invalid YAML in policy file {policy_file}: {e}")
             except (KeyError, ValueError) as e:
-                print(f"Warning: Invalid policy structure in {policy_file}: {e}")
+                self._log_warning(f"Invalid policy structure in {policy_file}: {e}")
             except PolicyError as e:
-                print(f"Warning: Policy error in {policy_file}: {e}")
+                self._log_warning(f"Policy error in {policy_file}: {e}")
             except Exception as e:
-                print(f"Warning: Unexpected error loading policy file {policy_file}: {e}")
-                print(traceback.format_exc())  # Log full traceback
+                self._log_warning(f"Unexpected error loading policy file {policy_file}: {e}")
+                self._log_debug(traceback.format_exc())
 
     def register_evaluator(self, policy_type: PolicyType, evaluator: PolicyEvaluator) -> None:
         """Register a custom evaluator for a policy type.
@@ -109,7 +111,7 @@ class PolicyEngine:
             if evaluator:
                 violations.extend(evaluator.evaluate(policy, resources))
             else:
-                print(f"Warning: No evaluator registered for policy type {policy.type}")
+                self._log_warning(f"No evaluator registered for policy type {policy.type}")
 
         return violations
 
@@ -141,3 +143,11 @@ class PolicyEngine:
             for p in self.policies
             if p.enabled and (p.environments is None or environment in p.environments)
         ]
+
+    @override
+    def cleanup(self) -> None:
+        """Clean up resources (required by BaseManager).
+
+        PolicyEngine has no persistent resources to clean up.
+        """
+        self._log_debug("PolicyEngine cleanup complete")

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -3,6 +3,7 @@
 import pytest
 import yaml
 
+from infrafoundry.core.base_manager import BaseManager
 from infrafoundry.core.policy import PolicyEngine, PolicyLevel, PolicyType, PolicyViolation
 from infrafoundry.core.provider import ResourceConfig
 
@@ -581,3 +582,36 @@ class TestPolicyEngine:
         )
         violations = engine.evaluate_resources([resource], "dev")
         assert len(violations) > 0
+
+    def test_inherits_from_base_manager(self, temp_dir):
+        """Test that PolicyEngine inherits from BaseManager."""
+        policy_dir = temp_dir / "policies"
+        policy_dir.mkdir()
+
+        engine = PolicyEngine(policy_dir)
+        assert isinstance(engine, BaseManager)
+        # Should have BaseManager methods
+        assert hasattr(engine, "_log_info")
+        assert hasattr(engine, "_log_warning")
+        assert hasattr(engine, "_log_error")
+        assert hasattr(engine, "_log_debug")
+        assert hasattr(engine, "cleanup")
+
+    def test_cleanup_method(self, temp_dir):
+        """Test that cleanup method works."""
+        policy_dir = temp_dir / "policies"
+        policy_dir.mkdir()
+
+        engine = PolicyEngine(policy_dir)
+        # cleanup() should not raise any exceptions
+        engine.cleanup()
+
+    def test_context_manager(self, temp_dir):
+        """Test that PolicyEngine can be used as context manager."""
+        policy_dir = temp_dir / "policies"
+        policy_dir.mkdir()
+
+        with PolicyEngine(policy_dir) as engine:
+            assert isinstance(engine, PolicyEngine)
+            assert len(engine.policies) == 0
+        # Exiting context should call cleanup without error


### PR DESCRIPTION
## Description

PolicyEngine now extends BaseManager for consistent logging patterns:
- Replace `print()` statements with `_log_warning()` and `_log_debug()` methods
- Add `cleanup()` method required by BaseManager interface
- Add `@override` decorator per codebase conventions

## Related Issue

Part of #198 (split into multiple PRs for easier review)

## Type of Change

- [x] Code refactoring

## Changes Made

### `src/infrafoundry/core/policy/engine.py`
- Import `BaseManager` and `override`
- `PolicyEngine` inherits from `BaseManager`
- Constructor calls `super().__init__()`
- Replace 5 `print()` calls with proper logging methods
- Add `cleanup()` method with `@override` decorator

### `tests/unit/test_policy.py`
- Add 3 new tests:
  - `test_inherits_from_base_manager` - verifies inheritance
  - `test_cleanup_method` - verifies cleanup works
  - `test_context_manager` - verifies context manager support

## Testing

- [x] All existing policy tests pass (25 tests)
- [x] 3 new tests added and passing
- [x] `doit check` passes (format, lint, type_check, security, spell_check, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
