### PR TITLE
fix: correct DHCPv6 reservation lookup field from subnet_id to subnet

### DIFF
--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -195,7 +195,7 @@ class OPNsenseProvider(
         # Create lookup maps for efficient searching
         existing_subnets_map = {s.get("subnet"): s.get("uuid") for s in existing_subnets}
         existing_reservations_map = {
-            (r.get("duid"), r.get("subnet_id")): r.get("uuid") for r in existing_reservations
+            (r.get("duid"), r.get("subnet")): r.get("uuid") for r in existing_reservations
         }
 
         # Process all subnets


### PR DESCRIPTION
## Description

Fix DHCPv6 reservation lookup that always missed existing reservations because it used `subnet_id` as the key field, but the OPNsense Kea DHCPv6 API returns the subnet UUID in a field called `subnet`. This caused every subsequent apply to fail with "Duplicate entry exists" errors.

## Related Issue

Addresses #298

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Changed `r.get("subnet_id")` to `r.get("subnet")` in the existing reservations lookup map in `__init__.py`

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Manually verified: existing DHCPv6 reservations are now found and updated in place instead of failing with duplicate errors