### PR TITLE
refactor: extract HookExecutionMixin from orchestrator workflows

### DIFF
--- a/src/infrafoundry/core/hooks/__init__.py
+++ b/src/infrafoundry/core/hooks/__init__.py
@@ -5,11 +5,13 @@ during plan, apply, and destroy operations.
 """
 
 from infrafoundry.core.hooks.manager import HookExecutionError, HookManager
+from infrafoundry.core.hooks.mixin import HookExecutionMixin
 from infrafoundry.core.hooks.models import HookConfig, HookResult, HooksConfig
 
 __all__ = [
     "HookConfig",
     "HookExecutionError",
+    "HookExecutionMixin",
     "HookManager",
     "HookResult",
     "HooksConfig",

--- a/src/infrafoundry/core/hooks/mixin.py
+++ b/src/infrafoundry/core/hooks/mixin.py
@@ -1,0 +1,104 @@
+"""Mixin for hook execution in orchestrator workflows.
+
+This module provides a reusable mixin that encapsulates the common hook
+execution logic used by PlanOrchestrator, ApplyOrchestrator, and
+DestroyOrchestrator.
+"""
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from rich.console import Console
+
+from infrafoundry.core.hooks.manager import HookExecutionError, HookManager
+
+if TYPE_CHECKING:
+    from infrafoundry.core.config.models import EnvironmentConfig
+    from infrafoundry.core.provider import ResourceConfig
+
+
+@runtime_checkable
+class HasHookExecutionDependencies(Protocol):
+    """Protocol defining required attributes for HookExecutionMixin."""
+
+    _hook_manager: HookManager | None
+    console: Console
+
+
+class HookExecutionMixin:
+    """Mixin providing hook execution methods for orchestrator classes.
+
+    This mixin requires the following attributes on the class:
+    - _hook_manager: HookManager | None
+    - console: Console
+
+    Example:
+        class MyOrchestrator(HookExecutionMixin):
+            def __init__(self, console: Console, hook_manager: HookManager | None):
+                self.console = console
+                self._hook_manager = hook_manager
+
+            def do_work(self, env_name: str, env_config: EnvironmentConfig):
+                self._execute_env_hooks(env_name, "before_plan", env_config)
+                # ... do actual work ...
+                self._execute_env_hooks(env_name, "after_plan", env_config)
+    """
+
+    # Type hints for mixin - these are provided by the class using this mixin
+    _hook_manager: HookManager | None
+    console: Console
+
+    def _execute_env_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        env_config: "EnvironmentConfig | None",
+    ) -> None:
+        """Execute environment-level hooks for a lifecycle stage.
+
+        Args:
+            env_name: Environment name
+            stage: Lifecycle stage (e.g., "before_plan", "after_apply")
+            env_config: Environment configuration containing hooks
+        """
+        if not self._hook_manager or not env_config or not env_config.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_environment_hooks(
+                env_name=env_name,
+                stage=stage,
+                hooks_config=env_config.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed: {e}[/red]")
+            raise
+
+    def _execute_resource_hooks(
+        self,
+        env_name: str,
+        stage: str,
+        resource: "ResourceConfig",
+        provider_name: str,
+    ) -> None:
+        """Execute resource-level hooks for a lifecycle stage.
+
+        Args:
+            env_name: Environment name
+            stage: Lifecycle stage (e.g., "before_plan", "after_apply")
+            resource: Resource configuration containing hooks
+            provider_name: Name of the provider for this resource
+        """
+        if not self._hook_manager or not resource.hooks:
+            return
+
+        try:
+            self._hook_manager.execute_resource_hooks(
+                env_name=env_name,
+                stage=stage,
+                resource_name=resource.name,
+                provider_name=provider_name,
+                hooks_config=resource.hooks,
+            )
+        except HookExecutionError as e:
+            self.console.print(f"[red]Hook failed for {resource.name}: {e}[/red]")
+            raise

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -15,7 +15,7 @@ from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import EventManager, EventType
-from infrafoundry.core.hooks import HookExecutionError, HookManager
+from infrafoundry.core.hooks import HookExecutionMixin, HookManager
 from infrafoundry.core.protocols import Destroyable, Plannable
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.runners import RunnerRegistry
@@ -258,7 +258,7 @@ class ValidationOrchestrator:
             self.console.print("[yellow]  Fix errors before deploying[/yellow]")
 
 
-class PlanOrchestrator:
+class PlanOrchestrator(HookExecutionMixin):
     """Handle plan execution for each provider."""
 
     def __init__(
@@ -515,49 +515,6 @@ class PlanOrchestrator:
                 raise
             self.console.print(f"[dim]Skipping secrets export: {exc}[/dim]")
 
-    def _execute_env_hooks(
-        self,
-        env_name: str,
-        stage: str,
-        env_config: EnvironmentConfig | None,
-    ) -> None:
-        """Execute environment-level hooks for a lifecycle stage."""
-        if not self._hook_manager or not env_config or not env_config.hooks:
-            return
-
-        try:
-            self._hook_manager.execute_environment_hooks(
-                env_name=env_name,
-                stage=stage,
-                hooks_config=env_config.hooks,
-            )
-        except HookExecutionError as e:
-            self.console.print(f"[red]Hook failed: {e}[/red]")
-            raise
-
-    def _execute_resource_hooks(
-        self,
-        env_name: str,
-        stage: str,
-        resource: ResourceConfig,
-        provider_name: str,
-    ) -> None:
-        """Execute resource-level hooks for a lifecycle stage."""
-        if not self._hook_manager or not resource.hooks:
-            return
-
-        try:
-            self._hook_manager.execute_resource_hooks(
-                env_name=env_name,
-                stage=stage,
-                resource_name=resource.name,
-                provider_name=provider_name,
-                hooks_config=resource.hooks,
-            )
-        except HookExecutionError as e:
-            self.console.print(f"[red]Hook failed for {resource.name}: {e}[/red]")
-            raise
-
 
 class RollbackOrchestrator:
     """Handle rollbacks by orchestrating confirmation and apply execution."""
@@ -662,7 +619,7 @@ class RollbackOrchestrator:
         )
 
 
-class ApplyOrchestrator:
+class ApplyOrchestrator(HookExecutionMixin):
     """Coordinate apply deployments after planning."""
 
     def __init__(
@@ -819,51 +776,8 @@ class ApplyOrchestrator:
         else:
             self.console.print(f"\n[{style}]{label} infrastructure for: {env_name}[/{style}]")
 
-    def _execute_env_hooks(
-        self,
-        env_name: str,
-        stage: str,
-        env_config: EnvironmentConfig | None,
-    ) -> None:
-        """Execute environment-level hooks for a lifecycle stage."""
-        if not self._hook_manager or not env_config or not env_config.hooks:
-            return
 
-        try:
-            self._hook_manager.execute_environment_hooks(
-                env_name=env_name,
-                stage=stage,
-                hooks_config=env_config.hooks,
-            )
-        except HookExecutionError as e:
-            self.console.print(f"[red]Hook failed: {e}[/red]")
-            raise
-
-    def _execute_resource_hooks(
-        self,
-        env_name: str,
-        stage: str,
-        resource: ResourceConfig,
-        provider_name: str,
-    ) -> None:
-        """Execute resource-level hooks for a lifecycle stage."""
-        if not self._hook_manager or not resource.hooks:
-            return
-
-        try:
-            self._hook_manager.execute_resource_hooks(
-                env_name=env_name,
-                stage=stage,
-                resource_name=resource.name,
-                provider_name=provider_name,
-                hooks_config=resource.hooks,
-            )
-        except HookExecutionError as e:
-            self.console.print(f"[red]Hook failed for {resource.name}: {e}[/red]")
-            raise
-
-
-class DestroyOrchestrator:
+class DestroyOrchestrator(HookExecutionMixin):
     """Handle destroy operations with consistent tracking."""
 
     def __init__(
@@ -1089,46 +1003,3 @@ class DestroyOrchestrator:
             )
         else:
             self.console.print(f"\n[{style}]{label} infrastructure for: {env_name}[/{style}]")
-
-    def _execute_env_hooks(
-        self,
-        env_name: str,
-        stage: str,
-        env_config: EnvironmentConfig | None,
-    ) -> None:
-        """Execute environment-level hooks for a lifecycle stage."""
-        if not self._hook_manager or not env_config or not env_config.hooks:
-            return
-
-        try:
-            self._hook_manager.execute_environment_hooks(
-                env_name=env_name,
-                stage=stage,
-                hooks_config=env_config.hooks,
-            )
-        except HookExecutionError as e:
-            self.console.print(f"[red]Hook failed: {e}[/red]")
-            raise
-
-    def _execute_resource_hooks(
-        self,
-        env_name: str,
-        stage: str,
-        resource: ResourceConfig,
-        provider_name: str,
-    ) -> None:
-        """Execute resource-level hooks for a lifecycle stage."""
-        if not self._hook_manager or not resource.hooks:
-            return
-
-        try:
-            self._hook_manager.execute_resource_hooks(
-                env_name=env_name,
-                stage=stage,
-                resource_name=resource.name,
-                provider_name=provider_name,
-                hooks_config=resource.hooks,
-            )
-        except HookExecutionError as e:
-            self.console.print(f"[red]Hook failed for {resource.name}: {e}[/red]")
-            raise

--- a/tests/unit/test_hook_execution_mixin.py
+++ b/tests/unit/test_hook_execution_mixin.py
@@ -1,0 +1,190 @@
+"""Unit tests for HookExecutionMixin."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from rich.console import Console
+
+from infrafoundry.core.config.models import EnvironmentConfig
+from infrafoundry.core.hooks import HookExecutionMixin, HookManager
+from infrafoundry.core.hooks.manager import HookExecutionError
+from infrafoundry.core.hooks.models import HookResult, HooksConfig
+from infrafoundry.core.provider import ResourceConfig
+
+
+class MockOrchestrator(HookExecutionMixin):
+    """Mock orchestrator class for testing the mixin."""
+
+    def __init__(
+        self, console: Console | None = None, hook_manager: HookManager | None = None
+    ) -> None:
+        self.console = console or MagicMock(spec=Console)
+        self._hook_manager = hook_manager
+
+
+@pytest.fixture
+def mock_console():
+    """Create a mock console."""
+    return MagicMock(spec=Console)
+
+
+@pytest.fixture
+def mock_hook_manager():
+    """Create a mock hook manager."""
+    return MagicMock(spec=HookManager)
+
+
+@pytest.fixture
+def orchestrator(mock_console, mock_hook_manager):
+    """Create a MockOrchestrator instance for testing."""
+    return MockOrchestrator(console=mock_console, hook_manager=mock_hook_manager)
+
+
+@pytest.mark.unit
+class TestHookExecutionMixin:
+    """Tests for HookExecutionMixin."""
+
+    def test_execute_env_hooks_no_hook_manager(self, mock_console):
+        """Test _execute_env_hooks when no hook manager is set."""
+        orchestrator = MockOrchestrator(console=mock_console, hook_manager=None)
+        env_config = MagicMock(spec=EnvironmentConfig)
+        env_config.hooks = MagicMock(spec=HooksConfig)
+
+        # Should not raise, just return early
+        orchestrator._execute_env_hooks("test-env", "before_plan", env_config)
+
+    def test_execute_env_hooks_no_env_config(self, orchestrator):
+        """Test _execute_env_hooks when env_config is None."""
+        # Should not raise, just return early
+        orchestrator._execute_env_hooks("test-env", "before_plan", None)
+        orchestrator._hook_manager.execute_environment_hooks.assert_not_called()
+
+    def test_execute_env_hooks_no_hooks_in_config(self, orchestrator):
+        """Test _execute_env_hooks when env_config has no hooks."""
+        env_config = MagicMock(spec=EnvironmentConfig)
+        env_config.hooks = None
+
+        # Should not raise, just return early
+        orchestrator._execute_env_hooks("test-env", "before_plan", env_config)
+        orchestrator._hook_manager.execute_environment_hooks.assert_not_called()
+
+    def test_execute_env_hooks_success(self, orchestrator):
+        """Test _execute_env_hooks calls hook manager correctly."""
+        env_config = MagicMock(spec=EnvironmentConfig)
+        env_config.hooks = MagicMock(spec=HooksConfig)
+
+        orchestrator._execute_env_hooks("test-env", "before_plan", env_config)
+
+        orchestrator._hook_manager.execute_environment_hooks.assert_called_once_with(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=env_config.hooks,
+        )
+
+    def test_execute_env_hooks_error(self, orchestrator, mock_console):
+        """Test _execute_env_hooks handles errors correctly."""
+        env_config = MagicMock(spec=EnvironmentConfig)
+        env_config.hooks = MagicMock(spec=HooksConfig)
+        mock_result = HookResult(
+            script="test_hook.sh",
+            success=False,
+            exit_code=1,
+            stdout="",
+            stderr="Test error",
+            duration_seconds=0.1,
+        )
+        orchestrator._hook_manager.execute_environment_hooks.side_effect = HookExecutionError(
+            "Test error", mock_result
+        )
+
+        with pytest.raises(HookExecutionError):
+            orchestrator._execute_env_hooks("test-env", "before_plan", env_config)
+
+        mock_console.print.assert_called_once()
+        assert "Hook failed" in mock_console.print.call_args[0][0]
+
+    def test_execute_resource_hooks_no_hook_manager(self, mock_console):
+        """Test _execute_resource_hooks when no hook manager is set."""
+        orchestrator = MockOrchestrator(console=mock_console, hook_manager=None)
+        resource = MagicMock(spec=ResourceConfig)
+        resource.hooks = MagicMock(spec=HooksConfig)
+
+        # Should not raise, just return early
+        orchestrator._execute_resource_hooks("test-env", "before_plan", resource, "proxmox")
+
+    def test_execute_resource_hooks_no_hooks_in_resource(self, orchestrator):
+        """Test _execute_resource_hooks when resource has no hooks."""
+        resource = MagicMock(spec=ResourceConfig)
+        resource.hooks = None
+
+        # Should not raise, just return early
+        orchestrator._execute_resource_hooks("test-env", "before_plan", resource, "proxmox")
+        orchestrator._hook_manager.execute_resource_hooks.assert_not_called()
+
+    def test_execute_resource_hooks_success(self, orchestrator):
+        """Test _execute_resource_hooks calls hook manager correctly."""
+        resource = MagicMock(spec=ResourceConfig)
+        resource.name = "test-resource"
+        resource.hooks = MagicMock(spec=HooksConfig)
+
+        orchestrator._execute_resource_hooks("test-env", "before_plan", resource, "proxmox")
+
+        orchestrator._hook_manager.execute_resource_hooks.assert_called_once_with(
+            env_name="test-env",
+            stage="before_plan",
+            resource_name="test-resource",
+            provider_name="proxmox",
+            hooks_config=resource.hooks,
+        )
+
+    def test_execute_resource_hooks_error(self, orchestrator, mock_console):
+        """Test _execute_resource_hooks handles errors correctly."""
+        resource = MagicMock(spec=ResourceConfig)
+        resource.name = "test-resource"
+        resource.hooks = MagicMock(spec=HooksConfig)
+        mock_result = HookResult(
+            script="test_hook.sh",
+            success=False,
+            exit_code=1,
+            stdout="",
+            stderr="Test error",
+            duration_seconds=0.1,
+        )
+        orchestrator._hook_manager.execute_resource_hooks.side_effect = HookExecutionError(
+            "Test error", mock_result
+        )
+
+        with pytest.raises(HookExecutionError):
+            orchestrator._execute_resource_hooks("test-env", "before_plan", resource, "proxmox")
+
+        mock_console.print.assert_called_once()
+        assert "Hook failed for test-resource" in mock_console.print.call_args[0][0]
+
+
+@pytest.mark.unit
+class TestOrchestratorIntegration:
+    """Tests verifying the mixin works with orchestrator classes."""
+
+    def test_plan_orchestrator_has_mixin_methods(self):
+        """Test that PlanOrchestrator has the mixin methods."""
+        from infrafoundry.core.orchestrator_workflows import PlanOrchestrator
+
+        assert hasattr(PlanOrchestrator, "_execute_env_hooks")
+        assert hasattr(PlanOrchestrator, "_execute_resource_hooks")
+        assert issubclass(PlanOrchestrator, HookExecutionMixin)
+
+    def test_apply_orchestrator_has_mixin_methods(self):
+        """Test that ApplyOrchestrator has the mixin methods."""
+        from infrafoundry.core.orchestrator_workflows import ApplyOrchestrator
+
+        assert hasattr(ApplyOrchestrator, "_execute_env_hooks")
+        assert hasattr(ApplyOrchestrator, "_execute_resource_hooks")
+        assert issubclass(ApplyOrchestrator, HookExecutionMixin)
+
+    def test_destroy_orchestrator_has_mixin_methods(self):
+        """Test that DestroyOrchestrator has the mixin methods."""
+        from infrafoundry.core.orchestrator_workflows import DestroyOrchestrator
+
+        assert hasattr(DestroyOrchestrator, "_execute_env_hooks")
+        assert hasattr(DestroyOrchestrator, "_execute_resource_hooks")
+        assert issubclass(DestroyOrchestrator, HookExecutionMixin)


### PR DESCRIPTION
## Description

Extract duplicated hook execution methods into a reusable `HookExecutionMixin`:
- `_execute_env_hooks()` and `_execute_resource_hooks()` were duplicated identically in PlanOrchestrator, ApplyOrchestrator, and DestroyOrchestrator
- Now consolidated into a single mixin class that all three orchestrators inherit from

## Related Issue

Part of #198 (split into multiple PRs for easier review)

## Type of Change

- [x] Code refactoring

## Changes Made

### `src/infrafoundry/core/hooks/mixin.py` (NEW)
- New `HookExecutionMixin` class providing:
  - `_execute_env_hooks()` - execute environment-level hooks
  - `_execute_resource_hooks()` - execute resource-level hooks
- Uses `TYPE_CHECKING` to avoid circular imports with config models

### `src/infrafoundry/core/hooks/__init__.py`
- Added export for `HookExecutionMixin`

### `src/infrafoundry/core/orchestrator_workflows.py`
- `PlanOrchestrator`, `ApplyOrchestrator`, `DestroyOrchestrator` now inherit from `HookExecutionMixin`
- Removed 6 duplicate methods (~126 lines total)
- Removed unused `HookExecutionError` import

### `tests/unit/test_hook_execution_mixin.py` (NEW)
- 12 tests covering:
  - Edge cases (no hook manager, no config, no hooks)
  - Success paths
  - Error handling
  - Integration verification for all three orchestrators

## Testing

- [x] All existing tests pass
- [x] 12 new tests added and passing
- [x] `doit check` passes (format, lint, type_check, security, spell_check, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
