### PR TITLE
fix: resource filter fails for prefixed terraform names

### DIFF
--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -256,6 +256,12 @@ class TerraformRunner(BaseRunner):
         # Add -target flags for resource filtering
         if target_resources:
             targets = self._resolve_terraform_targets(tf_dir, target_resources)
+            if not targets:
+                self.console.print(
+                    f"[yellow]Warning: No terraform resources matched filter: "
+                    f"{target_resources} — skipping[/yellow]"
+                )
+                return {"exit_code": 0, "success": True, "output": "", "error": ""}
             for target in targets:
                 cmd.extend(["-target", target])
 
@@ -307,7 +313,11 @@ class TerraformRunner(BaseRunner):
                     if match:
                         resource_type = match.group(1)
                         resource_name = match.group(2)
-                        if resource_name in tf_names:
+                        # Exact match or suffix match for prefixed resources
+                        # (e.g., "ovf_ontap_node_01" matches "ontap_node_01")
+                        if resource_name in tf_names or any(
+                            resource_name.endswith(f"_{tf_name}") for tf_name in tf_names
+                        ):
                             targets.append(f"{resource_type}.{resource_name}")
 
         return targets

--- a/tests/unit/test_runner_terraform.py
+++ b/tests/unit/test_runner_terraform.py
@@ -126,3 +126,62 @@ def test_parse_plan_for_drift_detects_changes(runner: TerraformRunner) -> None:
     assert result["to_change"] == 2
     assert result["to_destroy"] == 0
     assert "add" in result["summary"]
+
+
+class TestResolveTargets:
+    """Tests for _resolve_terraform_targets."""
+
+    def test_exact_match(self, runner: TerraformRunner, tmp_path: Path) -> None:
+        """Exact resource name matches."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text('resource "esxi_guest" "my_vm" {\n}\n')
+        targets = runner._resolve_terraform_targets(tmp_path, ["my-vm"])
+        assert targets == ["esxi_guest.my_vm"]
+
+    def test_prefix_suffix_match(self, runner: TerraformRunner, tmp_path: Path) -> None:
+        """Resource with prefix matches via suffix (e.g., ovf_ontap_node_01)."""
+        tf_file = tmp_path / "ovf.tf"
+        tf_file.write_text('resource "terraform_data" "ovf_ontap_node_01" {\n}\n')
+        targets = runner._resolve_terraform_targets(tmp_path, ["ontap-node-01"])
+        assert targets == ["terraform_data.ovf_ontap_node_01"]
+
+    def test_no_match_returns_empty(self, runner: TerraformRunner, tmp_path: Path) -> None:
+        """Unmatched filter returns empty list."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text('resource "esxi_guest" "other_vm" {\n}\n')
+        targets = runner._resolve_terraform_targets(tmp_path, ["my-vm"])
+        assert targets == []
+
+    def test_no_false_suffix_match(self, runner: TerraformRunner, tmp_path: Path) -> None:
+        """Suffix match requires underscore separator (no partial matches)."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text('resource "esxi_guest" "bigontap_node_01" {\n}\n')
+        targets = runner._resolve_terraform_targets(tmp_path, ["node-01"])
+        assert targets == ["esxi_guest.bigontap_node_01"]
+
+    def test_multiple_resources_matched(self, runner: TerraformRunner, tmp_path: Path) -> None:
+        """Multiple resources can match from different files."""
+        (tmp_path / "a.tf").write_text('resource "terraform_data" "ovf_node_01" {\n}\n')
+        (tmp_path / "b.tf").write_text('resource "terraform_data" "ovf_node_02" {\n}\n')
+        targets = runner._resolve_terraform_targets(tmp_path, ["node-01", "node-02"])
+        assert sorted(targets) == [
+            "terraform_data.ovf_node_01",
+            "terraform_data.ovf_node_02",
+        ]
+
+    def test_unmatched_filter_skips_terraform(
+        self, runner: TerraformRunner, provider: MagicMock
+    ) -> None:
+        """When no targets match, terraform is skipped instead of running unfiltered."""
+        (provider.terraform_dir / "main.tf").write_text('resource "esxi_guest" "other_vm" {\n}\n')
+        (provider.terraform_dir / ".terraform").mkdir()
+        with (
+            patch("shutil.which", return_value="/usr/bin/terraform"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            result = runner.apply(provider, auto_approve=True, target_resources=["no-match"])
+
+        assert result["success"]
+        # subprocess.run should NOT have been called (no init, no apply)
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Description

Fix `_resolve_terraform_targets` to match prefixed terraform resource names (e.g., `ovf_ontap_node_01` matching filter `ontap-node-01`) and safely skip terraform when no targets match instead of running unfiltered against all resources.

## Related Issue

Addresses #304

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added suffix matching in `_resolve_terraform_targets` so resources with template-added prefixes (e.g., `ovf_`) match filter names
- When no terraform targets match the `-r` filter, execution is skipped with a warning instead of running unfiltered
- Added 6 unit tests for target resolution and skip behavior

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
