### PR TITLE
fix: use self references in OVA VM destroy provisioner

### DIFF
--- a/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
@@ -8,6 +8,9 @@ resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
     ova_source = "{{ vm.config.ova_source }}"
     disk_bus   = "{{ vm.config.disk_bus | default('ide') }}"
     name       = "{{ vm.config.name }}"
+    ssh_cmd    = local.ssh_cmd
+    ssh_user   = var.proxmox_ssh_user
+    ssh_target = "{{ ssh_target }}"
   }
 
   # Phase 1: Extract OVA to temp directory on Proxmox host
@@ -81,7 +84,7 @@ resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
-      ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_target }} \
+      ${self.triggers_replace.ssh_cmd} ${self.triggers_replace.ssh_user}@${self.triggers_replace.ssh_target} \
         "qm stop ${self.triggers_replace.vmid} 2>/dev/null; \
          qm destroy ${self.triggers_replace.vmid} --purge"
     EOT

--- a/tests/unit/providers/proxmox/test_ova_vms.py
+++ b/tests/unit/providers/proxmox/test_ova_vms.py
@@ -348,3 +348,23 @@ class TestOVATriggers:
         vms = [_make_ova_vm(name="my-vm")]
         content = _render_ova_vms(provider, vms)
         assert 'name       = "my-vm"' in content
+
+    def test_triggers_include_ssh_fields(self, provider):
+        """Triggers should include ssh_cmd, ssh_user, and ssh_target for destroy provisioner."""
+        vms = [_make_ova_vm()]
+        content = _render_ova_vms(provider, vms)
+        assert "ssh_cmd    = local.ssh_cmd" in content
+        assert "ssh_user   = var.proxmox_ssh_user" in content
+        assert 'ssh_target = "10.0.0.1"' in content
+
+    def test_destroy_uses_self_ssh_references(self, provider):
+        """Destroy provisioner must use self.triggers_replace for SSH, not local/var."""
+        vms = [_make_ova_vm()]
+        content = _render_ova_vms(provider, vms)
+        # Find the destroy provisioner section
+        destroy_idx = content.find("when    = destroy")
+        assert destroy_idx != -1
+        destroy_section = content[destroy_idx:]
+        assert "${self.triggers_replace.ssh_cmd}" in destroy_section
+        assert "${self.triggers_replace.ssh_user}" in destroy_section
+        assert "${self.triggers_replace.ssh_target}" in destroy_section


### PR DESCRIPTION
## Description

Fix the OVA VM destroy provisioner to use `self.triggers_replace.*` instead of `${local.ssh_cmd}` and `${var.proxmox_ssh_user}`. Terraform destroy-time provisioners can only reference `self`, `count.index`, or `each.key` — referencing `local.*` or `var.*` causes a plan/apply error.

Added `ssh_cmd`, `ssh_user`, and `ssh_target` to `triggers_replace` so they are available via `self` in the destroy provisioner.

Addresses #325

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `ssh_cmd`, `ssh_user`, `ssh_target` to `triggers_replace` in `ova_vms.tf.j2`
- Changed destroy provisioner to use `${self.triggers_replace.ssh_cmd}`, `${self.triggers_replace.ssh_user}`, `${self.triggers_replace.ssh_target}`
- Added 2 tests for the new trigger fields and destroy self-references

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
