### PR TITLE
fix: parse imported disk path for NFS storage compatibility

### DIFF
--- a/src/infrafoundry/providers/proxmox/templates/proxmox/templates.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/templates.tf.j2
@@ -75,8 +75,9 @@ resource "null_resource" "configure_vm_{{ template.config.name | replace('-', '_
         # Import disk
         qm importdisk {{ template.config.vmid }} /var/lib/vz/template/iso/{{ image_file }} {{ template.config.disk.storage | default('local-lvm') }}
 
-        # Attach disk
-        qm set {{ template.config.vmid }} --scsi0 {{ template.config.disk.storage | default('local-lvm') }}:vm-{{ template.config.vmid }}-disk-0
+        # Attach disk (parse unused0 from config to handle both LVM and NFS path formats)
+        DISK_PATH=\$(qm config {{ template.config.vmid }} | grep '^unused0:' | sed 's/^unused0: //')
+        qm set {{ template.config.vmid }} --scsi0 \$DISK_PATH
 
         {% if template.config.efi_disk is defined %}
         # Add EFI disk for UEFI boot


### PR DESCRIPTION
## Description

Fix Proxmox template disk attachment that fails silently on NFS storage backends. The template hardcoded the disk path as `storage:vm-VMID-disk-0` which only works for LVM. NFS uses `storage:VMID/vm-VMID-disk-0.raw`. Now parses the `unused0` entry from `qm config` after `importdisk`, which works for all storage backends.

## Related Issue

Addresses #296

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Modified `templates.tf.j2` to parse the `unused0` disk path from `qm config` output instead of hardcoding the path format

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Manually tested: verified NFS storage creates disk as `nas01:900/vm-900-disk-0.raw` in `unused0`, and the fix correctly attaches it as `scsi0`