### PR TITLE
feat: standardize output formatting and add --format json option

### DIFF
--- a/src/infrafoundry/cli/commands/analyze/impact.py
+++ b/src/infrafoundry/cli/commands/analyze/impact.py
@@ -5,6 +5,7 @@ import click
 from infrafoundry.core.orchestrator import Orchestrator
 
 from ...decorators import with_orchestrator
+from ...output import BULLET
 from ...utils import console
 
 
@@ -29,7 +30,7 @@ def impact(_ctx: click.Context, orchestrator: Orchestrator, env: str, resource: 
         console.warning(f"Resource '{resource}' not found in environment '{env}'")
         console.info("\nAvailable resources:")
         for node_name in graph.nodes:
-            console.info(f"  - {node_name}")
+            console.info(f"  {BULLET} {node_name}")
         return
 
     # Display results

--- a/src/infrafoundry/cli/commands/audit/list.py
+++ b/src/infrafoundry/cli/commands/audit/list.py
@@ -1,6 +1,7 @@
 """List audit entries command."""
 
 from datetime import datetime
+from typing import Any
 
 import click
 from rich.table import Table
@@ -8,6 +9,7 @@ from rich.table import Table
 from infrafoundry.core.audit import AuditLogger
 from infrafoundry.core.state import StateManager
 
+from ...output import output_data
 from ...utils import console, raise_cli_error
 
 
@@ -35,6 +37,13 @@ def _parse_date(date_str: str | None) -> datetime | None:
 @click.option("--since", help="Start date (YYYY-MM-DD)")
 @click.option("--until", help="End date (YYYY-MM-DD)")
 @click.option("--limit", "-n", default=50, help="Maximum entries to display (default: 50)")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (default: text)",
+)
 @click.pass_context
 def list_audit(
     ctx: click.Context,
@@ -44,6 +53,7 @@ def list_audit(
     since: str | None,
     until: str | None,
     limit: int,
+    output_format: str,
 ) -> None:
     """List audit entries with optional filters.
 
@@ -54,6 +64,8 @@ def list_audit(
         infra audit list --user admin --since 2024-01-01
 
         infra audit list --action apply_completed --limit 100
+
+        infra audit list --format json
     """
     try:
         # Initialize state manager and audit logger
@@ -76,43 +88,65 @@ def list_audit(
         )
 
         if not entries:
-            console.warning("No audit entries found matching the criteria")
+            if output_format == "json":
+                output_data({"entries": [], "total": 0}, output_format)
+            else:
+                console.warning("No audit entries found matching the criteria")
             return
 
-        # Build and display table
-        table = Table(title=f"Audit Trail ({len(entries)} entries)")
-        table.add_column("ID", style="dim")
-        table.add_column("Timestamp", style="cyan")
-        table.add_column("User", style="green")
-        table.add_column("Env", style="yellow")
-        table.add_column("Action", style="magenta")
-        table.add_column("Status")
-        table.add_column("Provider")
-        table.add_column("Message", max_width=40)
-
+        # Build data structure
+        entry_data: list[dict[str, Any]] = []
         for entry in entries:
-            status_style = {
-                "success": "green",
-                "failed": "red",
-                "in_progress": "yellow",
-            }.get(entry.status, "")
-
-            table.add_row(
-                str(entry.id),
-                entry.timestamp.strftime("%Y-%m-%d %H:%M:%S") if entry.timestamp else "",
-                entry.user_identifier or "",
-                entry.environment or "",
-                entry.action or "",
-                f"[{status_style}]{entry.status}[/{status_style}]"
-                if status_style
-                else entry.status,
-                entry.provider or "",
-                (entry.message[:37] + "...")
-                if entry.message and len(entry.message) > 40
-                else (entry.message or ""),
+            entry_data.append(
+                {
+                    "id": entry.id,
+                    "timestamp": entry.timestamp.isoformat() if entry.timestamp else None,
+                    "user": entry.user_identifier or "",
+                    "environment": entry.environment or "",
+                    "action": entry.action or "",
+                    "status": entry.status,
+                    "provider": entry.provider or "",
+                    "message": entry.message or "",
+                }
             )
 
-        console.print(table)
+        if output_format == "json":
+            output_data({"entries": entry_data, "total": len(entry_data)}, output_format)
+        else:
+            # Build and display table
+            table = Table(title=f"Audit Trail ({len(entries)} entries)")
+            table.add_column("ID", style="dim")
+            table.add_column("Timestamp", style="cyan")
+            table.add_column("User", style="green")
+            table.add_column("Env", style="yellow")
+            table.add_column("Action", style="magenta")
+            table.add_column("Status")
+            table.add_column("Provider")
+            table.add_column("Message", max_width=40)
+
+            for entry in entries:
+                status_style = {
+                    "success": "green",
+                    "failed": "red",
+                    "in_progress": "yellow",
+                }.get(entry.status, "")
+
+                table.add_row(
+                    str(entry.id),
+                    entry.timestamp.strftime("%Y-%m-%d %H:%M:%S") if entry.timestamp else "",
+                    entry.user_identifier or "",
+                    entry.environment or "",
+                    entry.action or "",
+                    f"[{status_style}]{entry.status}[/{status_style}]"
+                    if status_style
+                    else entry.status,
+                    entry.provider or "",
+                    (entry.message[:37] + "...")
+                    if entry.message and len(entry.message) > 40
+                    else (entry.message or ""),
+                )
+
+            console.print(table)
 
     except click.ClickException:
         raise

--- a/src/infrafoundry/cli/commands/config/envs.py
+++ b/src/infrafoundry/cli/commands/config/envs.py
@@ -1,5 +1,7 @@
 """Envs command - List available environments."""
 
+from typing import Any
+
 import click
 
 from infrafoundry.core.config import ConfigManager
@@ -9,12 +11,20 @@ from infrafoundry.core.exceptions import (
     InfraFoundryError,
 )
 
+from ...output import output_data
 from ...utils import console, raise_cli_error
 
 
 @click.command()
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (default: text)",
+)
 @click.pass_context
-def envs(ctx: click.Context) -> None:
+def envs(ctx: click.Context, output_format: str) -> None:
     """List available environments."""
     try:
         config_repo = ctx.obj.get("config_dir")
@@ -25,16 +35,33 @@ def envs(ctx: click.Context) -> None:
         environments = config_manager.list_environments()
 
         if not environments:
-            console.warning(
-                "No environments found. Check that INFRAFOUNDRY_CONFIG_REPO is set correctly."
-            )
+            if output_format == "json":
+                output_data({"environments": []}, output_format)
+            else:
+                console.warning(
+                    "No environments found. Check that INFRAFOUNDRY_CONFIG_REPO is set correctly."
+                )
             return
 
-        console.header("Available environments:")
+        # Build data structure
+        env_data: list[dict[str, Any]] = []
         for env_name in environments:
             env_config = config_manager.load_environment(env_name)
-            console.info(f"  • {env_name}: {env_config.description or 'No description'}")
-            console.info(f"    Providers: {', '.join(env_config.providers)}")
+            env_data.append(
+                {
+                    "name": env_name,
+                    "description": env_config.description or "",
+                    "providers": env_config.providers,
+                }
+            )
+
+        if output_format == "json":
+            output_data({"environments": env_data}, output_format)
+        else:
+            console.header("Available environments:")
+            for env in env_data:
+                console.list_item(f"{env['name']}: {env['description'] or 'No description'}")
+                console.info(f"    Providers: {', '.join(env['providers'])}")
 
     except click.ClickException:
         raise

--- a/src/infrafoundry/cli/commands/config/init.py
+++ b/src/infrafoundry/cli/commands/config/init.py
@@ -11,6 +11,7 @@ import yaml
 from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.exceptions import EnvironmentNotFoundError
 
+from ...output import BULLET
 from ...utils import console
 
 
@@ -180,7 +181,7 @@ def init(
             try:
                 config_manager = ConfigManager(base_dir=envs_dir)
                 for env in config_manager.list_environments():
-                    console.info(f"  - {env}")
+                    console.info(f"  {BULLET} {env}")
             except Exception:
                 console.info("  (unable to list environments)")
             raise click.Abort() from None

--- a/src/infrafoundry/cli/commands/doctor.py
+++ b/src/infrafoundry/cli/commands/doctor.py
@@ -4,10 +4,13 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import click
 from rich.console import Console
 from rich.table import Table
+
+from ..output import output_data
 
 console = Console()
 
@@ -163,22 +166,30 @@ def _check_sops_keys() -> CheckResult:
 
 
 @click.command()
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (default: text)",
+)
 @click.pass_context
-def doctor(ctx: click.Context) -> None:
+def doctor(ctx: click.Context, output_format: str) -> None:
     """Check InfraFoundry setup and dependencies.
 
     Validates that all required tools are installed and properly configured.
     """
     config_dir = ctx.obj.get("config_dir")
 
-    console.print()
-    console.print("[bold cyan]InfraFoundry Doctor[/bold cyan]")
-    console.print()
-
     results: list[CheckResult] = []
 
     # Check dependencies
-    console.print("[bold]Checking dependencies...[/bold]")
+    if output_format == "text":
+        console.print()
+        console.print("[bold cyan]InfraFoundry Doctor[/bold cyan]")
+        console.print()
+        console.print("[bold]Checking dependencies...[/bold]")
+
     results.append(
         _check_dependency(
             "Terraform",
@@ -209,52 +220,76 @@ def doctor(ctx: click.Context) -> None:
     )
 
     # Check configuration
-    console.print("[bold]Checking configuration...[/bold]")
+    if output_format == "text":
+        console.print("[bold]Checking configuration...[/bold]")
+
     results.append(_check_config_repo(config_dir))
     results.append(_check_environments(config_dir))
     results.append(_check_state_backend())
     results.append(_check_sops_keys())
 
-    # Display results
-    console.print()
-    table = Table(title="Health Check Results", show_header=True)
-    table.add_column("Check", style="cyan")
-    table.add_column("Status")
-    table.add_column("Details")
+    # Count errors and warnings
+    errors = sum(1 for r in results if r.status == "error")
+    warnings = sum(1 for r in results if r.status == "warning")
 
-    status_icons = {
-        "ok": "[green]OK[/green]",
-        "warning": "[yellow]WARN[/yellow]",
-        "error": "[red]FAIL[/red]",
-    }
+    if output_format == "json":
+        # Build JSON output
+        check_data: list[dict[str, Any]] = []
+        for result in results:
+            check_dict: dict[str, Any] = {
+                "name": result.name,
+                "status": result.status,
+                "message": result.message,
+            }
+            if result.suggestion:
+                check_dict["suggestion"] = result.suggestion
+            check_data.append(check_dict)
 
-    errors = 0
-    warnings = 0
-
-    for result in results:
-        status_display = status_icons.get(result.status, result.status)
-        details = result.message
-        if result.suggestion:
-            details += f"\n[dim]{result.suggestion}[/dim]"
-        table.add_row(result.name, status_display, details)
-
-        if result.status == "error":
-            errors += 1
-        elif result.status == "warning":
-            warnings += 1
-
-    console.print(table)
-    console.print()
-
-    # Summary
-    if errors > 0:
-        console.print(f"[red]Found {errors} error(s) and {warnings} warning(s)[/red]")
-        console.print("[dim]Fix errors before using InfraFoundry[/dim]")
-    elif warnings > 0:
-        console.print(f"[yellow]Found {warnings} warning(s)[/yellow]")
-        console.print("[dim]InfraFoundry should work but some features may be limited[/dim]")
+        output_data(
+            {
+                "checks": check_data,
+                "summary": {
+                    "total": len(results),
+                    "errors": errors,
+                    "warnings": warnings,
+                    "ok": len(results) - errors - warnings,
+                },
+            },
+            output_format,
+        )
     else:
-        console.print("[green]All checks passed![/green]")
-        console.print("[dim]InfraFoundry is ready to use[/dim]")
+        # Display results as table
+        console.print()
+        table = Table(title="Health Check Results", show_header=True)
+        table.add_column("Check", style="cyan")
+        table.add_column("Status")
+        table.add_column("Details")
 
-    console.print()
+        status_icons = {
+            "ok": "[green]OK[/green]",
+            "warning": "[yellow]WARN[/yellow]",
+            "error": "[red]FAIL[/red]",
+        }
+
+        for result in results:
+            status_display = status_icons.get(result.status, result.status)
+            details = result.message
+            if result.suggestion:
+                details += f"\n[dim]{result.suggestion}[/dim]"
+            table.add_row(result.name, status_display, details)
+
+        console.print(table)
+        console.print()
+
+        # Summary
+        if errors > 0:
+            console.print(f"[red]Found {errors} error(s) and {warnings} warning(s)[/red]")
+            console.print("[dim]Fix errors before using InfraFoundry[/dim]")
+        elif warnings > 0:
+            console.print(f"[yellow]Found {warnings} warning(s)[/yellow]")
+            console.print("[dim]InfraFoundry should work but some features may be limited[/dim]")
+        else:
+            console.print("[green]All checks passed![/green]")
+            console.print("[dim]InfraFoundry is ready to use[/dim]")
+
+        console.print()

--- a/src/infrafoundry/cli/commands/infra/history.py
+++ b/src/infrafoundry/cli/commands/infra/history.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import click
 from rich.table import Table
 
@@ -6,6 +8,7 @@ from infrafoundry.core.orchestrator import Orchestrator
 from infrafoundry.core.state import DeploymentStatus
 
 from ...decorators import with_orchestrator
+from ...output import output_data
 from ...utils import console, raise_cli_error
 
 
@@ -25,15 +28,23 @@ from ...utils import console, raise_cli_error
 )
 @click.option("--limit", "-n", default=50, help="Number of deployments to show")
 @click.option("--exclude-dry-runs", is_flag=True, help="Exclude dry-run deployments from history")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (default: text)",
+)
 @with_orchestrator("Failed to show history", require_env=False, load_credentials=False)
 def history(
-    _ctx: click.Context,  # Added ctx argument to capture orchestrator
-    orchestrator: Orchestrator,  # Added orchestrator argument
+    _ctx: click.Context,
+    orchestrator: Orchestrator,
     env: str | None,
     command: str | None,
     status: str | None,
     limit: int,
     exclude_dry_runs: bool,
+    output_format: str,
 ) -> None:
     """Show deployment history."""
     try:
@@ -54,56 +65,78 @@ def history(
         )
 
         if not deployments:
-            console.warning("No deployment history found.")
-            # This info is relevant if the state DB is not initialized.
-            # However, orchestrator._setup_state_manager should handle this.
-            # If the DB doesn't exist, get_deployment_history would raise StateError.
-            # So, we can remove the explicit "Run 'infra init'" here if StateError is caught below.
-            console.info(
-                "Run 'infra init' to initialize state tracking."
-            )  # Keep for now, will remove below
+            if output_format == "json":
+                output_data({"deployments": []}, output_format)
+            else:
+                console.warning("No deployment history found.")
+                console.info("Run 'infra init' to initialize state tracking.")
             return
 
-        table = Table(title="Deployment History")
-        table.add_column("ID", style="cyan")
-        table.add_column("Environment", style="green")
-        table.add_column("Command", style="blue")
-        table.add_column("Status", style="magenta")
-        table.add_column("Dry Run", style="yellow")
-        table.add_column("Started", style="dim")
-        table.add_column("User", style="yellow")
-
+        # Build data structure
+        deployment_data: list[dict[str, Any]] = []
         for deployment in deployments:
             status_str = (
                 deployment.status.value
                 if hasattr(deployment.status, "value")
                 else str(deployment.status)
             )
-
-            status_color = {
-                "completed": "green",
-                "failed": "red",
-                "in_progress": "yellow",
-                "planned": "cyan",
-            }.get(status_str, "white")
-
-            dry_run_indicator = "✓" if deployment.dry_run else ""
-
-            table.add_row(
-                str(deployment.id),
-                deployment.environment,
-                deployment.command,
-                f"[{status_color}]{status_str}[/{status_color}]",
-                dry_run_indicator,
-                (
-                    deployment.started_at.strftime("%Y-%m-%d %H:%M:%S")
-                    if deployment.started_at
-                    else ""
-                ),
-                deployment.user or "unknown",
+            deployment_data.append(
+                {
+                    "id": deployment.id,
+                    "environment": deployment.environment,
+                    "command": deployment.command,
+                    "status": status_str,
+                    "dry_run": deployment.dry_run,
+                    "started_at": (
+                        deployment.started_at.isoformat() if deployment.started_at else None
+                    ),
+                    "user": deployment.user or "unknown",
+                }
             )
 
-        console.print(table)
+        if output_format == "json":
+            output_data({"deployments": deployment_data}, output_format)
+        else:
+            table = Table(title="Deployment History")
+            table.add_column("ID", style="cyan")
+            table.add_column("Environment", style="green")
+            table.add_column("Command", style="blue")
+            table.add_column("Status", style="magenta")
+            table.add_column("Dry Run", style="yellow")
+            table.add_column("Started", style="dim")
+            table.add_column("User", style="yellow")
+
+            for deployment in deployments:
+                status_str = (
+                    deployment.status.value
+                    if hasattr(deployment.status, "value")
+                    else str(deployment.status)
+                )
+
+                status_color = {
+                    "completed": "green",
+                    "failed": "red",
+                    "in_progress": "yellow",
+                    "planned": "cyan",
+                }.get(status_str, "white")
+
+                dry_run_indicator = "✓" if deployment.dry_run else ""
+
+                table.add_row(
+                    str(deployment.id),
+                    deployment.environment,
+                    deployment.command,
+                    f"[{status_color}]{status_str}[/{status_color}]",
+                    dry_run_indicator,
+                    (
+                        deployment.started_at.strftime("%Y-%m-%d %H:%M:%S")
+                        if deployment.started_at
+                        else ""
+                    ),
+                    deployment.user or "unknown",
+                )
+
+            console.print(table)
 
     except click.ClickException:
         raise

--- a/src/infrafoundry/cli/commands/state/list.py
+++ b/src/infrafoundry/cli/commands/state/list.py
@@ -1,5 +1,7 @@
 """List resources in an environment command."""
 
+from typing import Any
+
 import click
 
 from infrafoundry.core.config import ConfigManager
@@ -9,6 +11,7 @@ from infrafoundry.core.exceptions import (
     InfraFoundryError,
 )
 
+from ...output import BULLET, output_data
 from ...utils import console, raise_cli_error
 
 
@@ -16,8 +19,21 @@ from ...utils import console, raise_cli_error
 @click.option("--env", "-e", required=True, help="Environment name")
 @click.option("--provider", "-p", help="Filter by provider (e.g., proxmox, opnsense)")
 @click.option("--type", "-t", help="Filter by resource type (e.g., vms, firewall_rules)")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (default: text)",
+)
 @click.pass_context
-def list_resources(ctx: click.Context, env: str, provider: str | None, type: str | None) -> None:
+def list_resources(
+    ctx: click.Context,
+    env: str,
+    provider: str | None,
+    type: str | None,
+    output_format: str,
+) -> None:
     """List all resources in an environment."""
     try:
         config_repo = ctx.obj.get("config_dir")
@@ -36,6 +52,10 @@ def list_resources(ctx: click.Context, env: str, provider: str | None, type: str
             all_resources = [r for r in all_resources if r.type == type]
 
         if not all_resources:
+            if output_format == "json":
+                output_data({"environment": env, "resources": [], "total": 0}, output_format)
+                return
+
             if type and provider:
                 console.warning(f"No resources found with provider '{provider}' and type '{type}'")
             elif type:
@@ -46,16 +66,31 @@ def list_resources(ctx: click.Context, env: str, provider: str | None, type: str
                 console.warning("No resources found")
             return
 
-        console.header(f"Resources in {env}:")
-
         # Sort all resources by name
         all_resources.sort(key=lambda r: r.name)
 
-        # Display each resource on a single line
-        for resource in all_resources:
-            console.info(f"  • {resource.name:<40} {resource.provider:<12} ({resource.type})")
+        # Build data structure
+        resource_data: list[dict[str, Any]] = [
+            {
+                "name": r.name,
+                "provider": r.provider,
+                "type": r.type,
+            }
+            for r in all_resources
+        ]
 
-        console.info(f"Total: {len(all_resources)} resources")
+        if output_format == "json":
+            output_data(
+                {"environment": env, "resources": resource_data, "total": len(resource_data)},
+                output_format,
+            )
+        else:
+            console.header(f"Resources in {env}:")
+            for resource in all_resources:
+                console.info(
+                    f"  {BULLET} {resource.name:<40} {resource.provider:<12} ({resource.type})"
+                )
+            console.info(f"Total: {len(all_resources)} resources")
 
     except click.ClickException:
         raise

--- a/src/infrafoundry/cli/output.py
+++ b/src/infrafoundry/cli/output.py
@@ -1,0 +1,176 @@
+"""Output formatting utilities for CLI commands.
+
+This module provides standardized output formatting across all CLI commands,
+including consistent bullet styles, JSON/YAML output, and format options.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from enum import Enum
+from functools import wraps
+from typing import Any, TypeVar
+
+import click
+import yaml
+
+# Standardized bullet character for all list output
+BULLET = "•"
+
+# Type variable for decorated functions
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class OutputFormat(str, Enum):
+    """Output format options for CLI commands."""
+
+    TEXT = "text"
+    JSON = "json"
+    YAML = "yaml"
+    TABLE = "table"  # Alias for text with Rich tables
+
+
+def format_json(data: Any, *, indent: int = 2) -> str:
+    """Format data as JSON string.
+
+    Args:
+        data: Data to serialize
+        indent: Indentation level (default: 2)
+
+    Returns:
+        JSON formatted string
+    """
+    return json.dumps(data, indent=indent, default=str)
+
+
+def format_yaml(data: Any) -> str:
+    """Format data as YAML string.
+
+    Args:
+        data: Data to serialize
+
+    Returns:
+        YAML formatted string
+    """
+    return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+
+def output_data(data: Any, output_format: OutputFormat | str) -> None:
+    """Output data in the specified format.
+
+    For JSON/YAML formats, prints to stdout directly (machine-readable).
+    This bypasses Rich console formatting for clean output.
+
+    Args:
+        data: Data to output
+        output_format: Output format (text, json, yaml)
+    """
+    if isinstance(output_format, str):
+        output_format = OutputFormat(output_format)
+
+    if output_format == OutputFormat.JSON:
+        click.echo(format_json(data))
+    elif output_format == OutputFormat.YAML:
+        click.echo(format_yaml(data))
+    else:
+        # For text/table format, caller should handle display
+        raise ValueError(f"Use appropriate display method for format: {output_format}")
+
+
+def format_list_item(text: str, indent: int = 2) -> str:
+    """Format a list item with standard bullet.
+
+    Args:
+        text: Item text
+        indent: Number of spaces before bullet (default: 2)
+
+    Returns:
+        Formatted list item string
+    """
+    return f"{' ' * indent}{BULLET} {text}"
+
+
+def format_list(
+    items: Sequence[str],
+    *,
+    indent: int = 2,
+) -> list[str]:
+    """Format a list of items with standard bullets.
+
+    Args:
+        items: List of item strings
+        indent: Number of spaces before bullet (default: 2)
+
+    Returns:
+        List of formatted item strings
+    """
+    return [format_list_item(item, indent=indent) for item in items]
+
+
+def add_format_option(
+    formats: Sequence[str] | None = None,
+    default: str = "text",
+) -> Callable[[F], F]:
+    """Decorator to add --format option to a command.
+
+    Args:
+        formats: Allowed formats (default: ["text", "json"])
+        default: Default format (default: "text")
+
+    Returns:
+        Click option decorator
+    """
+    if formats is None:
+        formats = ["text", "json"]
+
+    def decorator(f: F) -> F:
+        return click.option(
+            "--format",
+            "output_format",
+            type=click.Choice(list(formats)),
+            default=default,
+            help=f"Output format (default: {default})",
+        )(f)
+
+    return decorator
+
+
+def with_format_output(
+    formats: Sequence[str] | None = None,
+    default: str = "text",
+) -> Callable[[Callable[..., dict[str, Any] | None]], Callable[..., None]]:
+    """Decorator combining format option and automatic output handling.
+
+    The decorated function should return a dict for JSON/YAML output,
+    or None if it handles text output itself.
+
+    Args:
+        formats: Allowed formats (default: ["text", "json"])
+        default: Default format (default: "text")
+
+    Returns:
+        Combined decorator
+    """
+    if formats is None:
+        formats = ["text", "json"]
+
+    def decorator(
+        f: Callable[..., dict[str, Any] | None],
+    ) -> Callable[..., None]:
+        @click.option(
+            "--format",
+            "output_format",
+            type=click.Choice(list(formats)),
+            default=default,
+            help=f"Output format (default: {default})",
+        )
+        @wraps(f)
+        def wrapper(*args: Any, output_format: str, **kwargs: Any) -> None:
+            result = f(*args, output_format=output_format, **kwargs)
+            if result is not None and output_format in ("json", "yaml"):
+                output_data(result, output_format)
+
+        return wrapper
+
+    return decorator

--- a/src/infrafoundry/cli/utils.py
+++ b/src/infrafoundry/cli/utils.py
@@ -11,6 +11,7 @@ from rich.console import Console as RichConsole
 from infrafoundry.core.exceptions import InfraFoundryError
 
 from .errors import format_error, get_error_code, get_error_info
+from .output import BULLET
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -41,6 +42,15 @@ class InfraFoundryConsole:
     def info(self, message: str) -> None:
         """Print an info message."""
         self._console.print(message)
+
+    def list_item(self, message: str, indent: int = 2) -> None:
+        """Print a list item with standard bullet.
+
+        Args:
+            message: Item text
+            indent: Number of spaces before bullet (default: 2)
+        """
+        self._console.print(f"{' ' * indent}{BULLET} {message}")
 
     def status(self, message: str) -> None:
         """Print a status update."""

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for CLI module."""

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -1,0 +1,236 @@
+"""Tests for CLI output formatting utilities."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from infrafoundry.cli.output import (
+    BULLET,
+    OutputFormat,
+    format_json,
+    format_list,
+    format_list_item,
+    format_yaml,
+    output_data,
+)
+
+
+class TestBulletConstant:
+    """Tests for the BULLET constant."""
+
+    def test_bullet_is_string(self) -> None:
+        """BULLET should be a string."""
+        assert isinstance(BULLET, str)
+
+    def test_bullet_is_not_empty(self) -> None:
+        """BULLET should not be empty."""
+        assert len(BULLET) > 0
+
+    def test_bullet_is_unicode_bullet(self) -> None:
+        """BULLET should be the standard bullet character."""
+        assert BULLET == "•"
+
+
+class TestOutputFormat:
+    """Tests for OutputFormat enum."""
+
+    def test_text_format(self) -> None:
+        """TEXT format should be 'text'."""
+        assert OutputFormat.TEXT == "text"
+        assert OutputFormat.TEXT.value == "text"
+
+    def test_json_format(self) -> None:
+        """JSON format should be 'json'."""
+        assert OutputFormat.JSON == "json"
+        assert OutputFormat.JSON.value == "json"
+
+    def test_yaml_format(self) -> None:
+        """YAML format should be 'yaml'."""
+        assert OutputFormat.YAML == "yaml"
+        assert OutputFormat.YAML.value == "yaml"
+
+    def test_table_format(self) -> None:
+        """TABLE format should be 'table'."""
+        assert OutputFormat.TABLE == "table"
+        assert OutputFormat.TABLE.value == "table"
+
+    def test_format_from_string(self) -> None:
+        """OutputFormat should be creatable from string."""
+        assert OutputFormat("text") == OutputFormat.TEXT
+        assert OutputFormat("json") == OutputFormat.JSON
+        assert OutputFormat("yaml") == OutputFormat.YAML
+
+
+class TestFormatJson:
+    """Tests for format_json function."""
+
+    def test_format_simple_dict(self) -> None:
+        """Should format a simple dict as JSON."""
+        data = {"name": "test", "value": 42}
+        result = format_json(data)
+
+        # Should be valid JSON
+        parsed = json.loads(result)
+        assert parsed == data
+
+    def test_format_nested_dict(self) -> None:
+        """Should format nested structures."""
+        data = {"outer": {"inner": {"deep": "value"}}}
+        result = format_json(data)
+
+        parsed = json.loads(result)
+        assert parsed == data
+
+    def test_format_list(self) -> None:
+        """Should format lists."""
+        data = [1, 2, 3, "four"]
+        result = format_json(data)
+
+        parsed = json.loads(result)
+        assert parsed == data
+
+    def test_format_with_custom_indent(self) -> None:
+        """Should respect custom indent."""
+        data = {"key": "value"}
+        result = format_json(data, indent=4)
+
+        # Check indentation is 4 spaces
+        lines = result.split("\n")
+        assert lines[1].startswith("    ")
+
+    def test_format_with_datetime(self) -> None:
+        """Should handle datetime using default=str."""
+        from datetime import datetime
+
+        data = {"timestamp": datetime(2024, 1, 15, 12, 0, 0)}
+        result = format_json(data)
+
+        # Should not raise, datetime converted to string
+        parsed = json.loads(result)
+        assert "2024-01-15" in parsed["timestamp"]
+
+
+class TestFormatYaml:
+    """Tests for format_yaml function."""
+
+    def test_format_simple_dict(self) -> None:
+        """Should format a simple dict as YAML."""
+        data = {"name": "test", "value": 42}
+        result = format_yaml(data)
+
+        # Should be valid YAML
+        parsed = yaml.safe_load(result)
+        assert parsed == data
+
+    def test_format_nested_dict(self) -> None:
+        """Should format nested structures."""
+        data = {"outer": {"inner": "value"}}
+        result = format_yaml(data)
+
+        parsed = yaml.safe_load(result)
+        assert parsed == data
+
+    def test_format_list(self) -> None:
+        """Should format lists."""
+        data = ["one", "two", "three"]
+        result = format_yaml(data)
+
+        parsed = yaml.safe_load(result)
+        assert parsed == data
+
+    def test_no_flow_style(self) -> None:
+        """Should not use flow style for collections."""
+        data = {"items": [1, 2, 3]}
+        result = format_yaml(data)
+
+        # Flow style would be like {items: [1, 2, 3]}
+        # Block style has newlines
+        assert "\n" in result
+
+
+class TestFormatListItem:
+    """Tests for format_list_item function."""
+
+    def test_basic_item(self) -> None:
+        """Should format item with default indent."""
+        result = format_list_item("test item")
+        assert result == f"  {BULLET} test item"
+
+    def test_custom_indent(self) -> None:
+        """Should respect custom indent."""
+        result = format_list_item("test", indent=4)
+        assert result == f"    {BULLET} test"
+
+    def test_zero_indent(self) -> None:
+        """Should work with zero indent."""
+        result = format_list_item("test", indent=0)
+        assert result == f"{BULLET} test"
+
+
+class TestFormatList:
+    """Tests for format_list function."""
+
+    def test_empty_list(self) -> None:
+        """Should handle empty list."""
+        result = format_list([])
+        assert result == []
+
+    def test_single_item(self) -> None:
+        """Should format single item."""
+        result = format_list(["item"])
+        assert result == [f"  {BULLET} item"]
+
+    def test_multiple_items(self) -> None:
+        """Should format multiple items."""
+        result = format_list(["one", "two", "three"])
+        assert len(result) == 3
+        assert all(item.startswith(f"  {BULLET} ") for item in result)
+
+    def test_custom_indent(self) -> None:
+        """Should respect custom indent for all items."""
+        result = format_list(["a", "b"], indent=6)
+        assert all(item.startswith(f"      {BULLET} ") for item in result)
+
+
+class TestOutputData:
+    """Tests for output_data function."""
+
+    def test_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Should output JSON to stdout."""
+        data = {"key": "value"}
+        output_data(data, OutputFormat.JSON)
+
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed == data
+
+    def test_yaml_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Should output YAML to stdout."""
+        data = {"key": "value"}
+        output_data(data, OutputFormat.YAML)
+
+        captured = capsys.readouterr()
+        parsed = yaml.safe_load(captured.out)
+        assert parsed == data
+
+    def test_string_format(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Should accept string format."""
+        data = {"test": 123}
+        output_data(data, "json")
+
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed == data
+
+    def test_text_format_raises(self) -> None:
+        """Should raise for text format."""
+        with pytest.raises(ValueError, match="Use appropriate display method"):
+            output_data({"key": "value"}, OutputFormat.TEXT)
+
+    def test_table_format_raises(self) -> None:
+        """Should raise for table format."""
+        with pytest.raises(ValueError, match="Use appropriate display method"):
+            output_data({"key": "value"}, OutputFormat.TABLE)


### PR DESCRIPTION
## Description

Add centralized output utilities module (`cli/output.py`) with standardized formatting, add `--format json` option to 5 commands for machine-readable output, and standardize bullet styles from mixed (-, •) to consistent • character.

## Related Issue

Closes #229

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Add `src/infrafoundry/cli/output.py` - Output formatting utilities with BULLET constant, OutputFormat enum, format_json/format_yaml helpers, output_data() for machine-readable output
- Add `--format json` option to: config envs, state list, infra history, audit list, doctor
- Standardize bullet styles from `-` to `•` in config/init.py and analyze/impact.py
- Add `list_item()` method to InfraFoundryConsole in utils.py
- Add 29 tests for output module in tests/unit/cli/test_output.py

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Note on Breaking Change Detection

The CI flagged `output_format` parameters as breaking changes. This is a **false positive** for CLI commands:

- The `--format` option uses `default="text"`, so existing CLI usage is fully backward compatible
- These are Click command functions, not public Python APIs meant to be called directly
- All existing behavior is preserved when `--format` is not specified
- This is a new feature addition, not a breaking change

## Additional Notes

Coverage at 75.25% (exceeds 69% requirement). All 1405 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)