### PR TITLE
refactor: make DriftDetector inherit from BaseManager

### DIFF
--- a/src/infrafoundry/core/drift_detector.py
+++ b/src/infrafoundry/core/drift_detector.py
@@ -1,10 +1,8 @@
 """Drift detection for infrastructure resources."""
 
-import traceback
-from typing import Any
+from typing import Any, override
 
-from rich.console import Console
-
+from infrafoundry.core.base_manager import BaseManager
 from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.events import EventManager, EventType
 from infrafoundry.core.exceptions import (
@@ -17,7 +15,7 @@ from infrafoundry.core.provider import ProviderBase
 from infrafoundry.core.runners import RunnerRegistry
 
 
-class DriftDetector:
+class DriftDetector(BaseManager):
     """Detects infrastructure drift from declared configuration."""
 
     def __init__(
@@ -26,7 +24,6 @@ class DriftDetector:
         runner_registry: RunnerRegistry,
         event_manager: EventManager,
         providers: dict[str, ProviderBase],
-        console: Console | None = None,
     ) -> None:
         """Initialize drift detector.
 
@@ -35,13 +32,12 @@ class DriftDetector:
             runner_registry: Registry for creating tool runners
             event_manager: Event manager for notifications
             providers: Dict of registered provider instances
-            console: Rich console for output (creates default if None)
         """
+        super().__init__()
         self.config_manager = config_manager
         self.runner_registry = runner_registry
         self.event_manager = event_manager
         self.providers = providers
-        self.console = console or Console()
 
     def detect(self, env_name: str) -> dict[str, Any]:
         """Detect infrastructure drift from declared configuration.
@@ -73,13 +69,13 @@ class DriftDetector:
             {"environment": env_name},
         )
 
-        self.console.print(f"\n[bold cyan]Checking for drift in: {env_name}[/bold cyan]")
+        self._log_info(f"Checking for drift in: {env_name}")
 
         results = {}
         drift_detected = False
 
         # Dynamically create the runner
-        terraform_runner = self.runner_registry.create_runner("terraform", console=self.console)
+        terraform_runner = self.runner_registry.create_runner("terraform")
         if not terraform_runner:
             raise InfraFoundryError("Could not create terraform runner")
 
@@ -100,20 +96,18 @@ class DriftDetector:
 
                 provider = self.providers[provider_name]
 
-                self.console.print(f"\n[bold]Checking {provider_name}...[/bold]")
+                self._log_info(f"Checking {provider_name}...")
 
                 # Check if runner supports plan and drift detection
                 if not isinstance(terraform_runner, Plannable):
-                    self.console.print(
-                        f"  [yellow]⚠ Runner {terraform_runner.tool_name} "
-                        "does not support plan operation[/yellow]"
+                    self._log_warning(
+                        f"Runner {terraform_runner.tool_name} does not support plan operation"
                     )
                     continue
 
                 if not isinstance(terraform_runner, DriftDetectable):
-                    self.console.print(
-                        f"  [yellow]⚠ Runner {terraform_runner.tool_name} "
-                        "does not support drift detection[/yellow]"
+                    self._log_warning(
+                        f"Runner {terraform_runner.tool_name} does not support drift detection"
                     )
                     continue
 
@@ -126,9 +120,7 @@ class DriftDetector:
 
                 if drift_info["has_changes"]:
                     drift_detected = True
-                    self.console.print(
-                        f"  [yellow]⚠ Drift detected: {drift_info['summary']}[/yellow]"
-                    )
+                    self._log_warning(f"Drift detected: {drift_info['summary']}")
 
                     # Emit drift detected event
                     self.event_manager.emit_event(
@@ -140,7 +132,7 @@ class DriftDetector:
                         },
                     )
                 else:
-                    self.console.print("  [green]✓ No drift detected[/green]")
+                    self._log_info(f"No drift detected for {provider_name}")
 
                 results[provider_name] = drift_info
 
@@ -155,19 +147,24 @@ class DriftDetector:
             )
 
             if not drift_detected:
-                self.console.print(
-                    "\n[bold green]✓ All infrastructure matches declared configuration[/bold green]"
-                )
+                self._log_info("All infrastructure matches declared configuration")
 
         except (ConfigurationError, TerraformError) as e:
-            self.console.print(f"\n[bold red]Error detecting drift:[/bold red] {e}")
+            self._log_error(f"Error detecting drift: {e}", e)
             raise
         except InfraFoundryError as e:
-            self.console.print(f"\n[bold red]InfraFoundry error detecting drift:[/bold red] {e}")
+            self._log_error(f"InfraFoundry error detecting drift: {e}", e)
             raise
         except Exception as e:
-            self.console.print(f"\n[bold red]Unexpected error detecting drift:[/bold red] {e}")
-            self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
+            self._log_error(f"Unexpected error detecting drift: {e}", e)
             raise
 
         return results
+
+    @override
+    def cleanup(self) -> None:
+        """Clean up resources (required by BaseManager).
+
+        DriftDetector has no persistent resources to clean up.
+        """
+        self._log_debug("DriftDetector cleanup complete")

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -108,7 +108,6 @@ class Orchestrator:
             self.runner_registry,
             self.event_manager,
             self.providers,
-            self.console,
         )
         self.deployment_executor = DeploymentExecutor(
             self.runner_registry,

--- a/tests/unit/test_drift_detector.py
+++ b/tests/unit/test_drift_detector.py
@@ -1,0 +1,137 @@
+"""Unit tests for DriftDetector."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.base_manager import BaseManager
+from infrafoundry.core.drift_detector import DriftDetector
+from infrafoundry.core.events import EventManager
+
+
+@pytest.fixture
+def mock_config_manager():
+    """Create a mock config manager."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_runner_registry():
+    """Create a mock runner registry."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_event_manager():
+    """Create a mock event manager."""
+    return MagicMock(spec=EventManager)
+
+
+@pytest.fixture
+def mock_providers():
+    """Create a mock providers dict."""
+    return {}
+
+
+@pytest.fixture
+def drift_detector(mock_config_manager, mock_runner_registry, mock_event_manager, mock_providers):
+    """Create a DriftDetector instance for testing."""
+    return DriftDetector(
+        config_manager=mock_config_manager,
+        runner_registry=mock_runner_registry,
+        event_manager=mock_event_manager,
+        providers=mock_providers,
+    )
+
+
+@pytest.mark.unit
+class TestDriftDetector:
+    """Tests for DriftDetector."""
+
+    def test_inherits_from_base_manager(self, drift_detector):
+        """Test that DriftDetector inherits from BaseManager."""
+        assert isinstance(drift_detector, BaseManager)
+        # Should have BaseManager methods
+        assert hasattr(drift_detector, "_log_info")
+        assert hasattr(drift_detector, "_log_warning")
+        assert hasattr(drift_detector, "_log_error")
+        assert hasattr(drift_detector, "_log_debug")
+        assert hasattr(drift_detector, "cleanup")
+
+    def test_cleanup_method(self, drift_detector):
+        """Test that cleanup method works."""
+        # cleanup() should not raise any exceptions
+        drift_detector.cleanup()
+
+    def test_context_manager(
+        self, mock_config_manager, mock_runner_registry, mock_event_manager, mock_providers
+    ):
+        """Test that DriftDetector can be used as context manager."""
+        with DriftDetector(
+            config_manager=mock_config_manager,
+            runner_registry=mock_runner_registry,
+            event_manager=mock_event_manager,
+            providers=mock_providers,
+        ) as detector:
+            assert isinstance(detector, DriftDetector)
+        # Exiting context should call cleanup without error
+
+    def test_init_stores_dependencies(
+        self, mock_config_manager, mock_runner_registry, mock_event_manager, mock_providers
+    ):
+        """Test that __init__ properly stores dependencies."""
+        detector = DriftDetector(
+            config_manager=mock_config_manager,
+            runner_registry=mock_runner_registry,
+            event_manager=mock_event_manager,
+            providers=mock_providers,
+        )
+
+        assert detector.config_manager is mock_config_manager
+        assert detector.runner_registry is mock_runner_registry
+        assert detector.event_manager is mock_event_manager
+        assert detector.providers is mock_providers
+
+    def test_detect_emits_started_event(
+        self, mock_config_manager, mock_runner_registry, mock_event_manager, mock_providers
+    ):
+        """Test that detect emits DRIFT_CHECK_STARTED event."""
+        # Set up mocks
+        mock_runner = MagicMock()
+        mock_runner_registry.create_runner.return_value = mock_runner
+        mock_config_manager.get_all_resources_all_providers.return_value = []
+
+        detector = DriftDetector(
+            config_manager=mock_config_manager,
+            runner_registry=mock_runner_registry,
+            event_manager=mock_event_manager,
+            providers=mock_providers,
+        )
+
+        detector.detect("test-env")
+
+        # Verify DRIFT_CHECK_STARTED was emitted
+        calls = mock_event_manager.emit_event.call_args_list
+        assert len(calls) >= 1
+        first_call = calls[0]
+        assert first_call[0][1] == "test-env"  # environment name
+
+    def test_detect_returns_empty_dict_when_no_providers(
+        self, mock_config_manager, mock_runner_registry, mock_event_manager, mock_providers
+    ):
+        """Test that detect returns empty dict when no providers have resources."""
+        # Set up mocks
+        mock_runner = MagicMock()
+        mock_runner_registry.create_runner.return_value = mock_runner
+        mock_config_manager.get_all_resources_all_providers.return_value = []
+
+        detector = DriftDetector(
+            config_manager=mock_config_manager,
+            runner_registry=mock_runner_registry,
+            event_manager=mock_event_manager,
+            providers=mock_providers,
+        )
+
+        results = detector.detect("test-env")
+
+        assert results == {}


### PR DESCRIPTION
## Description

DriftDetector now extends BaseManager for consistent logging patterns:
- Remove Console injection, use `_log_info()`, `_log_warning()`, `_log_error()` instead
- Add `cleanup()` method required by BaseManager interface
- Add `@override` decorator per codebase conventions

## Related Issue

Part of #198 (split into multiple PRs for easier review)

## Type of Change

- [x] Code refactoring
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ⚠️ Breaking Changes

**`DriftDetector.__init__()` signature changed:**
- Removed: `console: Console | None = None` parameter
- Removed: `self.console` attribute

**Migration:**
If you were instantiating `DriftDetector` directly with a console parameter, remove the console argument. Output is now handled via standard Python logging.

**Note:** `DriftDetector` is an internal class not exported in the public API (`__init__.py`), so most users interacting via CLI or Orchestrator should be unaffected.

## Changes Made

### `src/infrafoundry/core/drift_detector.py`
- Import `BaseManager` and `override`
- `DriftDetector` inherits from `BaseManager`
- Constructor calls `super().__init__()` and removes `console` parameter
- Replace 10+ `console.print()` calls with proper logging methods
- Add `cleanup()` method with `@override` decorator

### `src/infrafoundry/core/orchestrator.py`
- Remove `self.console` argument from `DriftDetector` instantiation

### `tests/unit/test_drift_detector.py` (NEW)
- 6 new tests for BaseManager inheritance and functionality

## Testing

- [x] All existing tests pass (65 drift/orchestrator tests)
- [x] 6 new tests added and passing
- [x] `doit check` passes (format, lint, type_check, security, spell_check, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
