### PR TITLE
fix: escape shell variables in OVA VM disk import loop for Terraform

### DIFF
--- a/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
@@ -52,8 +52,8 @@ resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
         DISK_INDEX=0
         for VMDK in \$(ls -1 *.vmdk 2>/dev/null | sort); do
           qm disk import ${self.triggers_replace.vmid} \$VMDK {{ vm.config.disk_storage | default('local-lvm') }} --format qcow2
-          DISK_PATH=\$(qm config ${self.triggers_replace.vmid} | grep \"^unused\${DISK_INDEX}:\" | sed 's/^unused[0-9]*: //')
-          qm set ${self.triggers_replace.vmid} --${self.triggers_replace.disk_bus}\${DISK_INDEX} \$DISK_PATH
+          DISK_PATH=\$(qm config ${self.triggers_replace.vmid} | grep \"^unused\$${DISK_INDEX}:\" | sed 's/^unused[0-9]*: //')
+          qm set ${self.triggers_replace.vmid} --${self.triggers_replace.disk_bus}\$${DISK_INDEX} \$DISK_PATH
           DISK_INDEX=\$((DISK_INDEX + 1))
         done
       "


### PR DESCRIPTION
## Description

Fix shell variable `${DISK_INDEX}` being parsed as Terraform interpolation in the OVA VM disk import loop. Changed `\${DISK_INDEX}` to `\$${DISK_INDEX}` so Terraform outputs a literal `$` and the shell variable is passed through correctly.

Addresses #327

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Changed `\${DISK_INDEX}` to `\$${DISK_INDEX}` in two places in `ova_vms.tf.j2` (grep pattern and qm set command)

## Testing

- [x] All existing tests pass (38/38)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
