### PR TITLE
fix: upgrade pip before running pip-audit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         run: uv run codespell src/ tests/ docs/ README.md
 
       - name: Run dependency audit
-        run: uv run pip-audit
+        run: uv run pip install --upgrade pip && uv run pip-audit
 
       - name: Run tests with coverage
         run: uv run pytest --cov=infrafoundry --cov-report=xml:tmp/coverage.xml --cov-report=term -v


### PR DESCRIPTION
## Description

The pip version bundled in GitHub Actions runners (25.3) has CVE-2026-1703, causing `pip-audit` to fail on every CI run. This upgrades pip before running the audit step.

## Related Issue

Closes #257

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Upgrade pip before running `pip-audit` in `.github/workflows/ci.yml`

## Testing

- [x] CI pipeline should pass with this change

## Checklist

- [x] My code follows the code style of this project
- [x] My changes generate no new warnings