### PR TITLE
refactor: standardize provider validators with ProviderValidator protocol

### DIFF
--- a/src/infrafoundry/core/types.py
+++ b/src/infrafoundry/core/types.py
@@ -40,6 +40,12 @@ class OPNsenseProviderSettings(TypedDict, total=False):
     api_secret: str
 
 
+class KubernetesProviderSettings(TypedDict, total=False):
+    """Provider settings expected by the Kubernetes provider."""
+
+    kubeconfig_path: str
+
+
 class OPNsenseEnvironmentConfig(TypedDict, total=False):
     """Subset of the environment configuration consumed by OPNsense."""
 
@@ -146,6 +152,7 @@ __all__ = [
     "DeploymentMetadata",
     "DestroyDeploymentMetadata",
     "EnvironmentData",
+    "KubernetesProviderSettings",
     "OCIProviderSettings",
     "OPNsenseEnvironmentConfig",
     "OPNsenseProviderSettings",

--- a/src/infrafoundry/core/validation.py
+++ b/src/infrafoundry/core/validation.py
@@ -1,8 +1,14 @@
 """Validation framework for pre-flight checks before infrastructure changes."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from infrafoundry.core.provider import ResourceConfig
+    from infrafoundry.core.types import EnvironmentData
 
 
 class ValidationLevel(Enum):
@@ -115,3 +121,64 @@ class ValidationReport:
             lines.append(f"  {result}")
 
         return "\n".join(lines)
+
+
+@runtime_checkable
+class ProviderValidator(Protocol):
+    """Protocol defining the standard interface for provider validators.
+
+    All provider validators should implement this protocol to ensure
+    consistent validation behavior across providers.
+
+    Attributes:
+        env_config: Environment configuration including provider_settings
+        report: ValidationReport to add results to
+
+    Example:
+        class MyProviderValidator:
+            def __init__(
+                self,
+                env_config: EnvironmentData,
+                report: ValidationReport,
+            ) -> None:
+                self.env_config = env_config
+                self.report = report
+
+            def validate_connectivity(self) -> None:
+                # Check API connectivity
+                ...
+
+            def validate_references(self, resources: list[ResourceConfig]) -> None:
+                # Validate resource references
+                ...
+    """
+
+    env_config: EnvironmentData
+    report: ValidationReport
+
+    def validate_connectivity(self) -> None:
+        """Validate connectivity to the provider's API.
+
+        Should check:
+        - Required credentials are present
+        - API endpoint is reachable
+        - Authentication is valid
+
+        Results should be added to self.report.
+        """
+        ...
+
+    def validate_references(self, resources: list[ResourceConfig]) -> None:
+        """Validate resource references against live state or config.
+
+        Should check:
+        - Referenced resources exist (in config or live API)
+        - No duplicate identifiers
+        - Cross-resource references are valid
+
+        Args:
+            resources: List of resources to validate
+
+        Results should be added to self.report.
+        """
+        ...

--- a/src/infrafoundry/providers/kubernetes/validator.py
+++ b/src/infrafoundry/providers/kubernetes/validator.py
@@ -1,0 +1,189 @@
+"""Validation logic for Kubernetes provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.types import EnvironmentData, KubernetesProviderSettings
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
+
+
+class KubernetesValidator:
+    """Validates Kubernetes configurations.
+
+    Performs pre-flight validation including:
+    - Kubeconfig file existence and accessibility
+    - Cross-resource reference validation (namespaces, secrets, configmaps)
+    """
+
+    def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+        """Initialize Kubernetes validator.
+
+        Args:
+            env_config: Environment configuration including provider_settings
+            report: ValidationReport to add results to
+        """
+        self.env_config = env_config
+        self.report = report
+        self.api_validator = BaseAPIValidator("kubernetes", env_config, report)
+        self.provider_settings = cast(
+            KubernetesProviderSettings, self.api_validator.provider_settings
+        )
+
+    def validate_connectivity(self) -> None:
+        """Validate Kubernetes connectivity prerequisites.
+
+        Checks:
+        - Kubeconfig file exists and is readable
+        """
+        kubeconfig_path = self.provider_settings.get("kubeconfig_path")
+
+        if not kubeconfig_path:
+            # Check default location
+            default_path = Path.home() / ".kube" / "config"
+            if default_path.exists():
+                self.report.add_check(
+                    check_name="kubernetes_kubeconfig",
+                    passed=True,
+                    message=f"Using default kubeconfig at {default_path}",
+                    level=ValidationLevel.INFO,
+                )
+            else:
+                self.report.add_check(
+                    check_name="kubernetes_kubeconfig",
+                    passed=False,
+                    message=("No kubeconfig_path specified and default ~/.kube/config not found"),
+                    level=ValidationLevel.WARNING,
+                )
+            return
+
+        kubeconfig = Path(kubeconfig_path).expanduser()
+        if kubeconfig.exists():
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig",
+                passed=True,
+                message=f"Kubeconfig found at {kubeconfig}",
+            )
+        else:
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig",
+                passed=False,
+                message=f"Kubeconfig not found at {kubeconfig}",
+                level=ValidationLevel.ERROR,
+            )
+
+    def validate_references(self, resources: list[ResourceConfig]) -> None:
+        """Validate Kubernetes resource references.
+
+        Checks:
+        - Resources reference valid namespaces
+        - ConfigMap/Secret references exist in config
+        - Service selectors match deployments
+
+        Args:
+            resources: List of resources to validate
+        """
+        # Collect resources by type
+        namespaces = {r.name for r in resources if r.type == "namespaces"}
+        configmaps = {r.name for r in resources if r.type == "configmaps"}
+        secrets = {r.name for r in resources if r.type == "secrets"}
+        deployments = {r.name for r in resources if r.type == "deployments"}
+        serviceaccounts = {r.name for r in resources if r.type == "serviceaccounts"}
+
+        # Validate namespace references
+        for resource in resources:
+            if resource.type in ("namespaces",):
+                continue  # Namespaces don't reference other namespaces
+
+            namespace = resource.config.get("namespace")
+            if namespace and namespace not in namespaces:
+                # It might be an existing namespace not in config - just warn
+                self.report.add_check(
+                    check_name=f"kubernetes_ref_{resource.name}_namespace",
+                    passed=True,
+                    message=(
+                        f"Resource '{resource.name}' references namespace '{namespace}' "
+                        f"(not in config - assuming it exists)"
+                    ),
+                    level=ValidationLevel.INFO,
+                )
+
+        # Validate deployment references to configmaps/secrets
+        for resource in resources:
+            if resource.type != "deployments":
+                continue
+
+            config = resource.config or {}
+
+            # Check configmap references in env_from
+            env_from = config.get("env_from", [])
+            for ref in env_from:
+                cm_ref = ref.get("configmap")
+                if cm_ref and cm_ref not in configmaps:
+                    self.report.add_check(
+                        check_name=f"kubernetes_ref_{resource.name}_configmap_{cm_ref}",
+                        passed=False,
+                        message=(
+                            f"Deployment '{resource.name}' references configmap '{cm_ref}' "
+                            f"which is not defined in configuration"
+                        ),
+                        level=ValidationLevel.ERROR,
+                    )
+                secret_ref = ref.get("secret")
+                if secret_ref and secret_ref not in secrets:
+                    self.report.add_check(
+                        check_name=f"kubernetes_ref_{resource.name}_secret_{secret_ref}",
+                        passed=False,
+                        message=(
+                            f"Deployment '{resource.name}' references secret '{secret_ref}' "
+                            f"which is not defined in configuration"
+                        ),
+                        level=ValidationLevel.ERROR,
+                    )
+
+            # Check service account references
+            sa_ref = config.get("service_account")
+            if sa_ref and sa_ref not in serviceaccounts:
+                self.report.add_check(
+                    check_name=f"kubernetes_ref_{resource.name}_serviceaccount",
+                    passed=True,
+                    message=(
+                        f"Deployment '{resource.name}' references service account '{sa_ref}' "
+                        f"(not in config - assuming it exists)"
+                    ),
+                    level=ValidationLevel.INFO,
+                )
+
+        # Validate service references to deployments
+        for resource in resources:
+            if resource.type != "services":
+                continue
+
+            config = resource.config or {}
+            selector = config.get("selector", {})
+
+            # Check if selector matches any deployment
+            if selector:
+                # Simple check - see if app label matches a deployment name
+                app_label = selector.get("app") or selector.get("app.kubernetes.io/name")
+                if app_label and app_label not in deployments:
+                    self.report.add_check(
+                        check_name=f"kubernetes_ref_{resource.name}_selector",
+                        passed=True,
+                        message=(
+                            f"Service '{resource.name}' selector may not match any deployment "
+                            f"in configuration (selector.app={app_label})"
+                        ),
+                        level=ValidationLevel.INFO,
+                    )
+
+        # Report success if we have resources
+        if resources:
+            self.report.add_check(
+                check_name="kubernetes_references",
+                passed=True,
+                message=f"Validated references for {len(resources)} Kubernetes resources",
+            )

--- a/tests/unit/test_kubernetes_validator.py
+++ b/tests/unit/test_kubernetes_validator.py
@@ -1,0 +1,206 @@
+"""Unit tests for KubernetesValidator."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import (
+    ProviderValidator,
+    ValidationLevel,
+    ValidationReport,
+)
+from infrafoundry.providers.kubernetes.validator import KubernetesValidator
+
+
+@pytest.fixture
+def mock_env_config():
+    """Create a mock environment config."""
+    return {
+        "name": "test-env",
+        "provider_settings": {
+            "kubernetes": {
+                "kubeconfig_path": "/path/to/kubeconfig",
+            }
+        },
+    }
+
+
+@pytest.fixture
+def validation_report():
+    """Create a ValidationReport instance."""
+    return ValidationReport()
+
+
+@pytest.fixture
+def validator(mock_env_config, validation_report):
+    """Create a KubernetesValidator instance."""
+    return KubernetesValidator(mock_env_config, validation_report)
+
+
+@pytest.mark.unit
+class TestKubernetesValidatorProtocol:
+    """Tests verifying KubernetesValidator implements ProviderValidator protocol."""
+
+    def test_implements_provider_validator_protocol(self, validator):
+        """Test that KubernetesValidator implements ProviderValidator protocol."""
+        assert isinstance(validator, ProviderValidator)
+        assert hasattr(validator, "env_config")
+        assert hasattr(validator, "report")
+        assert hasattr(validator, "validate_connectivity")
+        assert hasattr(validator, "validate_references")
+
+
+@pytest.mark.unit
+class TestKubernetesValidatorConnectivity:
+    """Tests for KubernetesValidator.validate_connectivity."""
+
+    def test_validate_connectivity_with_existing_kubeconfig(
+        self, mock_env_config, validation_report
+    ):
+        """Test validation when kubeconfig exists."""
+        with patch.object(Path, "exists", return_value=True):
+            validator = KubernetesValidator(mock_env_config, validation_report)
+            validator.validate_connectivity()
+
+        # Should have success result
+        assert any(r.passed for r in validation_report.results)
+        assert any("Kubeconfig found" in r.message for r in validation_report.results)
+
+    def test_validate_connectivity_with_missing_kubeconfig(
+        self, mock_env_config, validation_report
+    ):
+        """Test validation when kubeconfig doesn't exist."""
+        with patch.object(Path, "exists", return_value=False):
+            validator = KubernetesValidator(mock_env_config, validation_report)
+            validator.validate_connectivity()
+
+        # Should have error result
+        assert any(not r.passed for r in validation_report.results)
+        assert any("not found" in r.message for r in validation_report.results)
+
+    def test_validate_connectivity_no_kubeconfig_path_with_default(self, validation_report):
+        """Test validation when no kubeconfig path specified but default exists."""
+        env_config = {
+            "name": "test-env",
+            "provider_settings": {"kubernetes": {}},
+        }
+
+        with patch.object(Path, "exists", return_value=True):
+            validator = KubernetesValidator(env_config, validation_report)
+            validator.validate_connectivity()
+
+        # Should have info result about using default
+        assert any("default kubeconfig" in r.message for r in validation_report.results)
+
+    def test_validate_connectivity_no_kubeconfig_path_no_default(self, validation_report):
+        """Test validation when no kubeconfig path and no default."""
+        env_config = {
+            "name": "test-env",
+            "provider_settings": {"kubernetes": {}},
+        }
+
+        with patch.object(Path, "exists", return_value=False):
+            validator = KubernetesValidator(env_config, validation_report)
+            validator.validate_connectivity()
+
+        # Should have warning result
+        assert any(
+            r.level == ValidationLevel.WARNING and not r.passed for r in validation_report.results
+        )
+
+
+@pytest.mark.unit
+class TestKubernetesValidatorReferences:
+    """Tests for KubernetesValidator.validate_references."""
+
+    def test_validate_references_empty_resources(self, validator, validation_report):
+        """Test validation with no resources."""
+        validator.validate_references([])
+
+        # Should have no errors
+        assert not validation_report.has_errors()
+
+    def test_validate_references_valid_configmap_ref(self, validator, validation_report):
+        """Test validation with valid configmap reference."""
+        resources = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="configmaps",
+                name="my-config",
+                config={"namespace": "default", "data": {"key": "value"}},
+            ),
+            ResourceConfig(
+                provider="kubernetes",
+                type="deployments",
+                name="my-app",
+                config={
+                    "namespace": "default",
+                    "env_from": [{"configmap": "my-config"}],
+                },
+            ),
+        ]
+
+        validator.validate_references(resources)
+
+        # Should have no errors for configmap reference
+        errors = [r for r in validation_report.results if not r.passed]
+        configmap_errors = [e for e in errors if "configmap" in e.check_name]
+        assert len(configmap_errors) == 0
+
+    def test_validate_references_invalid_configmap_ref(self, validator, validation_report):
+        """Test validation with invalid configmap reference."""
+        resources = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="deployments",
+                name="my-app",
+                config={
+                    "namespace": "default",
+                    "env_from": [{"configmap": "missing-config"}],
+                },
+            ),
+        ]
+
+        validator.validate_references(resources)
+
+        # Should have error for missing configmap
+        assert validation_report.has_errors()
+        assert any("missing-config" in r.message for r in validation_report.results)
+
+    def test_validate_references_invalid_secret_ref(self, validator, validation_report):
+        """Test validation with invalid secret reference."""
+        resources = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="deployments",
+                name="my-app",
+                config={
+                    "namespace": "default",
+                    "env_from": [{"secret": "missing-secret"}],
+                },
+            ),
+        ]
+
+        validator.validate_references(resources)
+
+        # Should have error for missing secret
+        assert validation_report.has_errors()
+        assert any("missing-secret" in r.message for r in validation_report.results)
+
+    def test_validate_references_reports_success(self, validator, validation_report):
+        """Test that validation reports overall success."""
+        resources = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="namespaces",
+                name="my-namespace",
+                config={},
+            ),
+        ]
+
+        validator.validate_references(resources)
+
+        # Should report successful validation
+        assert any("Validated references" in r.message for r in validation_report.results)


### PR DESCRIPTION
## Description

Adds `ProviderValidator` protocol defining the standard interface for provider validators and implements `KubernetesValidator` following this pattern. All provider validators now have consistent structure.

## Related Issue

Part of #198

## Type of Change

- [x] Code refactoring

## Changes Made

- Added `ProviderValidator` protocol in `core/validation.py` with `@runtime_checkable`
- Added `KubernetesProviderSettings` TypedDict in `core/types.py`
- Implemented `KubernetesValidator` in `providers/kubernetes/validator.py`
- Added comprehensive tests in `tests/unit/test_kubernetes_validator.py`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
