### PR TITLE
feat: integrate hooks with event system

### DIFF
--- a/src/infrafoundry/core/events/types.py
+++ b/src/infrafoundry/core/events/types.py
@@ -14,6 +14,7 @@ class EventType(str, Enum):
     - Validation events: Config validation
     - Drift events: Drift detection
     - Policy events: Policy enforcement
+    - Hook events: Lifecycle hook execution
     """
 
     # Planning phase
@@ -66,6 +67,11 @@ class EventType(str, Enum):
     POLICY_VIOLATION = "policy_violation"
     POLICY_CHECK_PASSED = "policy_check_passed"
     POLICY_CHECK_FAILED = "policy_check_failed"
+
+    # Hook lifecycle
+    HOOK_STARTED = "hook_started"
+    HOOK_COMPLETED = "hook_completed"
+    HOOK_FAILED = "hook_failed"
 
 
 class HandlerType(str, Enum):

--- a/src/infrafoundry/core/hooks/manager.py
+++ b/src/infrafoundry/core/hooks/manager.py
@@ -1,15 +1,21 @@
 """Hook manager for executing lifecycle hooks."""
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess  # nosec B404 - required for running user scripts
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from infrafoundry.core.base_manager import PathBasedManager
 from infrafoundry.core.hooks.models import HookConfig, HookResult, HooksConfig
 from infrafoundry.core.secrets.secret_manager import SecretManager
+
+if TYPE_CHECKING:
+    from infrafoundry.core.events import EventManager
 
 
 class HookExecutionError(Exception):
@@ -45,16 +51,19 @@ class HookManager(PathBasedManager):
         self,
         config_base_dir: Path,
         secret_manager_factory: Callable[[str], SecretManager],
+        event_manager: EventManager | None = None,
     ) -> None:
         """Initialize hook manager.
 
         Args:
             config_base_dir: Base directory for configuration (contains envs/)
             secret_manager_factory: Factory function to create SecretManager for an environment
+            event_manager: Optional event manager for emitting hook lifecycle events
         """
         super().__init__()
         self.config_base_dir = config_base_dir
         self._secret_manager_factory = secret_manager_factory
+        self._event_manager = event_manager
 
     def execute_environment_hooks(
         self,
@@ -241,6 +250,17 @@ class HookManager(PathBasedManager):
             provider_name=provider_name,
         )
 
+        # Build event data for hook lifecycle events
+        hook_event_data: dict[str, Any] = {
+            "script": hook.script,
+            "stage": stage,
+            "description": hook.description,
+        }
+        if resource_name:
+            hook_event_data["resource_name"] = resource_name
+        if provider_name:
+            hook_event_data["provider_name"] = provider_name
+
         # Log execution
         desc = hook.description or hook.script
         if resource_name:
@@ -248,8 +268,12 @@ class HookManager(PathBasedManager):
         else:
             self._log_info(f"Running hook: {desc}")
 
+        # Emit HOOK_STARTED event
+        self._emit_hook_event("HOOK_STARTED", env_name, hook_event_data)
+
         # Execute script
         start_time = time.monotonic()
+        hook_result: HookResult
         try:
             result = subprocess.run(  # nosec B603 - user-controlled scripts
                 [str(script_path)],
@@ -261,7 +285,7 @@ class HookManager(PathBasedManager):
             )
             duration = time.monotonic() - start_time
 
-            return HookResult(
+            hook_result = HookResult(
                 script=hook.script,
                 success=result.returncode == 0,
                 exit_code=result.returncode,
@@ -274,7 +298,7 @@ class HookManager(PathBasedManager):
 
         except subprocess.TimeoutExpired as e:
             duration = time.monotonic() - start_time
-            return HookResult(
+            hook_result = HookResult(
                 script=hook.script,
                 success=False,
                 exit_code=-1,
@@ -287,7 +311,7 @@ class HookManager(PathBasedManager):
 
         except PermissionError:
             duration = time.monotonic() - start_time
-            return HookResult(
+            hook_result = HookResult(
                 script=hook.script,
                 success=False,
                 exit_code=-1,
@@ -300,7 +324,7 @@ class HookManager(PathBasedManager):
 
         except OSError as e:
             duration = time.monotonic() - start_time
-            return HookResult(
+            hook_result = HookResult(
                 script=hook.script,
                 success=False,
                 exit_code=-1,
@@ -310,6 +334,22 @@ class HookManager(PathBasedManager):
                 timed_out=False,
                 error_message=f"OS error: {e}",
             )
+
+        # Emit HOOK_COMPLETED or HOOK_FAILED event
+        result_event_data = {
+            **hook_event_data,
+            "success": hook_result.success,
+            "exit_code": hook_result.exit_code,
+            "duration_seconds": hook_result.duration_seconds,
+            "timed_out": hook_result.timed_out,
+        }
+        if hook_result.error_message:
+            result_event_data["error_message"] = hook_result.error_message
+
+        event_type = "HOOK_COMPLETED" if hook_result.success else "HOOK_FAILED"
+        self._emit_hook_event(event_type, env_name, result_event_data)
+
+        return hook_result
 
     def _prepare_environment(
         self,
@@ -394,3 +434,26 @@ class HookManager(PathBasedManager):
     def cleanup(self) -> None:
         """Clean up resources (required by BaseManager)."""
         self._log_debug("HookManager cleanup complete")
+
+    def _emit_hook_event(
+        self,
+        event_type_name: str,
+        env_name: str,
+        data: dict[str, Any],
+    ) -> None:
+        """Emit a hook lifecycle event if event_manager is configured.
+
+        Args:
+            event_type_name: Name of the event type (e.g., "HOOK_STARTED")
+            env_name: Environment name
+            data: Event data payload
+        """
+        if not self._event_manager:
+            return
+
+        # Import here to avoid circular imports at module level
+        from infrafoundry.core.events import EventType
+
+        event_type = getattr(EventType, event_type_name, None)
+        if event_type:
+            self._event_manager.emit_event(event_type, env_name, data)

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -556,3 +556,141 @@ class TestHookExecutionError:
         error = HookExecutionError("Hook failed", result)
         assert error.result == result
         assert "Hook failed" in str(error)
+
+
+@pytest.mark.unit
+class TestHookEventsIntegration:
+    """Tests for hook events integration."""
+
+    def test_hook_emits_events_on_success(
+        self, temp_config_dir, executable_script, mock_secret_manager_factory
+    ):
+        """Test that successful hook emits HOOK_STARTED and HOOK_COMPLETED events."""
+        from unittest.mock import MagicMock
+
+        from infrafoundry.core.events import EventManager, EventType
+
+        mock_event_manager = MagicMock(spec=EventManager)
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+            event_manager=mock_event_manager,
+        )
+        hook = HookConfig(script="scripts/test-hook.sh", description="Test hook")
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        # Should have emitted HOOK_STARTED and HOOK_COMPLETED
+        calls = mock_event_manager.emit_event.call_args_list
+        assert len(calls) == 2
+
+        # First call: HOOK_STARTED
+        assert calls[0][0][0] == EventType.HOOK_STARTED
+        assert calls[0][0][1] == "test-env"
+        assert calls[0][0][2]["script"] == "scripts/test-hook.sh"
+        assert calls[0][0][2]["stage"] == "before_plan"
+
+        # Second call: HOOK_COMPLETED
+        assert calls[1][0][0] == EventType.HOOK_COMPLETED
+        assert calls[1][0][1] == "test-env"
+        assert calls[1][0][2]["success"] is True
+
+    def test_hook_emits_events_on_failure(
+        self, temp_config_dir, failing_script, mock_secret_manager_factory
+    ):
+        """Test that failing hook emits HOOK_STARTED and HOOK_FAILED events."""
+        from unittest.mock import MagicMock
+
+        from infrafoundry.core.events import EventManager, EventType
+
+        mock_event_manager = MagicMock(spec=EventManager)
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+            event_manager=mock_event_manager,
+        )
+        hook = HookConfig(script="scripts/failing-hook.sh", continue_on_error=True)
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        # Should have emitted HOOK_STARTED and HOOK_FAILED
+        calls = mock_event_manager.emit_event.call_args_list
+        assert len(calls) == 2
+
+        # First call: HOOK_STARTED
+        assert calls[0][0][0] == EventType.HOOK_STARTED
+
+        # Second call: HOOK_FAILED
+        assert calls[1][0][0] == EventType.HOOK_FAILED
+        assert calls[1][0][2]["success"] is False
+        assert "error_message" in calls[1][0][2]
+
+    def test_hook_no_events_without_event_manager(
+        self, temp_config_dir, executable_script, mock_secret_manager_factory
+    ):
+        """Test that hooks work without event manager (no events emitted)."""
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+            event_manager=None,  # No event manager
+        )
+        hook = HookConfig(script="scripts/test-hook.sh")
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        # Should not raise any errors
+        results = manager.execute_environment_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            hooks_config=hooks_config,
+        )
+
+        assert len(results) == 1
+        assert results[0].success is True
+
+    def test_hook_events_include_resource_info(
+        self, temp_config_dir, executable_script, mock_secret_manager_factory
+    ):
+        """Test that resource hooks include resource info in events."""
+        from unittest.mock import MagicMock
+
+        from infrafoundry.core.events import EventManager
+
+        mock_event_manager = MagicMock(spec=EventManager)
+
+        manager = HookManager(
+            config_base_dir=temp_config_dir,
+            secret_manager_factory=mock_secret_manager_factory,
+            event_manager=mock_event_manager,
+        )
+        hook = HookConfig(script="scripts/test-hook.sh")
+        hooks_config = HooksConfig(before_plan=[hook])
+
+        manager.execute_resource_hooks(
+            env_name="test-env",
+            stage="before_plan",
+            resource_name="my-vm",
+            provider_name="proxmox",
+            hooks_config=hooks_config,
+        )
+
+        # Check that resource info is in event data
+        calls = mock_event_manager.emit_event.call_args_list
+        assert len(calls) == 2
+
+        # Both events should include resource info
+        for call in calls:
+            data = call[0][2]
+            assert data["resource_name"] == "my-vm"
+            assert data["provider_name"] == "proxmox"


### PR DESCRIPTION
## Description

Integrate HookManager with the unified event system so hooks emit lifecycle events when they execute. This enables:
- Monitoring hook execution via event subscriptions
- Consistent event-driven architecture across the codebase
- Notification/logging of hook lifecycle through existing event handlers

## Related Issue

Part of #198 (split into multiple PRs for easier review)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### `src/infrafoundry/core/events/types.py`
- Added `HOOK_STARTED` event type
- Added `HOOK_COMPLETED` event type
- Added `HOOK_FAILED` event type
- Updated docstring to include Hook events category

### `src/infrafoundry/core/hooks/manager.py`
- Added optional `event_manager: EventManager | None` parameter to `__init__`
- Added `_emit_hook_event()` helper method for emitting events
- Updated `_execute_single_hook()` to emit events:
  - `HOOK_STARTED` before hook execution begins
  - `HOOK_COMPLETED` when hook succeeds
  - `HOOK_FAILED` when hook fails

### Event Data Payload

```python
# HOOK_STARTED
{
    "script": "scripts/deploy.sh",
    "stage": "before_apply",
    "description": "Pre-deployment checks",
    "resource_name": "my-vm",      # if resource hook
    "provider_name": "proxmox",    # if resource hook
}

# HOOK_COMPLETED / HOOK_FAILED
{
    "script": "scripts/deploy.sh",
    "stage": "before_apply",
    "description": "Pre-deployment checks",
    "resource_name": "my-vm",
    "provider_name": "proxmox",
    "success": True,
    "exit_code": 0,
    "duration_seconds": 1.234,
    "timed_out": False,
    "error_message": "Exit code: 1",  # only if failed
}
```

### `tests/unit/test_hooks.py`
- Added 4 new tests for hook events integration

## Testing

- [x] All existing hook tests pass (24 tests)
- [x] 4 new tests added and passing
- [x] `doit check` passes (format, lint, type_check, security, spell_check, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
