### PR TITLE
fix: always grep for unused0 in OVA disk import loop

### DIFF
--- a/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
@@ -52,7 +52,7 @@ resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
         DISK_INDEX=0
         for VMDK in \$(ls -1 *.vmdk 2>/dev/null | sort); do
           qm disk import ${self.triggers_replace.vmid} \$VMDK {{ vm.config.disk_storage | default('local-lvm') }} --format qcow2
-          DISK_PATH=\$(qm config ${self.triggers_replace.vmid} | grep \"^unused\$${DISK_INDEX}:\" | sed 's/^unused[0-9]*: //')
+          DISK_PATH=\$(qm config ${self.triggers_replace.vmid} | grep \"^unused0:\" | sed 's/^unused[0-9]*: //')
           qm set ${self.triggers_replace.vmid} --${self.triggers_replace.disk_bus}\$${DISK_INDEX} \$DISK_PATH
           DISK_INDEX=\$((DISK_INDEX + 1))
         done

--- a/tests/unit/providers/proxmox/test_ova_vms.py
+++ b/tests/unit/providers/proxmox/test_ova_vms.py
@@ -103,6 +103,20 @@ class TestOVADiskImport:
         content = _render_ova_vms(provider, vms)
         assert "${self.triggers_replace.disk_bus}" in content
 
+    def test_unused_disk_always_greps_index_zero(self, provider):
+        """Grep for unused disk should always use unused0, not an incrementing index.
+
+        Proxmox renumbers unused disks when one is attached (unused1 becomes
+        unused0, etc.), so the grep must always look for unused0.
+        """
+        vms = [_make_ova_vm()]
+        content = _render_ova_vms(provider, vms)
+        assert 'grep \\"^unused0:\\"' in content
+        # Ensure no incrementing unused index pattern exists
+        assert "unused${DISK_INDEX}" not in content
+        assert "unused\\${DISK_INDEX}" not in content
+        assert "unused\\$${DISK_INDEX}" not in content
+
 
 class TestOVADiskStorage:
     """Tests for disk storage pool rendering."""


### PR DESCRIPTION
## Description

Fix the OVA disk import loop in the Proxmox provider template that fails when importing the 4th or more disks. Proxmox renumbers unused disk slots after each attachment (e.g., `unused1` becomes `unused0` when `unused0` is attached), so the grep must always target `unused0:` instead of using an incrementing `$DISK_INDEX`.

## Related Issue

Addresses #330

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Changed `grep "^unused${DISK_INDEX}:"` to `grep "^unused0:"` in the disk import loop within `ova_vms.tf.j2`
- Added test `test_unused_disk_always_greps_index_zero` to verify the template always greps for `unused0` and never uses an incrementing index

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
