### PR TITLE
feat: add OVF deployment support with network mapping

### DIFF
--- a/docs/providers/esxi.md
+++ b/docs/providers/esxi.md
@@ -9,6 +9,7 @@ The ESXi provider manages resources inside one or more VMware ESXi hosts using t
 | `vswitch` | Virtual switch with optional uplinks and MTU configuration |
 | `portgroup` | Port group on a vswitch with VLAN and security settings |
 | `vm` | Guest VM with OVF deployment, disk, and multi-NIC support |
+| `ovf_deployment` | Deploy an OVA/OVF appliance via `ovftool` with network mapping |
 
 ## Prerequisites
 
@@ -173,6 +174,47 @@ The `network` field accepts either a single dict or a list of dicts. A single di
 | `virtual_disk_id` | Yes | Path to the VMDK file |
 | `slot` | No | SCSI slot (default: `0:1`) |
 
+### ovf_deployment
+
+Use `ovf_deployment` when you need to deploy a pre-built OVA/OVF appliance (e.g., a vendor virtual appliance) using VMware `ovftool`. Unlike the `vm` resource, which creates VMs via the ESXi provider API, `ovf_deployment` invokes `ovftool` as a local-exec provisioner and supports explicit OVF network-to-portgroup mapping.
+
+```yaml
+ovf_deployment:
+  - name: vcsa
+    host: esxi-01
+    ovf_source: "/path/to/vcsa.ova"
+    disk_store: datastore1
+    disk_mode: thin
+    power: "on"
+    overwrite: false
+    notes: "vCenter Server Appliance"
+    network_map:
+      "Network 1": prod-network
+      "Management Network": mgmt-network
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Deployment name (used as the VM name unless `vm_name` is set) |
+| `host` | Yes | Logical host name from `provider_settings.esxi.hosts` |
+| `ovf_source` | Yes | Local path to the OVA/OVF file |
+| `disk_store` | Yes | Target datastore on the ESXi host |
+| `network_map` | Yes | Dict mapping OVF network names to ESXi portgroup names |
+| `vm_name` | No | Override the VM display name (defaults to `name`) |
+| `disk_mode` | No | Disk provisioning mode: `thin`, `thick`, `eagerzeroedthick` (default: `thin`) |
+| `power` | No | Power state after deployment: `on` or `off` (default: `on`) |
+| `overwrite` | No | Overwrite an existing VM with the same name (default: `false`) |
+| `notes` | No | Annotation/notes for the VM |
+
+**Prerequisites:**
+
+- `ovftool` must be installed and available on the system PATH
+- The OVA/OVF file must be accessible from the machine running Terraform
+
+**Destroy behavior:**
+
+On `terraform destroy`, the provisioner connects to the ESXi host via SSH and powers off then destroys the VM by name.
+
 ## Multi-Host Support
 
 The ESXi provider supports managing resources across multiple ESXi hosts simultaneously. Each host gets its own Terraform provider alias, and resources are routed to the correct host based on the `host` field.
@@ -201,6 +243,7 @@ The ESXi provider validates:
 - **Connectivity**: SSH access to each configured host on port 22
 - **Vswitch references**: Portgroups reference vswitches that exist on the same host
 - **Portgroup references**: VMs reference portgroups that exist on the same host
+- **OVF deployments**: Required fields (`host`, `ovf_source`, `disk_store`, `network_map`) and non-empty network mappings
 
 ```bash
 infra validate --env prod
@@ -247,6 +290,7 @@ generated/prod/terraform/esxi/
 ├── vswitch.tf           # Virtual switch resources
 ├── portgroup.tf         # Port group resources
 ├── vm.tf                # Guest VM resources
+├── ovf_deployment.tf    # OVF/OVA appliance deployments (if configured)
 └── outputs.tf           # VM IPs, vswitch names, portgroup names
 ```
 
@@ -256,6 +300,7 @@ Resources are created in dependency order:
 
 ```
 vswitch → portgroup → vm
+                    → ovf_deployment
 ```
 
-Portgroups depend on vswitches, and VMs depend on both vswitches and portgroups.
+Portgroups depend on vswitches. Both VMs and OVF deployments depend on vswitches and portgroups.

--- a/src/infrafoundry/providers/esxi/__init__.py
+++ b/src/infrafoundry/providers/esxi/__init__.py
@@ -115,6 +115,9 @@ class EsxiProvider(
             processed_vms = [self._normalize_vm_config(vm) for vm in resources_by_type["vm"]]
             self._generate_vms_terraform(processed_vms)
 
+        if "ovf_deployment" in resources_by_type:
+            self._generate_ovf_deployments_terraform(resources_by_type["ovf_deployment"])
+
         # Generate outputs
         self.render_outputs_terraform(resources_by_type)
 
@@ -131,13 +134,14 @@ class EsxiProvider(
     @override
     def get_resource_types(self) -> list[str]:
         """Get supported resource types."""
-        return ["vswitch", "portgroup", "vm"]
+        return ["vswitch", "portgroup", "vm", "ovf_deployment"]
 
     @override
     def get_dependencies(self) -> dict[str, list[str]]:
         """Get resource dependencies."""
         return {
             "vm": ["vswitch", "portgroup"],
+            "ovf_deployment": ["vswitch", "portgroup"],
             "portgroup": ["vswitch"],
             "vswitch": [],
         }
@@ -238,4 +242,12 @@ class EsxiProvider(
             "esxi/vm.tf.j2",
             context={"vms": vms, "host_alias": self._host_alias},
             output_name="vm.tf",
+        )
+
+    def _generate_ovf_deployments_terraform(self, ovf_deployments: list[ResourceConfig]) -> None:
+        """Generate Terraform for ESXi OVF deployments."""
+        self.render_and_write_terraform(
+            "esxi/ovf_deployment.tf.j2",
+            context={"ovf_deployments": ovf_deployments, "host_alias": self._host_alias},
+            output_name="ovf_deployment.tf",
         )

--- a/src/infrafoundry/providers/esxi/templates/esxi/outputs.tf.j2
+++ b/src/infrafoundry/providers/esxi/templates/esxi/outputs.tf.j2
@@ -35,3 +35,14 @@ output "portgroups" {
   ]
 }
 {% endif %}
+
+{% if resources_by_type.get('ovf_deployment') %}
+output "ovf_deployments" {
+  description = "Deployed OVF virtual machines"
+  value = [
+    {% for deployment in resources_by_type['ovf_deployment'] %}
+    "{{ deployment.config.vm_name | default(deployment.name) }}",
+    {% endfor %}
+  ]
+}
+{% endif %}

--- a/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
+++ b/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
@@ -1,0 +1,42 @@
+{% for deployment in ovf_deployments %}
+resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
+  triggers_replace = {
+    vm_name    = "{{ deployment.config.vm_name | default(deployment.name) }}"
+    ovf_source = "{{ deployment.config.ovf_source }}"
+    host       = "{{ deployment.config.host }}"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      ovftool --acceptAllEulas --noSSLVerify \
+        {% for ovf_net, target_pg in deployment.config.network_map.items() %}
+        --net:"{{ ovf_net }}"="{{ target_pg }}" \
+        {% endfor %}
+        --name="{{ deployment.config.vm_name | default(deployment.name) }}" \
+        -dm={{ deployment.config.disk_mode | default("thin") }} -ds="{{ deployment.config.disk_store }}" \
+        {% if deployment.config.power | default("on") == "on" %}
+        --powerOn \
+        {% endif %}
+        {% if deployment.config.overwrite | default(false) %}
+        --overwrite \
+        {% endif %}
+        {% if deployment.config.notes is defined %}
+        --annotation="{{ deployment.config.notes }}" \
+        {% endif %}
+        "{{ deployment.config.ovf_source }}" \
+        "vi://${var.esxi_username_{{ host_alias(deployment.config.host) }}}:${var.esxi_password_{{ host_alias(deployment.config.host) }}}@${var.esxi_hostname_{{ host_alias(deployment.config.host) }}}"
+    EOT
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      CMD='VMID=$(vim-cmd vmsvc/getallvms | grep "{{ deployment.config.vm_name | default(deployment.name) }}" | awk "{print \$1}"); vim-cmd vmsvc/power.off $VMID 2>/dev/null; vim-cmd vmsvc/destroy $VMID'
+      SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+      ssh $SSH_OPTS -o BatchMode=yes ${var.esxi_username_{{ host_alias(deployment.config.host) }}}@${var.esxi_hostname_{{ host_alias(deployment.config.host) }}} "$CMD" 2>/dev/null \
+        || sshpass -p "${var.esxi_password_{{ host_alias(deployment.config.host) }}}" ssh $SSH_OPTS ${var.esxi_username_{{ host_alias(deployment.config.host) }}}@${var.esxi_hostname_{{ host_alias(deployment.config.host) }}} "$CMD"
+    EOT
+  }
+}
+
+{% endfor %}

--- a/src/infrafoundry/providers/esxi/validator.py
+++ b/src/infrafoundry/providers/esxi/validator.py
@@ -8,6 +8,7 @@ from infrafoundry.core.validation import ValidationReport
 
 from .validators import (
     HostConnectivityValidator,
+    OvfDeploymentValidator,
     PortgroupReferenceValidator,
     VswitchReferenceValidator,
 )
@@ -35,6 +36,7 @@ class EsxiValidator:
         self.host_connectivity_validator = HostConnectivityValidator(report)
         self.vswitch_reference_validator = VswitchReferenceValidator(report)
         self.portgroup_reference_validator = PortgroupReferenceValidator(report)
+        self.ovf_deployment_validator = OvfDeploymentValidator(report)
 
     def validate_connectivity(self) -> None:
         """Validate SSH connectivity to ESXi hosts.
@@ -68,3 +70,4 @@ class EsxiValidator:
         """
         self.vswitch_reference_validator.validate(resources)
         self.portgroup_reference_validator.validate(resources)
+        self.ovf_deployment_validator.validate(resources)

--- a/src/infrafoundry/providers/esxi/validators/__init__.py
+++ b/src/infrafoundry/providers/esxi/validators/__init__.py
@@ -3,6 +3,9 @@
 from infrafoundry.providers.esxi.validators.host_connectivity_validator import (
     HostConnectivityValidator,
 )
+from infrafoundry.providers.esxi.validators.ovf_deployment_validator import (
+    OvfDeploymentValidator,
+)
 from infrafoundry.providers.esxi.validators.portgroup_reference_validator import (
     PortgroupReferenceValidator,
 )
@@ -12,6 +15,7 @@ from infrafoundry.providers.esxi.validators.vswitch_reference_validator import (
 
 __all__ = [
     "HostConnectivityValidator",
+    "OvfDeploymentValidator",
     "PortgroupReferenceValidator",
     "VswitchReferenceValidator",
 ]

--- a/src/infrafoundry/providers/esxi/validators/ovf_deployment_validator.py
+++ b/src/infrafoundry/providers/esxi/validators/ovf_deployment_validator.py
@@ -1,0 +1,128 @@
+"""OVF deployment validation for ESXi provider."""
+
+from pathlib import Path
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+
+
+class OvfDeploymentValidator:
+    """Validates OVF deployment resource configurations.
+
+    Checks that OVF deployment resources have all required fields
+    and that network mappings are properly defined.
+    """
+
+    def __init__(self, report: ValidationReport) -> None:
+        """Initialize OVF deployment validator.
+
+        Args:
+            report: ValidationReport to add results to
+        """
+        self.report = report
+
+    def validate(self, resources: list[ResourceConfig]) -> None:
+        """Validate OVF deployment resources.
+
+        Args:
+            resources: List of all resources to validate
+        """
+        for resource in resources:
+            if resource.type != "ovf_deployment":
+                continue
+            self._validate_resource(resource)
+
+    def _validate_resource(self, resource: ResourceConfig) -> None:
+        """Validate a single OVF deployment resource.
+
+        Args:
+            resource: The OVF deployment resource to validate
+        """
+        config = resource.config
+
+        # Validate required: host
+        host = config.get("host", "")
+        self.report.add_check(
+            check_name=f"esxi_ovf_deployment_host_{resource.name}",
+            passed=bool(host),
+            message=(
+                f"OVF deployment '{resource.name}' has host '{host}'"
+                if host
+                else f"OVF deployment '{resource.name}' is missing required field 'host'"
+            ),
+            level=ValidationLevel.INFO if host else ValidationLevel.ERROR,
+        )
+
+        # Validate required: ovf_source
+        ovf_source = config.get("ovf_source", "")
+        self.report.add_check(
+            check_name=f"esxi_ovf_deployment_ovf_source_{resource.name}",
+            passed=bool(ovf_source),
+            message=(
+                f"OVF deployment '{resource.name}' has ovf_source '{ovf_source}'"
+                if ovf_source
+                else f"OVF deployment '{resource.name}' is missing required field 'ovf_source'"
+            ),
+            level=ValidationLevel.INFO if ovf_source else ValidationLevel.ERROR,
+        )
+
+        # Warn if ovf_source file doesn't exist locally
+        if ovf_source and not Path(ovf_source).exists():
+            self.report.add_check(
+                check_name=f"esxi_ovf_deployment_ovf_source_exists_{resource.name}",
+                passed=True,
+                message=(
+                    f"OVF deployment '{resource.name}' ovf_source '{ovf_source}' "
+                    f"not found locally (may be valid if path is on remote host)"
+                ),
+                level=ValidationLevel.WARNING,
+            )
+
+        # Validate required: disk_store
+        disk_store = config.get("disk_store", "")
+        self.report.add_check(
+            check_name=f"esxi_ovf_deployment_disk_store_{resource.name}",
+            passed=bool(disk_store),
+            message=(
+                f"OVF deployment '{resource.name}' has disk_store '{disk_store}'"
+                if disk_store
+                else f"OVF deployment '{resource.name}' is missing required field 'disk_store'"
+            ),
+            level=ValidationLevel.INFO if disk_store else ValidationLevel.ERROR,
+        )
+
+        # Validate required: network_map (must be non-empty dict)
+        network_map = config.get("network_map")
+        if not network_map or not isinstance(network_map, dict):
+            self.report.add_check(
+                check_name=f"esxi_ovf_deployment_network_map_{resource.name}",
+                passed=False,
+                message=(
+                    f"OVF deployment '{resource.name}' is missing required field "
+                    f"'network_map' or it is empty"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+        else:
+            # Check that all network_map values are non-empty
+            empty_values = [k for k, v in network_map.items() if not v]
+            if empty_values:
+                self.report.add_check(
+                    check_name=f"esxi_ovf_deployment_network_map_{resource.name}",
+                    passed=False,
+                    message=(
+                        f"OVF deployment '{resource.name}' has empty port group names "
+                        f"for network mappings: {', '.join(empty_values)}"
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+            else:
+                self.report.add_check(
+                    check_name=f"esxi_ovf_deployment_network_map_{resource.name}",
+                    passed=True,
+                    message=(
+                        f"OVF deployment '{resource.name}' has valid network_map "
+                        f"with {len(network_map)} mapping(s)"
+                    ),
+                    level=ValidationLevel.INFO,
+                )

--- a/tests/unit/providers/esxi/test_ovf_deployment.py
+++ b/tests/unit/providers/esxi/test_ovf_deployment.py
@@ -1,0 +1,199 @@
+"""Unit tests for ESXi OVF deployment template rendering."""
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.esxi import EsxiProvider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    """Create an EsxiProvider for template testing."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    p = EsxiProvider(config_dir, output_dir)
+    p.set_environment("test")
+    return p
+
+
+def _make_ovf_deployment(name: str = "ontap-node-01", **config_overrides) -> ResourceConfig:
+    """Helper to create an ovf_deployment ResourceConfig."""
+    config: dict = {
+        "host": "esxi-01",
+        "ovf_source": "/path/to/vsim.ovf",
+        "disk_store": "datastore1",
+        "vm_name": "ontap-node-01",
+        "network_map": {
+            "hostonly": "PG-Cluster-esx-01",
+            "nat": "PG-Management-esx-01",
+        },
+        **config_overrides,
+    }
+    return ResourceConfig(name=name, type="ovf_deployment", provider="esxi", config=config)
+
+
+class TestOvfDeploymentTemplate:
+    """Tests for ovf_deployment.tf.j2 template."""
+
+    def test_basic_ovf_deployment(self, provider):
+        """Basic OVF deployment should render terraform_data resource."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert 'resource "terraform_data" "ovf_ontap_node_01"' in content
+        assert "ovftool" in content
+        assert "triggers_replace" in content
+
+    def test_network_map_renders_net_flags(self, provider):
+        """Network map should render --net: flags for each OVF network."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert '--net:"hostonly"="PG-Cluster-esx-01"' in content
+        assert '--net:"nat"="PG-Management-esx-01"' in content
+
+    def test_host_alias_in_variables(self, provider):
+        """Host alias should be used in variable references."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "var.esxi_hostname_esxi_01" in content
+        assert "var.esxi_username_esxi_01" in content
+        assert "var.esxi_password_esxi_01" in content
+
+    def test_multiple_deployments(self, provider):
+        """Multiple deployments should render multiple resources."""
+        deployments = [
+            _make_ovf_deployment("node-01", vm_name="ontap-01"),
+            _make_ovf_deployment("node-02", vm_name="ontap-02", host="esxi-02"),
+        ]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert 'resource "terraform_data" "ovf_node_01"' in content
+        assert 'resource "terraform_data" "ovf_node_02"' in content
+        assert "var.esxi_hostname_esxi_02" in content
+
+    def test_name_normalization(self, provider):
+        """Dashes in resource names should be converted to underscores."""
+        deployments = [_make_ovf_deployment("my-ovf-vm")]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert '"ovf_my_ovf_vm"' in content
+
+    def test_default_disk_mode_thin(self, provider):
+        """Default disk mode should be thin."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "-dm=thin" in content
+
+    def test_custom_disk_mode(self, provider):
+        """Custom disk mode should be rendered."""
+        deployments = [_make_ovf_deployment(disk_mode="thick")]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "-dm=thick" in content
+
+    def test_power_on_default(self, provider):
+        """Default power=on should render --powerOn flag."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "--powerOn" in content
+
+    def test_power_off(self, provider):
+        """Power=off should not render --powerOn flag."""
+        deployments = [_make_ovf_deployment(power="off")]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "--powerOn" not in content
+
+    def test_notes_rendered(self, provider):
+        """Notes should be rendered as --annotation flag."""
+        deployments = [_make_ovf_deployment(notes="ONTAP 9.17.1")]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert '--annotation="ONTAP 9.17.1"' in content
+
+    def test_no_notes(self, provider):
+        """Without notes, --annotation should not appear."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "--annotation" not in content
+
+    def test_destroy_provisioner(self, provider):
+        """Destroy provisioner should include SSH command with VM name."""
+        deployments = [_make_ovf_deployment(vm_name="ontap-node-01")]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "when    = destroy" in content
+        assert "vim-cmd vmsvc/power.off" in content
+        assert "vim-cmd vmsvc/destroy" in content
+        assert "ontap-node-01" in content
+        assert "sshpass" in content
+
+    def test_vm_name_defaults_to_resource_name(self, provider):
+        """When vm_name is not set, resource name should be used."""
+        deployment = _make_ovf_deployment("my-vm")
+        del deployment.config["vm_name"]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": [deployment], "host_alias": EsxiProvider._host_alias},
+        )
+        assert '--name="my-vm"' in content
+
+    def test_triggers_replace_block(self, provider):
+        """Triggers replace block should contain vm_name, ovf_source, host."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert 'vm_name    = "ontap-node-01"' in content
+        assert 'ovf_source = "/path/to/vsim.ovf"' in content
+        assert 'host       = "esxi-01"' in content
+
+    def test_overwrite_flag(self, provider):
+        """Overwrite=true should render --overwrite flag."""
+        deployments = [_make_ovf_deployment(overwrite=True)]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "--overwrite" in content
+
+    def test_no_overwrite_by_default(self, provider):
+        """By default --overwrite should not appear."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "--overwrite" not in content

--- a/tests/unit/providers/esxi/test_ovf_deployment_validator.py
+++ b/tests/unit/providers/esxi/test_ovf_deployment_validator.py
@@ -1,0 +1,187 @@
+"""Unit tests for ESXi OvfDeploymentValidator."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.esxi.validators.ovf_deployment_validator import (
+    OvfDeploymentValidator,
+)
+
+
+@pytest.fixture
+def report():
+    """Create a mock validation report."""
+    return MagicMock(spec=ValidationReport)
+
+
+@pytest.fixture
+def validator(report):
+    """Create an OvfDeploymentValidator instance."""
+    return OvfDeploymentValidator(report)
+
+
+def _make_ovf_deployment(name: str = "ontap-node-01", **config_overrides) -> ResourceConfig:
+    """Create an ovf_deployment resource."""
+    config: dict = {
+        "host": "esxi-01",
+        "ovf_source": "/path/to/vsim.ovf",
+        "disk_store": "datastore1",
+        "vm_name": "ontap-node-01",
+        "network_map": {
+            "hostonly": "PG-Cluster-esx-01",
+            "nat": "PG-Management-esx-01",
+        },
+        **config_overrides,
+    }
+    return ResourceConfig(name=name, type="ovf_deployment", provider="esxi", config=config)
+
+
+class TestOvfDeploymentValidatorRequired:
+    """Tests for required field validation."""
+
+    def test_valid_config_passes(self, validator, report):
+        """Valid OVF deployment config should pass all checks."""
+        validator.validate([_make_ovf_deployment()])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        failed = [c for c in calls if not c["passed"]]
+        # Only the ovf_source file warning might appear, but all required checks pass
+        error_fails = [c for c in failed if c.get("level") == ValidationLevel.ERROR]
+        assert len(error_fails) == 0
+
+    def test_missing_host_error(self, validator, report):
+        """Missing host should produce an error."""
+        validator.validate([_make_ovf_deployment(host="")])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        host_check = [
+            c
+            for c in calls
+            if "host" in c["check_name"]
+            and "ovf_source" not in c["check_name"]
+            and "disk_store" not in c["check_name"]
+            and "network_map" not in c["check_name"]
+            and "exists" not in c["check_name"]
+        ]
+        assert len(host_check) == 1
+        assert host_check[0]["passed"] is False
+        assert host_check[0]["level"] == ValidationLevel.ERROR
+        assert "missing required field 'host'" in host_check[0]["message"]
+
+    def test_missing_ovf_source_error(self, validator, report):
+        """Missing ovf_source should produce an error."""
+        validator.validate([_make_ovf_deployment(ovf_source="")])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        source_check = [
+            c for c in calls if "ovf_source" in c["check_name"] and "exists" not in c["check_name"]
+        ]
+        assert len(source_check) == 1
+        assert source_check[0]["passed"] is False
+        assert source_check[0]["level"] == ValidationLevel.ERROR
+
+    def test_missing_disk_store_error(self, validator, report):
+        """Missing disk_store should produce an error."""
+        validator.validate([_make_ovf_deployment(disk_store="")])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        store_check = [c for c in calls if "disk_store" in c["check_name"]]
+        assert len(store_check) == 1
+        assert store_check[0]["passed"] is False
+        assert store_check[0]["level"] == ValidationLevel.ERROR
+
+    def test_missing_network_map_error(self, validator, report):
+        """Missing network_map should produce an error."""
+        resource = _make_ovf_deployment()
+        del resource.config["network_map"]
+        validator.validate([resource])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        map_check = [c for c in calls if "network_map" in c["check_name"]]
+        assert len(map_check) == 1
+        assert map_check[0]["passed"] is False
+        assert map_check[0]["level"] == ValidationLevel.ERROR
+
+    def test_empty_network_map_error(self, validator, report):
+        """Empty network_map dict should produce an error."""
+        validator.validate([_make_ovf_deployment(network_map={})])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        map_check = [c for c in calls if "network_map" in c["check_name"]]
+        assert len(map_check) == 1
+        assert map_check[0]["passed"] is False
+
+    def test_network_map_empty_values_error(self, validator, report):
+        """Network map with empty port group names should produce an error."""
+        validator.validate([_make_ovf_deployment(network_map={"hostonly": "", "nat": "PG-Mgmt"})])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        map_check = [c for c in calls if "network_map" in c["check_name"]]
+        assert len(map_check) == 1
+        assert map_check[0]["passed"] is False
+        assert "empty port group names" in map_check[0]["message"]
+
+
+class TestOvfDeploymentValidatorWarnings:
+    """Tests for warning-level validation."""
+
+    def test_ovf_source_not_found_warning(self, validator, report):
+        """Non-existent ovf_source file should produce a warning."""
+        validator.validate([_make_ovf_deployment(ovf_source="/nonexistent/path.ovf")])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        exists_check = [c for c in calls if "exists" in c["check_name"]]
+        assert len(exists_check) == 1
+        assert exists_check[0]["level"] == ValidationLevel.WARNING
+        assert "not found locally" in exists_check[0]["message"]
+
+    def test_ovf_source_exists_no_warning(self, validator, report, tmp_path):
+        """Existing ovf_source file should not produce a warning."""
+        ovf_file = tmp_path / "test.ovf"
+        ovf_file.touch()
+        validator.validate([_make_ovf_deployment(ovf_source=str(ovf_file))])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        exists_check = [c for c in calls if "exists" in c["check_name"]]
+        assert len(exists_check) == 0
+
+
+class TestOvfDeploymentValidatorEdgeCases:
+    """Tests for edge cases."""
+
+    def test_non_ovf_deployment_ignored(self, validator, report):
+        """Non-ovf_deployment resources should be ignored."""
+        vm = ResourceConfig(
+            name="test-vm",
+            type="vm",
+            provider="esxi",
+            config={"host": "esxi-01"},
+        )
+        validator.validate([vm])
+        report.add_check.assert_not_called()
+
+    def test_empty_resources(self, validator, report):
+        """Empty resource list should produce no checks."""
+        validator.validate([])
+        report.add_check.assert_not_called()
+
+    def test_multiple_deployments(self, validator, report):
+        """Multiple OVF deployments should all be validated."""
+        resources = [
+            _make_ovf_deployment("node-01"),
+            _make_ovf_deployment("node-02"),
+        ]
+        validator.validate(resources)
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        node01_checks = [
+            c for c in calls if "node_01" in c["check_name"] or "node-01" in c.get("message", "")
+        ]
+        node02_checks = [
+            c for c in calls if "node_02" in c["check_name"] or "node-02" in c.get("message", "")
+        ]
+        assert len(node01_checks) > 0
+        assert len(node02_checks) > 0

--- a/tests/unit/providers/esxi/test_terraform_generation.py
+++ b/tests/unit/providers/esxi/test_terraform_generation.py
@@ -307,6 +307,50 @@ class TestOutputsTemplate:
         assert "pg-mgmt" in content
         assert "pg-storage" in content
 
+    def test_outputs_with_ovf_deployments(self, provider):
+        """Outputs should include OVF deployment VM names."""
+        resources_by_type = {
+            "ovf_deployment": [
+                ResourceConfig(
+                    name="node-01",
+                    type="ovf_deployment",
+                    provider="esxi",
+                    config={"vm_name": "ontap-01", "host": "esxi-01"},
+                ),
+                ResourceConfig(
+                    name="node-02",
+                    type="ovf_deployment",
+                    provider="esxi",
+                    config={"vm_name": "ontap-02", "host": "esxi-01"},
+                ),
+            ],
+        }
+        content = provider.render_template(
+            "esxi/outputs.tf.j2",
+            {"resources_by_type": resources_by_type},
+        )
+        assert "ovf_deployments" in content
+        assert "ontap-01" in content
+        assert "ontap-02" in content
+
+    def test_outputs_ovf_deployment_defaults_to_name(self, provider):
+        """OVF deployment output should fall back to resource name when vm_name missing."""
+        resources_by_type = {
+            "ovf_deployment": [
+                ResourceConfig(
+                    name="my-ovf-vm",
+                    type="ovf_deployment",
+                    provider="esxi",
+                    config={"host": "esxi-01"},
+                ),
+            ],
+        }
+        content = provider.render_template(
+            "esxi/outputs.tf.j2",
+            {"resources_by_type": resources_by_type},
+        )
+        assert "my-ovf-vm" in content
+
     def test_outputs_empty_resources(self, provider):
         """Outputs with no resources should not render output blocks."""
         content = provider.render_template(

--- a/tests/unit/test_provider_esxi.py
+++ b/tests/unit/test_provider_esxi.py
@@ -35,6 +35,7 @@ class TestEsxiProvider:
         assert "vswitch" in types
         assert "portgroup" in types
         assert "vm" in types
+        assert "ovf_deployment" in types
 
     def test_get_dependencies(self, temp_dir):
         """Test dependency resolution."""
@@ -49,6 +50,9 @@ class TestEsxiProvider:
         assert "vm" in deps
         assert "vswitch" in deps["vm"]
         assert "portgroup" in deps["vm"]
+        assert "ovf_deployment" in deps
+        assert "vswitch" in deps["ovf_deployment"]
+        assert "portgroup" in deps["ovf_deployment"]
         assert "vswitch" in deps["portgroup"]
         assert deps["vswitch"] == []
 


### PR DESCRIPTION
## Description

Add a new `ovf_deployment` resource type to the ESXi provider. This enables deploying OVA/OVF virtual appliances (e.g., vCenter Server Appliance, vendor appliances) using VMware `ovftool` with explicit OVF network-to-portgroup mapping.

Unlike the existing `vm` resource which creates VMs through the ESXi Terraform provider API, `ovf_deployment` uses a `terraform_data` resource with `local-exec` provisioners to invoke `ovftool` for deployment and SSH for destroy operations.

Addresses #310

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `ovf_deployment` to ESXi provider's supported resource types and dependency graph
- Created `ovf_deployment.tf.j2` Jinja2 template using `terraform_data` with `local-exec` provisioners for `ovftool` deploy and SSH-based destroy
- Created `OvfDeploymentValidator` that validates required fields (`host`, `ovf_source`, `disk_store`, `network_map`) and network mapping integrity
- Wired validator into the ESXi provider's validation pipeline
- Updated `outputs.tf.j2` to include OVF deployment outputs
- Updated ESXi provider documentation with full resource reference
- Added comprehensive unit tests for template generation and validation

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (test, lint, type-check, security, spellcheck)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
