### PR TITLE
feat: add mac_map support to ovf_deployment for deterministic MAC addresses

### DIFF
--- a/docs/providers/esxi.md
+++ b/docs/providers/esxi.md
@@ -193,6 +193,32 @@ ovf_deployment:
       "Management Network": mgmt-network
 ```
 
+**With static MAC addresses:**
+
+```yaml
+ovf_deployment:
+  - name: ontap-node-01
+    host: esxi-01
+    ovf_source: "/path/to/vsim.ovf"
+    disk_store: datastore1
+    vm_name: ontap-node-01
+    network_map:
+      hostonly: PG-Cluster-esx-01
+      nat: PG-Management-esx-01
+    mac_map:
+      nat: "BC:24:11:0A:01:01"
+    disk_mode: thin
+    power: "on"
+```
+
+When `mac_map` is present, the deployment workflow changes:
+
+1. The OVF is deployed with power **off** (regardless of the `power` setting)
+2. The provisioner SSHes to the ESXi host and modifies the VMX file to set static MAC addresses
+3. If `power` is `on`, a final provisioner powers on the VM
+
+This enables pre-configuring DHCP reservations for deterministic MAC addresses before the VM boots.
+
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Deployment name (used as the VM name unless `vm_name` is set) |
@@ -205,6 +231,7 @@ ovf_deployment:
 | `power` | No | Power state after deployment: `on` or `off` (default: `on`) |
 | `overwrite` | No | Overwrite an existing VM with the same name (default: `false`) |
 | `notes` | No | Annotation/notes for the VM |
+| `mac_map` | No | Dict mapping OVF network names to static MAC addresses. Keys must exist in `network_map`. MAC format: `XX:XX:XX:XX:XX:XX` (6 colon-separated hex pairs) |
 
 **Prerequisites:**
 
@@ -243,7 +270,7 @@ The ESXi provider validates:
 - **Connectivity**: SSH access to each configured host on port 22
 - **Vswitch references**: Portgroups reference vswitches that exist on the same host
 - **Portgroup references**: VMs reference portgroups that exist on the same host
-- **OVF deployments**: Required fields (`host`, `ovf_source`, `disk_store`, `network_map`) and non-empty network mappings
+- **OVF deployments**: Required fields (`host`, `ovf_source`, `disk_store`, `network_map`), non-empty network mappings, and `mac_map` key/format validation
 
 ```bash
 infra validate --env prod

--- a/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
+++ b/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
@@ -1,4 +1,5 @@
 {% for deployment in ovf_deployments %}
+{% set has_mac_map = deployment.config.mac_map is defined and deployment.config.mac_map %}
 resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
   triggers_replace = {
     vm_name       = "{{ deployment.config.vm_name | default(deployment.name) }}"
@@ -7,6 +8,11 @@ resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
     esxi_hostname = var.esxi_hostname_{{ host_alias(deployment.config.host) }}
     esxi_username = var.esxi_username_{{ host_alias(deployment.config.host) }}
     esxi_password = var.esxi_password_{{ host_alias(deployment.config.host) }}
+    {% if has_mac_map %}
+    {% for ovf_net, mac in deployment.config.mac_map.items() %}
+    mac_{{ ovf_net }} = "{{ mac }}"
+    {% endfor %}
+    {% endif %}
   }
 
   provisioner "local-exec" {
@@ -17,7 +23,7 @@ resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
         {% endfor %}
         --name="${self.triggers_replace.vm_name}" \
         -dm={{ deployment.config.disk_mode | default("thin") }} -ds="{{ deployment.config.disk_store }}" \
-        {% if deployment.config.power | default("on") == "on" %}
+        {% if not has_mac_map and deployment.config.power | default("on") == "on" %}
         --powerOn \
         {% endif %}
         {% if deployment.config.overwrite | default(false) %}
@@ -30,6 +36,45 @@ resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
         "vi://${self.triggers_replace.esxi_username}:$(python3 -c "import urllib.parse; print(urllib.parse.quote('${self.triggers_replace.esxi_password}', safe=''))")@${self.triggers_replace.esxi_hostname}"
     EOT
   }
+
+  {% if has_mac_map %}
+  provisioner "local-exec" {
+    command = <<-EOT
+      SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+      SSH_CMD="ssh $SSH_OPTS -o BatchMode=yes ${self.triggers_replace.esxi_username}@${self.triggers_replace.esxi_hostname}"
+      SSH_CMD_PW="sshpass -p '${self.triggers_replace.esxi_password}' ssh $SSH_OPTS ${self.triggers_replace.esxi_username}@${self.triggers_replace.esxi_hostname}"
+
+      # Find VMX path from vm inventory
+      VMX_INFO=$($SSH_CMD "vim-cmd vmsvc/getallvms" 2>/dev/null || $SSH_CMD_PW "vim-cmd vmsvc/getallvms")
+      VMX_PATH=$(echo "$VMX_INFO" | grep "${self.triggers_replace.vm_name}" | awk '{print $NF}')
+      DATASTORE=$(echo "$VMX_INFO" | grep "${self.triggers_replace.vm_name}" | sed 's/.*\[\(.*\)\].*/\1/')
+      FULL_PATH="/vmfs/volumes/$DATASTORE/$VMX_PATH"
+
+      {% for ovf_net, mac in deployment.config.mac_map.items() %}
+      {% set pg = deployment.config.network_map[ovf_net] %}
+      # Set MAC for {{ ovf_net }} (portgroup: {{ pg }})
+      CMD="IDX=\$(grep -n '{{ pg }}' \"$FULL_PATH\" | head -1 | sed 's/.*ethernet\([0-9]*\).*/\1/'); \
+        sed -i \"s/ethernet\${IDX}.addressType = .*/ethernet\${IDX}.addressType = \\\"static\\\"/\" \"$FULL_PATH\"; \
+        sed -i \"/ethernet\${IDX}.generatedAddress/d\" \"$FULL_PATH\"; \
+        grep -q \"ethernet\${IDX}.address \" \"$FULL_PATH\" && \
+          sed -i \"s/ethernet\${IDX}.address = .*/ethernet\${IDX}.address = \\\"{{ mac }}\\\"/\" \"$FULL_PATH\" || \
+          echo 'ethernet'\"$IDX\"'.address = \"{{ mac }}\"' >> \"$FULL_PATH\""
+      $SSH_CMD "$CMD" 2>/dev/null || $SSH_CMD_PW "$CMD"
+      {% endfor %}
+    EOT
+  }
+
+  {% if deployment.config.power | default("on") == "on" %}
+  provisioner "local-exec" {
+    command = <<-EOT
+      SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+      CMD='VMID=$(vim-cmd vmsvc/getallvms | grep "${self.triggers_replace.vm_name}" | awk "{print \$1}"); vim-cmd vmsvc/power.on $VMID'
+      ssh $SSH_OPTS -o BatchMode=yes ${self.triggers_replace.esxi_username}@${self.triggers_replace.esxi_hostname} "$CMD" 2>/dev/null \
+        || sshpass -p "${self.triggers_replace.esxi_password}" ssh $SSH_OPTS ${self.triggers_replace.esxi_username}@${self.triggers_replace.esxi_hostname} "$CMD"
+    EOT
+  }
+  {% endif %}
+  {% endif %}
 
   provisioner "local-exec" {
     when    = destroy

--- a/src/infrafoundry/providers/esxi/validators/ovf_deployment_validator.py
+++ b/src/infrafoundry/providers/esxi/validators/ovf_deployment_validator.py
@@ -1,9 +1,12 @@
 """OVF deployment validation for ESXi provider."""
 
+import re
 from pathlib import Path
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
+
+MAC_ADDRESS_PATTERN = re.compile(r"^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$")
 
 
 class OvfDeploymentValidator:
@@ -126,3 +129,62 @@ class OvfDeploymentValidator:
                     ),
                     level=ValidationLevel.INFO,
                 )
+
+        # Validate optional: mac_map
+        mac_map = config.get("mac_map")
+        if mac_map and isinstance(mac_map, dict):
+            self._validate_mac_map(resource, mac_map, network_map)
+
+    def _validate_mac_map(
+        self,
+        resource: ResourceConfig,
+        mac_map: dict[str, str],
+        network_map: dict[str, str] | None,
+    ) -> None:
+        """Validate mac_map entries against network_map and MAC address format.
+
+        Args:
+            resource: The OVF deployment resource being validated
+            mac_map: Dict mapping OVF network names to MAC addresses
+            network_map: Dict mapping OVF network names to portgroup names
+        """
+        # Validate keys are a subset of network_map keys
+        network_map_keys = (
+            set(network_map.keys()) if network_map and isinstance(network_map, dict) else set()
+        )
+        invalid_keys = [k for k in mac_map if k not in network_map_keys]
+        if invalid_keys:
+            self.report.add_check(
+                check_name=f"esxi_ovf_deployment_mac_map_keys_{resource.name}",
+                passed=False,
+                message=(
+                    f"OVF deployment '{resource.name}' mac_map has keys not in "
+                    f"network_map: {', '.join(invalid_keys)}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+        # Validate MAC address format
+        invalid_macs = {k: v for k, v in mac_map.items() if not MAC_ADDRESS_PATTERN.match(v)}
+        if invalid_macs:
+            details = ", ".join(f"{k}={v}" for k, v in invalid_macs.items())
+            self.report.add_check(
+                check_name=f"esxi_ovf_deployment_mac_map_format_{resource.name}",
+                passed=False,
+                message=(
+                    f"OVF deployment '{resource.name}' mac_map has invalid MAC "
+                    f"address format (expected XX:XX:XX:XX:XX:XX): {details}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+        if not invalid_keys and not invalid_macs:
+            self.report.add_check(
+                check_name=f"esxi_ovf_deployment_mac_map_{resource.name}",
+                passed=True,
+                message=(
+                    f"OVF deployment '{resource.name}' has valid mac_map "
+                    f"with {len(mac_map)} mapping(s)"
+                ),
+                level=ValidationLevel.INFO,
+            )

--- a/tests/unit/providers/esxi/test_ovf_deployment.py
+++ b/tests/unit/providers/esxi/test_ovf_deployment.py
@@ -219,3 +219,104 @@ class TestOvfDeploymentTemplate:
         )
         assert "urllib.parse.quote" in content
         assert "self.triggers_replace.esxi_password" in content
+
+
+class TestOvfDeploymentMacMap:
+    """Tests for mac_map support in ovf_deployment template."""
+
+    def _render_with_mac_map(self, provider, **config_overrides):
+        """Helper to render template with mac_map config."""
+        deployments = [_make_ovf_deployment(**config_overrides)]
+        return provider.render_template(
+            "esxi/ovf_deployment.tf.j2",
+            {"ovf_deployments": deployments, "host_alias": EsxiProvider._host_alias},
+        )
+
+    def test_mac_map_suppresses_power_on(self, provider):
+        """When mac_map is set, --powerOn should not appear in ovftool command."""
+        content = self._render_with_mac_map(
+            provider,
+            mac_map={"nat": "BC:24:11:0A:01:01"},
+        )
+        # The ovftool command should NOT have --powerOn
+        # Split by provisioner blocks to check only the ovftool provisioner
+        assert "--powerOn" not in content
+
+    def test_mac_map_set_mac_provisioner(self, provider):
+        """mac_map should generate a provisioner that modifies VMX via SSH."""
+        content = self._render_with_mac_map(
+            provider,
+            mac_map={"nat": "BC:24:11:0A:01:01"},
+        )
+        assert "vim-cmd vmsvc/getallvms" in content
+        assert "BC:24:11:0A:01:01" in content
+        assert "PG-Management-esx-01" in content
+        assert "addressType" in content
+        assert "static" in content
+        assert "generatedAddress" in content
+        assert "FULL_PATH" in content
+
+    def test_mac_map_power_on_provisioner(self, provider):
+        """When mac_map is set and power=on, a power-on provisioner should exist."""
+        content = self._render_with_mac_map(
+            provider,
+            mac_map={"nat": "BC:24:11:0A:01:01"},
+            power="on",
+        )
+        assert "vim-cmd vmsvc/power.on" in content
+
+    def test_mac_map_power_off_no_power_on(self, provider):
+        """When mac_map is set and power=off, no power-on provisioner should exist."""
+        content = self._render_with_mac_map(
+            provider,
+            mac_map={"nat": "BC:24:11:0A:01:01"},
+            power="off",
+        )
+        assert "vim-cmd vmsvc/power.on" not in content
+        # MAC provisioner should still exist
+        assert "addressType" in content
+
+    def test_mac_map_in_triggers_replace(self, provider):
+        """MAC values should appear in triggers_replace for change detection."""
+        content = self._render_with_mac_map(
+            provider,
+            mac_map={"nat": "BC:24:11:0A:01:01"},
+        )
+        assert "mac_nat" in content
+        assert '"BC:24:11:0A:01:01"' in content
+
+    def test_no_mac_map_unchanged(self, provider):
+        """Without mac_map, template output should be unchanged (no MAC provisioners)."""
+        content = self._render_with_mac_map(provider)
+        # Should have normal --powerOn
+        assert "--powerOn" in content
+        # Should NOT have MAC-related provisioner content
+        assert "addressType" not in content
+        assert "FULL_PATH" not in content
+        assert "vim-cmd vmsvc/power.on" not in content
+        assert "mac_" not in content
+
+    def test_mac_map_multiple_entries(self, provider):
+        """Multiple mac_map entries should generate commands for each."""
+        content = self._render_with_mac_map(
+            provider,
+            mac_map={
+                "nat": "BC:24:11:0A:01:01",
+                "hostonly": "BC:24:11:0A:01:02",
+            },
+        )
+        assert "BC:24:11:0A:01:01" in content
+        assert "BC:24:11:0A:01:02" in content
+        assert "PG-Management-esx-01" in content
+        assert "PG-Cluster-esx-01" in content
+        assert "mac_nat" in content
+        assert "mac_hostonly" in content
+
+    def test_mac_map_ssh_auth_pattern(self, provider):
+        """MAC provisioner should use the same SSH auth pattern (key then password)."""
+        content = self._render_with_mac_map(
+            provider,
+            mac_map={"nat": "BC:24:11:0A:01:01"},
+        )
+        assert "BatchMode=yes" in content
+        assert "sshpass" in content

--- a/tests/unit/providers/esxi/test_ovf_deployment_validator.py
+++ b/tests/unit/providers/esxi/test_ovf_deployment_validator.py
@@ -185,3 +185,85 @@ class TestOvfDeploymentValidatorEdgeCases:
         ]
         assert len(node01_checks) > 0
         assert len(node02_checks) > 0
+
+
+class TestOvfDeploymentValidatorMacMap:
+    """Tests for mac_map validation."""
+
+    def test_mac_map_valid(self, validator, report):
+        """Valid mac_map with keys in network_map and correct format should pass."""
+        validator.validate([_make_ovf_deployment(mac_map={"nat": "BC:24:11:0A:01:01"})])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        mac_checks = [c for c in calls if "mac_map" in c["check_name"]]
+        assert len(mac_checks) == 1
+        assert mac_checks[0]["passed"] is True
+        assert mac_checks[0]["level"] == ValidationLevel.INFO
+
+    def test_mac_map_keys_not_in_network_map(self, validator, report):
+        """mac_map keys not in network_map should produce an error."""
+        validator.validate([_make_ovf_deployment(mac_map={"unknown_net": "BC:24:11:0A:01:01"})])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        key_checks = [c for c in calls if "mac_map_keys" in c["check_name"]]
+        assert len(key_checks) == 1
+        assert key_checks[0]["passed"] is False
+        assert key_checks[0]["level"] == ValidationLevel.ERROR
+        assert "unknown_net" in key_checks[0]["message"]
+
+    def test_mac_map_invalid_format(self, validator, report):
+        """Invalid MAC address format should produce an error."""
+        validator.validate([_make_ovf_deployment(mac_map={"nat": "not-a-mac"})])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        format_checks = [c for c in calls if "mac_map_format" in c["check_name"]]
+        assert len(format_checks) == 1
+        assert format_checks[0]["passed"] is False
+        assert format_checks[0]["level"] == ValidationLevel.ERROR
+        assert "not-a-mac" in format_checks[0]["message"]
+
+    def test_mac_map_empty_dict(self, validator, report):
+        """Empty mac_map dict should be treated as no mac_map (no validation)."""
+        validator.validate([_make_ovf_deployment(mac_map={})])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        mac_checks = [c for c in calls if "mac_map" in c["check_name"]]
+        assert len(mac_checks) == 0
+
+    def test_no_mac_map(self, validator, report):
+        """Omitting mac_map should pass without mac_map validation."""
+        validator.validate([_make_ovf_deployment()])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        mac_checks = [c for c in calls if "mac_map" in c["check_name"]]
+        assert len(mac_checks) == 0
+
+    def test_mac_map_multiple_valid_entries(self, validator, report):
+        """Multiple valid mac_map entries should all pass."""
+        validator.validate(
+            [
+                _make_ovf_deployment(
+                    mac_map={
+                        "nat": "BC:24:11:0A:01:01",
+                        "hostonly": "BC:24:11:0A:01:02",
+                    }
+                )
+            ]
+        )
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        mac_checks = [c for c in calls if "mac_map" in c["check_name"]]
+        assert len(mac_checks) == 1
+        assert mac_checks[0]["passed"] is True
+        assert "2 mapping(s)" in mac_checks[0]["message"]
+
+    def test_mac_map_lowercase_mac_valid(self, validator, report):
+        """Lowercase MAC addresses should be accepted."""
+        validator.validate([_make_ovf_deployment(mac_map={"nat": "bc:24:11:0a:01:01"})])
+
+        calls = [c[1] for c in report.add_check.call_args_list]
+        format_checks = [c for c in calls if "mac_map_format" in c["check_name"]]
+        assert len(format_checks) == 0
+        mac_checks = [c for c in calls if "mac_map" in c["check_name"]]
+        assert len(mac_checks) == 1
+        assert mac_checks[0]["passed"] is True


### PR DESCRIPTION
## Description

Add `mac_map` support to OVF deployment resources, enabling deterministic MAC address assignment for deployed VMs. This allows users to map network interfaces to specific MAC addresses during OVF deployment.

## Related Issue

Addresses #314

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Extended `ovf_deployment.tf.j2` template to support `mac_map` configuration for deterministic MAC address assignment
- Added validation logic in `ovf_deployment_validator.py` for `mac_map` entries (format, uniqueness, network reference checks)
- Added unit tests for OVF deployment MAC map template rendering
- Added unit tests for MAC map validation rules
- Updated ESXi provider documentation with `mac_map` usage examples

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
