### PR TITLE
fix: use per-VM target_node as SSH target for OVA VMs

### DIFF
--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -130,30 +130,15 @@ class ProxmoxProvider(
 
         Uses terraform_data resources with SSH-based local-exec provisioners to
         extract OVA files, import VMDK disks, and configure VMs via qm commands.
+        Each VM's target_node is used as the SSH target since qm commands must
+        run on the node where the VM will be created.
 
         Args:
             ova_vms: List of OVA VM resource configs (must have ova_source).
         """
-        from urllib.parse import urlparse
-
-        from infrafoundry.core.config import ConfigManager
-
-        # Extract SSH hostname from API URL (same pattern as _generate_templates_terraform)
-        ssh_hostname = None
-        if self._current_environment:
-            config_manager = ConfigManager(self.config_dir)
-            try:
-                env_config = config_manager.load_environment(self._current_environment)
-                provider_settings = env_config.get_provider_settings("proxmox")
-                if provider_settings and "api_url" in provider_settings:
-                    parsed = urlparse(provider_settings["api_url"])
-                    ssh_hostname = parsed.hostname
-            except FileNotFoundError:
-                pass
-
         self.render_and_write_terraform(
             "proxmox/ova_vms.tf.j2",
-            context={"ova_vms": ova_vms, "ssh_hostname": ssh_hostname},
+            context={"ova_vms": ova_vms},
             output_name="ova_vms.tf",
         )
 

--- a/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
@@ -1,6 +1,6 @@
 {% for vm in ova_vms %}
 {% set vm_tf_name = vm.config.name | replace('-', '_') %}
-{% set ssh_target = ssh_hostname if ssh_hostname else vm.config.target_node %}
+{% set ssh_target = vm.config.target_node %}
 # OVA VM: {{ vm.config.name }}
 resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
   triggers_replace = {

--- a/tests/unit/providers/proxmox/test_ova_vms.py
+++ b/tests/unit/providers/proxmox/test_ova_vms.py
@@ -48,9 +48,7 @@ def _make_regular_vm(name: str = "regular-vm", **config_overrides) -> ResourceCo
 def _render_ova_vms(provider: ProxmoxProvider, vms: list[ResourceConfig]) -> str:
     """Normalize OVA VM configs and render through the ova_vms template."""
     processed = [provider._normalize_vm_config(vm) for vm in vms]
-    return provider.render_template(
-        "proxmox/ova_vms.tf.j2", {"ova_vms": processed, "ssh_hostname": "10.0.0.1"}
-    )
+    return provider.render_template("proxmox/ova_vms.tf.j2", {"ova_vms": processed})
 
 
 class TestOVAExtraction:
@@ -291,11 +289,25 @@ class TestOVADefaults:
         content = _render_ova_vms(provider, vms)
         assert "order=sata0;ide2" in content
 
-    def test_ssh_hostname_renders(self, provider):
-        """SSH hostname should render in SSH commands."""
-        vms = [_make_ova_vm()]
+    def test_target_node_used_as_ssh_target(self, provider):
+        """Each VM's target_node should be used as SSH target, not a global ssh_hostname."""
+        vms = [_make_ova_vm(target_node="pve02")]
         content = _render_ova_vms(provider, vms)
-        assert "10.0.0.1" in content
+        assert "pve02" in content
+
+    def test_multiple_vms_use_own_target_nodes(self, provider):
+        """Each VM should SSH to its own target_node, not a shared host."""
+        vms = [
+            _make_ova_vm(name="vm-a", vmid=900, target_node="pve01"),
+            _make_ova_vm(name="vm-b", vmid=901, target_node="pve02"),
+        ]
+        content = _render_ova_vms(provider, vms)
+        # Split by resource blocks to check each VM targets its own node
+        blocks = content.split("# OVA VM:")
+        vm_a_block = next(b for b in blocks if "vm-a" in b)
+        vm_b_block = next(b for b in blocks if "vm-b" in b)
+        assert 'ssh_target = "pve01"' in vm_a_block
+        assert 'ssh_target = "pve02"' in vm_b_block
 
 
 class TestOVAVMRouting:
@@ -369,7 +381,7 @@ class TestOVATriggers:
         content = _render_ova_vms(provider, vms)
         assert "ssh_cmd    = local.ssh_cmd" in content
         assert "ssh_user   = var.proxmox_ssh_user" in content
-        assert 'ssh_target = "10.0.0.1"' in content
+        assert 'ssh_target = "pve01"' in content
 
     def test_destroy_uses_self_ssh_references(self, provider):
         """Destroy provisioner must use self.triggers_replace for SSH, not local/var."""


### PR DESCRIPTION
## Description

The OVA VM template used a single `ssh_hostname` (extracted from the Proxmox API URL) as the SSH target for all VMs. Since `qm` commands only operate on the local node's VMs, this caused all OVA VMs to be created on the API host instead of their designated `target_node`.

Removed the `ssh_hostname` extraction logic from `_generate_ova_vms_terraform` and updated the Jinja2 template to use each VM's `target_node` directly as the SSH target.

Addresses #332

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Removed `ssh_hostname` extraction from Proxmox API URL in `_generate_ova_vms_terraform`
- Simplified template context to pass only `ova_vms` (no longer passes `ssh_hostname`)
- Updated `ova_vms.tf.j2` to use `vm.config.target_node` directly instead of preferring `ssh_hostname`
- Replaced `test_ssh_hostname_renders` with `test_target_node_used_as_ssh_target`
- Added `test_multiple_vms_use_own_target_nodes` to verify each VM targets its own node

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type_check, security, spell_check, test)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
