### PR TITLE
feat: add boot_order support for Proxmox VMs

### DIFF
--- a/src/infrafoundry/providers/proxmox/templates/proxmox/vms.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/vms.tf.j2
@@ -177,6 +177,9 @@ resource "proxmox_virtual_environment_vm" "{{ vm.config.name | replace('-', '_')
   {% endif %}
 
   # Boot and startup
+  {% if vm.config.boot_order is defined %}
+  boot_order = {{ vm.config.boot_order | tojson }}
+  {% endif %}
   {% if vm.config.onboot is defined %}
   on_boot = {{ vm.config.onboot | lower }}
   {% endif %}

--- a/tests/unit/providers/proxmox/test_vm_enhancements.py
+++ b/tests/unit/providers/proxmox/test_vm_enhancements.py
@@ -202,6 +202,31 @@ class TestAllNewFields:
         assert "efi_disk {" in content
 
 
+class TestBootOrder:
+    """Tests for boot_order rendering."""
+
+    def test_vm_with_boot_order(self, provider):
+        """Boot order should render as a list."""
+        vms = [_make_vm(boot_order=["sata0", "ide3"])]
+        content = _render_vms(provider, vms)
+        assert "boot_order" in content
+        assert '"sata0"' in content
+        assert '"ide3"' in content
+
+    def test_vm_without_boot_order(self, provider):
+        """No boot_order config should not render the attribute."""
+        vms = [_make_vm(clone="100")]
+        content = _render_vms(provider, vms)
+        assert "boot_order" not in content
+
+    def test_vm_single_boot_device(self, provider):
+        """Single device boot order should render correctly."""
+        vms = [_make_vm(boot_order=["scsi0"])]
+        content = _render_vms(provider, vms)
+        assert "boot_order" in content
+        assert '"scsi0"' in content
+
+
 class TestDefaultsUnchanged:
     """Verify that minimal configs still produce the same output."""
 


### PR DESCRIPTION
## Description

Adds a `boot_order` config option for Proxmox VMs that maps directly to the terraform provider's `boot_order` list attribute. This is needed for ISO-based installs (e.g., ESXi) where the disk must boot before the CD-ROM after installation to prevent infinite reinstall loops.

Example config:
```yaml
- provider: proxmox
  type: vm
  name: esx-01
  config:
    boot_order: [sata0, ide3]
```

## Related Issue

Addresses #308

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **vms.tf.j2**: Added `boot_order` attribute rendering when config option is present
- **test_vm_enhancements.py**: Added `TestBootOrder` class with 3 tests

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings