### PR TITLE
fix: correct Kea DHCPv6 API integration

### DIFF
--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -181,6 +181,13 @@ class OPNsenseProvider(
         )
         kea = KeaClient(client)
 
+        # Ensure DHCPv6 service is enabled with required interfaces
+        required_interfaces: list[str] = sorted(
+            {s.config["interface"] for s in subnets if s.config.get("interface")}
+        )
+        if required_interfaces:
+            kea.ensure_dhcp6_enabled(required_interfaces)
+
         # Search existing resources ONCE
         existing_subnets = kea.search_dhcp6_subnets() if subnets else []
         existing_reservations = kea.search_dhcp6_reservations() if reservations else []
@@ -200,29 +207,31 @@ class OPNsenseProvider(
             # Look up existing subnet
             existing_uuid = existing_subnets_map.get(subnet_address)
 
-            # Prepare subnet data
-            subnet_data = {
+            # Prepare subnet data — field names match OPNsense Kea DHCPv6 API
+            subnet_data: dict[str, Any] = {
                 "subnet": subnet_address,
                 "interface": config.get("interface"),
-                "option_data_autocollect": str(int(config.get("auto_collect", True))),
             }
 
-            # Add pools
+            # Pools is a newline-separated string of ranges
             if "pools" in config:
-                pools_list: list[dict[str, Any]] = []
-                for pool in config["pools"]:
-                    pools_list.append({"pool": pool["range"]})
-                subnet_data["pools"] = pools_list
+                pool_strings = [pool["range"] for pool in config["pools"]]
+                subnet_data["pools"] = "\n".join(pool_strings)
 
-            # Add optional fields
+            # Optional fields
             if "valid_lifetime" in config:
                 subnet_data["valid_lifetime"] = str(config["valid_lifetime"])
-            if "dns_servers" in config:
-                subnet_data["dns_servers"] = ",".join(config["dns_servers"])
-            if "dns_search_list" in config:
-                subnet_data["dns_search_list"] = ",".join(config["dns_search_list"])
             if "description" in config:
                 subnet_data["description"] = config["description"]
+
+            # DNS settings go under option_data
+            option_data: dict[str, str] = {}
+            if "dns_servers" in config:
+                option_data["dns_servers"] = ",".join(config["dns_servers"])
+            if "dns_search_list" in config:
+                option_data["domain_search"] = ",".join(config["dns_search_list"])
+            if option_data:
+                subnet_data["option_data"] = option_data
 
             # Create or update subnet
             if existing_uuid:
@@ -230,8 +239,16 @@ class OPNsenseProvider(
                 kea.update_dhcp6_subnet(existing_uuid, subnet_data)
             else:
                 print(f"Creating DHCPv6 subnet {subnet_name}")
-                response = kea.add_dhcp6_subnet(subnet_data)
-                created_uuid = response.get("uuid")
+                result = kea.add_dhcp6_subnet(subnet_data)
+                if result.get("result") == "failed":
+                    raise ValueError(f"Failed to create DHCPv6 subnet {subnet_name}: {result}")
+                # The add response doesn't include the UUID, so search for the
+                # newly created subnet to retrieve it
+                created_uuid = None
+                for s in kea.search_dhcp6_subnets():
+                    if s.get("subnet") == subnet_address:
+                        created_uuid = s.get("uuid")
+                        break
                 print(f"Created with UUID: {created_uuid}")
                 # Update map for use in reservations
                 existing_subnets_map[subnet_address] = created_uuid
@@ -255,11 +272,11 @@ class OPNsenseProvider(
             duid = config.get("duid")
             existing_uuid = existing_reservations_map.get((duid, subnet_id))
 
-            # Prepare reservation data
+            # Prepare reservation data — field names match OPNsense Kea DHCPv6 API
             reservation_data = {
-                "subnet_id": subnet_id,
+                "subnet": subnet_id,
+                "ip_address": config.get("ip_address"),
                 "duid": duid,
-                "ip_addresses": config.get("ip_address"),
                 "hostname": config.get("hostname", ""),
                 "description": config.get("description", ""),
             }
@@ -270,8 +287,13 @@ class OPNsenseProvider(
                 kea.update_dhcp6_reservation(existing_uuid, reservation_data)
             else:
                 print(f"Creating DHCPv6 reservation {reservation_name}")
-                response = kea.add_dhcp6_reservation(reservation_data)
-                print(f"Created with UUID: {response.get('uuid')}")
+                result = kea.add_dhcp6_reservation(reservation_data)
+                if result.get("result") == "failed":
+                    validations = result.get("validations", {})
+                    raise ValueError(
+                        f"Failed to create DHCPv6 reservation {reservation_name}: {validations}"
+                    )
+                print(f"Created reservation {reservation_name}")
 
         # Reconfigure service ONCE to apply all changes
         print("Reconfiguring Kea service...")

--- a/src/infrafoundry/providers/opnsense/api_client.py
+++ b/src/infrafoundry/providers/opnsense/api_client.py
@@ -145,7 +145,7 @@ class KeaClient:
             data: Resource configuration
 
         Returns:
-            Response with 'result' and 'uuid' fields
+            Response with 'result' field (uuid is NOT included in add responses)
         """
         endpoint = f"kea/dhcpv6/add{resource_type}"
         request_data = {resource_key: data}
@@ -219,7 +219,7 @@ class KeaClient:
         Returns:
             Response with 'result' and 'uuid' fields
         """
-        return self._crud_add("Subnet", "subnet", subnet_data)
+        return self._crud_add("Subnet", "subnet6", subnet_data)
 
     def update_dhcp6_subnet(self, uuid: str, subnet_data: dict[str, Any]) -> dict[str, Any]:
         """Update an existing DHCPv6 subnet.
@@ -231,7 +231,7 @@ class KeaClient:
         Returns:
             Response with 'result' field
         """
-        return self._crud_update("Subnet", uuid, "subnet", subnet_data)
+        return self._crud_update("Subnet", uuid, "subnet6", subnet_data)
 
     def delete_dhcp6_subnet(self, uuid: str) -> dict[str, Any]:
         """Delete a DHCPv6 subnet.
@@ -305,6 +305,93 @@ class KeaClient:
             Response with 'result' field
         """
         return self._crud_delete("Reservation", uuid)
+
+    # DHCPv6 General Settings operations
+
+    def get_dhcp6_general(self) -> dict[str, Any]:
+        """Get Kea DHCPv6 general settings.
+
+        Returns:
+            General settings dictionary with 'dhcpv6' key containing
+            'enabled', 'interfaces', and other configuration.
+        """
+        return self.client.request("GET", "kea/dhcpv6/get")
+
+    def set_dhcp6_general(self, settings: dict[str, Any]) -> dict[str, Any]:
+        """Update Kea DHCPv6 general settings.
+
+        Args:
+            settings: General settings to update, wrapped in 'dhcpv6' key.
+                Example: {"dhcpv6": {"enabled": "1", "interfaces": "opt1,opt2"}}
+
+        Returns:
+            Response with 'result' field
+        """
+        return self.client.request("POST", "kea/dhcpv6/set", data=settings)
+
+    def ensure_dhcp6_enabled(self, interfaces: list[str]) -> None:
+        """Ensure Kea DHCPv6 is enabled with the specified interfaces selected.
+
+        Reads current settings, enables the service if needed, and adds any
+        missing interfaces to the selection. Only makes API calls if changes
+        are required.
+
+        Args:
+            interfaces: List of interface names that must be enabled (e.g., ["opt1", "opt2"])
+        """
+        general = self.get_dhcp6_general()
+        # API returns: {"dhcpv6": {"general": {"enabled": "0", "interfaces": {...}}}}
+        general_settings = general.get("dhcpv6", {}).get("general", {})
+
+        # Determine current state
+        currently_enabled = general_settings.get("enabled", "0") == "1"
+
+        # Parse current interfaces — the API returns a dict of interface options
+        # with "selected" field indicating which are active
+        current_interfaces_raw = general_settings.get("interfaces", {})
+        selected_interfaces: set[str] = set()
+
+        if isinstance(current_interfaces_raw, dict):
+            for iface_name, iface_data in current_interfaces_raw.items():
+                if isinstance(iface_data, dict) and iface_data.get("selected", 0):
+                    selected_interfaces.add(iface_name)
+        elif isinstance(current_interfaces_raw, str) and current_interfaces_raw:
+            selected_interfaces = set(current_interfaces_raw.split(","))
+
+        # Determine required changes
+        required = set(interfaces)
+        missing_interfaces = required - selected_interfaces
+        needs_enable = not currently_enabled
+        needs_interface_update = bool(missing_interfaces)
+
+        if not needs_enable and not needs_interface_update:
+            logger.info("Kea DHCPv6 already enabled with required interfaces")
+            return
+
+        # Build update payload — must nest under dhcpv6.general to match API structure
+        new_interfaces = selected_interfaces | required
+        update_data: dict[str, Any] = {
+            "dhcpv6": {
+                "general": {
+                    "enabled": "1",
+                    "interfaces": ",".join(sorted(new_interfaces)),
+                }
+            }
+        }
+
+        if needs_enable:
+            print("Enabling Kea DHCPv6 service...")
+        if needs_interface_update:
+            print(f"Adding interfaces to DHCPv6: {', '.join(sorted(missing_interfaces))}")
+
+        result = self.set_dhcp6_general(update_data)
+        if result.get("result") == "failed":
+            validations = result.get("validations", {})
+            raise ValueError(f"Failed to update DHCPv6 general settings: {validations}")
+
+        # Reconfigure to apply the general settings change
+        self.reconfigure_service()
+        print("Kea DHCPv6 service configured and running")
 
     # Service operations
 


### PR DESCRIPTION
## Description

Fixes the Kea DHCPv6 API integration in the OPNsense provider which was completely broken due to incorrect API assumptions about wrapper keys, field names, and service prerequisites.

## Related Issue

Addresses #292

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `ensure_dhcp6_enabled()` to auto-enable DHCPv6 service and select interfaces in general settings before creating subnets
- Fixed general settings path (`dhcpv6.general.enabled`, not `dhcpv6.enabled`)
- Fixed subnet wrapper key (`subnet6`, not `subnet`)
- Fixed pools format (newline-separated string, not list of dicts)
- Fixed DNS field nesting (under `option_data`, not top-level)
- Fixed reservation field names (`subnet` not `subnet_id`, `ip_address` not `ip_addresses`)
- Search for UUID after subnet creation (add response doesn't include it)
- Added validation error checking on create responses

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes against live OPNsense — 3 DHCPv6 subnets and 1 reservation created successfully

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
