### PR TITLE
feat: add config init and show commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Config Init Command**: Added `foundry config init <env>` to create new environments, with `--from <existing>` flag to scaffold from existing environments.
+- **Config Show Command**: Added `foundry config show --env <env>` to display resolved configuration with filtering by provider, resource type, and output format (table/yaml/json).
 - **Error Code Catalog**: Added structured error codes (IF-CATEGORY-NNN) with actionable suggestions for all error types. Errors now display helpful resolution steps. See `docs/reference/errors.md` for full documentation.
 - **External Vault Integration**: Added support for Vaultwarden/Bitwarden, AWS Secrets Manager, and Azure Key Vault as secret providers.
 - **Dependency Analysis**: New command (`infra dependencies`?) to visualize and analyze resource dependencies.

--- a/src/infrafoundry/cli/commands/config/__init__.py
+++ b/src/infrafoundry/cli/commands/config/__init__.py
@@ -4,8 +4,10 @@ import click
 
 from .diff import diff
 from .envs import envs
+from .init import init
 from .migrate import migrate
 from .new import new
+from .show import show
 from .validate import validate
 
 
@@ -18,6 +20,8 @@ def config() -> None:
 # Register all subcommands
 config.add_command(envs)
 config.add_command(diff)
+config.add_command(init)
+config.add_command(show)
 config.add_command(validate)
 config.add_command(new)
 config.add_command(migrate)

--- a/src/infrafoundry/cli/commands/config/init.py
+++ b/src/infrafoundry/cli/commands/config/init.py
@@ -1,0 +1,213 @@
+"""Init command to scaffold new environments."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import click
+import yaml
+
+from infrafoundry.core.config import ConfigManager
+from infrafoundry.core.exceptions import EnvironmentNotFoundError
+
+from ...utils import console
+
+
+def _copy_environment(
+    source_dir: Path,
+    target_dir: Path,
+    new_env_name: str,
+    description: str | None,
+) -> None:
+    """Copy environment directory and update settings.
+
+    Args:
+        source_dir: Source environment directory
+        target_dir: Target environment directory
+        new_env_name: Name for the new environment
+        description: Optional description for the new environment
+    """
+    # Copy the entire directory
+    shutil.copytree(source_dir, target_dir)
+
+    # Update settings.yaml with new environment info
+    settings_file = target_dir / "settings.yaml"
+    if settings_file.exists():
+        with open(settings_file) as f:
+            settings = yaml.safe_load(f) or {}
+
+        # Update environment-specific settings
+        settings["name"] = new_env_name
+        if description:
+            settings["description"] = description
+        elif "description" in settings:
+            settings["description"] = "Environment scaffolded from source"
+
+        with open(settings_file, "w") as f:
+            yaml.safe_dump(settings, f, default_flow_style=False, sort_keys=False)
+
+
+def _create_minimal_environment(target_dir: Path, env_name: str, description: str | None) -> None:
+    """Create a minimal environment structure.
+
+    Args:
+        target_dir: Target environment directory
+        env_name: Name for the new environment
+        description: Optional description
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    settings = {
+        "name": env_name,
+        "description": description or f"New environment: {env_name}",
+        "providers": [],
+    }
+
+    settings_file = target_dir / "settings.yaml"
+    with open(settings_file, "w") as f:
+        yaml.safe_dump(settings, f, default_flow_style=False, sort_keys=False)
+
+    # Create empty resources directory
+    resources_dir = target_dir / "resources"
+    resources_dir.mkdir(exist_ok=True)
+
+    # Create a sample resource file
+    sample_file = resources_dir / "sample.yaml"
+    sample_content = """\
+# Sample resource configuration
+# Uncomment and modify as needed
+#
+# resources:
+#   - name: my-resource
+#     provider: proxmox
+#     type: vm
+#     config:
+#       # Add your configuration here
+"""
+    with open(sample_file, "w") as f:
+        f.write(sample_content)
+
+
+@click.command()
+@click.argument("env_name")
+@click.option(
+    "--from",
+    "from_env",
+    help="Existing environment to scaffold from (copies and customizes configs)",
+)
+@click.option(
+    "--description",
+    "-d",
+    help="Description for the new environment",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing environment directory",
+)
+@click.pass_context
+def init(
+    ctx: click.Context,
+    env_name: str,
+    from_env: str | None,
+    description: str | None,
+    force: bool,
+) -> None:
+    """Initialize a new environment.
+
+    Creates a new environment directory structure. Use --from to scaffold
+    from an existing environment (copies configs and customizes for new env).
+
+    Examples:
+
+        # Create minimal new environment
+        foundry config init staging
+
+        # Scaffold from existing environment
+        foundry config init staging --from dev
+
+        # With description
+        foundry config init prod --from staging -d "Production environment"
+    """
+    config_dir = ctx.obj.get("config_dir")
+
+    if not config_dir:
+        console.error("Config directory not set. Use --config-dir or set INFRAFOUNDRY_CONFIG_REPO.")
+        raise click.Abort()
+
+    envs_dir = config_dir / "envs"
+    target_dir = envs_dir / env_name
+
+    # Check if target already exists
+    if target_dir.exists():
+        if force:
+            console.warning(f"Removing existing environment: {env_name}")
+            shutil.rmtree(target_dir)
+        else:
+            console.error(f"Environment '{env_name}' already exists. Use --force to overwrite.")
+            raise click.Abort()
+
+    if from_env:
+        # Scaffold from existing environment
+        try:
+            config_manager = ConfigManager(base_dir=envs_dir)
+
+            # Verify source environment exists
+            if not config_manager.validate_environment(from_env):
+                raise EnvironmentNotFoundError(
+                    f"Source environment '{from_env}' not found",
+                    context={"environment": from_env},
+                )
+
+            source_dir = envs_dir / from_env
+            console.info(f"Scaffolding '{env_name}' from '{from_env}'...")
+
+            _copy_environment(source_dir, target_dir, env_name, description)
+
+            console.success(f"Environment '{env_name}' created from '{from_env}'")
+            console.info(f"  Location: {target_dir}")
+            console.info("")
+            console.info("Next steps:")
+            console.info(f"  1. Review and update: {target_dir}/settings.yaml")
+            console.info("  2. Modify resource configs for the new environment")
+            console.info("  3. Update any environment-specific secrets")
+
+        except EnvironmentNotFoundError:
+            console.error(f"Source environment '{from_env}' not found.")
+            console.info("Available environments:")
+            try:
+                config_manager = ConfigManager(base_dir=envs_dir)
+                for env in config_manager.list_environments():
+                    console.info(f"  - {env}")
+            except Exception:
+                console.info("  (unable to list environments)")
+            raise click.Abort() from None
+        except Exception as e:
+            console.error(f"Failed to scaffold environment: {e}")
+            # Cleanup partial directory if it was created
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+            raise click.Abort() from e
+    else:
+        # Create minimal new environment
+        console.info(f"Creating new environment: {env_name}")
+
+        try:
+            _create_minimal_environment(target_dir, env_name, description)
+
+            console.success(f"Environment '{env_name}' created")
+            console.info(f"  Location: {target_dir}")
+            console.info("")
+            console.info("Next steps:")
+            console.info(f"  1. Edit: {target_dir}/settings.yaml")
+            console.info(f"  2. Add resources in: {target_dir}/resources/")
+            console.info("  3. Run: foundry config validate --env " + env_name)
+
+        except Exception as e:
+            console.error(f"Failed to create environment: {e}")
+            # Cleanup partial directory if it was created
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+            raise click.Abort() from e

--- a/src/infrafoundry/cli/commands/config/show.py
+++ b/src/infrafoundry/cli/commands/config/show.py
@@ -1,0 +1,296 @@
+"""Show command to display resolved configuration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+import yaml
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+
+from infrafoundry.core.config import ConfigManager
+from infrafoundry.core.exceptions import (
+    ConfigurationError,
+    EnvironmentNotFoundError,
+    InfraFoundryError,
+)
+
+from ...utils import console, raise_cli_error
+
+
+def _resource_to_dict(resource: Any) -> dict[str, Any]:
+    """Convert a ResourceConfig to a dictionary.
+
+    Args:
+        resource: ResourceConfig object
+
+    Returns:
+        Dictionary representation
+    """
+    result: dict[str, Any] = {
+        "name": resource.name,
+        "provider": resource.provider,
+        "type": resource.type,
+        "config": resource.config,
+    }
+
+    # Include depends_on from config if present
+    if resource.config.get("depends_on"):
+        result["depends_on"] = resource.config["depends_on"]
+
+    return result
+
+
+def _format_yaml(data: dict[str, Any]) -> str:
+    """Format data as YAML string.
+
+    Args:
+        data: Dictionary to format
+
+    Returns:
+        YAML string
+    """
+    return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+
+def _format_json(data: dict[str, Any]) -> str:
+    """Format data as JSON string.
+
+    Args:
+        data: Dictionary to format
+
+    Returns:
+        JSON string
+    """
+    return json.dumps(data, indent=2)
+
+
+@click.command()
+@click.option("--env", "-e", required=True, help="Environment name")
+@click.option(
+    "--provider",
+    "-p",
+    help="Filter by provider (e.g., proxmox, kubernetes)",
+)
+@click.option(
+    "--resource-type",
+    "-t",
+    help="Filter by resource type (e.g., vm, container)",
+)
+@click.option(
+    "--resource",
+    "-r",
+    help="Show specific resource by name",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "yaml", "json"]),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option(
+    "--settings-only",
+    is_flag=True,
+    help="Show only environment settings, not resources",
+)
+@click.pass_context
+def show(
+    ctx: click.Context,
+    env: str,
+    provider: str | None,
+    resource_type: str | None,
+    resource: str | None,
+    output_format: str,
+    settings_only: bool,
+) -> None:
+    """Show resolved configuration for an environment.
+
+    Displays the effective configuration after variable substitution,
+    with options to filter by provider, resource type, or specific resource.
+
+    Examples:
+
+        # Show all config for dev environment
+        foundry config show --env dev
+
+        # Show only Proxmox resources
+        foundry config show --env dev --provider proxmox
+
+        # Show specific resource
+        foundry config show --env dev --resource my-vm
+
+        # Output as YAML
+        foundry config show --env dev --format yaml
+
+        # Show only environment settings
+        foundry config show --env dev --settings-only
+    """
+    try:
+        config_dir = ctx.obj.get("config_dir")
+        config_manager = ConfigManager(base_dir=config_dir / "envs" if config_dir else None)
+
+        # Load environment settings
+        env_config = config_manager.load_environment(env)
+
+        if settings_only:
+            _show_settings(env, env_config, output_format)
+            return
+
+        # Load all resources
+        all_resources = config_manager.get_all_resources_all_providers(env)
+
+        # Apply filters
+        filtered_resources = all_resources
+
+        if provider:
+            filtered_resources = [r for r in filtered_resources if r.provider == provider]
+
+        if resource_type:
+            filtered_resources = [r for r in filtered_resources if r.type == resource_type]
+
+        if resource:
+            filtered_resources = [r for r in filtered_resources if r.name == resource]
+
+        if not filtered_resources and (provider or resource_type or resource):
+            console.warning("No resources found matching the specified filters.")
+            return
+
+        # Display based on format
+        if output_format == "table":
+            _show_table(env, env_config, filtered_resources)
+        elif output_format == "yaml":
+            _show_yaml(env, env_config, filtered_resources)
+        elif output_format == "json":
+            _show_json(env, env_config, filtered_resources)
+
+    except click.ClickException:
+        raise
+    except (EnvironmentNotFoundError, ConfigurationError) as exc:
+        raise_cli_error("Failed to show configuration", exc)
+    except InfraFoundryError as exc:
+        raise_cli_error("Failed to show configuration", exc)
+    except Exception as exc:
+        raise_cli_error("Failed to show configuration", exc)
+
+
+def _show_settings(env: str, env_config: Any, output_format: str) -> None:
+    """Show only environment settings.
+
+    Args:
+        env: Environment name
+        env_config: EnvironmentConfig object
+        output_format: Output format (table, yaml, json)
+    """
+    settings_dict = {
+        "name": env_config.name or env,
+        "description": env_config.description,
+        "providers": env_config.providers,
+    }
+
+    # Add any additional settings from the config
+    if hasattr(env_config, "settings") and env_config.settings:
+        settings_dict["settings"] = env_config.settings
+
+    if output_format == "yaml":
+        syntax = Syntax(_format_yaml(settings_dict), "yaml", theme="monokai")
+        console.print(Panel(syntax, title=f"Environment: {env}", border_style="cyan"))
+    elif output_format == "json":
+        syntax = Syntax(_format_json(settings_dict), "json", theme="monokai")
+        console.print(Panel(syntax, title=f"Environment: {env}", border_style="cyan"))
+    else:
+        console.header(f"Environment: {env}")
+        console.info(f"  Description: {env_config.description or 'N/A'}")
+        console.info(
+            f"  Providers: {', '.join(env_config.providers) if env_config.providers else 'N/A'}"
+        )
+
+
+def _show_table(env: str, env_config: Any, resources: list[Any]) -> None:
+    """Show configuration as formatted tables.
+
+    Args:
+        env: Environment name
+        env_config: EnvironmentConfig object
+        resources: List of ResourceConfig objects
+    """
+    # Environment header
+    console.header(f"Environment: {env}")
+    console.info(f"  Description: {env_config.description or 'N/A'}")
+    console.info(
+        f"  Providers: {', '.join(env_config.providers) if env_config.providers else 'N/A'}"
+    )
+    console.print("")
+
+    if not resources:
+        console.warning("No resources defined.")
+        return
+
+    # Group resources by provider
+    by_provider: dict[str, list[Any]] = {}
+    for r in resources:
+        if r.provider not in by_provider:
+            by_provider[r.provider] = []
+        by_provider[r.provider].append(r)
+
+    # Display each provider's resources
+    for provider_name, provider_resources in sorted(by_provider.items()):
+        table = Table(title=f"Provider: {provider_name}", show_header=True)
+        table.add_column("Name", style="cyan")
+        table.add_column("Type", style="green")
+        table.add_column("Dependencies", style="dim")
+        table.add_column("Config Keys", style="yellow")
+
+        for r in sorted(provider_resources, key=lambda x: x.name):
+            deps_list = r.config.get("depends_on", [])
+            deps = ", ".join(deps_list) if deps_list else "-"
+            config_keys = ", ".join(sorted(r.config.keys())) if r.config else "-"
+            table.add_row(r.name, r.type, deps, config_keys)
+
+        console.print(table)
+        console.print("")
+
+
+def _show_yaml(env: str, env_config: Any, resources: list[Any]) -> None:
+    """Show configuration as YAML.
+
+    Args:
+        env: Environment name
+        env_config: EnvironmentConfig object
+        resources: List of ResourceConfig objects
+    """
+    output = {
+        "environment": {
+            "name": env_config.name or env,
+            "description": env_config.description,
+            "providers": env_config.providers,
+        },
+        "resources": [_resource_to_dict(r) for r in resources],
+    }
+
+    syntax = Syntax(_format_yaml(output), "yaml", theme="monokai", line_numbers=True)
+    console.print(Panel(syntax, title=f"Configuration: {env}", border_style="cyan"))
+
+
+def _show_json(env: str, env_config: Any, resources: list[Any]) -> None:
+    """Show configuration as JSON.
+
+    Args:
+        env: Environment name
+        env_config: EnvironmentConfig object
+        resources: List of ResourceConfig objects
+    """
+    output = {
+        "environment": {
+            "name": env_config.name or env,
+            "description": env_config.description,
+            "providers": env_config.providers,
+        },
+        "resources": [_resource_to_dict(r) for r in resources],
+    }
+
+    syntax = Syntax(_format_json(output), "json", theme="monokai", line_numbers=True)
+    console.print(Panel(syntax, title=f"Configuration: {env}", border_style="cyan"))

--- a/tests/unit/test_cli_config_tools.py
+++ b/tests/unit/test_cli_config_tools.py
@@ -1,0 +1,397 @@
+"""Unit tests for config init and show CLI commands."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from infrafoundry.cli.main import main
+
+
+@pytest.fixture
+def cli_runner():
+    """Fixture for invoking CLI commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_config_dir(tmp_path):
+    """Create a temporary config directory with sample environment."""
+    config_dir = tmp_path / "config"
+    envs_dir = config_dir / "envs"
+
+    # Create dev environment
+    dev_dir = envs_dir / "dev"
+    dev_dir.mkdir(parents=True)
+
+    settings = {
+        "name": "dev",
+        "description": "Development environment",
+        "providers": ["proxmox", "kubernetes"],
+    }
+    with open(dev_dir / "settings.yaml", "w") as f:
+        yaml.safe_dump(settings, f)
+
+    # Create a sample resource file
+    resources_dir = dev_dir / "resources"
+    resources_dir.mkdir()
+    resource_config = {
+        "resources": [
+            {
+                "name": "test-vm",
+                "provider": "proxmox",
+                "type": "vm",
+                "config": {"cpu": 2, "memory": 4096},
+            }
+        ]
+    }
+    with open(resources_dir / "vms.yaml", "w") as f:
+        yaml.safe_dump(resource_config, f)
+
+    return config_dir
+
+
+class TestConfigInit:
+    """Tests for config init command."""
+
+    def test_init_creates_minimal_environment(self, cli_runner, tmp_path):
+        """Test init creates minimal environment structure."""
+        config_dir = tmp_path / "config"
+        envs_dir = config_dir / "envs"
+        envs_dir.mkdir(parents=True)
+
+        result = cli_runner.invoke(
+            main,
+            ["--config-dir", str(config_dir), "config", "init", "staging"],
+        )
+
+        assert result.exit_code == 0
+        assert "Environment 'staging' created" in result.output
+
+        # Verify directory structure
+        staging_dir = envs_dir / "staging"
+        assert staging_dir.exists()
+        assert (staging_dir / "settings.yaml").exists()
+        assert (staging_dir / "resources").exists()
+
+        # Verify settings content
+        with open(staging_dir / "settings.yaml") as f:
+            settings = yaml.safe_load(f)
+        assert settings["name"] == "staging"
+
+    def test_init_with_description(self, cli_runner, tmp_path):
+        """Test init with custom description."""
+        config_dir = tmp_path / "config"
+        envs_dir = config_dir / "envs"
+        envs_dir.mkdir(parents=True)
+
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(config_dir),
+                "config",
+                "init",
+                "prod",
+                "-d",
+                "Production environment",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        with open(envs_dir / "prod" / "settings.yaml") as f:
+            settings = yaml.safe_load(f)
+        assert settings["description"] == "Production environment"
+
+    def test_init_from_existing_environment(self, cli_runner, temp_config_dir):
+        """Test init --from scaffolds from existing environment."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "init",
+                "staging",
+                "--from",
+                "dev",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Environment 'staging' created from 'dev'" in result.output
+
+        # Verify the new environment has copied structure
+        staging_dir = temp_config_dir / "envs" / "staging"
+        assert staging_dir.exists()
+        assert (staging_dir / "settings.yaml").exists()
+        assert (staging_dir / "resources").exists()
+        assert (staging_dir / "resources" / "vms.yaml").exists()
+
+        # Verify settings were updated
+        with open(staging_dir / "settings.yaml") as f:
+            settings = yaml.safe_load(f)
+        assert settings["name"] == "staging"
+
+    def test_init_from_nonexistent_environment(self, cli_runner, temp_config_dir):
+        """Test init --from with nonexistent source fails."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "init",
+                "staging",
+                "--from",
+                "nonexistent",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_init_existing_environment_fails_without_force(self, cli_runner, temp_config_dir):
+        """Test init fails if environment exists without --force."""
+        result = cli_runner.invoke(
+            main,
+            ["--config-dir", str(temp_config_dir), "config", "init", "dev"],
+        )
+
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    def test_init_existing_environment_with_force(self, cli_runner, temp_config_dir):
+        """Test init --force overwrites existing environment."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "init",
+                "dev",
+                "--force",
+                "-d",
+                "Recreated dev",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Environment 'dev' created" in result.output
+
+        with open(temp_config_dir / "envs" / "dev" / "settings.yaml") as f:
+            settings = yaml.safe_load(f)
+        assert settings["description"] == "Recreated dev"
+
+    def test_init_without_config_dir(self, cli_runner, monkeypatch):
+        """Test init fails without config directory."""
+        # Clear the env var to ensure no config dir is set
+        monkeypatch.delenv("INFRAFOUNDRY_CONFIG_REPO", raising=False)
+
+        with cli_runner.isolated_filesystem():
+            result = cli_runner.invoke(main, ["config", "init", "test-env-no-config"])
+
+            # Should fail because no config dir is set
+            assert result.exit_code != 0
+            assert "Config directory not set" in result.output or "config" in result.output.lower()
+
+
+class TestConfigShow:
+    """Tests for config show command."""
+
+    def test_show_displays_environment_info(self, cli_runner, temp_config_dir):
+        """Test show displays environment information."""
+        result = cli_runner.invoke(
+            main,
+            ["--config-dir", str(temp_config_dir), "config", "show", "--env", "dev"],
+        )
+
+        assert result.exit_code == 0
+        assert "dev" in result.output
+        assert "Development environment" in result.output or "Description" in result.output
+
+    def test_show_settings_only(self, cli_runner, temp_config_dir):
+        """Test show --settings-only displays only settings."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "dev",
+                "--settings-only",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "dev" in result.output
+
+    def test_show_yaml_format(self, cli_runner, temp_config_dir):
+        """Test show --format yaml outputs YAML."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "dev",
+                "--format",
+                "yaml",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # YAML output should contain these patterns
+        assert "environment:" in result.output or "name:" in result.output
+
+    def test_show_json_format(self, cli_runner, temp_config_dir):
+        """Test show --format json outputs JSON."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "dev",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # JSON output should contain these patterns
+        assert '"environment"' in result.output or '"name"' in result.output
+
+    def test_show_filter_by_provider(self, cli_runner, temp_config_dir):
+        """Test show --provider filters resources."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "dev",
+                "--provider",
+                "proxmox",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    def test_show_filter_by_resource_type(self, cli_runner, temp_config_dir):
+        """Test show --resource-type filters resources."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "dev",
+                "--resource-type",
+                "vm",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    def test_show_specific_resource(self, cli_runner, temp_config_dir):
+        """Test show --resource shows specific resource."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "dev",
+                "--resource",
+                "test-vm",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+    def test_show_nonexistent_environment(self, cli_runner, temp_config_dir):
+        """Test show with nonexistent environment fails."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "nonexistent",
+            ],
+        )
+
+        assert result.exit_code != 0
+
+    def test_show_no_matching_resources(self, cli_runner, temp_config_dir):
+        """Test show with no matching filter shows warning."""
+        result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "dev",
+                "--provider",
+                "nonexistent-provider",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "No resources found" in result.output
+
+
+class TestConfigInitShowIntegration:
+    """Integration tests for init and show commands working together."""
+
+    def test_init_then_show(self, cli_runner, temp_config_dir):
+        """Test creating environment with init then viewing with show."""
+        # Create new environment from dev
+        init_result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "init",
+                "staging",
+                "--from",
+                "dev",
+            ],
+        )
+        assert init_result.exit_code == 0
+
+        # Show the new environment
+        show_result = cli_runner.invoke(
+            main,
+            [
+                "--config-dir",
+                str(temp_config_dir),
+                "config",
+                "show",
+                "--env",
+                "staging",
+            ],
+        )
+        assert show_result.exit_code == 0
+        assert "staging" in show_result.output


### PR DESCRIPTION
## Description

Add config management tools for initializing new environments and displaying resolved configuration.

## Related Issue

Closes #227

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test improvement

## Changes Made

### `foundry config init <env>`
Create new environments with optional scaffolding from existing:
- `--from <existing>` - copy and customize from existing environment
- `--description` - set environment description
- `--force` - overwrite existing environment

### `foundry config show --env <env>`
Display resolved configuration with filtering:
- `--provider` - filter by provider
- `--resource-type` - filter by resource type
- `--resource` - show specific resource
- `--format` - output as table/yaml/json
- `--settings-only` - show only environment settings

### Examples

```bash
# Create minimal new environment
foundry config init staging

# Scaffold from existing environment
foundry config init staging --from dev

# Show all config for dev environment
foundry config show --env dev

# Show only Proxmox resources as YAML
foundry config show --env dev --provider proxmox --format yaml
```

## Testing

- [x] All existing tests pass
- [x] Added 17 new tests for init and show commands
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
