### PR TITLE
feat: add LXC container support to Proxmox provider

### DIFF
--- a/example-config/envs/dev/proxmox/containers.yaml
+++ b/example-config/envs/dev/proxmox/containers.yaml
@@ -1,0 +1,121 @@
+containers:
+  # ------------------------------------------------------------------
+  # Basic Alpine LXC Container
+  # ------------------------------------------------------------------
+  # Minimal container with DHCP networking
+  - name: alpine-basic-01
+    target_node: pve01
+    ctid: 300
+    ostemplate: "nas01:vztmpl/alpine-3.21-default_20250108_amd64.tar.xz"
+    ostype: alpine
+    cores: 1
+    memory: 64
+    swap: 0
+    rootfs:
+      storage: local-lvm
+      size: 1
+    network:
+      - name: eth0
+        bridge: vmbr0
+        ip: dhcp
+    hostname: alpine-basic-01
+    unprivileged: true
+    onboot: true
+    start: true
+    tags: [alpine, basic]
+
+  # ------------------------------------------------------------------
+  # Ubuntu Container with Mount Points and Static IP
+  # ------------------------------------------------------------------
+  # Web server container with NFS-mounted webroot
+  - name: web-01
+    target_node: pve01
+    ctid: 301
+    ostemplate: "nas01:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst"
+    ostype: ubuntu
+    cores: 2
+    memory: 256
+    swap: 128
+    rootfs:
+      storage: nas01
+      size: 4
+    network:
+      - name: eth0
+        bridge: vmbr0
+        tag: 10
+        ip: 192.168.10.50/24
+        gw: 192.168.10.1
+        firewall: true
+    mount_point:
+      - volume: "nas01:infra"
+        path: /var/www/html
+        shared: true
+        read_only: true
+    hostname: web-01
+    dns:
+      domain: example.com
+      servers: ["192.168.10.1", "1.1.1.1"]
+    ssh_keys: ["ssh-rsa AAAA... user@host"]
+    unprivileged: true
+    onboot: true
+    start: true
+    tags: [ubuntu, webserver, infra]
+    startup:
+      order: 2
+      up_delay: 10
+      down_delay: 5
+
+  # ------------------------------------------------------------------
+  # Container with Nesting and NFS Features
+  # ------------------------------------------------------------------
+  # Docker-in-LXC with NFS mount support
+  - name: docker-host-01
+    target_node: pve01
+    ctid: 302
+    ostemplate: "nas01:vztmpl/debian-12-standard_12.7-1_amd64.tar.zst"
+    ostype: debian
+    cores: 4
+    memory: 2048
+    swap: 512
+    rootfs:
+      storage: local-lvm
+      size: 16
+    network:
+      - name: eth0
+        bridge: vmbr0
+        tag: 10
+        ip: 192.168.10.51/24
+        gw: 192.168.10.1
+      - name: eth1
+        bridge: vmbr1
+        tag: 20
+        ip: 192.168.20.51/24
+    mount_point:
+      - volume: "nas01:docker-data"
+        path: /var/lib/docker
+        shared: true
+      - volume: "nas01:backups"
+        path: /mnt/backups
+        read_only: true
+        backup: false
+    hostname: docker-host-01
+    dns:
+      domain: example.com
+      servers: ["192.168.10.1"]
+    ssh_keys: ["ssh-rsa AAAA... admin@host"]
+    unprivileged: false
+    features:
+      nesting: true
+      mount: [nfs, cifs]
+      keyctl: true
+    onboot: true
+    start: true
+    tags: [debian, docker, infra]
+    startup:
+      order: 3
+      up_delay: 15
+      down_delay: 10
+    console:
+      enabled: true
+      type: console
+      tty_count: 2

--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -22,7 +22,7 @@ class ProxmoxProvider(
     ResourceGrouperMixin,
     TerraformGeneratorMixin,
 ):
-    """Proxmox VE provider for managing VMs, templates, and networks."""
+    """Proxmox VE provider for managing VMs, containers, templates, and networks."""
 
     _PROXMOX_TFVARS_MAPPING: ClassVar[dict[str, str]] = {
         "api_url": "proxmox_api_url",
@@ -83,6 +83,9 @@ class ProxmoxProvider(
         if "vm" in resources_by_type:
             self._generate_vms_terraform(resources_by_type["vm"])
 
+        if "container" in resources_by_type:
+            self._generate_containers_terraform(resources_by_type["container"])
+
         if "template" in resources_by_type:
             self._generate_templates_terraform(resources_by_type["template"])
 
@@ -106,6 +109,47 @@ class ProxmoxProvider(
             context={"vms": processed_vms},
             output_name="vms.tf",
         )
+
+    def _generate_containers_terraform(self, containers: list[ResourceConfig]) -> None:
+        """Generate Terraform for Proxmox LXC containers."""
+        processed_containers = []
+        for container in containers:
+            processed_containers.append(self._normalize_container_config(container))
+
+        self.render_and_write_terraform(
+            "proxmox/containers.tf.j2",
+            context={"containers": processed_containers},
+            output_name="containers.tf",
+        )
+
+    def _normalize_container_config(self, container: ResourceConfig) -> ResourceConfig:
+        """Normalize container config for template consumption.
+
+        Ensures the network and mount_point fields are always lists of dicts,
+        even when the user provides a single dict.
+
+        Args:
+            container: The container resource config to normalize.
+
+        Returns:
+            The container resource config with normalized fields.
+        """
+        import copy
+
+        ct_copy = copy.deepcopy(container)
+        config = ct_copy.config
+
+        # Normalize network: wrap single dict in a list
+        network = config.get("network")
+        if isinstance(network, dict):
+            config["network"] = [network]
+
+        # Normalize mount_point: wrap single dict in a list
+        mount_point = config.get("mount_point")
+        if isinstance(mount_point, dict):
+            config["mount_point"] = [mount_point]
+
+        return ct_copy
 
     def _normalize_vm_config(self, vm: ResourceConfig) -> ResourceConfig:
         """Normalize VM config for template consumption.
@@ -345,13 +389,14 @@ class ProxmoxProvider(
     @override
     def get_resource_types(self) -> list[str]:
         """Get supported resource types."""
-        return ["vm", "template", "network"]
+        return ["vm", "container", "template", "network"]
 
     @override
     def get_dependencies(self) -> dict[str, list[str]]:
         """Get resource dependencies."""
         return {
             "vm": ["template", "network"],
+            "container": ["network"],
             "template": [],
             "network": [],
         }

--- a/src/infrafoundry/providers/proxmox/templates/proxmox/containers.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/containers.tf.j2
@@ -1,0 +1,262 @@
+{% for container in containers %}
+resource "proxmox_virtual_environment_container" "{{ container.config.name | replace('-', '_') }}" {
+  node_name   = "{{ container.config.target_node }}"
+  {% if container.config.ctid is defined %}
+  vm_id       = {{ container.config.ctid }}
+  {% endif %}
+  {% if container.config.description is defined %}
+  description = "{{ container.config.description }}"
+  {% endif %}
+  {% if container.config.unprivileged is defined %}
+  unprivileged = {{ container.config.unprivileged | lower }}
+  {% endif %}
+  {% if container.config.start is defined %}
+  started     = {{ container.config.start | lower }}
+  {% endif %}
+  {% if container.config.onboot is defined %}
+  start_on_boot = {{ container.config.onboot | lower }}
+  {% endif %}
+  {% if container.config.tags is defined %}
+  tags        = {{ container.config.tags | tojson }}
+  {% endif %}
+  {% if container.config.template is defined %}
+  template    = {{ container.config.template | lower }}
+  {% endif %}
+  {% if container.config.protection is defined %}
+  protection  = {{ container.config.protection | lower }}
+  {% endif %}
+  {% if container.config.pool_id is defined %}
+  pool_id     = "{{ container.config.pool_id }}"
+  {% endif %}
+
+  {% if container.config.clone is defined %}
+  # Clone from existing container
+  clone {
+    vm_id = {{ container.config.clone.vm_id }}
+    {% if container.config.clone.node_name is defined %}
+    node_name    = "{{ container.config.clone.node_name }}"
+    {% endif %}
+    {% if container.config.clone.datastore_id is defined %}
+    datastore_id = "{{ container.config.clone.datastore_id }}"
+    {% endif %}
+  }
+  {% endif %}
+
+  {% if container.config.ostemplate is defined %}
+  # Operating System Template
+  operating_system {
+    template_file_id = "{{ container.config.ostemplate }}"
+    {% if container.config.ostype is defined %}
+    type             = "{{ container.config.ostype }}"
+    {% endif %}
+  }
+  {% endif %}
+
+  # CPU Configuration
+  cpu {
+    cores        = {{ container.config.cores | default(1) }}
+    {% if container.config.arch is defined %}
+    architecture = "{{ container.config.arch }}"
+    {% endif %}
+  }
+
+  # Memory Configuration
+  memory {
+    dedicated = {{ container.config.memory | default(512) }}
+    {% if container.config.swap is defined %}
+    swap      = {{ container.config.swap }}
+    {% endif %}
+  }
+
+  {% if container.config.rootfs is defined %}
+  # Root Filesystem
+  disk {
+    datastore_id = "{{ container.config.rootfs.storage | default('local-lvm') }}"
+    size         = {{ container.config.rootfs.size | default(8) }}
+  }
+  {% endif %}
+
+  {% if container.config.network is defined %}
+  # Network Interfaces
+  {% for nic in container.config.network %}
+  network_interface {
+    name     = "{{ nic.name }}"
+    {% if nic.bridge is defined %}
+    bridge   = "{{ nic.bridge }}"
+    {% endif %}
+    {% if nic.enabled is defined %}
+    enabled  = {{ nic.enabled | lower }}
+    {% endif %}
+    {% if nic.firewall is defined %}
+    firewall = {{ nic.firewall | lower }}
+    {% endif %}
+    {% if nic.macaddr is defined %}
+    mac_address = "{{ nic.macaddr }}"
+    {% endif %}
+    {% if nic.mtu is defined %}
+    mtu      = {{ nic.mtu }}
+    {% endif %}
+    {% if nic.rate_limit is defined %}
+    rate_limit = {{ nic.rate_limit }}
+    {% endif %}
+    {% if nic.tag is defined %}
+    vlan_id  = {{ nic.tag }}
+    {% endif %}
+  }
+  {% endfor %}
+  {% endif %}
+
+  {% if container.config.mount_point is defined %}
+  # Mount Points
+  {% for mp in container.config.mount_point %}
+  mount_point {
+    volume = "{{ mp.volume }}"
+    path   = "{{ mp.path }}"
+    {% if mp.size is defined %}
+    size   = "{{ mp.size }}G"
+    {% endif %}
+    {% if mp.acl is defined %}
+    acl    = {{ mp.acl | lower }}
+    {% endif %}
+    {% if mp.backup is defined %}
+    backup = {{ mp.backup | lower }}
+    {% endif %}
+    {% if mp.mount_options is defined %}
+    mount_options = {{ mp.mount_options | tojson }}
+    {% endif %}
+    {% if mp.quota is defined %}
+    quota  = {{ mp.quota | lower }}
+    {% endif %}
+    {% if mp.read_only is defined %}
+    read_only = {{ mp.read_only | lower }}
+    {% endif %}
+    {% if mp.replicate is defined %}
+    replicate = {{ mp.replicate | lower }}
+    {% endif %}
+    {% if mp.shared is defined %}
+    shared = {{ mp.shared | lower }}
+    {% endif %}
+  }
+  {% endfor %}
+  {% endif %}
+
+  {% if container.config.hostname is defined or container.config.dns is defined or container.config.network is defined or container.config.ssh_keys is defined or container.config.password is defined %}
+  # Initialization
+  initialization {
+    {% if container.config.hostname is defined %}
+    hostname {
+      name = "{{ container.config.hostname }}"
+    }
+    {% endif %}
+
+    {% if container.config.dns is defined %}
+    dns {
+      {% if container.config.dns.domain is defined %}
+      domain  = "{{ container.config.dns.domain }}"
+      {% endif %}
+      {% if container.config.dns.servers is defined %}
+      servers = {{ container.config.dns.servers | tojson }}
+      {% endif %}
+    }
+    {% endif %}
+
+    {% if container.config.network is defined %}
+    {% for nic in container.config.network %}
+    {% if nic.ip is defined or nic.ip6 is defined %}
+    ip_config {
+      {% if nic.ip is defined %}
+      ipv4 {
+        {% if nic.ip == 'dhcp' %}
+        address = "dhcp"
+        {% else %}
+        address = "{{ nic.ip }}"
+        {% if nic.gw is defined %}
+        gateway = "{{ nic.gw }}"
+        {% endif %}
+        {% endif %}
+      }
+      {% endif %}
+      {% if nic.ip6 is defined %}
+      ipv6 {
+        {% if nic.ip6 == 'dhcp' %}
+        address = "dhcp"
+        {% else %}
+        address = "{{ nic.ip6 }}"
+        {% if nic.gw6 is defined %}
+        gateway = "{{ nic.gw6 }}"
+        {% endif %}
+        {% endif %}
+      }
+      {% endif %}
+    }
+    {% endif %}
+    {% endfor %}
+    {% endif %}
+
+    {% if container.config.ssh_keys is defined or container.config.password is defined %}
+    user_account {
+      {% if container.config.ssh_keys is defined %}
+      keys = [
+        {% for key in container.config.ssh_keys %}
+        "{{ key }}",
+        {% endfor %}
+      ]
+      {% endif %}
+      {% if container.config.password is defined %}
+      password = "{{ container.config.password }}"
+      {% endif %}
+    }
+    {% endif %}
+  }
+  {% endif %}
+
+  {% if container.config.features is defined %}
+  # Features
+  features {
+    {% if container.config.features.nesting is defined %}
+    nesting = {{ container.config.features.nesting | lower }}
+    {% endif %}
+    {% if container.config.features.fuse is defined %}
+    fuse    = {{ container.config.features.fuse | lower }}
+    {% endif %}
+    {% if container.config.features.keyctl is defined %}
+    keyctl  = {{ container.config.features.keyctl | lower }}
+    {% endif %}
+    {% if container.config.features.mount is defined %}
+    mount   = {{ container.config.features.mount | tojson }}
+    {% endif %}
+  }
+  {% endif %}
+
+  {% if container.config.startup is defined %}
+  # Startup Configuration
+  startup {
+    {% if container.config.startup.order is defined %}
+    order      = {{ container.config.startup.order }}
+    {% endif %}
+    {% if container.config.startup.up_delay is defined %}
+    up_delay   = {{ container.config.startup.up_delay }}
+    {% endif %}
+    {% if container.config.startup.down_delay is defined %}
+    down_delay = {{ container.config.startup.down_delay }}
+    {% endif %}
+  }
+  {% endif %}
+
+  {% if container.config.console is defined %}
+  # Console Configuration
+  console {
+    {% if container.config.console.enabled is defined %}
+    enabled   = {{ container.config.console.enabled | lower }}
+    {% endif %}
+    {% if container.config.console.type is defined %}
+    type      = "{{ container.config.console.type }}"
+    {% endif %}
+    {% if container.config.console.tty_count is defined %}
+    tty_count = {{ container.config.console.tty_count }}
+    {% endif %}
+  }
+  {% endif %}
+}
+
+{% endfor %}

--- a/src/infrafoundry/providers/proxmox/templates/proxmox/outputs.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/outputs.tf.j2
@@ -11,6 +11,17 @@ output "vm_ips" {
 }
 {% endif %}
 
+{% if resources_by_type.get('container') %}
+output "container_ids" {
+  description = "IDs of created LXC containers"
+  value = {
+    {% for ct in resources_by_type['container'] %}
+    "{{ ct.config.name }}" = proxmox_virtual_environment_container.{{ ct.config.name | replace('-', '_') }}.id
+    {% endfor %}
+  }
+}
+{% endif %}
+
 {% if resources_by_type.get('templates') %}
 output "templates" {
   description = "Created templates"

--- a/src/infrafoundry/providers/proxmox/validator.py
+++ b/src/infrafoundry/providers/proxmox/validator.py
@@ -221,11 +221,18 @@ class ProxmoxValidator:
             if target_node:
                 nodes.add(target_node)
 
-            # Collect storage pools
+            # Collect storage pools (VM disk, container rootfs, or top-level storage)
             if (
                 (disk_config := config.get("disk"))
                 and isinstance(disk_config, dict)
                 and (storage := disk_config.get("storage"))
+                and target_node
+            ):
+                storage_pools.add((target_node, storage))
+            if (
+                (rootfs_config := config.get("rootfs"))
+                and isinstance(rootfs_config, dict)
+                and (storage := rootfs_config.get("storage"))
                 and target_node
             ):
                 storage_pools.add((target_node, storage))
@@ -248,8 +255,10 @@ class ProxmoxValidator:
                 key = str(clone_ref)
                 template_refs.setdefault(key, []).append(resource_name)
 
-            # Collect VMIDs and check for duplicates
-            if vmid := config.get("vmid"):
+            # Collect VMIDs/CTIDs and check for duplicates
+            # Containers use 'ctid' but share the same Proxmox ID space as VMs
+            vmid = config.get("vmid") or config.get("ctid")
+            if vmid:
                 if vmid in vmids:
                     self.report.add_check(
                         check_name=f"proxmox_vmid_{vmid}_duplicate",

--- a/src/infrafoundry/providers/proxmox/validators/__init__.py
+++ b/src/infrafoundry/providers/proxmox/validators/__init__.py
@@ -1,5 +1,8 @@
 """Specialized validators for Proxmox resources."""
 
+from infrafoundry.providers.proxmox.validators.container_config_validator import (
+    ContainerConfigValidator,
+)
 from infrafoundry.providers.proxmox.validators.network_validator import NetworkValidator
 from infrafoundry.providers.proxmox.validators.node_validator import NodeValidator
 from infrafoundry.providers.proxmox.validators.storage_validator import StorageValidator
@@ -8,6 +11,7 @@ from infrafoundry.providers.proxmox.validators.vm_config_validator import VMConf
 from infrafoundry.providers.proxmox.validators.vmid_validator import VMIDValidator
 
 __all__ = [
+    "ContainerConfigValidator",
     "NetworkValidator",
     "NodeValidator",
     "StorageValidator",

--- a/src/infrafoundry/providers/proxmox/validators/container_config_validator.py
+++ b/src/infrafoundry/providers/proxmox/validators/container_config_validator.py
@@ -1,0 +1,270 @@
+"""LXC container configuration field-level validation for Proxmox."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+
+# Known valid OS types for LXC containers
+KNOWN_OS_TYPES = frozenset(
+    {
+        "alpine",
+        "archlinux",
+        "centos",
+        "debian",
+        "devuan",
+        "fedora",
+        "gentoo",
+        "nixos",
+        "opensuse",
+        "ubuntu",
+        "unmanaged",
+    }
+)
+
+# Known valid feature mount types
+KNOWN_FEATURE_MOUNT_TYPES = frozenset({"cifs", "nfs"})
+
+# Known valid CPU architectures
+KNOWN_CPU_ARCHITECTURES = frozenset({"amd64", "arm64", "armhf", "i386"})
+
+# Pattern: storage_id:vztmpl/filename.tar.* (e.g., "nas01:vztmpl/alpine-3.21-default.tar.xz")
+OSTEMPLATE_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+:vztmpl/.+\.tar\..+$")
+
+
+class ContainerConfigValidator:
+    """Validates LXC container configuration fields before Terraform generation.
+
+    Performs field-level validation with appropriate severity levels:
+    - ERROR for invalid values that would cause Terraform failures
+    - WARNING for unusual but potentially valid values
+    """
+
+    def __init__(self, report: ValidationReport) -> None:
+        """Initialize container config validator.
+
+        Args:
+            report: ValidationReport to add results to.
+        """
+        self.report = report
+
+    def validate(self, resources: list[ResourceConfig]) -> None:
+        """Validate container-specific configuration fields.
+
+        Args:
+            resources: List of resources to validate.
+        """
+        for resource in resources:
+            if resource.type != "container":
+                continue
+            config = resource.config or {}
+            name = resource.name
+            self._validate_ostemplate(name, config)
+            self._validate_ostype(name, config)
+            self._validate_rootfs(name, config)
+            self._validate_network_names(name, config)
+            self._validate_mount_points(name, config)
+            self._validate_features_mount(name, config)
+            self._validate_cores(name, config)
+            self._validate_memory(name, config)
+            self._validate_swap(name, config)
+            self._validate_cpu_architecture(name, config)
+
+    def _validate_ostemplate(self, name: str, config: dict[str, Any]) -> None:
+        """Error if ostemplate format is invalid (required when not cloning)."""
+        ostemplate = config.get("ostemplate")
+        has_clone = "clone" in config
+
+        if ostemplate is None:
+            if not has_clone:
+                self.report.add_check(
+                    check_name=f"proxmox_container_{name}_ostemplate_missing",
+                    passed=False,
+                    message=(
+                        f"Container '{name}': 'ostemplate' is required when not cloning. "
+                        f"Format: 'storage:vztmpl/template-file.tar.xz'"
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+            return
+
+        if not OSTEMPLATE_PATTERN.match(ostemplate):
+            self.report.add_check(
+                check_name=f"proxmox_container_{name}_ostemplate",
+                passed=False,
+                message=(
+                    f"Container '{name}': ostemplate '{ostemplate}' does not match expected "
+                    f"format 'storage:vztmpl/filename.tar.*'."
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_ostype(self, name: str, config: dict[str, Any]) -> None:
+        """Warn if ostype is not in the known set."""
+        ostype = config.get("ostype")
+        if ostype is not None and ostype not in KNOWN_OS_TYPES:
+            self.report.add_check(
+                check_name=f"proxmox_container_{name}_ostype",
+                passed=True,
+                message=(
+                    f"Container '{name}': ostype '{ostype}' is not in the known set "
+                    f"{sorted(KNOWN_OS_TYPES)}. Verify this is a valid LXC OS type."
+                ),
+                level=ValidationLevel.WARNING,
+            )
+
+    def _validate_rootfs(self, name: str, config: dict[str, Any]) -> None:
+        """Error if rootfs.size is not a positive integer."""
+        rootfs = config.get("rootfs")
+        if not isinstance(rootfs, dict):
+            return
+
+        size = rootfs.get("size")
+        if size is not None and (not isinstance(size, int) or size <= 0):
+            self.report.add_check(
+                check_name=f"proxmox_container_{name}_rootfs_size",
+                passed=False,
+                message=(
+                    f"Container '{name}': rootfs size '{size}' is invalid. "
+                    f"Must be a positive integer (in GB)."
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_network_names(self, name: str, config: dict[str, Any]) -> None:
+        """Error if network entries are missing the required 'name' field."""
+        network = config.get("network")
+        if network is None:
+            return
+
+        nic_list: list[dict[str, Any]] = []
+        if isinstance(network, dict):
+            nic_list = [network]
+        elif isinstance(network, list):
+            nic_list = [n for n in network if isinstance(n, dict)]
+
+        for i, nic in enumerate(nic_list):
+            if "name" not in nic:
+                self.report.add_check(
+                    check_name=f"proxmox_container_{name}_nic{i}_name",
+                    passed=False,
+                    message=(
+                        f"Container '{name}': network interface {i} is missing required "
+                        f"'name' field (e.g., 'eth0')."
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+
+    def _validate_mount_points(self, name: str, config: dict[str, Any]) -> None:
+        """Error if mount_point entries are missing required fields."""
+        mount_points = config.get("mount_point")
+        if mount_points is None:
+            return
+
+        mp_list: list[dict[str, Any]] = []
+        if isinstance(mount_points, dict):
+            mp_list = [mount_points]
+        elif isinstance(mount_points, list):
+            mp_list = [m for m in mount_points if isinstance(m, dict)]
+
+        for i, mp in enumerate(mp_list):
+            if "volume" not in mp:
+                self.report.add_check(
+                    check_name=f"proxmox_container_{name}_mp{i}_volume",
+                    passed=False,
+                    message=(
+                        f"Container '{name}': mount_point {i} is missing required 'volume' field."
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+            if "path" not in mp:
+                self.report.add_check(
+                    check_name=f"proxmox_container_{name}_mp{i}_path",
+                    passed=False,
+                    message=(
+                        f"Container '{name}': mount_point {i} is missing required 'path' field."
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+
+    def _validate_features_mount(self, name: str, config: dict[str, Any]) -> None:
+        """Warn if features.mount contains unknown mount types."""
+        features = config.get("features")
+        if not isinstance(features, dict):
+            return
+
+        mount_types = features.get("mount")
+        if not isinstance(mount_types, list):
+            return
+
+        for mount_type in mount_types:
+            if mount_type not in KNOWN_FEATURE_MOUNT_TYPES:
+                self.report.add_check(
+                    check_name=f"proxmox_container_{name}_feature_mount_{mount_type}",
+                    passed=True,
+                    message=(
+                        f"Container '{name}': features.mount type '{mount_type}' is not "
+                        f"in the known set {sorted(KNOWN_FEATURE_MOUNT_TYPES)}. "
+                        f"Verify this is valid."
+                    ),
+                    level=ValidationLevel.WARNING,
+                )
+
+    def _validate_cores(self, name: str, config: dict[str, Any]) -> None:
+        """Error if cores is not a positive integer."""
+        cores = config.get("cores")
+        if cores is not None and (not isinstance(cores, int) or cores <= 0):
+            self.report.add_check(
+                check_name=f"proxmox_container_{name}_cores",
+                passed=False,
+                message=(
+                    f"Container '{name}': cores value '{cores}' is invalid. "
+                    f"Must be a positive integer."
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_memory(self, name: str, config: dict[str, Any]) -> None:
+        """Error if memory is not a positive integer."""
+        memory = config.get("memory")
+        if memory is not None and (not isinstance(memory, int) or memory <= 0):
+            self.report.add_check(
+                check_name=f"proxmox_container_{name}_memory",
+                passed=False,
+                message=(
+                    f"Container '{name}': memory value '{memory}' is invalid. "
+                    f"Must be a positive integer (in MB)."
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_swap(self, name: str, config: dict[str, Any]) -> None:
+        """Error if swap is not a non-negative integer."""
+        swap = config.get("swap")
+        if swap is not None and (not isinstance(swap, int) or swap < 0):
+            self.report.add_check(
+                check_name=f"proxmox_container_{name}_swap",
+                passed=False,
+                message=(
+                    f"Container '{name}': swap value '{swap}' is invalid. "
+                    f"Must be a non-negative integer (in MB, 0 to disable)."
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_cpu_architecture(self, name: str, config: dict[str, Any]) -> None:
+        """Warn if CPU architecture is not in the known set."""
+        arch = config.get("arch")
+        if arch is not None and arch not in KNOWN_CPU_ARCHITECTURES:
+            self.report.add_check(
+                check_name=f"proxmox_container_{name}_arch",
+                passed=True,
+                message=(
+                    f"Container '{name}': architecture '{arch}' is not in the known set "
+                    f"{sorted(KNOWN_CPU_ARCHITECTURES)}. Verify this is valid."
+                ),
+                level=ValidationLevel.WARNING,
+            )

--- a/tests/unit/providers/proxmox/test_container_config_validator.py
+++ b/tests/unit/providers/proxmox/test_container_config_validator.py
@@ -1,0 +1,436 @@
+"""Unit tests for Proxmox ContainerConfigValidator."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.proxmox.validators.container_config_validator import (
+    ContainerConfigValidator,
+)
+
+
+@pytest.fixture
+def report():
+    """Create a mock validation report."""
+    return MagicMock(spec=ValidationReport)
+
+
+@pytest.fixture
+def validator(report):
+    """Create a ContainerConfigValidator instance."""
+    return ContainerConfigValidator(report)
+
+
+def _ct(name: str = "test-ct", **config) -> ResourceConfig:
+    """Helper to create a container ResourceConfig."""
+    return ResourceConfig(
+        name=name,
+        type="container",
+        provider="proxmox",
+        config={"name": name, "target_node": "pve01", **config},
+    )
+
+
+class TestOSTemplateValidation:
+    """Tests for ostemplate validation."""
+
+    def test_valid_ostemplate(self, validator, report):
+        """Valid ostemplate should not trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="nas01:vztmpl/alpine-3.21-default_20250108_amd64.tar.xz")]
+        )
+        report.add_check.assert_not_called()
+
+    def test_valid_ostemplate_zst(self, validator, report):
+        """Zstandard-compressed ostemplate should be valid."""
+        validator.validate(
+            [_ct(ostemplate="local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst")]
+        )
+        report.add_check.assert_not_called()
+
+    def test_invalid_ostemplate_format(self, validator, report):
+        """Invalid ostemplate format should trigger an error."""
+        validator.validate([_ct(ostemplate="/path/to/template.tar.xz")])
+        report.add_check.assert_called_once()
+        call_args = report.add_check.call_args[1]
+        assert call_args["passed"] is False
+        assert call_args["level"] == ValidationLevel.ERROR
+        assert "ostemplate" in call_args["message"]
+
+    def test_missing_ostemplate_no_clone(self, validator, report):
+        """Missing ostemplate without clone should trigger an error."""
+        validator.validate([_ct()])
+        calls = [
+            c[1]
+            for c in report.add_check.call_args_list
+            if "ostemplate" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+        assert calls[0]["level"] == ValidationLevel.ERROR
+
+    def test_missing_ostemplate_with_clone(self, validator, report):
+        """Missing ostemplate with clone should not trigger ostemplate error."""
+        validator.validate([_ct(clone={"vm_id": 100})])
+        ostemplate_calls = [
+            c[1]
+            for c in report.add_check.call_args_list
+            if "ostemplate" in c[1].get("check_name", "")
+        ]
+        assert len(ostemplate_calls) == 0
+
+
+class TestOSTypeValidation:
+    """Tests for ostype validation."""
+
+    def test_known_ostype_no_warning(self, validator, report):
+        """Known ostype should not trigger a warning."""
+        for ostype in ("alpine", "debian", "ubuntu", "centos"):
+            report.reset_mock()
+            validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", ostype=ostype)])
+            ostype_calls = [
+                c[1]
+                for c in report.add_check.call_args_list
+                if "ostype" in c[1].get("check_name", "")
+            ]
+            assert len(ostype_calls) == 0
+
+    def test_unknown_ostype_warning(self, validator, report):
+        """Unknown ostype should trigger a warning."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", ostype="freebsd")])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "ostype" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is True
+        assert calls[0]["level"] == ValidationLevel.WARNING
+
+    def test_no_ostype_no_check(self, validator, report):
+        """No ostype should not trigger any check."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz")])
+        ostype_calls = [
+            c[1] for c in report.add_check.call_args_list if "ostype" in c[1].get("check_name", "")
+        ]
+        assert len(ostype_calls) == 0
+
+
+class TestRootfsValidation:
+    """Tests for rootfs.size validation."""
+
+    def test_valid_rootfs_size(self, validator, report):
+        """Valid rootfs size should not trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", rootfs={"storage": "local", "size": 8})]
+        )
+        rootfs_calls = [
+            c[1] for c in report.add_check.call_args_list if "rootfs" in c[1].get("check_name", "")
+        ]
+        assert len(rootfs_calls) == 0
+
+    def test_invalid_rootfs_size_zero(self, validator, report):
+        """Rootfs size of 0 should trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", rootfs={"storage": "local", "size": 0})]
+        )
+        report.add_check.assert_called()
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "rootfs" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+
+    def test_invalid_rootfs_size_negative(self, validator, report):
+        """Negative rootfs size should trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", rootfs={"storage": "local", "size": -1})]
+        )
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "rootfs" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+        assert calls[0]["level"] == ValidationLevel.ERROR
+
+    def test_invalid_rootfs_size_string(self, validator, report):
+        """String rootfs size should trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", rootfs={"storage": "local", "size": "8G"})]
+        )
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "rootfs" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+
+
+class TestNetworkNameValidation:
+    """Tests for network name validation."""
+
+    def test_network_with_name(self, validator, report):
+        """Network with name should not trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", network=[{"name": "eth0", "bridge": "vmbr0"}])]
+        )
+        nic_calls = [
+            c[1] for c in report.add_check.call_args_list if "nic" in c[1].get("check_name", "")
+        ]
+        assert len(nic_calls) == 0
+
+    def test_network_missing_name(self, validator, report):
+        """Network without name should trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", network=[{"bridge": "vmbr0"}])])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "nic" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+        assert calls[0]["level"] == ValidationLevel.ERROR
+        assert "name" in calls[0]["message"]
+
+    def test_single_dict_network_missing_name(self, validator, report):
+        """Single dict network without name should trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", network={"bridge": "vmbr0"})])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "nic" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+
+
+class TestMountPointValidation:
+    """Tests for mount_point validation."""
+
+    def test_valid_mount_point(self, validator, report):
+        """Valid mount_point should not trigger an error."""
+        validator.validate(
+            [
+                _ct(
+                    ostemplate="s:vztmpl/t.tar.xz",
+                    mount_point=[{"volume": "nas:data", "path": "/mnt/data"}],
+                )
+            ]
+        )
+        mp_calls = [
+            c[1] for c in report.add_check.call_args_list if "mp" in c[1].get("check_name", "")
+        ]
+        assert len(mp_calls) == 0
+
+    def test_mount_point_missing_volume(self, validator, report):
+        """Mount point without volume should trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", mount_point=[{"path": "/mnt/data"}])]
+        )
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "volume" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+
+    def test_mount_point_missing_path(self, validator, report):
+        """Mount point without path should trigger an error."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", mount_point=[{"volume": "nas:data"}])]
+        )
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "path" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+
+    def test_mount_point_missing_both(self, validator, report):
+        """Mount point without volume and path should trigger two errors."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", mount_point=[{}])])
+        mp_calls = [
+            c[1] for c in report.add_check.call_args_list if "mp" in c[1].get("check_name", "")
+        ]
+        assert len(mp_calls) == 2
+
+    def test_single_dict_mount_point(self, validator, report):
+        """Single dict mount_point should be handled."""
+        validator.validate(
+            [
+                _ct(
+                    ostemplate="s:vztmpl/t.tar.xz",
+                    mount_point={"volume": "nas:data", "path": "/mnt/data"},
+                )
+            ]
+        )
+        mp_calls = [
+            c[1] for c in report.add_check.call_args_list if "mp" in c[1].get("check_name", "")
+        ]
+        assert len(mp_calls) == 0
+
+
+class TestFeaturesMountValidation:
+    """Tests for features.mount validation."""
+
+    def test_known_mount_types(self, validator, report):
+        """Known mount types should not trigger a warning."""
+        validator.validate(
+            [
+                _ct(
+                    ostemplate="s:vztmpl/t.tar.xz",
+                    features={"mount": ["nfs", "cifs"]},
+                )
+            ]
+        )
+        mount_calls = [
+            c[1]
+            for c in report.add_check.call_args_list
+            if "feature_mount" in c[1].get("check_name", "")
+        ]
+        assert len(mount_calls) == 0
+
+    def test_unknown_mount_type_warning(self, validator, report):
+        """Unknown mount type should trigger a warning."""
+        validator.validate(
+            [_ct(ostemplate="s:vztmpl/t.tar.xz", features={"mount": ["nfs", "gluster"]})]
+        )
+        calls = [
+            c[1]
+            for c in report.add_check.call_args_list
+            if "feature_mount" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is True
+        assert calls[0]["level"] == ValidationLevel.WARNING
+        assert "gluster" in calls[0]["message"]
+
+
+class TestNumericFieldValidation:
+    """Tests for cores, memory, and swap validation."""
+
+    def test_valid_cores(self, validator, report):
+        """Valid cores should not trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", cores=2)])
+        cores_calls = [
+            c[1] for c in report.add_check.call_args_list if "cores" in c[1].get("check_name", "")
+        ]
+        assert len(cores_calls) == 0
+
+    def test_invalid_cores_zero(self, validator, report):
+        """Zero cores should trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", cores=0)])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "cores" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+
+    def test_invalid_cores_negative(self, validator, report):
+        """Negative cores should trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", cores=-1)])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "cores" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+        assert calls[0]["level"] == ValidationLevel.ERROR
+
+    def test_valid_memory(self, validator, report):
+        """Valid memory should not trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", memory=512)])
+        memory_calls = [
+            c[1] for c in report.add_check.call_args_list if "memory" in c[1].get("check_name", "")
+        ]
+        assert len(memory_calls) == 0
+
+    def test_invalid_memory_zero(self, validator, report):
+        """Zero memory should trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", memory=0)])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "memory" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+
+    def test_valid_swap_zero(self, validator, report):
+        """Zero swap (disabled) should be valid."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", swap=0)])
+        swap_calls = [
+            c[1] for c in report.add_check.call_args_list if "swap" in c[1].get("check_name", "")
+        ]
+        assert len(swap_calls) == 0
+
+    def test_invalid_swap_negative(self, validator, report):
+        """Negative swap should trigger an error."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", swap=-1)])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "swap" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is False
+        assert calls[0]["level"] == ValidationLevel.ERROR
+
+
+class TestCPUArchitectureValidation:
+    """Tests for CPU architecture validation."""
+
+    def test_known_arch(self, validator, report):
+        """Known architecture should not trigger a warning."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", arch="amd64")])
+        arch_calls = [
+            c[1] for c in report.add_check.call_args_list if "arch" in c[1].get("check_name", "")
+        ]
+        assert len(arch_calls) == 0
+
+    def test_unknown_arch_warning(self, validator, report):
+        """Unknown architecture should trigger a warning."""
+        validator.validate([_ct(ostemplate="s:vztmpl/t.tar.xz", arch="mips")])
+        calls = [
+            c[1] for c in report.add_check.call_args_list if "arch" in c[1].get("check_name", "")
+        ]
+        assert len(calls) == 1
+        assert calls[0]["passed"] is True
+        assert calls[0]["level"] == ValidationLevel.WARNING
+
+
+class TestNonContainerResourcesSkipped:
+    """Verify that non-container resources are skipped."""
+
+    def test_vm_resource_skipped(self, validator, report):
+        """VM resources should be ignored."""
+        resource = ResourceConfig(
+            name="test-vm",
+            type="vm",
+            provider="proxmox",
+            config={"name": "test", "cores": -1},
+        )
+        validator.validate([resource])
+        report.add_check.assert_not_called()
+
+    def test_template_resource_skipped(self, validator, report):
+        """Template resources should be ignored."""
+        resource = ResourceConfig(
+            name="test-template",
+            type="template",
+            provider="proxmox",
+            config={"name": "test"},
+        )
+        validator.validate([resource])
+        report.add_check.assert_not_called()
+
+
+class TestValidContainerPasses:
+    """Verify that a fully valid container produces no errors."""
+
+    def test_valid_full_config(self, validator, report):
+        """A fully configured valid container should produce no errors."""
+        validator.validate(
+            [
+                _ct(
+                    ostemplate="nas01:vztmpl/alpine-3.21-default_20250108_amd64.tar.xz",
+                    ostype="alpine",
+                    cores=2,
+                    memory=256,
+                    swap=0,
+                    rootfs={"storage": "local-lvm", "size": 4},
+                    network=[{"name": "eth0", "bridge": "vmbr0"}],
+                    mount_point=[{"volume": "nas:data", "path": "/mnt/data"}],
+                    features={"nesting": True, "mount": ["nfs"]},
+                )
+            ]
+        )
+        report.add_check.assert_not_called()

--- a/tests/unit/providers/proxmox/test_container_support.py
+++ b/tests/unit/providers/proxmox/test_container_support.py
@@ -1,0 +1,619 @@
+"""Unit tests for Proxmox LXC container support.
+
+Tests template rendering, config normalization, resource type registration,
+and dependency resolution for LXC containers.
+"""
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.proxmox import ProxmoxProvider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    """Create a ProxmoxProvider for template testing."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    p = ProxmoxProvider(config_dir, output_dir)
+    p.set_environment("test")
+    return p
+
+
+def _make_ct(name: str = "test-ct", **config_overrides) -> ResourceConfig:
+    """Helper to create a container ResourceConfig with sensible defaults."""
+    config: dict = {
+        "name": name,
+        "target_node": "pve01",
+        **config_overrides,
+    }
+    return ResourceConfig(name=name, type="container", provider="proxmox", config=config)
+
+
+def _render_containers(provider: ProxmoxProvider, containers: list[ResourceConfig]) -> str:
+    """Normalize container configs and render through the template."""
+    processed = [provider._normalize_container_config(ct) for ct in containers]
+    return provider.render_template("proxmox/containers.tf.j2", {"containers": processed})
+
+
+class TestResourceRegistration:
+    """Tests for container resource type registration."""
+
+    def test_resource_types_include_container(self, provider):
+        """Container should be in the list of supported resource types."""
+        types = provider.get_resource_types()
+        assert "container" in types
+
+    def test_dependencies_include_container(self, provider):
+        """Container dependencies should include network."""
+        deps = provider.get_dependencies()
+        assert "container" in deps
+        assert "network" in deps["container"]
+
+    def test_existing_types_still_present(self, provider):
+        """Existing resource types should still be registered."""
+        types = provider.get_resource_types()
+        assert "vm" in types
+        assert "template" in types
+        assert "network" in types
+
+
+class TestBasicContainerRendering:
+    """Tests for basic container template rendering."""
+
+    def test_basic_container(self, provider):
+        """A basic container should render the correct Terraform resource."""
+        containers = [
+            _make_ct(
+                ostemplate="nas01:vztmpl/alpine-3.21.tar.xz",
+                ostype="alpine",
+                cores=1,
+                memory=64,
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert 'resource "proxmox_virtual_environment_container"' in content
+        assert 'node_name   = "pve01"' in content
+        assert 'template_file_id = "nas01:vztmpl/alpine-3.21.tar.xz"' in content
+        assert 'type             = "alpine"' in content
+        assert "cores        = 1" in content
+        assert "dedicated = 64" in content
+
+    def test_container_with_ctid(self, provider):
+        """Container with ctid should render vm_id."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", ctid=300)]
+        content = _render_containers(provider, containers)
+        assert "vm_id       = 300" in content
+
+    def test_container_unprivileged(self, provider):
+        """Unprivileged flag should render correctly."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", unprivileged=True)]
+        content = _render_containers(provider, containers)
+        assert "unprivileged = true" in content
+
+    def test_container_started_and_onboot(self, provider):
+        """Started and start_on_boot should render correctly."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", start=True, onboot=True)]
+        content = _render_containers(provider, containers)
+        assert "started     = true" in content
+        assert "start_on_boot = true" in content
+
+    def test_container_tags(self, provider):
+        """Tags should render as a JSON array."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", tags=["web", "infra"])]
+        content = _render_containers(provider, containers)
+        assert '["web", "infra"]' in content
+
+    def test_container_description(self, provider):
+        """Description should render correctly."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", description="Test container")]
+        content = _render_containers(provider, containers)
+        assert 'description = "Test container"' in content
+
+    def test_container_name_with_dashes(self, provider):
+        """Container name with dashes should be converted to underscores in resource ID."""
+        containers = [_make_ct(name="web-server-01", ostemplate="s:vztmpl/t.tar.xz")]
+        content = _render_containers(provider, containers)
+        assert "web_server_01" in content
+
+
+class TestContainerRootfs:
+    """Tests for rootfs/disk rendering."""
+
+    def test_rootfs_rendering(self, provider):
+        """Rootfs should render as a disk block."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                rootfs={"storage": "local-lvm", "size": 8},
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "disk {" in content
+        assert 'datastore_id = "local-lvm"' in content
+        assert "size         = 8" in content
+
+    def test_rootfs_default_storage(self, provider):
+        """Rootfs without explicit storage should use default."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", rootfs={"size": 4})]
+        content = _render_containers(provider, containers)
+        assert 'datastore_id = "local-lvm"' in content
+
+
+class TestContainerNetwork:
+    """Tests for network interface rendering."""
+
+    def test_single_nic(self, provider):
+        """Single NIC should render as network_interface block."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                network=[{"name": "eth0", "bridge": "vmbr0"}],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "network_interface {" in content
+        assert 'name     = "eth0"' in content
+        assert 'bridge   = "vmbr0"' in content
+
+    def test_multi_nic(self, provider):
+        """Multiple NICs should produce multiple network_interface blocks."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                network=[
+                    {"name": "eth0", "bridge": "vmbr0", "tag": 10},
+                    {"name": "eth1", "bridge": "vmbr1", "tag": 20},
+                ],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert content.count("network_interface {") == 2
+        assert 'name     = "eth0"' in content
+        assert 'name     = "eth1"' in content
+        assert "vlan_id  = 10" in content
+        assert "vlan_id  = 20" in content
+
+    def test_nic_with_all_options(self, provider):
+        """NIC with all options should render all fields."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                network=[
+                    {
+                        "name": "eth0",
+                        "bridge": "vmbr0",
+                        "tag": 10,
+                        "macaddr": "AA:BB:CC:DD:EE:FF",
+                        "firewall": True,
+                        "mtu": 1500,
+                        "rate_limit": 100,
+                    }
+                ],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert 'mac_address = "AA:BB:CC:DD:EE:FF"' in content
+        assert "firewall = true" in content
+        assert "mtu      = 1500" in content
+        assert "rate_limit = 100" in content
+
+    def test_no_network(self, provider):
+        """No network should not render network_interface block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz")]
+        content = _render_containers(provider, containers)
+        assert "network_interface" not in content
+
+
+class TestContainerMountPoints:
+    """Tests for mount point rendering."""
+
+    def test_single_mount_point(self, provider):
+        """Single mount point should render correctly."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                mount_point=[{"volume": "nas:data", "path": "/mnt/data"}],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "mount_point {" in content
+        assert 'volume = "nas:data"' in content
+        assert 'path   = "/mnt/data"' in content
+
+    def test_multiple_mount_points(self, provider):
+        """Multiple mount points should produce multiple blocks."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                mount_point=[
+                    {"volume": "nas:data1", "path": "/mnt/data1"},
+                    {
+                        "volume": "nas:data2",
+                        "path": "/mnt/data2",
+                        "shared": True,
+                        "read_only": True,
+                    },
+                ],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert content.count("mount_point {") == 2
+        assert "shared = true" in content
+        assert "read_only = true" in content
+
+    def test_mount_point_with_all_options(self, provider):
+        """Mount point with all options should render all fields."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                mount_point=[
+                    {
+                        "volume": "nas:data",
+                        "path": "/mnt/data",
+                        "size": 10,
+                        "acl": True,
+                        "backup": False,
+                        "quota": True,
+                        "read_only": False,
+                        "replicate": True,
+                        "shared": True,
+                    }
+                ],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert '"10G"' in content
+        assert "acl    = true" in content
+        assert "backup = false" in content
+        assert "quota  = true" in content
+        assert "replicate = true" in content
+
+    def test_no_mount_points(self, provider):
+        """No mount points should not render mount_point block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz")]
+        content = _render_containers(provider, containers)
+        assert "mount_point" not in content
+
+
+class TestContainerInitialization:
+    """Tests for initialization block rendering."""
+
+    def test_hostname(self, provider):
+        """Hostname should render in initialization block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", hostname="web-01")]
+        content = _render_containers(provider, containers)
+        assert "initialization {" in content
+        assert "hostname {" in content
+        assert 'name = "web-01"' in content
+
+    def test_dns(self, provider):
+        """DNS should render in initialization block."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                dns={"domain": "example.com", "servers": ["8.8.8.8", "1.1.1.1"]},
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "dns {" in content
+        assert 'domain  = "example.com"' in content
+        assert '["8.8.8.8", "1.1.1.1"]' in content
+
+    def test_ip_config_dhcp(self, provider):
+        """DHCP IP config should render correctly."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                network=[{"name": "eth0", "bridge": "vmbr0", "ip": "dhcp"}],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "ip_config {" in content
+        assert 'address = "dhcp"' in content
+
+    def test_ip_config_static(self, provider):
+        """Static IP config should render address and gateway."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                network=[
+                    {
+                        "name": "eth0",
+                        "bridge": "vmbr0",
+                        "ip": "192.168.10.50/24",
+                        "gw": "192.168.10.1",
+                    }
+                ],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert 'address = "192.168.10.50/24"' in content
+        assert 'gateway = "192.168.10.1"' in content
+
+    def test_ssh_keys(self, provider):
+        """SSH keys should render in user_account block."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                ssh_keys=["ssh-rsa AAAA..."],
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "user_account {" in content
+        assert '"ssh-rsa AAAA..."' in content
+
+    def test_password(self, provider):
+        """Password should render in user_account block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", password="secret123")]
+        content = _render_containers(provider, containers)
+        assert "user_account {" in content
+        assert 'password = "secret123"' in content
+
+    def test_no_initialization(self, provider):
+        """No initialization fields should not render initialization block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz")]
+        content = _render_containers(provider, containers)
+        assert "initialization" not in content
+
+
+class TestContainerFeatures:
+    """Tests for features block rendering."""
+
+    def test_nesting(self, provider):
+        """Nesting feature should render correctly."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", features={"nesting": True})]
+        content = _render_containers(provider, containers)
+        assert "features {" in content
+        assert "nesting = true" in content
+
+    def test_mount_features(self, provider):
+        """Mount features should render as JSON list."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz", features={"mount": ["nfs", "cifs"]})]
+        content = _render_containers(provider, containers)
+        assert '["nfs", "cifs"]' in content
+
+    def test_all_features(self, provider):
+        """All features should render correctly."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                features={"nesting": True, "fuse": True, "keyctl": True, "mount": ["nfs"]},
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "nesting = true" in content
+        assert "fuse    = true" in content
+        assert "keyctl  = true" in content
+        assert '["nfs"]' in content
+
+    def test_no_features(self, provider):
+        """No features should not render features block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz")]
+        content = _render_containers(provider, containers)
+        assert "features" not in content
+
+
+class TestContainerStartup:
+    """Tests for startup block rendering."""
+
+    def test_startup_config(self, provider):
+        """Startup configuration should render correctly."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                startup={"order": 1, "up_delay": 10, "down_delay": 5},
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "startup {" in content
+        assert "order      = 1" in content
+        assert "up_delay   = 10" in content
+        assert "down_delay = 5" in content
+
+    def test_no_startup(self, provider):
+        """No startup should not render startup block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz")]
+        content = _render_containers(provider, containers)
+        assert "startup" not in content
+
+
+class TestContainerConsole:
+    """Tests for console block rendering."""
+
+    def test_console_config(self, provider):
+        """Console configuration should render correctly."""
+        containers = [
+            _make_ct(
+                ostemplate="s:vztmpl/t.tar.xz",
+                console={"enabled": True, "type": "console", "tty_count": 2},
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "console {" in content
+        assert "enabled   = true" in content
+        assert 'type      = "console"' in content
+        assert "tty_count = 2" in content
+
+    def test_no_console(self, provider):
+        """No console should not render console block."""
+        containers = [_make_ct(ostemplate="s:vztmpl/t.tar.xz")]
+        content = _render_containers(provider, containers)
+        assert "console" not in content
+
+
+class TestContainerClone:
+    """Tests for clone block rendering."""
+
+    def test_clone(self, provider):
+        """Clone configuration should render correctly."""
+        containers = [
+            _make_ct(
+                clone={"vm_id": 100, "node_name": "pve02", "datastore_id": "local-lvm"},
+            )
+        ]
+        content = _render_containers(provider, containers)
+        assert "clone {" in content
+        assert "vm_id = 100" in content
+        assert 'node_name    = "pve02"' in content
+        assert 'datastore_id = "local-lvm"' in content
+
+    def test_clone_minimal(self, provider):
+        """Minimal clone (vm_id only) should render correctly."""
+        containers = [_make_ct(clone={"vm_id": 100})]
+        content = _render_containers(provider, containers)
+        assert "clone {" in content
+        assert "vm_id = 100" in content
+        assert "node_name" not in content.split("clone {")[1].split("}")[0]
+
+
+class TestNormalization:
+    """Tests for _normalize_container_config()."""
+
+    def test_normalize_dict_network_to_list(self, provider):
+        """Single dict network should be wrapped in a list."""
+        ct = _make_ct(network={"name": "eth0", "bridge": "vmbr0"})
+        result = provider._normalize_container_config(ct)
+        assert isinstance(result.config["network"], list)
+        assert len(result.config["network"]) == 1
+        assert result.config["network"][0]["name"] == "eth0"
+
+    def test_normalize_list_network_unchanged(self, provider):
+        """List network should remain a list."""
+        nics = [{"name": "eth0", "bridge": "vmbr0"}, {"name": "eth1", "bridge": "vmbr1"}]
+        ct = _make_ct(network=nics)
+        result = provider._normalize_container_config(ct)
+        assert isinstance(result.config["network"], list)
+        assert len(result.config["network"]) == 2
+
+    def test_normalize_dict_mount_point_to_list(self, provider):
+        """Single dict mount_point should be wrapped in a list."""
+        ct = _make_ct(mount_point={"volume": "nas:data", "path": "/mnt/data"})
+        result = provider._normalize_container_config(ct)
+        assert isinstance(result.config["mount_point"], list)
+        assert len(result.config["mount_point"]) == 1
+        assert result.config["mount_point"][0]["volume"] == "nas:data"
+
+    def test_normalize_list_mount_point_unchanged(self, provider):
+        """List mount_point should remain a list."""
+        mps = [
+            {"volume": "nas:data1", "path": "/mnt/data1"},
+            {"volume": "nas:data2", "path": "/mnt/data2"},
+        ]
+        ct = _make_ct(mount_point=mps)
+        result = provider._normalize_container_config(ct)
+        assert isinstance(result.config["mount_point"], list)
+        assert len(result.config["mount_point"]) == 2
+
+    def test_normalize_no_network(self, provider):
+        """No network key should remain absent."""
+        ct = _make_ct(ostemplate="s:vztmpl/t.tar.xz")
+        result = provider._normalize_container_config(ct)
+        assert "network" not in result.config
+
+    def test_normalize_no_mount_point(self, provider):
+        """No mount_point key should remain absent."""
+        ct = _make_ct(ostemplate="s:vztmpl/t.tar.xz")
+        result = provider._normalize_container_config(ct)
+        assert "mount_point" not in result.config
+
+    def test_normalize_does_not_mutate_original(self, provider):
+        """Original container config should not be modified."""
+        ct = _make_ct(
+            network={"name": "eth0", "bridge": "vmbr0"},
+            mount_point={"volume": "nas:data", "path": "/mnt"},
+        )
+        provider._normalize_container_config(ct)
+        # Original should still be dicts
+        assert isinstance(ct.config["network"], dict)
+        assert isinstance(ct.config["mount_point"], dict)
+
+
+class TestFullContainerRendering:
+    """Integration test with a fully-configured container."""
+
+    def test_full_container(self, provider):
+        """A container with all fields should render them all correctly."""
+        containers = [
+            _make_ct(
+                name="web-01",
+                ctid=300,
+                ostemplate="nas01:vztmpl/alpine-3.21.tar.xz",
+                ostype="alpine",
+                cores=2,
+                memory=256,
+                swap=128,
+                unprivileged=True,
+                start=True,
+                onboot=True,
+                tags=["web", "infra"],
+                rootfs={"storage": "nas01", "size": 4},
+                network=[
+                    {
+                        "name": "eth0",
+                        "bridge": "vmbr0",
+                        "tag": 10,
+                        "ip": "192.168.10.50/24",
+                        "gw": "192.168.10.1",
+                    }
+                ],
+                mount_point=[{"volume": "nas01:infra", "path": "/var/www/html", "shared": True}],
+                hostname="web-01",
+                dns={"domain": "example.com", "servers": ["192.168.10.1"]},
+                ssh_keys=["ssh-rsa AAAA..."],
+                features={"nesting": False, "mount": ["nfs"]},
+                startup={"order": 2, "up_delay": 10, "down_delay": 5},
+                console={"enabled": True, "type": "console", "tty_count": 2},
+            )
+        ]
+        content = _render_containers(provider, containers)
+
+        # Resource declaration
+        assert 'resource "proxmox_virtual_environment_container" "web_01"' in content
+
+        # Top-level attributes
+        assert "vm_id       = 300" in content
+        assert "unprivileged = true" in content
+        assert "started     = true" in content
+        assert "start_on_boot = true" in content
+
+        # Operating system
+        assert 'template_file_id = "nas01:vztmpl/alpine-3.21.tar.xz"' in content
+        assert 'type             = "alpine"' in content
+
+        # CPU & Memory
+        assert "cores        = 2" in content
+        assert "dedicated = 256" in content
+        assert "swap      = 128" in content
+
+        # Disk
+        assert 'datastore_id = "nas01"' in content
+        assert "size         = 4" in content
+
+        # Network
+        assert "network_interface {" in content
+        assert 'name     = "eth0"' in content
+
+        # Mount point
+        assert "mount_point {" in content
+        assert 'volume = "nas01:infra"' in content
+
+        # Initialization
+        assert "initialization {" in content
+        assert 'name = "web-01"' in content
+        assert "dns {" in content
+        assert "ip_config {" in content
+
+        # Features
+        assert "features {" in content
+        assert "nesting = false" in content
+
+        # Startup
+        assert "startup {" in content
+        assert "order      = 2" in content
+
+        # Console
+        assert "console {" in content
+        assert "tty_count = 2" in content


### PR DESCRIPTION
## Description

Add LXC container support to the Proxmox provider, enabling users to define and manage LXC containers alongside existing VM, template, and network resources.

Addresses #290

## Related Issue

Addresses #290

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Register `container` as a supported resource type in the Proxmox provider with `network` as its dependency
- Add `_generate_containers_terraform()` and `_normalize_container_config()` methods to handle LXC container resource generation, including normalizing `network` and `mount_point` fields from single dicts to lists
- Add `containers.tf.j2` Jinja2 template for rendering LXC container Terraform resources
- Update `outputs.tf.j2` to include container output blocks
- Extend `ProxmoxValidator` to collect `rootfs` storage pools and `ctid` values (which share the same Proxmox ID space as `vmid`)
- Add `ContainerConfigValidator` for container-specific validation and register it in the validators package
- Add example configuration at `example-config/envs/dev/proxmox/containers.yaml`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New test files:
- `tests/unit/providers/proxmox/test_container_config_validator.py` - container config validation tests
- `tests/unit/providers/proxmox/test_container_support.py` - container generation and normalization tests

Validated with `doit check` (format, lint, type-check, security, spell-check, all tests pass).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- No existing `docs/providers/proxmox.md` documentation exists, so no doc update was needed
- No ADR required (issue does not have `needs-adr` label)
- The container resource type follows the same patterns as the existing VM resource type: provider method, Jinja2 template, dedicated config validator, and example config
