### PR TITLE
feat: add shell completion for bash, zsh, and fish

### DIFF
--- a/src/infrafoundry/cli/commands/completion.py
+++ b/src/infrafoundry/cli/commands/completion.py
@@ -1,0 +1,288 @@
+"""Shell completion commands for bash, zsh, and fish."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import click
+
+from ..utils import console
+
+# Shell completion script templates
+# These use Click's built-in completion mechanism
+BASH_SCRIPT = """\
+# InfraFoundry bash completion
+# Add this to ~/.bashrc or ~/.bash_completion
+
+eval "$(_FOUNDRY_COMPLETE=bash_source foundry)"
+"""
+
+ZSH_SCRIPT = """\
+# InfraFoundry zsh completion
+# Add this to ~/.zshrc
+
+eval "$(_FOUNDRY_COMPLETE=zsh_source foundry)"
+"""
+
+FISH_SCRIPT = """\
+# InfraFoundry fish completion
+# Add this to ~/.config/fish/completions/foundry.fish
+
+eval (env _FOUNDRY_COMPLETE=fish_source foundry)
+"""
+
+# Shell config file paths
+SHELL_CONFIGS = {
+    "bash": [
+        Path.home() / ".bashrc",
+        Path.home() / ".bash_profile",
+    ],
+    "zsh": [
+        Path.home() / ".zshrc",
+    ],
+    "fish": [
+        Path.home() / ".config" / "fish" / "completions" / "foundry.fish",
+    ],
+}
+
+COMPLETION_MARKER = "_FOUNDRY_COMPLETE"
+
+
+def _detect_shell() -> str | None:
+    """Detect the current shell.
+
+    Returns:
+        Shell name (bash, zsh, fish) or None if unknown
+    """
+    shell = os.environ.get("SHELL", "")
+    if "bash" in shell:
+        return "bash"
+    elif "zsh" in shell:
+        return "zsh"
+    elif "fish" in shell:
+        return "fish"
+    return None
+
+
+def _get_completion_script(shell: str) -> str:
+    """Get the completion script for a shell.
+
+    Args:
+        shell: Shell name (bash, zsh, fish)
+
+    Returns:
+        Completion script content
+    """
+    scripts = {
+        "bash": BASH_SCRIPT,
+        "zsh": ZSH_SCRIPT,
+        "fish": FISH_SCRIPT,
+    }
+    return scripts.get(shell, "")
+
+
+def _find_config_file(shell: str) -> Path | None:
+    """Find the appropriate config file for a shell.
+
+    Args:
+        shell: Shell name
+
+    Returns:
+        Path to config file or None
+    """
+    for config_path in SHELL_CONFIGS.get(shell, []):
+        if shell == "fish":
+            # For fish, we create the completions file directly
+            return config_path
+        if config_path.exists():
+            return config_path
+    return None
+
+
+def _is_completion_installed(config_path: Path) -> bool:
+    """Check if completion is already installed.
+
+    Args:
+        config_path: Path to shell config file
+
+    Returns:
+        True if completion marker is found
+    """
+    if not config_path.exists():
+        return False
+    content = config_path.read_text()
+    return COMPLETION_MARKER in content
+
+
+@click.group()
+def completion() -> None:
+    """Manage shell completion for bash, zsh, and fish.
+
+    Examples:
+
+        # Install completion for your shell
+        foundry completion bash
+        foundry completion zsh
+        foundry completion fish
+
+        # Remove completion (auto-detects installed shells)
+        foundry completion uninstall
+    """
+    pass
+
+
+def _install_completion(shell_type: str) -> None:
+    """Install completion for a specific shell.
+
+    Args:
+        shell_type: Shell name (bash, zsh, fish)
+    """
+    script = _get_completion_script(shell_type)
+    config_path = _find_config_file(shell_type)
+
+    if not config_path:
+        console.error(f"Could not find config file for {shell_type}")
+        console.info(f"Manually add this to your shell config:\n\n{script}")
+        sys.exit(1)
+
+    # Check if already installed
+    if _is_completion_installed(config_path):
+        console.success(f"Completion already installed in {config_path}")
+        return
+
+    # Install completion
+    try:
+        if shell_type == "fish":
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(script)
+            console.success(f"Completion installed to {config_path}")
+        else:
+            with open(config_path, "a") as f:
+                f.write(f"\n{script}\n")
+            console.success(f"Completion installed to {config_path}")
+
+        console.info("")
+        console.info("To activate, either:")
+        console.info("  1. Restart your terminal")
+        console.info(f"  2. Run: source {config_path}")
+
+    except PermissionError:
+        console.error(f"Permission denied writing to {config_path}")
+        console.info(f"Manually add this to your shell config:\n\n{script}")
+        sys.exit(1)
+    except OSError as e:
+        console.error(f"Failed to install completion: {e}")
+        sys.exit(1)
+
+
+@completion.command(name="bash")
+def completion_bash() -> None:
+    """Install bash completion to ~/.bashrc."""
+    _install_completion("bash")
+
+
+@completion.command(name="zsh")
+def completion_zsh() -> None:
+    """Install zsh completion to ~/.zshrc."""
+    _install_completion("zsh")
+
+
+@completion.command(name="fish")
+def completion_fish() -> None:
+    """Install fish completion to ~/.config/fish/completions/."""
+    _install_completion("fish")
+
+
+def _get_installed_shells() -> list[str]:
+    """Find which shells have completion installed.
+
+    Returns:
+        List of shell names with completion installed
+    """
+    installed = []
+    for shell in ["bash", "zsh", "fish"]:
+        config_path = _find_config_file(shell)
+        if config_path and _is_completion_installed(config_path):
+            installed.append(shell)
+    return installed
+
+
+def _uninstall_completion(shell_type: str) -> bool:
+    """Uninstall completion for a specific shell.
+
+    Args:
+        shell_type: Shell name (bash, zsh, fish)
+
+    Returns:
+        True if uninstalled, False if not installed
+    """
+    config_path = _find_config_file(shell_type)
+    if not config_path or not config_path.exists():
+        return False
+
+    if not _is_completion_installed(config_path):
+        return False
+
+    try:
+        if shell_type == "fish":
+            config_path.unlink()
+        else:
+            content = config_path.read_text()
+            script = _get_completion_script(shell_type)
+            new_content = content.replace(f"\n{script}\n", "\n")
+            new_content = new_content.replace(script, "")
+            config_path.write_text(new_content)
+
+        console.success(f"Removed {shell_type} completion")
+        return True
+
+    except PermissionError:
+        console.error(f"Permission denied modifying {config_path}")
+        return False
+    except OSError as e:
+        console.error(f"Failed to remove {shell_type} completion: {e}")
+        return False
+
+
+@completion.command(name="uninstall")
+def completion_uninstall() -> None:
+    """Remove shell completion.
+
+    Detects which shells have completion installed and prompts
+    you to select which ones to remove.
+    """
+    installed = _get_installed_shells()
+
+    if not installed:
+        console.info("No shell completions are currently installed")
+        return
+
+    # Build choices: individual shells + "all" option
+    if len(installed) == 1:
+        # Only one installed, just remove it
+        shell = installed[0]
+        if _uninstall_completion(shell):
+            console.info("Restart your terminal to apply changes")
+        return
+
+    # Multiple installed - prompt user
+    console.info("Found completion installed for:")
+    for i, shell in enumerate(installed, 1):
+        console.info(f"  {i}. {shell}")
+    console.info(f"  {len(installed) + 1}. all")
+
+    choice = click.prompt(
+        "Which to uninstall?",
+        type=click.IntRange(1, len(installed) + 1),
+    )
+
+    if choice == len(installed) + 1:
+        # Uninstall all
+        for shell in installed:
+            _uninstall_completion(shell)
+    else:
+        _uninstall_completion(installed[choice - 1])
+
+    console.info("Restart your terminal to apply changes")

--- a/src/infrafoundry/cli/main.py
+++ b/src/infrafoundry/cli/main.py
@@ -278,6 +278,7 @@ def foundry(
 # Import and register command groups
 from infrafoundry.cli.commands.analyze import analyze
 from infrafoundry.cli.commands.audit import audit
+from infrafoundry.cli.commands.completion import completion
 from infrafoundry.cli.commands.config import config
 from infrafoundry.cli.commands.doctor import doctor
 from infrafoundry.cli.commands.infra import infra
@@ -286,6 +287,7 @@ from infrafoundry.cli.commands.proxmox import proxmox
 from infrafoundry.cli.commands.secrets import secrets
 from infrafoundry.cli.commands.state import state
 
+foundry.add_command(completion)
 foundry.add_command(doctor)
 foundry.add_command(infra)
 foundry.add_command(config)

--- a/tests/unit/cli/test_completion.py
+++ b/tests/unit/cli/test_completion.py
@@ -1,0 +1,326 @@
+"""Tests for shell completion commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from infrafoundry.cli.commands.completion import (
+    BASH_SCRIPT,
+    COMPLETION_MARKER,
+    FISH_SCRIPT,
+    ZSH_SCRIPT,
+    _detect_shell,
+    _find_config_file,
+    _get_completion_script,
+    _is_completion_installed,
+    completion,
+)
+
+
+class TestDetectShell:
+    """Tests for shell detection."""
+
+    def test_detect_bash(self) -> None:
+        """Should detect bash shell."""
+        with patch.dict("os.environ", {"SHELL": "/bin/bash"}):
+            assert _detect_shell() == "bash"
+
+    def test_detect_zsh(self) -> None:
+        """Should detect zsh shell."""
+        with patch.dict("os.environ", {"SHELL": "/usr/bin/zsh"}):
+            assert _detect_shell() == "zsh"
+
+    def test_detect_fish(self) -> None:
+        """Should detect fish shell."""
+        with patch.dict("os.environ", {"SHELL": "/usr/bin/fish"}):
+            assert _detect_shell() == "fish"
+
+    def test_detect_unknown(self) -> None:
+        """Should return None for unknown shell."""
+        with patch.dict("os.environ", {"SHELL": "/bin/sh"}):
+            assert _detect_shell() is None
+
+    def test_detect_no_shell_env(self) -> None:
+        """Should return None when SHELL not set."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert _detect_shell() is None
+
+
+class TestGetCompletionScript:
+    """Tests for getting completion scripts."""
+
+    def test_get_bash_script(self) -> None:
+        """Should return bash script."""
+        script = _get_completion_script("bash")
+        assert "bash" in script.lower()
+        assert "_FOUNDRY_COMPLETE=bash_source" in script
+
+    def test_get_zsh_script(self) -> None:
+        """Should return zsh script."""
+        script = _get_completion_script("zsh")
+        assert "zsh" in script.lower()
+        assert "_FOUNDRY_COMPLETE=zsh_source" in script
+
+    def test_get_fish_script(self) -> None:
+        """Should return fish script."""
+        script = _get_completion_script("fish")
+        assert "fish" in script.lower()
+        assert "_FOUNDRY_COMPLETE=fish_source" in script
+
+    def test_get_unknown_script(self) -> None:
+        """Should return empty string for unknown shell."""
+        assert _get_completion_script("unknown") == ""
+
+
+class TestFindConfigFile:
+    """Tests for finding config files."""
+
+    def test_find_bash_config(self, tmp_path: Path) -> None:
+        """Should find bash config file."""
+        bashrc = tmp_path / ".bashrc"
+        bashrc.touch()
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [bashrc]},
+        ):
+            assert _find_config_file("bash") == bashrc
+
+    def test_find_zsh_config(self, tmp_path: Path) -> None:
+        """Should find zsh config file."""
+        zshrc = tmp_path / ".zshrc"
+        zshrc.touch()
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"zsh": [zshrc]},
+        ):
+            assert _find_config_file("zsh") == zshrc
+
+    def test_find_fish_config(self, tmp_path: Path) -> None:
+        """Should return fish completions path (doesn't need to exist)."""
+        fish_path = tmp_path / ".config" / "fish" / "completions" / "foundry.fish"
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"fish": [fish_path]},
+        ):
+            assert _find_config_file("fish") == fish_path
+
+    def test_find_nonexistent_config(self, tmp_path: Path) -> None:
+        """Should return None if no config exists."""
+        nonexistent = tmp_path / ".nonexistent"
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [nonexistent]},
+        ):
+            assert _find_config_file("bash") is None
+
+
+class TestIsCompletionInstalled:
+    """Tests for checking if completion is installed."""
+
+    def test_completion_installed(self, tmp_path: Path) -> None:
+        """Should detect installed completion."""
+        config_file = tmp_path / ".bashrc"
+        config_file.write_text(f"some content\n{COMPLETION_MARKER}\nmore content")
+
+        assert _is_completion_installed(config_file) is True
+
+    def test_completion_not_installed(self, tmp_path: Path) -> None:
+        """Should detect when completion is not installed."""
+        config_file = tmp_path / ".bashrc"
+        config_file.write_text("some content\nno completion here")
+
+        assert _is_completion_installed(config_file) is False
+
+    def test_file_not_exists(self, tmp_path: Path) -> None:
+        """Should return False for nonexistent file."""
+        config_file = tmp_path / ".nonexistent"
+
+        assert _is_completion_installed(config_file) is False
+
+
+class TestCompletionBashCommand:
+    """Tests for 'foundry completion bash' command."""
+
+    def test_installs_bash_completion(self, tmp_path: Path) -> None:
+        """Should install bash completion to ~/.bashrc."""
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text("# existing content\n")
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [bashrc]},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(completion, ["bash"])
+
+            assert result.exit_code == 0
+            assert "installed" in result.output.lower()
+
+            content = bashrc.read_text()
+            assert COMPLETION_MARKER in content
+            assert "_FOUNDRY_COMPLETE=bash_source" in content
+
+    def test_already_installed(self, tmp_path: Path) -> None:
+        """Should report when already installed."""
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text(f"# existing\n{BASH_SCRIPT}\n")
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [bashrc]},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(completion, ["bash"])
+
+            assert result.exit_code == 0
+            assert "already installed" in result.output.lower()
+
+
+class TestCompletionZshCommand:
+    """Tests for 'foundry completion zsh' command."""
+
+    def test_installs_zsh_completion(self, tmp_path: Path) -> None:
+        """Should install zsh completion to ~/.zshrc."""
+        zshrc = tmp_path / ".zshrc"
+        zshrc.write_text("# existing content\n")
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"zsh": [zshrc]},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(completion, ["zsh"])
+
+            assert result.exit_code == 0
+            assert "installed" in result.output.lower()
+
+            content = zshrc.read_text()
+            assert COMPLETION_MARKER in content
+            assert "_FOUNDRY_COMPLETE=zsh_source" in content
+
+
+class TestCompletionFishCommand:
+    """Tests for 'foundry completion fish' command."""
+
+    def test_installs_fish_completion(self, tmp_path: Path) -> None:
+        """Should install fish completion (creates file)."""
+        fish_path = tmp_path / "completions" / "foundry.fish"
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"fish": [fish_path]},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(completion, ["fish"])
+
+            assert result.exit_code == 0
+            assert fish_path.exists()
+            assert "_FOUNDRY_COMPLETE=fish_source" in fish_path.read_text()
+
+
+class TestCompletionUninstallCommand:
+    """Tests for 'foundry completion uninstall' command."""
+
+    def test_uninstall_single_shell(self, tmp_path: Path) -> None:
+        """Should uninstall when only one shell has completion."""
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text(f"# before\n{BASH_SCRIPT}\n# after\n")
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [bashrc], "zsh": [tmp_path / ".zshrc"], "fish": [tmp_path / "f.fish"]},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(completion, ["uninstall"])
+
+            assert result.exit_code == 0
+            assert "removed" in result.output.lower()
+
+            content = bashrc.read_text()
+            assert COMPLETION_MARKER not in content
+
+    def test_uninstall_multiple_shells_select_one(self, tmp_path: Path) -> None:
+        """Should prompt when multiple shells have completion."""
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text(f"# before\n{BASH_SCRIPT}\n")
+        zshrc = tmp_path / ".zshrc"
+        zshrc.write_text(f"# before\n{ZSH_SCRIPT}\n")
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [bashrc], "zsh": [zshrc], "fish": [tmp_path / "f.fish"]},
+        ):
+            runner = CliRunner()
+            # Select option 1 (bash)
+            result = runner.invoke(completion, ["uninstall"], input="1\n")
+
+            assert result.exit_code == 0
+            assert COMPLETION_MARKER not in bashrc.read_text()
+            # zsh should still have it
+            assert COMPLETION_MARKER in zshrc.read_text()
+
+    def test_uninstall_multiple_shells_select_all(self, tmp_path: Path) -> None:
+        """Should uninstall all when 'all' selected."""
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text(f"# before\n{BASH_SCRIPT}\n")
+        zshrc = tmp_path / ".zshrc"
+        zshrc.write_text(f"# before\n{ZSH_SCRIPT}\n")
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [bashrc], "zsh": [zshrc], "fish": [tmp_path / "f.fish"]},
+        ):
+            runner = CliRunner()
+            # Select option 3 (all) - bash=1, zsh=2, all=3
+            result = runner.invoke(completion, ["uninstall"], input="3\n")
+
+            assert result.exit_code == 0
+            assert COMPLETION_MARKER not in bashrc.read_text()
+            assert COMPLETION_MARKER not in zshrc.read_text()
+
+    def test_uninstall_none_installed(self, tmp_path: Path) -> None:
+        """Should handle when nothing is installed."""
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text("# no completion here\n")
+
+        with patch(
+            "infrafoundry.cli.commands.completion.SHELL_CONFIGS",
+            {"bash": [bashrc], "zsh": [tmp_path / ".zshrc"], "fish": [tmp_path / "f.fish"]},
+        ):
+            runner = CliRunner()
+            result = runner.invoke(completion, ["uninstall"])
+
+            assert result.exit_code == 0
+            assert "no shell completions" in result.output.lower()
+
+
+class TestScriptContents:
+    """Tests for script content correctness."""
+
+    def test_bash_script_has_marker(self) -> None:
+        """Bash script should have completion marker."""
+        assert COMPLETION_MARKER in BASH_SCRIPT
+        assert "bash_source" in BASH_SCRIPT
+
+    def test_zsh_script_has_marker(self) -> None:
+        """Zsh script should have completion marker."""
+        assert COMPLETION_MARKER in ZSH_SCRIPT
+        assert "zsh_source" in ZSH_SCRIPT
+
+    def test_fish_script_has_marker(self) -> None:
+        """Fish script should have completion marker."""
+        assert COMPLETION_MARKER in FISH_SCRIPT
+        assert "fish_source" in FISH_SCRIPT
+
+    def test_scripts_use_foundry_command(self) -> None:
+        """All scripts should reference 'foundry' command."""
+        assert "foundry" in BASH_SCRIPT
+        assert "foundry" in ZSH_SCRIPT
+        assert "foundry" in FISH_SCRIPT


### PR DESCRIPTION
## Description

Add shell completion support for bash, zsh, and fish shells using Click's built-in completion mechanism. Users can now tab-complete commands, subcommands, and options.

## Related Issue

Closes #228

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Add `src/infrafoundry/cli/commands/completion.py` with:
  - `foundry completion bash` - Install bash completion
  - `foundry completion zsh` - Install zsh completion
  - `foundry completion fish` - Install fish completion
  - `foundry completion uninstall` - Auto-detects installed shells, prompts to select which to remove (includes "all" option)
- Register completion command in `main.py`
- Add 26 tests covering all functionality

## Usage

```bash
# Install completion for your shell
foundry completion bash
foundry completion zsh
foundry completion fish

# Remove completion (interactive)
foundry completion uninstall
# -> Detects which shells have completion installed
# -> If multiple, prompts: "1. bash  2. zsh  3. all"
# -> Removes selected
```

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (26 tests)
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Clean UX: install is one command per shell, uninstall auto-detects and prompts. Idempotent - install reports if already installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)