### PR TITLE
fix: URL-encode ESXi password in OVF deployment vi:// URL

### DIFF
--- a/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
+++ b/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
@@ -1,9 +1,12 @@
 {% for deployment in ovf_deployments %}
 resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
   triggers_replace = {
-    vm_name    = "{{ deployment.config.vm_name | default(deployment.name) }}"
-    ovf_source = "{{ deployment.config.ovf_source }}"
-    host       = "{{ deployment.config.host }}"
+    vm_name       = "{{ deployment.config.vm_name | default(deployment.name) }}"
+    ovf_source    = "{{ deployment.config.ovf_source }}"
+    host          = "{{ deployment.config.host }}"
+    esxi_hostname = var.esxi_hostname_{{ host_alias(deployment.config.host) }}
+    esxi_username = var.esxi_username_{{ host_alias(deployment.config.host) }}
+    esxi_password = var.esxi_password_{{ host_alias(deployment.config.host) }}
   }
 
   provisioner "local-exec" {
@@ -12,7 +15,7 @@ resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
         {% for ovf_net, target_pg in deployment.config.network_map.items() %}
         --net:"{{ ovf_net }}"="{{ target_pg }}" \
         {% endfor %}
-        --name="{{ deployment.config.vm_name | default(deployment.name) }}" \
+        --name="${self.triggers_replace.vm_name}" \
         -dm={{ deployment.config.disk_mode | default("thin") }} -ds="{{ deployment.config.disk_store }}" \
         {% if deployment.config.power | default("on") == "on" %}
         --powerOn \
@@ -23,18 +26,18 @@ resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
         {% if deployment.config.notes is defined %}
         --annotation="{{ deployment.config.notes }}" \
         {% endif %}
-        "{{ deployment.config.ovf_source }}" \
-        "vi://${var.esxi_username_{{ host_alias(deployment.config.host) }}}:${var.esxi_password_{{ host_alias(deployment.config.host) }}}@${var.esxi_hostname_{{ host_alias(deployment.config.host) }}}"
+        "${self.triggers_replace.ovf_source}" \
+        "vi://${self.triggers_replace.esxi_username}:$(python3 -c "import urllib.parse; print(urllib.parse.quote('${self.triggers_replace.esxi_password}', safe=''))")@${self.triggers_replace.esxi_hostname}"
     EOT
   }
 
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
-      CMD='VMID=$(vim-cmd vmsvc/getallvms | grep "{{ deployment.config.vm_name | default(deployment.name) }}" | awk "{print \$1}"); vim-cmd vmsvc/power.off $VMID 2>/dev/null; vim-cmd vmsvc/destroy $VMID'
+      CMD='VMID=$(vim-cmd vmsvc/getallvms | grep "${self.triggers_replace.vm_name}" | awk "{print \$1}"); vim-cmd vmsvc/power.off $VMID 2>/dev/null; vim-cmd vmsvc/destroy $VMID'
       SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
-      ssh $SSH_OPTS -o BatchMode=yes ${var.esxi_username_{{ host_alias(deployment.config.host) }}}@${var.esxi_hostname_{{ host_alias(deployment.config.host) }}} "$CMD" 2>/dev/null \
-        || sshpass -p "${var.esxi_password_{{ host_alias(deployment.config.host) }}}" ssh $SSH_OPTS ${var.esxi_username_{{ host_alias(deployment.config.host) }}}@${var.esxi_hostname_{{ host_alias(deployment.config.host) }}} "$CMD"
+      ssh $SSH_OPTS -o BatchMode=yes ${self.triggers_replace.esxi_username}@${self.triggers_replace.esxi_hostname} "$CMD" 2>/dev/null \
+        || sshpass -p "${self.triggers_replace.esxi_password}" ssh $SSH_OPTS ${self.triggers_replace.esxi_username}@${self.triggers_replace.esxi_hostname} "$CMD"
     EOT
   }
 }

--- a/tests/unit/providers/esxi/test_ovf_deployment.py
+++ b/tests/unit/providers/esxi/test_ovf_deployment.py
@@ -58,16 +58,20 @@ class TestOvfDeploymentTemplate:
         assert '--net:"hostonly"="PG-Cluster-esx-01"' in content
         assert '--net:"nat"="PG-Management-esx-01"' in content
 
-    def test_host_alias_in_variables(self, provider):
-        """Host alias should be used in variable references."""
+    def test_host_alias_in_triggers(self, provider):
+        """Host alias should be used in triggers_replace variable references."""
         deployments = [_make_ovf_deployment()]
         content = provider.render_template(
             "esxi/ovf_deployment.tf.j2",
             {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
         )
+        # Connection details stored in triggers_replace via var references
         assert "var.esxi_hostname_esxi_01" in content
         assert "var.esxi_username_esxi_01" in content
         assert "var.esxi_password_esxi_01" in content
+        # Create provisioner uses self references
+        assert "self.triggers_replace.esxi_username" in content
+        assert "self.triggers_replace.esxi_hostname" in content
 
     def test_multiple_deployments(self, provider):
         """Multiple deployments should render multiple resources."""
@@ -147,7 +151,7 @@ class TestOvfDeploymentTemplate:
         assert "--annotation" not in content
 
     def test_destroy_provisioner(self, provider):
-        """Destroy provisioner should include SSH command with VM name."""
+        """Destroy provisioner should use self references for SSH commands."""
         deployments = [_make_ovf_deployment(vm_name="ontap-node-01")]
         content = provider.render_template(
             "esxi/ovf_deployment.tf.j2",
@@ -156,29 +160,37 @@ class TestOvfDeploymentTemplate:
         assert "when    = destroy" in content
         assert "vim-cmd vmsvc/power.off" in content
         assert "vim-cmd vmsvc/destroy" in content
-        assert "ontap-node-01" in content
+        assert "self.triggers_replace.vm_name" in content
+        assert "self.triggers_replace.esxi_hostname" in content
+        assert "self.triggers_replace.esxi_password" in content
         assert "sshpass" in content
 
     def test_vm_name_defaults_to_resource_name(self, provider):
-        """When vm_name is not set, resource name should be used."""
+        """When vm_name is not set, resource name should be used in triggers."""
         deployment = _make_ovf_deployment("my-vm")
         del deployment.config["vm_name"]
         content = provider.render_template(
             "esxi/ovf_deployment.tf.j2",
             {"ovf_deployments": [deployment], "host_alias": EsxiProvider._host_alias},
         )
-        assert '--name="my-vm"' in content
+        assert "vm_name" in content
+        assert '"my-vm"' in content
 
     def test_triggers_replace_block(self, provider):
-        """Triggers replace block should contain vm_name, ovf_source, host."""
+        """Triggers replace block should contain config and connection details."""
         deployments = [_make_ovf_deployment()]
         content = provider.render_template(
             "esxi/ovf_deployment.tf.j2",
             {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
         )
-        assert 'vm_name    = "ontap-node-01"' in content
-        assert 'ovf_source = "/path/to/vsim.ovf"' in content
-        assert 'host       = "esxi-01"' in content
+        assert "vm_name" in content
+        assert '"ontap-node-01"' in content
+        assert "ovf_source" in content
+        assert '"/path/to/vsim.ovf"' in content
+        assert '"esxi-01"' in content
+        assert "esxi_hostname = var.esxi_hostname_esxi_01" in content
+        assert "esxi_username = var.esxi_username_esxi_01" in content
+        assert "esxi_password = var.esxi_password_esxi_01" in content
 
     def test_overwrite_flag(self, provider):
         """Overwrite=true should render --overwrite flag."""
@@ -197,3 +209,13 @@ class TestOvfDeploymentTemplate:
             {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
         )
         assert "--overwrite" not in content
+
+    def test_password_url_encoded_in_vi_url(self, provider):
+        """Password should be URL-encoded in the vi:// URL to handle special chars."""
+        deployments = [_make_ovf_deployment()]
+        content = provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+        assert "urllib.parse.quote" in content
+        assert "self.triggers_replace.esxi_password" in content


### PR DESCRIPTION
## Description

Fix two issues in the `ovf_deployment` template:

1. **URL-encode password**: Passwords containing URL-special characters (`#`, `@`, `?`, `&`, etc.) broke the `vi://` URL passed to ovftool. The `#` character was interpreted as a URL fragment separator, causing `Cannot parse locator` errors. Now URL-encoded using `python3 -c "import urllib.parse; print(urllib.parse.quote(...))"`.

2. **Use self references in destroy provisioner**: Terraform requires destroy-time provisioners to only reference `self`, `count.index`, or `each.key` — not `var.*`. Moved connection details (hostname, username, password) into `triggers_replace` and updated both create and destroy provisioners to use `self.triggers_replace.*`.

Addresses #312

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Updated `ovf_deployment.tf.j2` to store ESXi connection details in `triggers_replace`
- Updated create provisioner to use `self.triggers_replace.*` and URL-encode the password
- Updated destroy provisioner to use `self.triggers_replace.*` instead of `var.*`
- Updated tests to assert on new `self.triggers_replace` references
- Added test for URL-encoding of password in vi:// URL

## Testing

- [x] All existing tests pass
- [x] Added new test for URL-encoding
- [x] `doit check` passes
- [x] Verified fix deploys ONTAP VM with password containing `#` character

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass