### PR TITLE
fix: change mac_map keys from network names to ethernet adapter names

### DIFF
--- a/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
+++ b/src/infrafoundry/providers/esxi/templates/esxi/ovf_deployment.tf.j2
@@ -50,15 +50,13 @@ resource "terraform_data" "ovf_{{ deployment.name | to_terraform_name }}" {
       DATASTORE=$(echo "$VMX_INFO" | grep "${self.triggers_replace.vm_name}" | sed 's/.*\[\(.*\)\].*/\1/')
       FULL_PATH="/vmfs/volumes/$DATASTORE/$VMX_PATH"
 
-      {% for ovf_net, mac in deployment.config.mac_map.items() %}
-      {% set pg = deployment.config.network_map[ovf_net] %}
-      # Set MAC for {{ ovf_net }} (portgroup: {{ pg }})
-      CMD="IDX=\$(grep -n '{{ pg }}' \"$FULL_PATH\" | head -1 | sed 's/.*ethernet\([0-9]*\).*/\1/'); \
-        sed -i \"s/ethernet\${IDX}.addressType = .*/ethernet\${IDX}.addressType = \\\"static\\\"/\" \"$FULL_PATH\"; \
-        sed -i \"/ethernet\${IDX}.generatedAddress/d\" \"$FULL_PATH\"; \
-        grep -q \"ethernet\${IDX}.address \" \"$FULL_PATH\" && \
-          sed -i \"s/ethernet\${IDX}.address = .*/ethernet\${IDX}.address = \\\"{{ mac }}\\\"/\" \"$FULL_PATH\" || \
-          echo 'ethernet'\"$IDX\"'.address = \"{{ mac }}\"' >> \"$FULL_PATH\""
+      {% for eth_name, mac in deployment.config.mac_map.items() %}
+      # Set MAC for {{ eth_name }}
+      CMD="sed -i 's/{{ eth_name }}.addressType = .*/{{ eth_name }}.addressType = \"static\"/' \"$FULL_PATH\"; \
+        sed -i '/{{ eth_name }}.generatedAddress/d' \"$FULL_PATH\"; \
+        grep -q '{{ eth_name }}.address ' \"$FULL_PATH\" && \
+          sed -i 's/{{ eth_name }}.address = .*/{{ eth_name }}.address = \"{{ mac }}\"/' \"$FULL_PATH\" || \
+          echo '{{ eth_name }}.address = \"{{ mac }}\"' >> \"$FULL_PATH\""
       $SSH_CMD "$CMD" 2>/dev/null || $SSH_CMD_PW "$CMD"
       {% endfor %}
     EOT

--- a/src/infrafoundry/providers/esxi/validators/ovf_deployment_validator.py
+++ b/src/infrafoundry/providers/esxi/validators/ovf_deployment_validator.py
@@ -7,6 +7,7 @@ from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 
 MAC_ADDRESS_PATTERN = re.compile(r"^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$")
+ETHERNET_NAME_PATTERN = re.compile(r"^ethernet\d+$")
 
 
 class OvfDeploymentValidator:
@@ -133,33 +134,28 @@ class OvfDeploymentValidator:
         # Validate optional: mac_map
         mac_map = config.get("mac_map")
         if mac_map and isinstance(mac_map, dict):
-            self._validate_mac_map(resource, mac_map, network_map)
+            self._validate_mac_map(resource, mac_map)
 
     def _validate_mac_map(
         self,
         resource: ResourceConfig,
         mac_map: dict[str, str],
-        network_map: dict[str, str] | None,
     ) -> None:
-        """Validate mac_map entries against network_map and MAC address format.
+        """Validate mac_map ethernet name keys and MAC address format.
 
         Args:
             resource: The OVF deployment resource being validated
-            mac_map: Dict mapping OVF network names to MAC addresses
-            network_map: Dict mapping OVF network names to portgroup names
+            mac_map: Dict mapping ethernet names to MAC addresses
         """
-        # Validate keys are a subset of network_map keys
-        network_map_keys = (
-            set(network_map.keys()) if network_map and isinstance(network_map, dict) else set()
-        )
-        invalid_keys = [k for k in mac_map if k not in network_map_keys]
+        # Validate keys match ethernet name format (e.g., ethernet0, ethernet1)
+        invalid_keys = [k for k in mac_map if not ETHERNET_NAME_PATTERN.match(k)]
         if invalid_keys:
             self.report.add_check(
                 check_name=f"esxi_ovf_deployment_mac_map_keys_{resource.name}",
                 passed=False,
                 message=(
-                    f"OVF deployment '{resource.name}' mac_map has keys not in "
-                    f"network_map: {', '.join(invalid_keys)}"
+                    f"OVF deployment '{resource.name}' mac_map has invalid ethernet "
+                    f"names (expected ethernetN): {', '.join(invalid_keys)}"
                 ),
                 level=ValidationLevel.ERROR,
             )

--- a/tests/unit/providers/esxi/test_ovf_deployment.py
+++ b/tests/unit/providers/esxi/test_ovf_deployment.py
@@ -236,31 +236,28 @@ class TestOvfDeploymentMacMap:
         """When mac_map is set, --powerOn should not appear in ovftool command."""
         content = self._render_with_mac_map(
             provider,
-            mac_map={"nat": "BC:24:11:0A:01:01"},
+            mac_map={"ethernet0": "BC:24:11:0A:01:01"},
         )
-        # The ovftool command should NOT have --powerOn
-        # Split by provisioner blocks to check only the ovftool provisioner
         assert "--powerOn" not in content
 
     def test_mac_map_set_mac_provisioner(self, provider):
         """mac_map should generate a provisioner that modifies VMX via SSH."""
         content = self._render_with_mac_map(
             provider,
-            mac_map={"nat": "BC:24:11:0A:01:01"},
+            mac_map={"ethernet2": "BC:24:11:0A:01:01"},
         )
         assert "vim-cmd vmsvc/getallvms" in content
         assert "BC:24:11:0A:01:01" in content
-        assert "PG-Management-esx-01" in content
-        assert "addressType" in content
+        assert "ethernet2.addressType" in content
         assert "static" in content
-        assert "generatedAddress" in content
+        assert "ethernet2.generatedAddress" in content
         assert "FULL_PATH" in content
 
     def test_mac_map_power_on_provisioner(self, provider):
         """When mac_map is set and power=on, a power-on provisioner should exist."""
         content = self._render_with_mac_map(
             provider,
-            mac_map={"nat": "BC:24:11:0A:01:01"},
+            mac_map={"ethernet0": "BC:24:11:0A:01:01"},
             power="on",
         )
         assert "vim-cmd vmsvc/power.on" in content
@@ -269,28 +266,25 @@ class TestOvfDeploymentMacMap:
         """When mac_map is set and power=off, no power-on provisioner should exist."""
         content = self._render_with_mac_map(
             provider,
-            mac_map={"nat": "BC:24:11:0A:01:01"},
+            mac_map={"ethernet0": "BC:24:11:0A:01:01"},
             power="off",
         )
         assert "vim-cmd vmsvc/power.on" not in content
-        # MAC provisioner should still exist
         assert "addressType" in content
 
     def test_mac_map_in_triggers_replace(self, provider):
         """MAC values should appear in triggers_replace for change detection."""
         content = self._render_with_mac_map(
             provider,
-            mac_map={"nat": "BC:24:11:0A:01:01"},
+            mac_map={"ethernet0": "BC:24:11:0A:01:01"},
         )
-        assert "mac_nat" in content
+        assert "mac_ethernet0" in content
         assert '"BC:24:11:0A:01:01"' in content
 
     def test_no_mac_map_unchanged(self, provider):
         """Without mac_map, template output should be unchanged (no MAC provisioners)."""
         content = self._render_with_mac_map(provider)
-        # Should have normal --powerOn
         assert "--powerOn" in content
-        # Should NOT have MAC-related provisioner content
         assert "addressType" not in content
         assert "FULL_PATH" not in content
         assert "vim-cmd vmsvc/power.on" not in content
@@ -301,22 +295,28 @@ class TestOvfDeploymentMacMap:
         content = self._render_with_mac_map(
             provider,
             mac_map={
-                "nat": "BC:24:11:0A:01:01",
-                "hostonly": "BC:24:11:0A:01:02",
+                "ethernet0": "BC:24:11:0A:01:01",
+                "ethernet1": "BC:24:11:0A:01:02",
+                "ethernet2": "BC:24:11:0A:01:03",
+                "ethernet3": "BC:24:11:0A:01:04",
             },
         )
         assert "BC:24:11:0A:01:01" in content
         assert "BC:24:11:0A:01:02" in content
-        assert "PG-Management-esx-01" in content
-        assert "PG-Cluster-esx-01" in content
-        assert "mac_nat" in content
-        assert "mac_hostonly" in content
+        assert "BC:24:11:0A:01:03" in content
+        assert "BC:24:11:0A:01:04" in content
+        assert "mac_ethernet0" in content
+        assert "mac_ethernet1" in content
+        assert "mac_ethernet2" in content
+        assert "mac_ethernet3" in content
+        assert "ethernet0.addressType" in content
+        assert "ethernet3.addressType" in content
 
     def test_mac_map_ssh_auth_pattern(self, provider):
         """MAC provisioner should use the same SSH auth pattern (key then password)."""
         content = self._render_with_mac_map(
             provider,
-            mac_map={"nat": "BC:24:11:0A:01:01"},
+            mac_map={"ethernet0": "BC:24:11:0A:01:01"},
         )
         assert "BatchMode=yes" in content
         assert "sshpass" in content

--- a/tests/unit/providers/esxi/test_ovf_deployment_validator.py
+++ b/tests/unit/providers/esxi/test_ovf_deployment_validator.py
@@ -191,8 +191,8 @@ class TestOvfDeploymentValidatorMacMap:
     """Tests for mac_map validation."""
 
     def test_mac_map_valid(self, validator, report):
-        """Valid mac_map with keys in network_map and correct format should pass."""
-        validator.validate([_make_ovf_deployment(mac_map={"nat": "BC:24:11:0A:01:01"})])
+        """Valid mac_map with ethernet names and correct format should pass."""
+        validator.validate([_make_ovf_deployment(mac_map={"ethernet0": "BC:24:11:0A:01:01"})])
 
         calls = [c[1] for c in report.add_check.call_args_list]
         mac_checks = [c for c in calls if "mac_map" in c["check_name"]]
@@ -200,20 +200,20 @@ class TestOvfDeploymentValidatorMacMap:
         assert mac_checks[0]["passed"] is True
         assert mac_checks[0]["level"] == ValidationLevel.INFO
 
-    def test_mac_map_keys_not_in_network_map(self, validator, report):
-        """mac_map keys not in network_map should produce an error."""
-        validator.validate([_make_ovf_deployment(mac_map={"unknown_net": "BC:24:11:0A:01:01"})])
+    def test_mac_map_invalid_ethernet_name(self, validator, report):
+        """mac_map keys not matching ethernetN format should produce an error."""
+        validator.validate([_make_ovf_deployment(mac_map={"not_ethernet": "BC:24:11:0A:01:01"})])
 
         calls = [c[1] for c in report.add_check.call_args_list]
         key_checks = [c for c in calls if "mac_map_keys" in c["check_name"]]
         assert len(key_checks) == 1
         assert key_checks[0]["passed"] is False
         assert key_checks[0]["level"] == ValidationLevel.ERROR
-        assert "unknown_net" in key_checks[0]["message"]
+        assert "not_ethernet" in key_checks[0]["message"]
 
     def test_mac_map_invalid_format(self, validator, report):
         """Invalid MAC address format should produce an error."""
-        validator.validate([_make_ovf_deployment(mac_map={"nat": "not-a-mac"})])
+        validator.validate([_make_ovf_deployment(mac_map={"ethernet0": "not-a-mac"})])
 
         calls = [c[1] for c in report.add_check.call_args_list]
         format_checks = [c for c in calls if "mac_map_format" in c["check_name"]]
@@ -244,8 +244,10 @@ class TestOvfDeploymentValidatorMacMap:
             [
                 _make_ovf_deployment(
                     mac_map={
-                        "nat": "BC:24:11:0A:01:01",
-                        "hostonly": "BC:24:11:0A:01:02",
+                        "ethernet0": "BC:24:11:0A:01:01",
+                        "ethernet1": "BC:24:11:0A:01:02",
+                        "ethernet2": "BC:24:11:0A:01:03",
+                        "ethernet3": "BC:24:11:0A:01:04",
                     }
                 )
             ]
@@ -255,11 +257,11 @@ class TestOvfDeploymentValidatorMacMap:
         mac_checks = [c for c in calls if "mac_map" in c["check_name"]]
         assert len(mac_checks) == 1
         assert mac_checks[0]["passed"] is True
-        assert "2 mapping(s)" in mac_checks[0]["message"]
+        assert "4 mapping(s)" in mac_checks[0]["message"]
 
     def test_mac_map_lowercase_mac_valid(self, validator, report):
         """Lowercase MAC addresses should be accepted."""
-        validator.validate([_make_ovf_deployment(mac_map={"nat": "bc:24:11:0a:01:01"})])
+        validator.validate([_make_ovf_deployment(mac_map={"ethernet0": "bc:24:11:0a:01:01"})])
 
         calls = [c[1] for c in report.add_check.call_args_list]
         format_checks = [c for c in calls if "mac_map_format" in c["check_name"]]


### PR DESCRIPTION
## Description

Changes `mac_map` keys from OVF network names (e.g., `nat`, `hostonly`) to ethernet adapter names (e.g., `ethernet0`, `ethernet1`).

OVFs like the ONTAP Simulator define multiple NICs on the same network (e.g., `ethernet0` and `ethernet1` both on `hostonly`). Using network names as keys couldn't distinguish between them. Ethernet adapter names map directly to VMX file entries, simplifying the MAC modification script and supporting all NICs.

## Related Issue

Addresses #314

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Template: simplified VMX modification — directly targets `ethernetN.addressType` and `ethernetN.address` without port group lookup
- Validator: validates keys match `ethernetN` format instead of checking against `network_map` keys
- Tests: updated all mac_map tests to use ethernet name keys

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
