### PR TITLE
fix: catch SecretNotFoundError in --allow-missing-secrets

### DIFF
--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -15,6 +15,7 @@ from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import EventManager, EventType
+from infrafoundry.core.exceptions import SecretNotFoundError
 from infrafoundry.core.hooks import HookExecutionMixin, HookManager
 from infrafoundry.core.protocols import Destroyable, Plannable
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
@@ -527,7 +528,7 @@ class PlanOrchestrator(HookExecutionMixin):
             secrets_file = f"{provider_name}.yaml"
             tf_vars = provider.terraform_dir / "secrets.auto.tfvars"
             secret_manager.export_for_terraform(secrets_file, tf_vars)
-        except FileNotFoundError as exc:
+        except (FileNotFoundError, SecretNotFoundError) as exc:
             message = f"No secrets file for {provider_name}"
             if self._fail_on_missing_secrets:
                 raise FileNotFoundError(message) from exc

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -9,6 +9,7 @@ import pytest
 
 from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.events import EventManager
+from infrafoundry.core.exceptions import SecretNotFoundError
 from infrafoundry.core.notifications import NotificationManager
 from infrafoundry.core.orchestrator import Orchestrator, OrchestratorStrictConfig
 from infrafoundry.core.orchestrator_workflows import PlanOrchestrator
@@ -469,6 +470,54 @@ class TestPlanOrchestratorStrictMode:
     def test_export_secrets_permissive_mode_warns(self, tmp_path):
         """Permissive mode should not raise when secrets are missing."""
         workflow = self._make_plan_workflow(tmp_path, fail_on_missing_secrets=False)
+        provider = SimpleNamespace(terraform_dir=tmp_path)
+
+        workflow._export_secrets("proxmox", "dev", provider)
+
+    def _make_plan_workflow_with_secret_not_found(
+        self, tmp_path, fail_on_missing_secrets: bool
+    ) -> PlanOrchestrator:
+        secret_manager = Mock(spec=SecretManager)
+        secret_manager.export_for_terraform.side_effect = SecretNotFoundError(
+            "Encrypted file not found: prod/proxmox.yaml"
+        )
+
+        mock_runner_registry = Mock()
+        mock_runner_registry.list_runners.return_value = []
+        mock_runner_registry.create_runner.return_value = None
+
+        return PlanOrchestrator(
+            console=Mock(),
+            state_manager=Mock(),
+            event_manager=Mock(),
+            runner_registry=mock_runner_registry,
+            get_providers=lambda: {},
+            load_resources=lambda env: ([], {}),
+            iter_provider_batches=lambda *_args, **_kwargs: [],
+            validate_resources=lambda resources: None,
+            has_policies=lambda: False,
+            check_policies=lambda env, resources, enforce: None,
+            secret_manager_factory=lambda env: secret_manager,
+            get_current_user=lambda: "tester",
+            fail_on_missing_secrets=fail_on_missing_secrets,
+            get_runner_priorities=lambda env: {},
+        )
+
+    def test_export_secrets_strict_mode_raises_on_secret_not_found(self, tmp_path):
+        """Strict mode should raise when SecretNotFoundError occurs."""
+        workflow = self._make_plan_workflow_with_secret_not_found(
+            tmp_path, fail_on_missing_secrets=True
+        )
+        provider = SimpleNamespace(terraform_dir=tmp_path)
+
+        with pytest.raises(FileNotFoundError):
+            workflow._export_secrets("proxmox", "dev", provider)
+
+    def test_export_secrets_permissive_mode_warns_on_secret_not_found(self, tmp_path):
+        """Permissive mode should not raise when SecretNotFoundError occurs."""
+        workflow = self._make_plan_workflow_with_secret_not_found(
+            tmp_path, fail_on_missing_secrets=False
+        )
         provider = SimpleNamespace(terraform_dir=tmp_path)
 
         workflow._export_secrets("proxmox", "dev", provider)


### PR DESCRIPTION
## Description

The `_export_secrets` method in `PlanOrchestrator` only caught `FileNotFoundError` when handling missing secrets files. However, the SOPS provider raises `SecretNotFoundError` (which inherits from `InfraFoundryError`, not `FileNotFoundError`), causing `--allow-missing-secrets` to have no effect when encrypted secrets files are missing.

## Related Issue

Addresses #288

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `SecretNotFoundError` to the except clause in `_export_secrets` (`orchestrator_workflows.py:530`)
- Added 2 new tests verifying both strict and permissive mode behavior with `SecretNotFoundError`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings