### PR TITLE
feat: emit runner lifecycle events in deployment executor

### DIFF
--- a/docs/architecture/events.md
+++ b/docs/architecture/events.md
@@ -90,18 +90,23 @@ Categorized event types for different lifecycle phases and operations.
    - `RESOURCE_DELETED`
    - `RESOURCE_FAILED`
 
-3. **Drift Events** - Configuration drift detection
+3. **Runner Events** - Runner lifecycle within a workflow
+   - `RUNNER_STARTING` - Emitted before a runner executes (plan, apply, destroy)
+   - `RUNNER_COMPLETED` - Emitted after a runner finishes successfully
+   - `RUNNER_FAILED` - Emitted when a runner raises an exception
+
+5. **Drift Events** - Configuration drift detection
    - `DRIFT_DETECTED`
    - `DRIFT_REMEDIATION_STARTED`
    - `DRIFT_REMEDIATION_COMPLETED`
    - `DRIFT_REMEDIATION_FAILED`
 
-4. **Policy Events** - Governance validation
+6. **Policy Events** - Governance validation
    - `POLICY_CHECK_STARTED`
    - `POLICY_VIOLATION`
    - `POLICY_CHECK_PASSED`
 
-5. **Validation Events** - Configuration validation
+7. **Validation Events** - Configuration validation
    - `VALIDATION_STARTED`
    - `VALIDATION_COMPLETED`
    - `VALIDATION_FAILED`
@@ -178,6 +183,24 @@ Each event type includes specific data fields:
     "resource_name": "web-01",
     "resource_id": "vm-101",
     "provider": "proxmox"
+}
+```
+
+### Runner Events
+
+```python
+# RUNNER_STARTING / RUNNER_COMPLETED
+{
+    "provider": "proxmox",
+    "runner": "terraform",
+    "success": True          # RUNNER_COMPLETED only
+}
+
+# RUNNER_FAILED
+{
+    "provider": "proxmox",
+    "runner": "terraform",
+    "error": "Command exited with code 1"
 }
 ```
 

--- a/docs/development/event-system.md
+++ b/docs/development/event-system.md
@@ -30,10 +30,50 @@ event_manager.emit_event(EventType.RESOURCE_CREATED, environment="prod", data={"
 
 ## Architecture Details
 
-- **Event types:** Lifecycle (`BEFORE/AFTER/FAILED` for PLAN/APPLY/DESTROY), resource lifecycle (`RESOURCE_*`), drift (`DRIFT_*`), policy (`POLICY_*`), validation.
+- **Event types:** Lifecycle (`BEFORE/AFTER/FAILED` for PLAN/APPLY/DESTROY), runner lifecycle (`RUNNER_STARTING/COMPLETED/FAILED`), resource lifecycle (`RESOURCE_*`), drift (`DRIFT_*`), policy (`POLICY_*`), validation.
 - **Event object:** `event_type`, `environment`, `data` (context), `timestamp`.
 - **Managers:** `EventManager` supports `subscribe`, `subscribe_all`, and `emit_event`.
 - **Integration:** `NotificationManager` listens to events and forwards to configured channels.
+
+### Runner Lifecycle Events
+
+Runner events are emitted in all three workflows (plan, apply, destroy) around each runner invocation:
+
+- `RUNNER_STARTING` - Before `runner.plan()`, `runner.apply()`, or `runner.destroy()`
+- `RUNNER_COMPLETED` - After a runner finishes successfully
+- `RUNNER_FAILED` - When a runner raises an exception (the exception is re-raised)
+
+The `EventContext` includes `provider` and `runner` fields, and the `data` dict carries a `RunnerEventData` payload with `provider`, `runner`, and optionally `success` or `error`.
+
+**ScriptHandler** exposes the runner name as `INFRAFOUNDRY_RUNNER` environment variable, allowing scripts to filter by runner type:
+
+| Variable | Set When |
+| :--- | :--- |
+| `INFRAFOUNDRY_ENV` | Always |
+| `INFRAFOUNDRY_EVENT` | Always |
+| `INFRAFOUNDRY_PROVIDER` | `context.provider` is set |
+| `INFRAFOUNDRY_RESOURCE` | `context.resource` is set |
+| `INFRAFOUNDRY_RUNNER` | `context.runner` is set |
+| `INFRAFOUNDRY_CONFIG_DIR` | Always |
+| `INFRAFOUNDRY_DEPLOYMENT_ID` | `context.deployment_id` is set |
+
+**Example:** Run an Ansible playbook after Terraform finishes for a specific provider:
+
+```yaml
+events:
+  - type: script
+    on: runner_completed
+    script: scripts/post-terraform.sh
+    description: "Run post-Terraform Ansible setup"
+```
+
+```bash
+#!/bin/bash
+# scripts/post-terraform.sh
+if [ "$INFRAFOUNDRY_RUNNER" = "terraform" ] && [ "$INFRAFOUNDRY_PROVIDER" = "proxmox" ]; then
+    ansible-playbook -i inventory.yml site.yml
+fi
+```
 
 ## Validation and Checks
 

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -14,7 +14,7 @@ from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.runners import RunnerRegistry
 from infrafoundry.core.runners.base_runner import BaseRunner
 from infrafoundry.core.state import ResourceState, StateManager
-from infrafoundry.core.types import ResourceEventData
+from infrafoundry.core.types import ResourceEventData, RunnerEventData
 
 # Registry keys for mutually exclusive IaC runners
 _IAC_TOOL_KEYS = {tool.value for tool in IaCTool}
@@ -334,14 +334,54 @@ class DeploymentExecutor:
 
             self.console.print(f"  [dim]Running {tool_name} apply...[/dim]")
 
-            # Ansible interprets auto_approve=False as check mode (dry-run)
-            # Other runners use it to skip confirmation prompts
-            run_result = runner.apply(
-                provider,
-                auto_approve=auto_approve,
-                target_resources=resource_filter if resource_filter else None,
+            starting_event: RunnerEventData = {
+                "provider": provider_name,
+                "runner": tool_name,
+            }
+            self.event_manager.emit_event(
+                EventType.RUNNER_STARTING,
+                env_name,
+                starting_event,
+                provider=provider_name,
+                runner=tool_name,
             )
-            runner_results[tool_name] = run_result
+
+            try:
+                # Ansible interprets auto_approve=False as check mode (dry-run)
+                # Other runners use it to skip confirmation prompts
+                run_result = runner.apply(
+                    provider,
+                    auto_approve=auto_approve,
+                    target_resources=resource_filter if resource_filter else None,
+                )
+                runner_results[tool_name] = run_result
+
+                completed_event: RunnerEventData = {
+                    "provider": provider_name,
+                    "runner": tool_name,
+                    "success": run_result.get("success", True),
+                }
+                self.event_manager.emit_event(
+                    EventType.RUNNER_COMPLETED,
+                    env_name,
+                    completed_event,
+                    provider=provider_name,
+                    runner=tool_name,
+                )
+            except Exception as exc:
+                failed_event: RunnerEventData = {
+                    "provider": provider_name,
+                    "runner": tool_name,
+                    "error": str(exc),
+                }
+                self.event_manager.emit_event(
+                    EventType.RUNNER_FAILED,
+                    env_name,
+                    failed_event,
+                    provider=provider_name,
+                    runner=tool_name,
+                )
+                raise
 
             # Update state with resource IDs if the runner supports state tracking
             if run_result["success"] and isinstance(runner, StateAware):

--- a/src/infrafoundry/core/events/context.py
+++ b/src/infrafoundry/core/events/context.py
@@ -5,10 +5,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from infrafoundry.core.events.types import EventType
-from infrafoundry.core.types import DeploymentEventData, ResourceEventData
+from infrafoundry.core.types import DeploymentEventData, ResourceEventData, RunnerEventData
 
 # Backward compatibility type aliases from legacy EventManager
-type EventPayload = ResourceEventData | DeploymentEventData | dict[str, Any]
+type EventPayload = ResourceEventData | DeploymentEventData | RunnerEventData | dict[str, Any]
 
 
 @dataclass

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -26,6 +26,7 @@ class ScriptHandler(BaseHandler):
         INFRAFOUNDRY_EVENT: Event type
         INFRAFOUNDRY_PROVIDER: Provider name (if applicable)
         INFRAFOUNDRY_RESOURCE: Resource name (if applicable)
+        INFRAFOUNDRY_RUNNER: Runner name (if applicable, e.g., "terraform")
         INFRAFOUNDRY_CONFIG_DIR: Path to environment config directory
 
     Example config:
@@ -182,6 +183,9 @@ class ScriptHandler(BaseHandler):
 
         if context.resource:
             env["INFRAFOUNDRY_RESOURCE"] = context.resource
+
+        if context.runner:
+            env["INFRAFOUNDRY_RUNNER"] = context.runner
 
         if context.deployment_id:
             env["INFRAFOUNDRY_DEPLOYMENT_ID"] = str(context.deployment_id)

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -30,6 +30,7 @@ from infrafoundry.core.types import (
     PlanDeploymentMetadata,
     RollbackData,
     RollbackDeploymentMetadata,
+    RunnerEventData,
 )
 from infrafoundry.core.validation import ValidationReport
 
@@ -437,12 +438,53 @@ class PlanOrchestrator(HookExecutionMixin):
                             )
                             generate_method(generate_resources)
                             self.console.print(f"  [dim]Running {tool_name} plan...[/dim]")
-                            # Pass resource filter as target names for terraform
-                            runner_result = runner.plan(
-                                provider,
-                                target_resources=resource_filter if resource_filter else None,
+
+                            starting_event: RunnerEventData = {
+                                "provider": provider_name,
+                                "runner": tool_name,
+                            }
+                            self.event_manager.emit_event(
+                                EventType.RUNNER_STARTING,
+                                env_name,
+                                starting_event,
+                                provider=provider_name,
+                                runner=tool_name,
                             )
-                            provider_results[f"{tool_name}_plan"] = runner_result
+
+                            try:
+                                # Pass resource filter as target names for terraform
+                                runner_result = runner.plan(
+                                    provider,
+                                    target_resources=resource_filter if resource_filter else None,
+                                )
+                                provider_results[f"{tool_name}_plan"] = runner_result
+
+                                completed_event: RunnerEventData = {
+                                    "provider": provider_name,
+                                    "runner": tool_name,
+                                    "success": True,
+                                }
+                                self.event_manager.emit_event(
+                                    EventType.RUNNER_COMPLETED,
+                                    env_name,
+                                    completed_event,
+                                    provider=provider_name,
+                                    runner=tool_name,
+                                )
+                            except Exception as exc:
+                                failed_event: RunnerEventData = {
+                                    "provider": provider_name,
+                                    "runner": tool_name,
+                                    "error": str(exc),
+                                }
+                                self.event_manager.emit_event(
+                                    EventType.RUNNER_FAILED,
+                                    env_name,
+                                    failed_event,
+                                    provider=provider_name,
+                                    runner=tool_name,
+                                )
+                                raise
                         else:
                             self.console.print(
                                 f"  [dim]Skipping {tool_name} for {provider_name}: "
@@ -953,12 +995,53 @@ class DestroyOrchestrator(HookExecutionMixin):
                         continue
 
                     self.console.print(f"  [dim]Running {tool_name} destroy...[/dim]")
-                    runner_result = runner.destroy(
-                        provider,
-                        auto_approve=auto_approve,
-                        target_resources=resource_filter if resource_filter else None,
+
+                    starting_event: RunnerEventData = {
+                        "provider": provider_name,
+                        "runner": tool_name,
+                    }
+                    self.event_manager.emit_event(
+                        EventType.RUNNER_STARTING,
+                        env_name,
+                        starting_event,
+                        provider=provider_name,
+                        runner=tool_name,
                     )
-                    provider_results[tool_name] = runner_result
+
+                    try:
+                        runner_result = runner.destroy(
+                            provider,
+                            auto_approve=auto_approve,
+                            target_resources=resource_filter if resource_filter else None,
+                        )
+                        provider_results[tool_name] = runner_result
+
+                        completed_event: RunnerEventData = {
+                            "provider": provider_name,
+                            "runner": tool_name,
+                            "success": True,
+                        }
+                        self.event_manager.emit_event(
+                            EventType.RUNNER_COMPLETED,
+                            env_name,
+                            completed_event,
+                            provider=provider_name,
+                            runner=tool_name,
+                        )
+                    except Exception as exc:
+                        failed_event: RunnerEventData = {
+                            "provider": provider_name,
+                            "runner": tool_name,
+                            "error": str(exc),
+                        }
+                        self.event_manager.emit_event(
+                            EventType.RUNNER_FAILED,
+                            env_name,
+                            failed_event,
+                            provider=provider_name,
+                            runner=tool_name,
+                        )
+                        raise
 
                 self._finalize_destroyed_resources(env_name, provider_name, resource_ids)
 

--- a/src/infrafoundry/core/types.py
+++ b/src/infrafoundry/core/types.py
@@ -144,6 +144,15 @@ class DeploymentEventData(TypedDict, total=False):
     error: str | None
 
 
+class RunnerEventData(TypedDict, total=False):
+    """Event payload for runner lifecycle events."""
+
+    provider: str
+    runner: str
+    success: bool
+    error: str | None
+
+
 class RollbackResourceSnapshot(TypedDict):
     """Snapshot of a single resource for rollback purposes."""
 
@@ -181,5 +190,6 @@ __all__ = [
     "RollbackData",
     "RollbackDeploymentMetadata",
     "RollbackResourceSnapshot",
+    "RunnerEventData",
     "SSHConfigData",
 ]

--- a/tests/unit/test_deployment_executor.py
+++ b/tests/unit/test_deployment_executor.py
@@ -590,3 +590,146 @@ def test_get_sorted_runners_filters_inactive_iac_tool():
     assert "opentofu" in names
     assert "terraform" not in names
     assert "ansible" in names
+
+
+def test_apply_emits_runner_starting_and_completed():
+    """Runner events are emitted around each runner.apply() call."""
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = ["terraform"]
+
+    tf_runner = MagicMock()
+    tf_runner.priority = 0
+    tf_runner.apply = MagicMock(return_value={"success": True})
+    tf_runner.plan = MagicMock()
+    tf_runner.destroy = MagicMock()
+    tf_runner.get_resource_ids = MagicMock(return_value={})
+
+    runner_registry.create_runner.return_value = tf_runner
+
+    state_manager = MagicMock()
+    state_manager.track_resource.return_value = MagicMock(id=1, terraform_id=None)
+    event_manager = MagicMock()
+
+    provider = MagicMock()
+    providers = {"proxmox": provider}
+    resources = [_resource("vm1")]
+
+    executor = DeploymentExecutor(
+        runner_registry=runner_registry,
+        state_manager=state_manager,
+        event_manager=event_manager,
+        providers=providers,
+    )
+
+    executor.apply_single_provider(
+        env_name="dev",
+        deployment_id=1,
+        provider_name="proxmox",
+        provider=provider,
+        resources=resources,
+        auto_approve=True,
+    )
+
+    # Extract runner event calls
+    starting_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_STARTING
+    ]
+    completed_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_COMPLETED
+    ]
+
+    assert len(starting_calls) == 1
+    assert len(completed_calls) == 1
+
+    # Verify data and kwargs
+    assert starting_calls[0][0][2] == {"provider": "proxmox", "runner": "terraform"}
+    assert starting_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+
+    assert completed_calls[0][0][2] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "success": True,
+    }
+    assert completed_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+
+    # Verify ordering: STARTING before apply, COMPLETED after
+    all_call_types = [call[0][0] for call in event_manager.emit_event.call_args_list]
+    starting_idx = all_call_types.index(EventType.RUNNER_STARTING)
+    completed_idx = all_call_types.index(EventType.RUNNER_COMPLETED)
+    assert starting_idx < completed_idx
+
+
+def test_apply_emits_runner_failed_on_exception():
+    """RUNNER_FAILED is emitted when runner.apply() raises, and exception propagates."""
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = ["terraform"]
+
+    tf_runner = MagicMock()
+    tf_runner.priority = 0
+    tf_runner.apply = MagicMock(side_effect=RuntimeError("terraform crashed"))
+    tf_runner.plan = MagicMock()
+    tf_runner.destroy = MagicMock()
+    tf_runner.get_resource_ids = MagicMock(return_value={})
+
+    runner_registry.create_runner.return_value = tf_runner
+
+    state_manager = MagicMock()
+    state_manager.track_resource.return_value = MagicMock(id=1, terraform_id=None)
+    event_manager = MagicMock()
+
+    provider = MagicMock()
+    providers = {"proxmox": provider}
+    resources = [_resource("vm1")]
+
+    executor = DeploymentExecutor(
+        runner_registry=runner_registry,
+        state_manager=state_manager,
+        event_manager=event_manager,
+        providers=providers,
+    )
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="terraform crashed"):
+        executor.apply_single_provider(
+            env_name="dev",
+            deployment_id=1,
+            provider_name="proxmox",
+            provider=provider,
+            resources=resources,
+            auto_approve=True,
+        )
+
+    # RUNNER_STARTING should have been emitted
+    starting_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_STARTING
+    ]
+    assert len(starting_calls) == 1
+
+    # RUNNER_FAILED should have been emitted with error details
+    failed_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_FAILED
+    ]
+    assert len(failed_calls) == 1
+    assert failed_calls[0][0][2] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "error": "terraform crashed",
+    }
+    assert failed_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+
+    # RUNNER_COMPLETED should NOT have been emitted
+    completed_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_COMPLETED
+    ]
+    assert len(completed_calls) == 0

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,8 +1,12 @@
-"""Unit tests for EventManager."""
+"""Unit tests for EventManager and event handlers."""
+
+from pathlib import Path
 
 import pytest
 
 from infrafoundry.core.events import Event, EventHandlerError, EventManager, EventType
+from infrafoundry.core.events.context import EventContext
+from infrafoundry.core.events.handlers.script import ScriptHandler
 
 
 @pytest.mark.unit
@@ -194,3 +198,30 @@ class TestEventManager:
 
         # Should not raise exception when unsubscribing non-existent handler
         manager.unsubscribe(EventType.BEFORE_PLAN, handler)
+
+
+@pytest.mark.unit
+class TestScriptHandlerEnvironment:
+    """Tests for ScriptHandler._prepare_environment."""
+
+    def test_runner_env_var_injected_when_present(self, tmp_path: Path):
+        """INFRAFOUNDRY_RUNNER is set when context.runner is provided."""
+        handler = ScriptHandler({"script": "test.sh"}, config_base_dir=tmp_path)
+        context = EventContext(
+            event_type=EventType.RUNNER_COMPLETED,
+            environment="dev",
+            runner="terraform",
+            provider="proxmox",
+        )
+        env = handler._prepare_environment(context, tmp_path)
+        assert env["INFRAFOUNDRY_RUNNER"] == "terraform"
+
+    def test_runner_env_var_omitted_when_none(self, tmp_path: Path):
+        """INFRAFOUNDRY_RUNNER is not set when context.runner is None."""
+        handler = ScriptHandler({"script": "test.sh"}, config_base_dir=tmp_path)
+        context = EventContext(
+            event_type=EventType.BEFORE_PLAN,
+            environment="dev",
+        )
+        env = handler._prepare_environment(context, tmp_path)
+        assert "INFRAFOUNDRY_RUNNER" not in env

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -264,6 +264,138 @@ def test_status_orchestrator_marks_unregistered_provider(console):
     assert "Not registered" in rows[0][2]
 
 
+def test_plan_emits_runner_starting_and_completed(console):
+    """Runner events are emitted around each runner.plan() call."""
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 10
+    event_manager = MagicMock()
+
+    tf_runner = MagicMock()
+    tf_runner.priority = 0
+    tf_runner.plan = MagicMock(return_value={"success": True})
+
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = ["terraform"]
+    runner_registry.create_runner.return_value = tf_runner
+
+    provider = MagicMock()
+    provider.generate_terraform = MagicMock()
+    providers = {"proxmox": provider}
+
+    def load_resources(env: str):
+        res = [_resource("vm1")]
+        return res, {"proxmox": res}
+
+    orchestrator = PlanOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        runner_registry,
+        get_providers=lambda: providers,
+        load_resources=load_resources,
+        iter_provider_batches=lambda resources_by_provider, filt, reverse, env_name: [
+            ProviderResourceBatch("proxmox", resources_by_provider["proxmox"], 1)
+        ],
+        validate_resources=MagicMock(),
+        has_policies=lambda: False,
+        check_policies=MagicMock(),
+        secret_manager_factory=MagicMock(),
+        get_current_user=lambda: "tester",
+        fail_on_missing_secrets=False,
+        get_runner_priorities=lambda _: {},
+    )
+
+    orchestrator.plan(env_name="dev", dry_run=False, resource_filter=None, enforce_policies=False)
+
+    starting_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_STARTING
+    ]
+    completed_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_COMPLETED
+    ]
+
+    assert len(starting_calls) == 1
+    assert len(completed_calls) == 1
+    assert starting_calls[0][0][2] == {"provider": "proxmox", "runner": "terraform"}
+    assert starting_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+    assert completed_calls[0][0][2] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "success": True,
+    }
+
+
+def test_destroy_emits_runner_starting_and_completed(console):
+    """Runner events are emitted around each runner.destroy() call."""
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 20
+    state_manager.track_resource.return_value = MagicMock(id=1, terraform_id=None)
+    event_manager = MagicMock()
+
+    tf_runner = MagicMock()
+    tf_runner.priority = 0
+    tf_runner.destroy = MagicMock(return_value={"success": True})
+
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = ["terraform"]
+
+    runners = {"terraform": tf_runner}
+
+    provider = MagicMock()
+    providers = {"proxmox": provider}
+
+    def load_resources(env: str):
+        res = [_resource("vm1")]
+        return res, {"proxmox": res}
+
+    orchestrator = DestroyOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        runner_registry,
+        get_providers=lambda: providers,
+        load_resources=load_resources,
+        iter_provider_batches=lambda resources_by_provider, filt, reverse, env_name: [
+            ProviderResourceBatch("proxmox", resources_by_provider["proxmox"], 1)
+        ],
+        get_current_user=lambda: "tester",
+    )
+    # Inject runners directly for the destroy loop
+    orchestrator.runners = runners
+
+    orchestrator.destroy(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        confirm_callback=lambda: True,
+    )
+
+    starting_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_STARTING
+    ]
+    completed_calls = [
+        call
+        for call in event_manager.emit_event.call_args_list
+        if call[0][0] == EventType.RUNNER_COMPLETED
+    ]
+
+    assert len(starting_calls) == 1
+    assert len(completed_calls) == 1
+    assert starting_calls[0][0][2] == {"provider": "proxmox", "runner": "terraform"}
+    assert starting_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+    assert completed_calls[0][0][2] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "success": True,
+    }
+
+
 def test_drift_orchestrator_sets_providers():
     """DriftOrchestrator injects providers before detection."""
     drift_detector = MagicMock()


### PR DESCRIPTION
## Description

Emit `RUNNER_STARTING`, `RUNNER_COMPLETED`, and `RUNNER_FAILED` lifecycle events around every runner invocation (plan, apply, destroy) in the deployment executor and orchestrator workflows. This enables event-driven integrations (e.g., script handlers, notifications) to react to individual runner executions with full provider and runner context.

Addresses #334

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Added `RunnerEventData` TypedDict to `src/infrafoundry/core/types.py` for typed runner event payloads (`provider`, `runner`, `success`, `error`)
- Wrapped `runner.apply()` in `DeploymentExecutor.apply_single_provider()` with RUNNER_STARTING/COMPLETED/FAILED events
- Wrapped `runner.plan()` in `PlanOrchestrator.plan()` with RUNNER_STARTING/COMPLETED/FAILED events
- Wrapped `runner.destroy()` in `DestroyOrchestrator.destroy()` with RUNNER_STARTING/COMPLETED/FAILED events
- Added `RunnerEventData` to the `EventPayload` union type in `events/context.py`
- Added `INFRAFOUNDRY_RUNNER` environment variable to `ScriptHandler._prepare_environment()` when `context.runner` is set
- Updated `docs/architecture/events.md` with Runner Events category and data conventions
- Updated `docs/development/event-system.md` with runner lifecycle events section, env var table, and script example

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (all checks green)

New tests added:
- `test_apply_emits_runner_starting_and_completed` — verifies RUNNER_STARTING and RUNNER_COMPLETED around `runner.apply()`
- `test_apply_emits_runner_failed_on_exception` — verifies RUNNER_FAILED on exception with error propagation
- `test_plan_emits_runner_starting_and_completed` — verifies events around `runner.plan()`
- `test_destroy_emits_runner_starting_and_completed` — verifies events around `runner.destroy()`
- `test_runner_env_var_injected_when_present` — verifies `INFRAFOUNDRY_RUNNER` env var in ScriptHandler
- `test_runner_env_var_omitted_when_none` — verifies env var is absent when no runner context

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
