### PR TITLE
fix: show user-friendly error messages instead of tracebacks

### DIFF
--- a/src/infrafoundry/cli/decorators.py
+++ b/src/infrafoundry/cli/decorators.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import inspect
+import os
 import sys
-import traceback
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
@@ -21,6 +21,44 @@ from infrafoundry.core.exceptions import (
 from .utils import raise_cli_error
 
 console = Console()
+
+
+def _is_debug_mode() -> bool:
+    """Check if debug mode is enabled."""
+    return os.getenv("INFRAFOUNDRY_LOG_LEVEL") == "DEBUG"
+
+
+def _get_error_hint(exc: Exception) -> str | None:
+    """Get a helpful hint for common errors.
+
+    Args:
+        exc: The exception to analyze
+
+    Returns:
+        A hint string, or None if no hint is available
+    """
+    exc_str = str(exc).lower()
+
+    if isinstance(exc, FileNotFoundError):
+        if "generated" in exc_str or "terraform" in exc_str:
+            return "Make sure you're running from the project root directory."
+        if "kubeconfig" in exc_str or ".kube" in exc_str:
+            return "Check that your kubeconfig file exists and is readable."
+        return "Check that the file path is correct and the file exists."
+
+    if isinstance(exc, PermissionError):
+        return "Check file permissions or try running with appropriate access."
+
+    if isinstance(exc, ConnectionError | OSError) and "connection" in exc_str:
+        return "Check your network connection and that the service is reachable."
+
+    if "timeout" in exc_str:
+        return "The operation timed out. Try again or increase the timeout."
+
+    if "authentication" in exc_str or "unauthorized" in exc_str:
+        return "Check your credentials and authentication settings."
+
+    return None
 
 
 def with_orchestrator(
@@ -83,8 +121,21 @@ def with_orchestrator(
                 # Other InfraFoundry errors - show with context
                 raise_cli_error(action, exc)
             except Exception as exc:
-                console.print(f"[bold red]ERROR:[/bold red] {action} - {exc}")
-                console.print(traceback.format_exc(), style="dim red")  # Log full traceback
+                # Show user-friendly error message
+                console.print(f"[bold red]Error:[/bold red] {action}")
+                console.print(f"  {exc}")
+
+                # Show hint if available
+                if hint := _get_error_hint(exc):
+                    console.print(f"\n[yellow]Hint:[/yellow] {hint}")
+
+                # Show traceback only in debug mode
+                if _is_debug_mode():
+                    console.print("\n[dim]Debug traceback:[/dim]")
+                    console.print_exception(show_locals=False)
+                else:
+                    console.print("\n[dim]Use --debug for full error details.[/dim]")
+
                 sys.exit(1)
 
         return wrapper

--- a/src/infrafoundry/cli/main.py
+++ b/src/infrafoundry/cli/main.py
@@ -161,6 +161,12 @@ def _load_env_credentials(env_name: str, config_dir: Path | None = None) -> None
 @click.group()
 @click.version_option(version="0.1.0", prog_name="foundry")
 @click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help="Enable debug mode (show full tracebacks on errors)",
+)
+@click.option(
     "--config-dir",
     "-c",
     type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
@@ -184,6 +190,7 @@ def _load_env_credentials(env_name: str, config_dir: Path | None = None) -> None
 @click.pass_context
 def foundry(
     ctx: click.Context,
+    debug: bool,
     config_dir: Path | None,
     strict_mode: bool | None,
     fail_on_missing_secrets: bool | None,
@@ -191,6 +198,12 @@ def foundry(
 ) -> None:
     """InfraFoundry - Infrastructure automation framework."""
     ctx.ensure_object(dict)
+
+    # Enable debug mode if requested
+    if debug:
+        os.environ["INFRAFOUNDRY_LOG_LEVEL"] = "DEBUG"
+    ctx.obj["debug"] = debug
+
     # Use --config-dir flag if provided, otherwise check environment variable
     if config_dir:
         ctx.obj["config_dir"] = config_dir

--- a/tests/unit/test_cli_decorators.py
+++ b/tests/unit/test_cli_decorators.py
@@ -1,0 +1,106 @@
+"""Unit tests for CLI decorators."""
+
+import os
+from unittest.mock import patch
+
+from infrafoundry.cli.decorators import _get_error_hint, _is_debug_mode
+
+
+class TestIsDebugMode:
+    """Tests for _is_debug_mode function."""
+
+    def test_returns_true_when_debug_env_set(self):
+        """Test returns True when INFRAFOUNDRY_LOG_LEVEL is DEBUG."""
+        with patch.dict(os.environ, {"INFRAFOUNDRY_LOG_LEVEL": "DEBUG"}):
+            assert _is_debug_mode() is True
+
+    def test_returns_false_when_debug_env_not_set(self):
+        """Test returns False when INFRAFOUNDRY_LOG_LEVEL is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure the variable is not set
+            os.environ.pop("INFRAFOUNDRY_LOG_LEVEL", None)
+            assert _is_debug_mode() is False
+
+    def test_returns_false_when_debug_env_is_other_value(self):
+        """Test returns False when INFRAFOUNDRY_LOG_LEVEL is not DEBUG."""
+        with patch.dict(os.environ, {"INFRAFOUNDRY_LOG_LEVEL": "INFO"}):
+            assert _is_debug_mode() is False
+
+
+class TestGetErrorHint:
+    """Tests for _get_error_hint function."""
+
+    def test_file_not_found_with_generated_path(self):
+        """Test hint for FileNotFoundError with generated directory."""
+        exc = FileNotFoundError("No such file: generated/env/terraform/provider")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "project root" in hint
+
+    def test_file_not_found_with_terraform_path(self):
+        """Test hint for FileNotFoundError with terraform path."""
+        exc = FileNotFoundError("terraform directory not found")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "project root" in hint
+
+    def test_file_not_found_with_kubeconfig(self):
+        """Test hint for FileNotFoundError with kubeconfig."""
+        exc = FileNotFoundError("kubeconfig file missing")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "kubeconfig" in hint
+
+    def test_file_not_found_generic(self):
+        """Test hint for generic FileNotFoundError."""
+        exc = FileNotFoundError("some_file.txt not found")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "file path" in hint or "file exists" in hint
+
+    def test_permission_error(self):
+        """Test hint for PermissionError."""
+        exc = PermissionError("Permission denied")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "permission" in hint.lower()
+
+    def test_connection_error(self):
+        """Test hint for connection-related errors."""
+        exc = ConnectionError("Connection refused")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "network" in hint.lower() or "connection" in hint.lower()
+
+    def test_timeout_error(self):
+        """Test hint for timeout errors."""
+        exc = Exception("Operation timeout exceeded")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "timeout" in hint.lower()
+
+    def test_authentication_error(self):
+        """Test hint for authentication errors."""
+        exc = Exception("Authentication failed")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "credential" in hint.lower() or "authentication" in hint.lower()
+
+    def test_unauthorized_error(self):
+        """Test hint for unauthorized errors."""
+        exc = Exception("Unauthorized access")
+        hint = _get_error_hint(exc)
+        assert hint is not None
+        assert "credential" in hint.lower() or "authentication" in hint.lower()
+
+    def test_no_hint_for_generic_error(self):
+        """Test no hint for errors without known patterns."""
+        exc = Exception("Some random error")
+        hint = _get_error_hint(exc)
+        assert hint is None
+
+    def test_no_hint_for_value_error(self):
+        """Test no hint for ValueError."""
+        exc = ValueError("Invalid value")
+        hint = _get_error_hint(exc)
+        assert hint is None


### PR DESCRIPTION
## Description

Shows user-friendly error messages instead of Python tracebacks. Users now see concise error messages with helpful hints by default, with full debug info available via `--debug` flag.

**Before:**
```
Traceback (most recent call last):
  File "/home/.../orchestrator_workflows.py", line 832, in destroy
    runner_result = runner.destroy(provider, auto_approve=auto_approve)
  ...
FileNotFoundError: [Errno 2] No such file or directory: PosixPath('generated/ocik8/terraform/kubernetes')
```

**After:**
```
Error: Destroy failed
  [Errno 2] No such file or directory: 'generated/ocik8/terraform/kubernetes'

Hint: Make sure you're running from the project root directory.

Use --debug for full error details.
```

## Related Issue

Closes #186

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `--debug` flag to main CLI group (sets `INFRAFOUNDRY_LOG_LEVEL=DEBUG`)
- Updated error handler in `@with_orchestrator` decorator to show concise messages by default
- Added `_get_error_hint()` function providing contextual hints for common errors
- Added `_is_debug_mode()` helper for consistent debug mode checking
- Added comprehensive unit tests for new functionality

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
