### PR TITLE
feat: add security scanning integration with Checkov

### DIFF
--- a/src/infrafoundry/cli/commands/infra/__init__.py
+++ b/src/infrafoundry/cli/commands/infra/__init__.py
@@ -9,6 +9,7 @@ from .history import history
 from .plan import plan
 from .reset import reset
 from .rollback import rollback
+from .security import security
 from .status import status
 
 
@@ -25,6 +26,7 @@ infra.add_command(destroy)
 infra.add_command(drift)
 infra.add_command(rollback)
 infra.add_command(reset)
+infra.add_command(security)
 infra.add_command(status)
 infra.add_command(history)
 

--- a/src/infrafoundry/cli/commands/infra/security.py
+++ b/src/infrafoundry/cli/commands/infra/security.py
@@ -1,0 +1,202 @@
+"""Security scanning commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+from rich.table import Table
+
+from infrafoundry.cli.decorators import with_orchestrator
+from infrafoundry.cli.utils import console
+from infrafoundry.core.security import ScanResult, ScanSeverity, SecurityScanner
+
+if TYPE_CHECKING:
+    from infrafoundry.core.orchestrator import Orchestrator
+
+
+@click.command("security")
+@click.option("--env", "-e", required=True, help="Environment to scan")
+@click.option(
+    "--severity",
+    "-s",
+    type=click.Choice(["critical", "high", "medium", "low", "info"], case_sensitive=False),
+    default="high",
+    help="Minimum severity to fail on (default: high)",
+)
+@click.option(
+    "--skip-check",
+    multiple=True,
+    help="Check IDs to skip (can be specified multiple times)",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=300,
+    help="Scan timeout in seconds (default: 300)",
+)
+@with_orchestrator("Security scan failed", require_env=True, load_credentials=False)
+def security(
+    _ctx: click.Context,
+    orchestrator: Orchestrator,
+    env: str,
+    severity: str,
+    skip_check: tuple[str, ...],
+    output: str,
+    timeout: int,
+) -> None:
+    """Scan infrastructure configurations for security issues.
+
+    Uses Checkov to scan generated Terraform and Ansible configurations
+    for security vulnerabilities, misconfigurations, and compliance issues.
+
+    Example:
+        infra security --env prod
+        infra security --env dev --severity medium
+        infra security --env staging --skip-check CKV_AWS_1 --skip-check CKV_AWS_2
+    """
+    import json as json_module
+    import sys
+
+    # Map severity string to enum
+    severity_map = {
+        "critical": ScanSeverity.CRITICAL,
+        "high": ScanSeverity.HIGH,
+        "medium": ScanSeverity.MEDIUM,
+        "low": ScanSeverity.LOW,
+        "info": ScanSeverity.INFO,
+    }
+    severity_threshold = severity_map[severity.lower()]
+
+    # Initialize scanner
+    scanner = SecurityScanner(
+        severity_threshold=severity_threshold,
+        skip_checks=list(skip_check),
+    )
+
+    # Check if checkov is available
+    if not scanner.is_available():
+        console.error("Checkov is not installed.")
+        console.info("Install with: pip install checkov")
+        console.info("Or: pipx install checkov")
+        sys.exit(1)
+
+    version = scanner.get_version()
+    console.header(f"Security Scan: {env}")
+    if version:
+        console.status(f"Using Checkov {version}")
+
+    # Determine scan directory (generated configs)
+    generated_dir = Path("generated") / env
+    if not generated_dir.exists():
+        console.error(f"Generated directory not found: {generated_dir}")
+        console.info("Run 'infra plan --env {env}' first to generate configurations.")
+        sys.exit(1)
+
+    console.status(f"Scanning {generated_dir}...")
+
+    # Run scan
+    result = scanner.scan(generated_dir, timeout=timeout)
+
+    # Handle errors
+    if result.error:
+        console.error(f"Scan error: {result.error}")
+        sys.exit(1)
+
+    # Output results
+    if output == "json":
+        console.print(json_module.dumps(result.to_dict(), indent=2))
+    else:
+        _display_table_results(result, severity_threshold)
+
+    # Exit with appropriate code
+    if not result.passed:
+        sys.exit(1)
+
+
+def _display_table_results(result: ScanResult, threshold: ScanSeverity) -> None:
+    """Display scan results as a formatted table."""
+    # Summary
+    console.print()
+    console.header("Scan Summary")
+    console.info(f"  Total checks: {result.total_checks}")
+    console.success(f"  Passed: {result.passed_checks}")
+    if result.failed_checks > 0:
+        console.error(f"  Failed: {result.failed_checks}")
+    else:
+        console.info(f"  Failed: {result.failed_checks}")
+    if result.skipped_checks > 0:
+        console.info(f"  Skipped: {result.skipped_checks}")
+    console.status(f"  Duration: {result.scan_duration_seconds:.1f}s")
+    console.info(f"  Severity threshold: {threshold.value}")
+
+    if not result.violations:
+        console.print()
+        console.success("No security issues found!")
+        return
+
+    # Violations table
+    console.print()
+    console.header(f"Security Issues ({len(result.violations)} found)")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Severity", style="bold", width=10)
+    table.add_column("Check ID", style="cyan", width=15)
+    table.add_column("Resource", width=30)
+    table.add_column("Description", width=40)
+
+    # Sort by severity
+    severity_order = {
+        ScanSeverity.CRITICAL: 0,
+        ScanSeverity.HIGH: 1,
+        ScanSeverity.MEDIUM: 2,
+        ScanSeverity.LOW: 3,
+        ScanSeverity.INFO: 4,
+    }
+    sorted_violations = sorted(result.violations, key=lambda v: severity_order[v.severity])
+
+    severity_styles = {
+        ScanSeverity.CRITICAL: "bold red",
+        ScanSeverity.HIGH: "red",
+        ScanSeverity.MEDIUM: "yellow",
+        ScanSeverity.LOW: "blue",
+        ScanSeverity.INFO: "dim",
+    }
+
+    for violation in sorted_violations:
+        style = severity_styles.get(violation.severity, "")
+        table.add_row(
+            f"[{style}]{violation.severity.value.upper()}[/{style}]",
+            violation.check_id,
+            _truncate(violation.resource, 30),
+            _truncate(violation.description, 40),
+        )
+
+    console.print(table)
+
+    # Overall result
+    console.print()
+    if result.passed:
+        console.success(f"Scan passed (no issues at {threshold.value} severity or above)")
+    else:
+        blocking = [
+            v for v in result.violations if severity_order[v.severity] <= severity_order[threshold]
+        ]
+        console.error(
+            f"Scan failed: {len(blocking)} issue(s) at {threshold.value} severity or above"
+        )
+
+
+def _truncate(text: str, max_length: int) -> str:
+    """Truncate text to max length with ellipsis."""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."

--- a/src/infrafoundry/core/security/__init__.py
+++ b/src/infrafoundry/core/security/__init__.py
@@ -1,0 +1,19 @@
+"""Security scanning module for infrastructure configurations.
+
+This module provides security scanning capabilities for generated
+Terraform and Ansible configurations using tools like Checkov.
+"""
+
+from infrafoundry.core.security.scanner import (
+    ScanResult,
+    ScanSeverity,
+    SecurityScanner,
+    SecurityViolation,
+)
+
+__all__ = [
+    "ScanResult",
+    "ScanSeverity",
+    "SecurityScanner",
+    "SecurityViolation",
+]

--- a/src/infrafoundry/core/security/scanner.py
+++ b/src/infrafoundry/core/security/scanner.py
@@ -1,0 +1,337 @@
+"""Security scanner base classes and types."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404 - required for running checkov
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, override
+
+from infrafoundry.core.base_manager import BaseManager
+
+
+class ScanSeverity(str, Enum):
+    """Severity levels for security violations."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    INFO = "info"
+
+
+@dataclass
+class SecurityViolation:
+    """A single security violation found during scanning."""
+
+    check_id: str
+    check_name: str
+    severity: ScanSeverity
+    resource: str
+    file_path: str
+    description: str
+    guideline: str | None = None
+    line_range: tuple[int, int] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert violation to dictionary."""
+        return {
+            "check_id": self.check_id,
+            "check_name": self.check_name,
+            "severity": self.severity.value,
+            "resource": self.resource,
+            "file_path": self.file_path,
+            "description": self.description,
+            "guideline": self.guideline,
+            "line_range": self.line_range,
+        }
+
+
+@dataclass
+class ScanResult:
+    """Result of a security scan."""
+
+    passed: bool
+    violations: list[SecurityViolation] = field(default_factory=list)
+    passed_checks: int = 0
+    failed_checks: int = 0
+    skipped_checks: int = 0
+    scan_duration_seconds: float = 0.0
+    scanner_version: str | None = None
+    error: str | None = None
+
+    @property
+    def total_checks(self) -> int:
+        """Total number of checks performed."""
+        return self.passed_checks + self.failed_checks + self.skipped_checks
+
+    def get_violations_by_severity(self, severity: ScanSeverity) -> list[SecurityViolation]:
+        """Get violations filtered by severity."""
+        return [v for v in self.violations if v.severity == severity]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert result to dictionary."""
+        return {
+            "passed": self.passed,
+            "violations": [v.to_dict() for v in self.violations],
+            "passed_checks": self.passed_checks,
+            "failed_checks": self.failed_checks,
+            "skipped_checks": self.skipped_checks,
+            "total_checks": self.total_checks,
+            "scan_duration_seconds": self.scan_duration_seconds,
+            "scanner_version": self.scanner_version,
+            "error": self.error,
+        }
+
+
+class SecurityScanner(BaseManager):
+    """Security scanner using Checkov for Terraform/Ansible configurations.
+
+    Scans generated infrastructure configurations for security issues,
+    misconfigurations, and compliance violations.
+    """
+
+    def __init__(
+        self,
+        severity_threshold: ScanSeverity = ScanSeverity.HIGH,
+        skip_checks: list[str] | None = None,
+        frameworks: list[str] | None = None,
+    ) -> None:
+        """Initialize security scanner.
+
+        Args:
+            severity_threshold: Minimum severity to fail on (default: HIGH)
+            skip_checks: List of check IDs to skip
+            frameworks: Frameworks to scan (default: terraform, ansible)
+        """
+        super().__init__()
+        self.severity_threshold = severity_threshold
+        self.skip_checks = skip_checks or []
+        self.frameworks = frameworks or ["terraform", "ansible"]
+        self._checkov_path: str | None = None
+
+    @override
+    def cleanup(self) -> None:
+        """Clean up scanner resources.
+
+        SecurityScanner has no persistent resources to clean up.
+        """
+        pass
+
+    @property
+    def checkov_path(self) -> str:
+        """Get path to checkov executable."""
+        if self._checkov_path is None:
+            path = shutil.which("checkov")
+            if path is None:
+                raise FileNotFoundError(
+                    "checkov not found on PATH. Install with: pip install checkov"
+                )
+            self._checkov_path = path
+        return self._checkov_path
+
+    def is_available(self) -> bool:
+        """Check if checkov is installed and available."""
+        try:
+            _ = self.checkov_path
+            return True
+        except FileNotFoundError:
+            return False
+
+    def get_version(self) -> str | None:
+        """Get checkov version."""
+        try:
+            result = subprocess.run(  # nosec B603 - using list args, not shell
+                [self.checkov_path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return result.stdout.strip() if result.returncode == 0 else None
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return None
+
+    def scan(self, directory: Path, timeout: int = 300) -> ScanResult:
+        """Scan a directory for security issues.
+
+        Args:
+            directory: Directory to scan (should contain terraform/ansible files)
+            timeout: Maximum scan time in seconds
+
+        Returns:
+            ScanResult with violations and summary
+        """
+        import time
+
+        start_time = time.time()
+
+        if not directory.exists():
+            return ScanResult(
+                passed=False,
+                error=f"Directory not found: {directory}",
+            )
+
+        try:
+            result = self._run_checkov(directory, timeout)
+            result.scan_duration_seconds = time.time() - start_time
+            result.scanner_version = self.get_version()
+            return result
+        except FileNotFoundError as exc:
+            return ScanResult(
+                passed=False,
+                error=str(exc),
+                scan_duration_seconds=time.time() - start_time,
+            )
+        except subprocess.TimeoutExpired:
+            return ScanResult(
+                passed=False,
+                error=f"Scan timed out after {timeout} seconds",
+                scan_duration_seconds=timeout,
+            )
+        except Exception as exc:
+            self._log_error(f"Security scan failed: {exc}")
+            return ScanResult(
+                passed=False,
+                error=str(exc),
+                scan_duration_seconds=time.time() - start_time,
+            )
+
+    def _run_checkov(self, directory: Path, timeout: int) -> ScanResult:
+        """Run checkov and parse results."""
+        cmd = [
+            self.checkov_path,
+            "-d",
+            str(directory),
+            "-o",
+            "json",
+            "--compact",
+            "--quiet",
+        ]
+
+        # Add framework filters
+        for framework in self.frameworks:
+            cmd.extend(["--framework", framework])
+
+        # Add skip checks
+        for check_id in self.skip_checks:
+            cmd.extend(["--skip-check", check_id])
+
+        self._log_debug(f"Running: {' '.join(cmd)}")
+
+        result = subprocess.run(  # nosec B603 - using list args, not shell
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=directory,
+        )
+
+        # Checkov returns non-zero if it finds issues
+        return self._parse_checkov_output(result.stdout, result.stderr)
+
+    def _parse_checkov_output(self, stdout: str, stderr: str) -> ScanResult:
+        """Parse checkov JSON output into ScanResult."""
+        if not stdout.strip():
+            # No output might mean no files to scan
+            if "No files to scan" in stderr or not stderr:
+                return ScanResult(passed=True)
+            return ScanResult(passed=False, error=stderr)
+
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            self._log_warning(f"Failed to parse checkov output: {exc}")
+            return ScanResult(passed=False, error=f"Invalid checkov output: {exc}")
+
+        violations: list[SecurityViolation] = []
+        passed_checks = 0
+        failed_checks = 0
+        skipped_checks = 0
+
+        # Handle both single result and array of results
+        results_list = data if isinstance(data, list) else [data]
+
+        for result_block in results_list:
+            if not isinstance(result_block, dict):
+                continue
+
+            # Handle check_type results (terraform, ansible, etc.)
+            check_results = result_block.get("results", {})
+
+            # Count passed checks
+            for _passed_check in check_results.get("passed_checks", []):
+                passed_checks += 1
+
+            # Count skipped checks
+            for _skipped_check in check_results.get("skipped_checks", []):
+                skipped_checks += 1
+
+            # Process failed checks
+            for failed_check in check_results.get("failed_checks", []):
+                failed_checks += 1
+                violation = self._parse_violation(failed_check)
+                if violation:
+                    violations.append(violation)
+
+        # Determine if scan passed based on severity threshold
+        threshold_order = [
+            ScanSeverity.CRITICAL,
+            ScanSeverity.HIGH,
+            ScanSeverity.MEDIUM,
+            ScanSeverity.LOW,
+            ScanSeverity.INFO,
+        ]
+        threshold_idx = threshold_order.index(self.severity_threshold)
+        blocking_severities = set(threshold_order[: threshold_idx + 1])
+
+        blocking_violations = [v for v in violations if v.severity in blocking_severities]
+        passed = len(blocking_violations) == 0
+
+        return ScanResult(
+            passed=passed,
+            violations=violations,
+            passed_checks=passed_checks,
+            failed_checks=failed_checks,
+            skipped_checks=skipped_checks,
+        )
+
+    def _parse_violation(self, check_data: dict[str, Any]) -> SecurityViolation | None:
+        """Parse a single failed check into a SecurityViolation."""
+        try:
+            severity_str = check_data.get("check_result", {}).get("severity", "medium")
+            severity_str = severity_str.lower() if severity_str else "medium"
+
+            # Map checkov severity to our enum
+            severity_map = {
+                "critical": ScanSeverity.CRITICAL,
+                "high": ScanSeverity.HIGH,
+                "medium": ScanSeverity.MEDIUM,
+                "low": ScanSeverity.LOW,
+                "info": ScanSeverity.INFO,
+                "none": ScanSeverity.INFO,
+            }
+            severity = severity_map.get(severity_str, ScanSeverity.MEDIUM)
+
+            # Extract line range if available
+            line_range = None
+            if "file_line_range" in check_data:
+                lines = check_data["file_line_range"]
+                if isinstance(lines, list) and len(lines) >= 2:
+                    line_range = (lines[0], lines[1])
+
+            return SecurityViolation(
+                check_id=check_data.get("check_id", "UNKNOWN"),
+                check_name=check_data.get("check_name", "Unknown check"),
+                severity=severity,
+                resource=check_data.get("resource", "unknown"),
+                file_path=check_data.get("file_path", "unknown"),
+                description=check_data.get("check_name", ""),
+                guideline=check_data.get("guideline"),
+                line_range=line_range,
+            )
+        except Exception as exc:
+            self._log_warning(f"Failed to parse violation: {exc}")
+            return None

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -1,0 +1,326 @@
+"""Unit tests for security scanner."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infrafoundry.core.security import (
+    ScanResult,
+    ScanSeverity,
+    SecurityScanner,
+    SecurityViolation,
+)
+
+
+class TestScanSeverity:
+    """Tests for ScanSeverity enum."""
+
+    def test_severity_values(self):
+        """Test severity enum values."""
+        assert ScanSeverity.CRITICAL.value == "critical"
+        assert ScanSeverity.HIGH.value == "high"
+        assert ScanSeverity.MEDIUM.value == "medium"
+        assert ScanSeverity.LOW.value == "low"
+        assert ScanSeverity.INFO.value == "info"
+
+
+class TestSecurityViolation:
+    """Tests for SecurityViolation dataclass."""
+
+    def test_create_violation(self):
+        """Test creating a security violation."""
+        violation = SecurityViolation(
+            check_id="CKV_AWS_1",
+            check_name="Ensure S3 bucket has encryption",
+            severity=ScanSeverity.HIGH,
+            resource="aws_s3_bucket.test",
+            file_path="/path/to/main.tf",
+            description="S3 bucket should have encryption enabled",
+            guideline="https://docs.checkov.io/docs/CKV_AWS_1",
+            line_range=(10, 20),
+        )
+        assert violation.check_id == "CKV_AWS_1"
+        assert violation.severity == ScanSeverity.HIGH
+
+    def test_violation_to_dict(self):
+        """Test converting violation to dictionary."""
+        violation = SecurityViolation(
+            check_id="CKV_AWS_1",
+            check_name="Test check",
+            severity=ScanSeverity.MEDIUM,
+            resource="resource.test",
+            file_path="/test.tf",
+            description="Test description",
+        )
+        result = violation.to_dict()
+        assert result["check_id"] == "CKV_AWS_1"
+        assert result["severity"] == "medium"
+        assert result["guideline"] is None
+
+
+class TestScanResult:
+    """Tests for ScanResult dataclass."""
+
+    def test_create_passed_result(self):
+        """Test creating a passed scan result."""
+        result = ScanResult(passed=True, passed_checks=10)
+        assert result.passed is True
+        assert result.total_checks == 10
+
+    def test_create_failed_result(self):
+        """Test creating a failed scan result."""
+        violation = SecurityViolation(
+            check_id="CKV_AWS_1",
+            check_name="Test",
+            severity=ScanSeverity.HIGH,
+            resource="test",
+            file_path="/test.tf",
+            description="Test",
+        )
+        result = ScanResult(
+            passed=False,
+            violations=[violation],
+            passed_checks=5,
+            failed_checks=1,
+        )
+        assert result.passed is False
+        assert result.total_checks == 6
+        assert len(result.violations) == 1
+
+    def test_get_violations_by_severity(self):
+        """Test filtering violations by severity."""
+        violations = [
+            SecurityViolation(
+                check_id="CKV_1",
+                check_name="Test1",
+                severity=ScanSeverity.HIGH,
+                resource="r1",
+                file_path="/t1.tf",
+                description="D1",
+            ),
+            SecurityViolation(
+                check_id="CKV_2",
+                check_name="Test2",
+                severity=ScanSeverity.LOW,
+                resource="r2",
+                file_path="/t2.tf",
+                description="D2",
+            ),
+            SecurityViolation(
+                check_id="CKV_3",
+                check_name="Test3",
+                severity=ScanSeverity.HIGH,
+                resource="r3",
+                file_path="/t3.tf",
+                description="D3",
+            ),
+        ]
+        result = ScanResult(passed=False, violations=violations)
+        high_violations = result.get_violations_by_severity(ScanSeverity.HIGH)
+        assert len(high_violations) == 2
+
+    def test_result_to_dict(self):
+        """Test converting result to dictionary."""
+        result = ScanResult(
+            passed=True,
+            passed_checks=10,
+            failed_checks=0,
+            skipped_checks=2,
+            scan_duration_seconds=5.5,
+            scanner_version="2.0.0",
+        )
+        d = result.to_dict()
+        assert d["passed"] is True
+        assert d["total_checks"] == 12
+        assert d["scan_duration_seconds"] == 5.5
+
+
+class TestSecurityScanner:
+    """Tests for SecurityScanner class."""
+
+    def test_init_defaults(self):
+        """Test scanner initialization with defaults."""
+        scanner = SecurityScanner()
+        assert scanner.severity_threshold == ScanSeverity.HIGH
+        assert scanner.skip_checks == []
+        assert scanner.frameworks == ["terraform", "ansible"]
+
+    def test_init_custom(self):
+        """Test scanner initialization with custom options."""
+        scanner = SecurityScanner(
+            severity_threshold=ScanSeverity.MEDIUM,
+            skip_checks=["CKV_AWS_1", "CKV_AWS_2"],
+            frameworks=["terraform"],
+        )
+        assert scanner.severity_threshold == ScanSeverity.MEDIUM
+        assert scanner.skip_checks == ["CKV_AWS_1", "CKV_AWS_2"]
+        assert scanner.frameworks == ["terraform"]
+
+    def test_is_available_when_checkov_installed(self):
+        """Test is_available returns True when checkov is found."""
+        scanner = SecurityScanner()
+        with patch("shutil.which", return_value="/usr/bin/checkov"):
+            assert scanner.is_available() is True
+
+    def test_is_available_when_checkov_not_installed(self):
+        """Test is_available returns False when checkov is not found."""
+        scanner = SecurityScanner()
+        with patch("shutil.which", return_value=None):
+            assert scanner.is_available() is False
+
+    def test_checkov_path_raises_when_not_found(self):
+        """Test checkov_path raises FileNotFoundError when not found."""
+        scanner = SecurityScanner()
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(FileNotFoundError) as exc_info:
+                _ = scanner.checkov_path
+            assert "checkov not found" in str(exc_info.value)
+
+    def test_get_version_success(self):
+        """Test getting checkov version."""
+        scanner = SecurityScanner()
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "2.3.0"
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/checkov"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            version = scanner.get_version()
+            assert version == "2.3.0"
+
+    def test_get_version_failure(self):
+        """Test getting version when checkov not available."""
+        scanner = SecurityScanner()
+        with patch("shutil.which", return_value=None):
+            version = scanner.get_version()
+            assert version is None
+
+    def test_scan_directory_not_found(self):
+        """Test scanning a non-existent directory."""
+        scanner = SecurityScanner()
+        result = scanner.scan(Path("/nonexistent/path"))
+        assert result.passed is False
+        assert "not found" in result.error
+
+    def test_scan_success(self, tmp_path: Path):
+        """Test successful scan with no violations."""
+        scanner = SecurityScanner()
+
+        # Create test terraform file
+        (tmp_path / "main.tf").write_text("resource {}")
+
+        mock_result = MagicMock()
+        mock_result.stdout = (
+            '{"results": {"passed_checks": [], "failed_checks": [], "skipped_checks": []}}'
+        )
+        mock_result.stderr = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/checkov"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            result = scanner.scan(tmp_path)
+            assert result.passed is True
+
+    def test_scan_with_violations(self, tmp_path: Path):
+        """Test scan that finds violations."""
+        scanner = SecurityScanner()
+
+        # Create test terraform file
+        (tmp_path / "main.tf").write_text("resource {}")
+
+        checkov_output = {
+            "results": {
+                "passed_checks": [{"check_id": "CKV_1"}],
+                "failed_checks": [
+                    {
+                        "check_id": "CKV_AWS_2",
+                        "check_name": "Test check failed",
+                        "check_result": {"severity": "HIGH"},
+                        "resource": "aws_s3_bucket.test",
+                        "file_path": "/main.tf",
+                    }
+                ],
+                "skipped_checks": [],
+            }
+        }
+
+        mock_result = MagicMock()
+        mock_result.stdout = str(checkov_output).replace("'", '"')
+        mock_result.stderr = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/checkov"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            result = scanner.scan(tmp_path)
+            assert result.passed is False
+            assert result.failed_checks == 1
+            assert result.passed_checks == 1
+
+    def test_scan_timeout(self, tmp_path: Path):
+        """Test scan timeout handling."""
+        import subprocess
+
+        scanner = SecurityScanner()
+        (tmp_path / "main.tf").write_text("resource {}")
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/checkov"),
+            patch("subprocess.run", side_effect=subprocess.TimeoutExpired("checkov", 10)),
+        ):
+            result = scanner.scan(tmp_path, timeout=10)
+            assert result.passed is False
+            assert "timed out" in result.error
+
+    def test_cleanup(self):
+        """Test cleanup method."""
+        scanner = SecurityScanner()
+        # Should not raise
+        scanner.cleanup()
+
+    def test_parse_checkov_empty_output(self):
+        """Test parsing empty checkov output."""
+        scanner = SecurityScanner()
+        result = scanner._parse_checkov_output("", "")
+        assert result.passed is True
+
+    def test_severity_threshold_filtering(self, tmp_path: Path):
+        """Test that violations below threshold don't fail scan."""
+        scanner = SecurityScanner(severity_threshold=ScanSeverity.HIGH)
+
+        (tmp_path / "main.tf").write_text("resource {}")
+
+        # Only LOW severity violation
+        checkov_output = {
+            "results": {
+                "passed_checks": [],
+                "failed_checks": [
+                    {
+                        "check_id": "CKV_1",
+                        "check_name": "Low severity check",
+                        "check_result": {"severity": "LOW"},
+                        "resource": "test",
+                        "file_path": "/main.tf",
+                    }
+                ],
+                "skipped_checks": [],
+            }
+        }
+
+        mock_result = MagicMock()
+        mock_result.stdout = str(checkov_output).replace("'", '"')
+        mock_result.stderr = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/checkov"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            result = scanner.scan(tmp_path)
+            # Should pass because LOW is below HIGH threshold
+            assert result.passed is True
+            # But violation should still be recorded
+            assert len(result.violations) == 1


### PR DESCRIPTION
## Description

Adds security scanning integration using Checkov to scan generated Terraform and Ansible configurations for security vulnerabilities, misconfigurations, and compliance issues.

**New CLI command:**
```bash
# Basic usage
infra security --env prod

# With severity threshold
infra security --env dev --severity medium

# Skip specific checks
infra security --env staging --skip-check CKV_AWS_1 --skip-check CKV_AWS_2

# JSON output
infra security --env prod --output json
```

## Related Issue

Part of #199

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `core/security/__init__.py` - New module exports
- `core/security/scanner.py` - SecurityScanner class with Checkov integration
- `cli/commands/infra/security.py` - CLI command implementation
- `cli/commands/infra/__init__.py` - Register security command
- `tests/unit/test_security_scanner.py` - 21 unit tests

**Key features:**
- Runs Checkov on generated configs in `generated/<env>/`
- Configurable severity threshold (defaults to HIGH)
- Ability to skip specific checks
- Table and JSON output formats
- Proper exit codes (0 for pass, 1 for fail)

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (21 tests)
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

Requires Checkov to be installed separately: `pip install checkov` or `pipx install checkov`
