### PR TITLE
feat: add example config and Ansible roles for Proxmox ONTAP Simulator cluster

### DIFF
--- a/example-config/README.md
+++ b/example-config/README.md
@@ -20,6 +20,10 @@ This repository contains your infrastructure configurations, environment definit
 │   │   ├── age.key          # Age encryption key (DO NOT COMMIT)
 │   │   ├── settings.yaml    # Environment definition + provider credentials (SOPS encrypted)
 │   │   ├── proxmox/         # Proxmox resources (YAML, not encrypted)
+│   │   │   ├── vms.yaml           # Standard VMs (clone, ISO boot)
+│   │   │   ├── ova_vms.yaml       # OVA-based VMs (ONTAP Simulator)
+│   │   │   ├── ontap-lab-playbook.yml   # ONTAP post-deploy automation
+│   │   │   └── ontap-lab-inventory.yml  # ONTAP lab Ansible inventory
 │   │   ├── opnsense/        # OPNsense resources (YAML, not encrypted)
 │   │   └── kubernetes/      # Kubernetes resources (YAML, not encrypted)
 │   ├── staging/             # Staging environment
@@ -28,6 +32,13 @@ This repository contains your infrastructure configurations, environment definit
 │   └── prod/                # Production environment
 │       ├── age.key          # Production encryption key (DO NOT COMMIT)
 │       └── settings.yaml    # Production environment + credentials (SOPS encrypted)
+├── roles/                   # Ansible roles for post-deploy automation
+│   ├── ontap-serial-setup/  # Assign unique serial/sysid to ONTAP nodes
+│   ├── ontap-cluster-setup/ # Create/join ONTAP cluster via serial console
+│   ├── ontap-post-cluster/  # Configure ONTAP via REST API (netapp.ontap)
+│   ├── k3s-server/          # Install k3s control plane
+│   ├── k3s-agent/           # Install k3s worker node
+│   └── tailscale-exit-node/ # Configure Tailscale exit node
 ├── .sops.yaml               # SOPS configuration (in config repo root)
 ├── .gitignore               # Ignore age.key files and generated files
 ├── .envrc.local.example     # Example environment variables

--- a/example-config/envs/dev/proxmox/ontap-lab-inventory.yml
+++ b/example-config/envs/dev/proxmox/ontap-lab-inventory.yml
@@ -1,0 +1,31 @@
+---
+# ONTAP Simulator Lab — Ansible Inventory
+#
+# Defines Proxmox hosts for serial console automation and the
+# ONTAP cluster management endpoint for API-based configuration.
+#
+# Replace placeholder IPs with your actual Proxmox host addresses
+# and desired ONTAP cluster management IP.
+
+all:
+  children:
+    # Proxmox hosts running the ONTAP Simulator VMs
+    # Used by ontap-serial-setup and ontap-cluster-setup roles
+    proxmox_hosts:
+      hosts:
+        pve1:
+          ansible_host: "192.168.1.10"
+          ansible_user: root
+          ontap_vmid: 220
+        pve2:
+          ansible_host: "192.168.1.11"
+          ansible_user: root
+          ontap_vmid: 221
+
+    # ONTAP cluster management endpoint
+    # Used by ontap-post-cluster role (connects via REST API, not SSH)
+    ontap_cluster:
+      hosts:
+        ontap-cluster:
+          ansible_host: "192.168.1.220"
+          ansible_connection: local

--- a/example-config/envs/dev/proxmox/ontap-lab-playbook.yml
+++ b/example-config/envs/dev/proxmox/ontap-lab-playbook.yml
@@ -1,0 +1,87 @@
+---
+# ONTAP Simulator Lab — Orchestration Playbook
+#
+# Automates the post-deploy setup of a 2-node ONTAP Simulator cluster
+# on Proxmox. Run this after the VMs have been created via
+# `infra apply --env dev`.
+#
+# Usage:
+#   ansible-playbook -i ontap-lab-inventory.yml ontap-lab-playbook.yml
+#
+# Prerequisites:
+#   - ONTAP Simulator VMs created (see ova_vms.yaml)
+#   - pexpect installed on the Ansible control node
+#   - netapp.ontap collection installed: ansible-galaxy collection install netapp.ontap
+#   - SSH access to Proxmox hosts (pve1, pve2)
+#
+# Plays:
+#   1. Serial setup — Assign unique serial/sysid to node 02 (pve2 only)
+#   2. Cluster setup — Create cluster on node 01, join on node 02
+#   3. Post-cluster — Configure aggregates, SVMs, LIFs via ONTAP REST API
+
+# ------------------------------------------------------------------
+# Play 1: Change serial number on node 02
+# ------------------------------------------------------------------
+# Only node 02 needs a unique serial — node 01 keeps the OVA defaults.
+# This must happen before cluster setup.
+- name: Assign unique serial number to ONTAP node 02
+  hosts: pve2
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-serial-setup
+      vars:
+        ontap_vmid: 221
+        ontap_serial_number: "4082368-50-7"
+        ontap_sysid: "4082368507"
+
+# ------------------------------------------------------------------
+# Play 2: Create cluster on node 01, then join node 02
+# ------------------------------------------------------------------
+- name: Create ONTAP cluster on node 01
+  hosts: pve1
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-cluster-setup
+      vars:
+        ontap_vmid: 220
+        ontap_cluster_create: true
+        ontap_cluster_name: "ontap-lab"
+        ontap_cluster_mgmt_ip: "192.168.1.220"
+        ontap_cluster_mgmt_mask: "255.255.255.0"
+        ontap_cluster_mgmt_gateway: "192.168.1.1"
+        ontap_node_mgmt_ip: "192.168.1.222"
+        ontap_node_mgmt_mask: "255.255.255.0"
+        ontap_node_mgmt_gateway: "192.168.1.1"
+        ontap_password: "{{ vault_ontap_password | default('changeme123') }}"
+
+- name: Join ONTAP node 02 to cluster
+  hosts: pve2
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-cluster-setup
+      vars:
+        ontap_vmid: 221
+        ontap_cluster_create: false
+        ontap_cluster_join_ip: "192.168.1.220"
+        ontap_node_mgmt_ip: "192.168.1.223"
+        ontap_node_mgmt_mask: "255.255.255.0"
+        ontap_node_mgmt_gateway: "192.168.1.1"
+        ontap_password: "{{ vault_ontap_password | default('changeme123') }}"
+
+# ------------------------------------------------------------------
+# Play 3: Post-cluster configuration via ONTAP REST API
+# ------------------------------------------------------------------
+- name: Configure ONTAP cluster (aggregates, SVMs, LIFs)
+  hosts: ontap_cluster
+  gather_facts: false
+  connection: local
+  roles:
+    - role: ontap-post-cluster
+      vars:
+        ontap_cluster_mgmt_ip: "192.168.1.220"
+        ontap_admin_user: "admin"
+        ontap_admin_password: "{{ vault_ontap_password | default('changeme123') }}"
+        ontap_validate_certs: false

--- a/example-config/envs/dev/proxmox/ova_vms.yaml
+++ b/example-config/envs/dev/proxmox/ova_vms.yaml
@@ -1,0 +1,71 @@
+ova_vms:
+  # ------------------------------------------------------------------
+  # ONTAP Simulator 2-Node Cluster (OVA-based)
+  # ------------------------------------------------------------------
+  # Deploys a 2-node NetApp ONTAP Simulator cluster on Proxmox using
+  # OVA import. The OVA is extracted, VMDKs are converted to qcow2,
+  # and disks are attached as IDE devices.
+  #
+  # Prerequisites:
+  #   - ONTAP Simulator OVA downloaded from NetApp support site
+  #   - Proxmox cluster with at least 2 nodes (pve1, pve2)
+  #   - Cluster interconnect network (vmbr_cluster) configured
+  #
+  # Post-deploy automation:
+  #   - ontap-serial-setup: Assign unique serial/sysid to node 02
+  #   - ontap-cluster-setup: Create cluster on node 01, join node 02
+  #   - ontap-post-cluster: Configure aggregates, SVMs, LIFs via API
+  #
+  # See: ontap-lab-playbook.yml and ontap-lab-inventory.yml
+
+  - name: ontap-node-01
+    target_node: pve1
+    vmid: 220
+    ova_source: "/path/to/vsim-netapp-DOT9.17.1-cm_nodar.ova"
+    cores: 2
+    cpu_type: SandyBridge
+    memory: 6144
+    disk_bus: ide
+    disk_storage: local-lvm
+    serial: true
+    boot_order:
+      - ide0
+    onboot: false
+    tags:
+      - ontap
+      - ontap-lab
+    network:
+      - bridge: vmbr0
+        model: e1000        # e0a — management
+      - bridge: vmbr_cluster
+        model: e1000        # e0b — cluster interconnect
+      - bridge: vmbr_cluster
+        model: e1000        # e0c — cluster interconnect
+      - bridge: vmbr0
+        model: e1000        # e0d — data
+
+  - name: ontap-node-02
+    target_node: pve2
+    vmid: 221
+    ova_source: "/path/to/vsim-netapp-DOT9.17.1-cm_nodar.ova"
+    cores: 2
+    cpu_type: SandyBridge
+    memory: 6144
+    disk_bus: ide
+    disk_storage: local-lvm
+    serial: true
+    boot_order:
+      - ide0
+    onboot: false
+    tags:
+      - ontap
+      - ontap-lab
+    network:
+      - bridge: vmbr0
+        model: e1000        # e0a — management
+      - bridge: vmbr_cluster
+        model: e1000        # e0b — cluster interconnect
+      - bridge: vmbr_cluster
+        model: e1000        # e0c — cluster interconnect
+      - bridge: vmbr0
+        model: e1000        # e0d — data

--- a/example-config/roles/ontap-cluster-setup/defaults/main.yml
+++ b/example-config/roles/ontap-cluster-setup/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+# ONTAP Cluster Setup — Default Variables
+#
+# These variables control the cluster creation and node join process
+# for a 2-node ONTAP Simulator cluster via `qm terminal`.
+
+# Proxmox VM ID of the ONTAP node on this host
+ontap_vmid: 220
+
+# Cluster name
+ontap_cluster_name: "ontap-lab"
+
+# Cluster management interface configuration
+ontap_cluster_mgmt_ip: "192.168.1.220"
+ontap_cluster_mgmt_mask: "255.255.255.0"
+ontap_cluster_mgmt_gateway: "192.168.1.1"
+
+# Node management IP (for the node running on this host)
+ontap_node_mgmt_ip: "192.168.1.221"
+ontap_node_mgmt_mask: "255.255.255.0"
+ontap_node_mgmt_gateway: "192.168.1.1"
+
+# Admin password for the cluster
+ontap_password: "changeme123"
+
+# Whether this host creates the cluster (true) or joins it (false)
+ontap_cluster_create: true
+
+# Cluster IP to join (only used when ontap_cluster_create is false)
+ontap_cluster_join_ip: "192.168.1.220"
+
+# Timeout (seconds) to wait for the cluster setup wizard
+ontap_setup_timeout: 600
+
+# Timeout (seconds) to wait for cluster join
+ontap_join_timeout: 300

--- a/example-config/roles/ontap-cluster-setup/meta/main.yml
+++ b/example-config/roles/ontap-cluster-setup/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: ontap-cluster-setup
+  author: InfraFoundry
+  description: Create or join an ONTAP Simulator cluster via serial console wizard
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []

--- a/example-config/roles/ontap-cluster-setup/tasks/main.yml
+++ b/example-config/roles/ontap-cluster-setup/tasks/main.yml
@@ -1,0 +1,138 @@
+---
+# ONTAP Cluster Setup — Tasks
+#
+# Creates a new ONTAP cluster on the first node or joins an existing
+# cluster on subsequent nodes via Proxmox `qm terminal`.
+#
+# This role runs on Proxmox hosts and uses `ansible.builtin.expect`
+# to interact with the ONTAP cluster setup wizard through the VM
+# serial console.
+#
+# Requirements:
+#   - pexpect Python library on the Proxmox host
+#   - ONTAP node must be booted and at the cluster setup wizard
+#
+# Variables:
+#   ontap_vmid: VM ID on the Proxmox host
+#   ontap_cluster_create: true to create cluster, false to join
+#   ontap_cluster_name: Name for the new cluster
+#   ontap_cluster_mgmt_ip: Cluster management IP
+#   ontap_password: Admin password
+
+- name: Create new cluster (first node)
+  when: ontap_cluster_create | bool
+  block:
+    - name: Wait for cluster setup wizard prompt
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Type yes to confirm and continue":
+            - "yes"
+        timeout: "{{ ontap_setup_timeout }}"
+
+    - name: Enter admin password
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Enter the password for.*admin":
+            - "{{ ontap_password }}"
+          "Retype the password":
+            - "{{ ontap_password }}"
+        timeout: 60
+
+    - name: Configure cluster — create new cluster
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Do you want to create a new cluster or join an existing":
+            - "create"
+          "Do you intend for this node to be used as a single node cluster":
+            - "no"
+          "Enter the cluster name":
+            - "{{ ontap_cluster_name }}"
+          "Enter the cluster management interface port":
+            - "e0a"
+          "Enter the cluster management interface IP address":
+            - "{{ ontap_cluster_mgmt_ip }}"
+          "Enter the cluster management interface netmask":
+            - "{{ ontap_cluster_mgmt_mask }}"
+          "Enter the cluster management interface default gateway":
+            - "{{ ontap_cluster_mgmt_gateway }}"
+          "Enter the DNS domain name":
+            - "lab.local"
+          "Enter the name server IP address":
+            - "{{ ontap_cluster_mgmt_gateway }}"
+          "Enter the node management interface port.*e0a":
+            - "e0a"
+          "Enter the node management interface IP address":
+            - "{{ ontap_node_mgmt_ip }}"
+          "Enter the node management interface netmask":
+            - "{{ ontap_node_mgmt_mask }}"
+          "Enter the node management interface default gateway":
+            - "{{ ontap_node_mgmt_gateway }}"
+          "Where is the controller located":
+            - ""
+        timeout: "{{ ontap_setup_timeout }}"
+
+    - name: Wait for cluster setup to complete
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Cluster setup is complete":
+            - ""
+          "login:":
+            - ""
+        timeout: "{{ ontap_setup_timeout }}"
+      register: cluster_complete
+
+- name: Join existing cluster (additional nodes)
+  when: not (ontap_cluster_create | bool)
+  block:
+    - name: Wait for cluster setup wizard prompt
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Type yes to confirm and continue":
+            - "yes"
+        timeout: "{{ ontap_setup_timeout }}"
+
+    - name: Enter admin password
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Enter the password for.*admin":
+            - "{{ ontap_password }}"
+          "Retype the password":
+            - "{{ ontap_password }}"
+        timeout: 60
+
+    - name: Configure node — join existing cluster
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Do you want to create a new cluster or join an existing":
+            - "join"
+          "Enter the IP address of the cluster you want to join":
+            - "{{ ontap_cluster_join_ip }}"
+          "Enter the node management interface port.*e0a":
+            - "e0a"
+          "Enter the node management interface IP address":
+            - "{{ ontap_node_mgmt_ip }}"
+          "Enter the node management interface netmask":
+            - "{{ ontap_node_mgmt_mask }}"
+          "Enter the node management interface default gateway":
+            - "{{ ontap_node_mgmt_gateway }}"
+          "Where is the controller located":
+            - ""
+        timeout: "{{ ontap_join_timeout }}"
+
+    - name: Wait for cluster join to complete
+      ansible.builtin.expect:
+        command: "qm terminal {{ ontap_vmid }}"
+        responses:
+          "Cluster setup is complete":
+            - ""
+          "login:":
+            - ""
+        timeout: "{{ ontap_join_timeout }}"
+      register: join_complete

--- a/example-config/roles/ontap-post-cluster/defaults/main.yml
+++ b/example-config/roles/ontap-post-cluster/defaults/main.yml
@@ -1,0 +1,78 @@
+---
+# ONTAP Post-Cluster Setup — Default Variables
+#
+# These variables configure the ONTAP cluster after it has been
+# created and all nodes have joined. Uses netapp.ontap modules
+# via the ONTAP REST API.
+
+# Cluster management endpoint
+ontap_cluster_mgmt_ip: "192.168.1.220"
+ontap_admin_user: "admin"
+ontap_admin_password: "changeme123"
+
+# Set to true to validate SSL certificates
+ontap_validate_certs: false
+
+# ONTAP feature licenses (comma-separated license keys)
+# Leave empty to skip license installation
+ontap_licenses: []
+# Example:
+# ontap_licenses:
+#   - "AAAAAAAAAAAAAAAA"
+#   - "BBBBBBBBBBBBBBBB"
+
+# Disk assignment — assign all unowned disks
+ontap_assign_disks: true
+
+# Aggregate configuration
+ontap_aggregates:
+  - name: aggr1_node01
+    node: "ontap-node-01"
+    disk_count: 5
+    raid_type: raid_dp
+  - name: aggr1_node02
+    node: "ontap-node-02"
+    disk_count: 5
+    raid_type: raid_dp
+
+# Storage Virtual Machine (SVM) configuration
+ontap_svms:
+  - name: svm_data
+    root_volume: svm_data_root
+    root_volume_aggregate: aggr1_node01
+    allowed_protocols:
+      - nfs
+      - cifs
+      - iscsi
+
+# Data LIF configuration
+ontap_lifs:
+  - name: svm_data_lif1
+    vserver: svm_data
+    role: data
+    protocol: nfs
+    home_node: "ontap-node-01"
+    home_port: e0d
+    address: "192.168.1.230"
+    netmask: "255.255.255.0"
+
+  - name: svm_data_lif2
+    vserver: svm_data
+    role: data
+    protocol: nfs
+    home_node: "ontap-node-02"
+    home_port: e0d
+    address: "192.168.1.231"
+    netmask: "255.255.255.0"
+
+# DNS configuration for the SVM
+ontap_dns:
+  - vserver: svm_data
+    domains:
+      - lab.local
+    nameservers:
+      - "192.168.1.1"
+
+# NTP server configuration
+ontap_ntp_servers:
+  - "192.168.1.1"

--- a/example-config/roles/ontap-post-cluster/meta/main.yml
+++ b/example-config/roles/ontap-post-cluster/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ontap-post-cluster
+  author: InfraFoundry
+  description: Configure ONTAP cluster post-creation via netapp.ontap API modules
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+dependencies:
+  - netapp.ontap

--- a/example-config/roles/ontap-post-cluster/tasks/main.yml
+++ b/example-config/roles/ontap-post-cluster/tasks/main.yml
@@ -1,0 +1,130 @@
+---
+# ONTAP Post-Cluster Setup — Tasks
+#
+# Configures an ONTAP cluster after creation using the netapp.ontap
+# Ansible collection modules via the ONTAP REST API.
+#
+# This role runs against the cluster management endpoint (not
+# Proxmox hosts) and handles:
+#   - License installation
+#   - Disk assignment
+#   - Aggregate creation
+#   - SVM creation
+#   - Data LIF creation
+#   - DNS configuration
+#   - NTP configuration
+#
+# Requirements:
+#   - netapp.ontap Ansible collection installed
+#   - Network connectivity to the ONTAP cluster management IP
+#   - Cluster must be fully formed (all nodes joined)
+
+# ---------------------------------------------------------------
+# Connection defaults for netapp.ontap modules
+# ---------------------------------------------------------------
+- name: Set ONTAP connection facts
+  ansible.builtin.set_fact:
+    ontap_connection: &ontap_conn
+      hostname: "{{ ontap_cluster_mgmt_ip }}"
+      username: "{{ ontap_admin_user }}"
+      password: "{{ ontap_admin_password }}"
+      https: true
+      validate_certs: "{{ ontap_validate_certs }}"
+
+# ---------------------------------------------------------------
+# License installation
+# ---------------------------------------------------------------
+- name: Install ONTAP licenses
+  netapp.ontap.na_ontap_license:
+    <<: *ontap_conn
+    state: present
+    license_codes: "{{ ontap_licenses }}"
+  when: ontap_licenses | length > 0
+
+# ---------------------------------------------------------------
+# Disk assignment
+# ---------------------------------------------------------------
+- name: Assign all unowned disks
+  netapp.ontap.na_ontap_disks:
+    <<: *ontap_conn
+    node: "{{ item.node }}"
+  loop: "{{ ontap_aggregates }}"
+  loop_control:
+    label: "{{ item.node }}"
+  when: ontap_assign_disks | bool
+
+# ---------------------------------------------------------------
+# Aggregate creation
+# ---------------------------------------------------------------
+- name: Create data aggregates
+  netapp.ontap.na_ontap_aggregate:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    nodes:
+      - "{{ item.node }}"
+    disk_count: "{{ item.disk_count }}"
+    raid_type: "{{ item.raid_type }}"
+  loop: "{{ ontap_aggregates }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
+# SVM creation
+# ---------------------------------------------------------------
+- name: Create storage virtual machines
+  netapp.ontap.na_ontap_svm:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    root_volume: "{{ item.root_volume }}"
+    root_volume_aggregate: "{{ item.root_volume_aggregate }}"
+    allowed_protocols: "{{ item.allowed_protocols }}"
+  loop: "{{ ontap_svms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
+# Data LIF creation
+# ---------------------------------------------------------------
+- name: Create data LIFs
+  netapp.ontap.na_ontap_interface:
+    <<: *ontap_conn
+    state: present
+    interface_name: "{{ item.name }}"
+    vserver: "{{ item.vserver }}"
+    role: "{{ item.role }}"
+    protocols: "{{ item.protocol }}"
+    home_node: "{{ item.home_node }}"
+    home_port: "{{ item.home_port }}"
+    address: "{{ item.address }}"
+    netmask: "{{ item.netmask }}"
+  loop: "{{ ontap_lifs }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
+# DNS configuration
+# ---------------------------------------------------------------
+- name: Configure DNS for SVMs
+  netapp.ontap.na_ontap_dns:
+    <<: *ontap_conn
+    state: present
+    vserver: "{{ item.vserver }}"
+    domains: "{{ item.domains }}"
+    nameservers: "{{ item.nameservers }}"
+  loop: "{{ ontap_dns }}"
+  loop_control:
+    label: "{{ item.vserver }}"
+
+# ---------------------------------------------------------------
+# NTP configuration
+# ---------------------------------------------------------------
+- name: Configure NTP servers
+  netapp.ontap.na_ontap_ntp:
+    <<: *ontap_conn
+    state: present
+    server_name: "{{ item }}"
+  loop: "{{ ontap_ntp_servers }}"
+  loop_control:
+    label: "{{ item }}"

--- a/example-config/roles/ontap-serial-setup/defaults/main.yml
+++ b/example-config/roles/ontap-serial-setup/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# ONTAP Serial Setup — Default Variables
+#
+# These variables control the serial number and system ID assignment
+# for ONTAP Simulator nodes via the LOADER prompt.
+
+# Proxmox VM ID of the ONTAP node to configure
+ontap_vmid: 221
+
+# Unique serial number to assign to the node
+# Each node in a cluster must have a distinct serial number.
+# Format: 8-digit numeric string
+ontap_serial_number: "4082368-50-7"
+
+# Unique system ID to assign to the node
+# Each node in a cluster must have a distinct sysid.
+# Format: numeric string
+ontap_sysid: "4082368507"
+
+# Timeout (seconds) to wait for the LOADER prompt
+ontap_loader_timeout: 120
+
+# Timeout (seconds) to wait for boot completion
+ontap_boot_timeout: 600

--- a/example-config/roles/ontap-serial-setup/meta/main.yml
+++ b/example-config/roles/ontap-serial-setup/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: ontap-serial-setup
+  author: InfraFoundry
+  description: Assign unique serial number and system ID to ONTAP Simulator node via LOADER prompt
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []

--- a/example-config/roles/ontap-serial-setup/tasks/main.yml
+++ b/example-config/roles/ontap-serial-setup/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+# ONTAP Serial Setup — Tasks
+#
+# Assigns a unique serial number and system ID to an ONTAP Simulator
+# node at the LOADER prompt via Proxmox `qm terminal`.
+#
+# This role runs on a Proxmox host and uses `ansible.builtin.expect`
+# to interact with the VM serial console.
+#
+# Requirements:
+#   - pexpect Python library on the Proxmox host
+#   - VM must be at the LOADER> prompt (first boot or halted)
+#
+# Variables:
+#   ontap_vmid: VM ID on the Proxmox host
+#   ontap_serial_number: Unique serial number to assign
+#   ontap_sysid: Unique system ID to assign
+
+- name: Start VM if not running
+  ansible.builtin.command:
+    cmd: "qm start {{ ontap_vmid }}"
+  register: vm_start
+  failed_when: vm_start.rc != 0 and 'already running' not in vm_start.stderr
+  changed_when: vm_start.rc == 0
+
+- name: Wait for VM to reach LOADER prompt
+  ansible.builtin.expect:
+    command: "qm terminal {{ ontap_vmid }}"
+    responses:
+      "LOADER-.*>":
+        - ""
+    timeout: "{{ ontap_loader_timeout }}"
+  register: loader_wait
+
+- name: Set serial number at LOADER prompt
+  ansible.builtin.expect:
+    command: "qm terminal {{ ontap_vmid }}"
+    responses:
+      "LOADER-.*>":
+        - "setenv SYS_SERIAL_NUM {{ ontap_serial_number }}"
+    timeout: 30
+  register: serial_set
+
+- name: Set system ID at LOADER prompt
+  ansible.builtin.expect:
+    command: "qm terminal {{ ontap_vmid }}"
+    responses:
+      "LOADER-.*>":
+        - "setenv bootarg.nvram.sysid {{ ontap_sysid }}"
+    timeout: 30
+  register: sysid_set
+
+- name: Boot the node from LOADER prompt
+  ansible.builtin.expect:
+    command: "qm terminal {{ ontap_vmid }}"
+    responses:
+      "LOADER-.*>":
+        - "boot_ontap"
+    timeout: 30
+  register: boot_cmd
+
+- name: Wait for ONTAP boot to complete
+  ansible.builtin.expect:
+    command: "qm terminal {{ ontap_vmid }}"
+    responses:
+      "Press Ctrl-C for Boot Menu":
+        - ""
+    timeout: "{{ ontap_boot_timeout }}"
+  register: boot_wait
+  ignore_errors: true


### PR DESCRIPTION
## Description

Add example configuration and Ansible roles for deploying a NetApp ONTAP Simulator cluster on Proxmox via OVA VM import. This provides a complete reference for setting up a two-node ONTAP cluster with serial console configuration, cluster formation, and post-cluster network/aggregate setup.

## Related Issue

Addresses #283

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `example-config/envs/dev/proxmox/ova_vms.yaml` — OVA VM resource definitions for two ONTAP simulator nodes
- Added `example-config/envs/dev/proxmox/ontap-lab-playbook.yml` — Ansible playbook orchestrating the full ONTAP cluster setup
- Added `example-config/envs/dev/proxmox/ontap-lab-inventory.yml` — Ansible inventory for the ONTAP nodes
- Added `example-config/roles/ontap-serial-setup/` — Role for initial ONTAP node setup via serial console
- Added `example-config/roles/ontap-cluster-setup/` — Role for forming the ONTAP cluster
- Added `example-config/roles/ontap-post-cluster/` — Role for post-cluster configuration (network, aggregates)
- Updated `example-config/README.md` with documentation for the new Proxmox ONTAP lab files

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

No framework code changed — these are example configuration files and Ansible roles only. All existing tests pass via `doit check`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No framework source code was modified — all changes are in `example-config/`. No new tests are required as these are declarative configuration files and Ansible roles, not Python code. The ONTAP serial setup role uses `expect`-style interaction via the `ansible.builtin.expect` module for automated serial console configuration.
