### PR TITLE
fix: show event handler output and resolve scripts from config repo

### DIFF
--- a/src/infrafoundry/cli/main.py
+++ b/src/infrafoundry/cli/main.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from rich.console import Console
 
 from infrafoundry.core.config import ConfigManager
+from infrafoundry.core.events import EventManager
 from infrafoundry.core.orchestrator import Orchestrator, OrchestratorStrictConfig
 
 # Load environment variables
@@ -76,9 +77,13 @@ def _get_orchestrator(
     else:
         config_manager = ConfigManager()
 
+    # Create event manager with config repo path for script handler resolution
+    event_manager = EventManager(config_base_dir=config_repo.resolve()) if config_repo else None
+
     # Create orchestrator (SecretManager is created per-operation now)
     orchestrator = Orchestrator(
         config_manager,
+        event_manager=event_manager,
         strict_config=strict_config,
         policy_dir=config_repo / "policies" if config_repo else None,
     )

--- a/src/infrafoundry/core/events/bus.py
+++ b/src/infrafoundry/core/events/bus.py
@@ -9,6 +9,8 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
+from rich.console import Console
+
 from infrafoundry.core.base_manager import BaseManager
 from infrafoundry.core.events.context import Event, EventContext, EventResult
 from infrafoundry.core.events.handlers.base import BaseHandler
@@ -89,16 +91,19 @@ class UnifiedEventBus(BaseManager):
         self,
         config_base_dir: Path | None = None,
         secret_resolver: Callable[[str, str], str] | None = None,
+        console: Console | None = None,
     ) -> None:
         """Initialize the event bus.
 
         Args:
             config_base_dir: Base directory for config (for script handlers)
             secret_resolver: Function to resolve secrets (env_name, secret_path) -> value
+            console: Rich console for user-facing output
         """
         super().__init__()
         self.config_base_dir = config_base_dir or Path.cwd()
         self.secret_resolver = secret_resolver
+        self.console = console or Console()
 
         # Handlers by event type
         self._handlers: dict[EventType, list[BaseHandler]] = defaultdict(list)
@@ -226,6 +231,7 @@ class UnifiedEventBus(BaseManager):
         for handler in self._handlers[event_type]:
             result = self._execute_handler(handler, context, results)
             results.append(result)
+            self._print_handler_result(handler, result)
 
             # Check for abort
             if result.abort and abort_on_failure and event_type in ABORTABLE_EVENTS:
@@ -303,6 +309,34 @@ class UnifiedEventBus(BaseManager):
                 reason=f"Handler error: {e}",
                 handler_name=handler.name,
             )
+
+    def _print_handler_result(
+        self,
+        handler: BaseHandler,
+        result: EventResult,
+    ) -> None:
+        """Print handler execution result to console.
+
+        Args:
+            handler: The handler that was executed
+            result: The result from the handler
+        """
+        name = handler.name
+        if result.success:
+            self.console.print(f"  [green]✓[/green] Event handler [bold]{name}[/bold] completed")
+            if result.stdout:
+                for line in result.stdout.strip().splitlines():
+                    self.console.print(f"    {line}")
+        else:
+            self.console.print(
+                f"  [red]✗[/red] Event handler [bold]{name}[/bold] failed: {result.reason}"
+            )
+            if result.stderr:
+                for line in result.stderr.strip().splitlines():
+                    self.console.print(f"    [red]{line}[/red]")
+            if result.stdout:
+                for line in result.stdout.strip().splitlines():
+                    self.console.print(f"    {line}")
 
     def _invoke_callback(
         self,


### PR DESCRIPTION
## Description

Fix two bugs in the event handler system introduced with the events config wiring (#336/#337):

1. **Silent handler execution**: Event handlers ran with `capture_output=True` and results were discarded by all `emit_event()` callers — handlers could fail completely with zero user visibility.

2. **Wrong script path resolution**: `ScriptHandler` resolved scripts relative to `Path.cwd()` (the framework repo) instead of the config repo passed via `-c`. Scripts in `settings.yaml` would always get "Script not found" when using an external config repo.

## Related Issue

Addresses #338

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **`src/infrafoundry/cli/main.py`**: Create `EventManager` with `config_base_dir=config_repo.resolve()` and pass it to the `Orchestrator` so `ScriptHandler` resolves scripts relative to the config repo.
- **`src/infrafoundry/core/events/bus.py`**: Add `console` parameter to `UnifiedEventBus.__init__()` and `_print_handler_result()` method that prints handler results after each execution:
  - `✓ Event handler {name} completed` with stdout lines
  - `✗ Event handler {name} failed: {reason}` with stderr and stdout lines

## Testing

- [x] All existing tests pass (42 event/deployment/hook tests + 15 orchestrator workflow tests)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

Manual testing confirmed:
- Handler output now visible in `infra apply` output
- Script correctly resolved from config repo
- Filtering (`runner != terraform || provider != proxmox`) shows "Skipping" on success
- Failed handlers show error details (e.g., missing Ansible role)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
