### PR TITLE
feat: stream event handler output in real-time

### DIFF
--- a/docs/development/event-system.md
+++ b/docs/development/event-system.md
@@ -93,6 +93,16 @@ if [ "$INFRAFOUNDRY_RUNNER" = "terraform" ] && [ "$INFRAFOUNDRY_PROVIDER" = "pro
 fi
 ```
 
+### Real-Time Output Streaming
+
+Script handlers stream stdout and stderr to the console in real-time, line by line, instead of buffering all output until the script completes. This is essential for long-running handlers (e.g., Ansible playbooks) where the user needs to see progress.
+
+- **stdout** lines are printed with 4-space indent
+- **stderr** lines are printed with 4-space indent and `[red]` Rich styling
+- Output is still captured in `EventResult.stdout` and `EventResult.stderr` for programmatic use
+- The summary line (success/failure) is printed after the script finishes, but the output is not re-printed since it was already streamed
+- When no console is available (e.g., programmatic usage), output is captured silently as before
+
 ## Validation and Checks
 
 - Use consistent event types to ensure subscribers receive expected notifications.

--- a/src/infrafoundry/core/events/bus.py
+++ b/src/infrafoundry/core/events/bus.py
@@ -158,6 +158,7 @@ class UnifiedEventBus(BaseManager):
                 config,
                 config_base_dir=self.config_base_dir,
                 secret_resolver=self.secret_resolver,
+                console=self.console,
             )
 
         elif handler_type == HandlerType.WEBHOOK.value:
@@ -317,26 +318,32 @@ class UnifiedEventBus(BaseManager):
     ) -> None:
         """Print handler execution result to console.
 
+        For ScriptHandlers with a console, output was already streamed in
+        real-time, so only the summary line is printed (not stdout/stderr).
+
         Args:
             handler: The handler that was executed
             result: The result from the handler
         """
         name = handler.name
+        already_streamed = isinstance(handler, ScriptHandler) and handler.console is not None
+
         if result.success:
             self.console.print(f"  [green]✓[/green] Event handler [bold]{name}[/bold] completed")
-            if result.stdout:
+            if result.stdout and not already_streamed:
                 for line in result.stdout.strip().splitlines():
                     self.console.print(f"    {line}")
         else:
             self.console.print(
                 f"  [red]✗[/red] Event handler [bold]{name}[/bold] failed: {result.reason}"
             )
-            if result.stderr:
-                for line in result.stderr.strip().splitlines():
-                    self.console.print(f"    [red]{line}[/red]")
-            if result.stdout:
-                for line in result.stdout.strip().splitlines():
-                    self.console.print(f"    {line}")
+            if not already_streamed:
+                if result.stderr:
+                    for line in result.stderr.strip().splitlines():
+                        self.console.print(f"    [red]{line}[/red]")
+                if result.stdout:
+                    for line in result.stdout.strip().splitlines():
+                        self.console.print(f"    {line}")
 
     def _invoke_callback(
         self,

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -1,14 +1,20 @@
 """Shell script handler for events."""
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess  # nosec B404 - required for running user scripts
+import threading
 import time
 from pathlib import Path
-from typing import Any, override
+from typing import IO, TYPE_CHECKING, Any, override
 
 from infrafoundry.core.events.context import EventContext, EventResult
 from infrafoundry.core.events.handlers.base import BaseHandler
+
+if TYPE_CHECKING:
+    from rich.console import Console
 
 
 class ScriptHandler(BaseHandler):
@@ -46,6 +52,7 @@ class ScriptHandler(BaseHandler):
         config: dict[str, Any],
         config_base_dir: Path | None = None,
         secret_resolver: Any | None = None,
+        console: Console | None = None,
     ) -> None:
         """Initialize script handler.
 
@@ -53,10 +60,12 @@ class ScriptHandler(BaseHandler):
             config: Handler configuration
             config_base_dir: Base directory for config (contains envs/)
             secret_resolver: Optional callable to resolve secrets
+            console: Rich console for real-time output streaming
         """
         super().__init__(config)
         self.config_base_dir = config_base_dir or Path.cwd()
         self.secret_resolver = secret_resolver
+        self.console = console
 
     @override
     def validate_config(self) -> list[str]:
@@ -105,38 +114,62 @@ class ScriptHandler(BaseHandler):
         # Prepare environment
         env = self._prepare_environment(context, env_dir)
 
-        # Execute script
+        # Execute script with real-time streaming
         start_time = time.monotonic()
         try:
-            result = subprocess.run(  # nosec B603 - user-controlled scripts
+            process = subprocess.Popen(  # nosec B603 - user-controlled scripts
                 [str(script_path)],
                 cwd=env_dir,
                 env=env,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=timeout,
             )
+
+            stdout_lines: list[str] = []
+            stderr_lines: list[str] = []
+
+            stdout_thread = threading.Thread(
+                target=self._read_stream,
+                args=(process.stdout, stdout_lines, ""),
+                daemon=True,
+            )
+            stderr_thread = threading.Thread(
+                target=self._read_stream,
+                args=(process.stderr, stderr_lines, "red"),
+                daemon=True,
+            )
+            stdout_thread.start()
+            stderr_thread.start()
+
+            try:
+                process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout_thread.join(timeout=5)
+                stderr_thread.join(timeout=5)
+                duration = time.monotonic() - start_time
+                return EventResult(
+                    success=False,
+                    abort=not self.config.get("continue_on_error", False),
+                    reason=f"Timeout after {timeout} seconds",
+                    stdout="\n".join(stdout_lines),
+                    stderr="\n".join(stderr_lines),
+                    duration_seconds=duration,
+                    handler_name=self.name,
+                )
+
+            stdout_thread.join(timeout=5)
+            stderr_thread.join(timeout=5)
             duration = time.monotonic() - start_time
 
-            success = result.returncode == 0
+            success = process.returncode == 0
             return EventResult(
                 success=success,
                 abort=not success and not self.config.get("continue_on_error", False),
-                reason=None if success else f"Exit code: {result.returncode}",
-                stdout=result.stdout,
-                stderr=result.stderr,
-                duration_seconds=duration,
-                handler_name=self.name,
-            )
-
-        except subprocess.TimeoutExpired as e:
-            duration = time.monotonic() - start_time
-            return EventResult(
-                success=False,
-                abort=not self.config.get("continue_on_error", False),
-                reason=f"Timeout after {timeout} seconds",
-                stdout=e.stdout.decode() if e.stdout else "",
-                stderr=e.stderr.decode() if e.stderr else "",
+                reason=None if success else f"Exit code: {process.returncode}",
+                stdout="\n".join(stdout_lines),
+                stderr="\n".join(stderr_lines),
                 duration_seconds=duration,
                 handler_name=self.name,
             )
@@ -156,6 +189,30 @@ class ScriptHandler(BaseHandler):
                 handler_name=self.name,
                 duration_seconds=time.monotonic() - start_time,
             )
+
+    def _read_stream(
+        self,
+        stream: IO[str] | None,
+        collected: list[str],
+        style: str = "",
+    ) -> None:
+        """Read a stream line-by-line, optionally printing to console.
+
+        Args:
+            stream: The stdout or stderr pipe to read
+            collected: List to append lines to for later capture
+            style: Rich style name for console output (e.g. "red" for stderr)
+        """
+        if stream is None:
+            return
+        for line in stream:
+            stripped = line.rstrip("\n")
+            collected.append(stripped)
+            if self.console is not None:
+                if style:
+                    self.console.print(f"    [{style}]{stripped}[/{style}]")
+                else:
+                    self.console.print(f"    {stripped}")
 
     def _prepare_environment(
         self,

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,11 +1,14 @@
 """Unit tests for EventManager and event handlers."""
 
+import stat
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from infrafoundry.core.events import Event, EventHandlerError, EventManager, EventType
-from infrafoundry.core.events.context import EventContext
+from infrafoundry.core.events.bus import UnifiedEventBus
+from infrafoundry.core.events.context import EventContext, EventResult
 from infrafoundry.core.events.handlers.script import ScriptHandler
 
 
@@ -225,3 +228,260 @@ class TestScriptHandlerEnvironment:
         )
         env = handler._prepare_environment(context, tmp_path)
         assert "INFRAFOUNDRY_RUNNER" not in env
+
+
+def _make_script(tmp_path: Path, name: str, content: str) -> Path:
+    """Create an executable script in the expected directory structure.
+
+    Args:
+        tmp_path: Pytest temporary directory
+        name: Script filename
+        content: Script content
+
+    Returns:
+        Path to the script relative to envs/dev/
+    """
+    env_dir = tmp_path / "envs" / "dev"
+    env_dir.mkdir(parents=True, exist_ok=True)
+    script = env_dir / name
+    script.write_text(content)
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return Path(name)
+
+
+@pytest.mark.unit
+class TestScriptHandlerStreaming:
+    """Tests for ScriptHandler real-time output streaming."""
+
+    def test_streaming_prints_stdout_to_console(self, tmp_path: Path):
+        """Stdout lines are printed to console in real-time."""
+        script_rel = _make_script(
+            tmp_path,
+            "echo.sh",
+            "#!/bin/bash\necho line1\necho line2\n",
+        )
+        console = MagicMock()
+        handler = ScriptHandler(
+            {"script": str(script_rel)},
+            config_base_dir=tmp_path,
+            console=console,
+        )
+        context = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="dev",
+        )
+        result = handler.execute(context)
+
+        assert result.success
+        assert "line1" in result.stdout
+        assert "line2" in result.stdout
+        # Console should have been called with each line
+        print_calls = [str(c) for c in console.print.call_args_list]
+        assert any("line1" in c for c in print_calls)
+        assert any("line2" in c for c in print_calls)
+
+    def test_streaming_prints_stderr_with_red_style(self, tmp_path: Path):
+        """Stderr lines are printed to console with red styling."""
+        script_rel = _make_script(
+            tmp_path,
+            "stderr.sh",
+            "#!/bin/bash\necho err_msg >&2\n",
+        )
+        console = MagicMock()
+        handler = ScriptHandler(
+            {"script": str(script_rel)},
+            config_base_dir=tmp_path,
+            console=console,
+        )
+        context = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="dev",
+        )
+        result = handler.execute(context)
+
+        assert "err_msg" in result.stderr
+        print_calls = [str(c) for c in console.print.call_args_list]
+        assert any("[red]" in c and "err_msg" in c for c in print_calls)
+
+    def test_stdout_and_stderr_captured_in_result(self, tmp_path: Path):
+        """EventResult still contains full stdout and stderr."""
+        script_rel = _make_script(
+            tmp_path,
+            "both.sh",
+            "#!/bin/bash\necho out_line\necho err_line >&2\n",
+        )
+        console = MagicMock()
+        handler = ScriptHandler(
+            {"script": str(script_rel)},
+            config_base_dir=tmp_path,
+            console=console,
+        )
+        context = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="dev",
+        )
+        result = handler.execute(context)
+
+        assert result.success
+        assert "out_line" in result.stdout
+        assert "err_line" in result.stderr
+
+    def test_no_console_backward_compat(self, tmp_path: Path):
+        """ScriptHandler works without console (backward compatibility)."""
+        script_rel = _make_script(
+            tmp_path,
+            "compat.sh",
+            "#!/bin/bash\necho hello\n",
+        )
+        handler = ScriptHandler(
+            {"script": str(script_rel)},
+            config_base_dir=tmp_path,
+        )
+        assert handler.console is None
+
+        context = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="dev",
+        )
+        result = handler.execute(context)
+
+        assert result.success
+        assert "hello" in result.stdout
+
+    def test_timeout_kills_process_returns_partial(self, tmp_path: Path):
+        """Timeout kills the process and returns partial output."""
+        script_rel = _make_script(
+            tmp_path,
+            "slow.sh",
+            "#!/bin/bash\necho partial_out\nsleep 60\n",
+        )
+        console = MagicMock()
+        handler = ScriptHandler(
+            {"script": str(script_rel), "timeout": 1},
+            config_base_dir=tmp_path,
+            console=console,
+        )
+        context = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="dev",
+        )
+        result = handler.execute(context)
+
+        assert not result.success
+        assert "Timeout" in (result.reason or "")
+        assert "partial_out" in result.stdout
+
+    def test_empty_output(self, tmp_path: Path):
+        """Empty output produces empty strings in result."""
+        script_rel = _make_script(
+            tmp_path,
+            "empty.sh",
+            "#!/bin/bash\n",
+        )
+        handler = ScriptHandler(
+            {"script": str(script_rel)},
+            config_base_dir=tmp_path,
+        )
+        context = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="dev",
+        )
+        result = handler.execute(context)
+
+        assert result.success
+        assert result.stdout == ""
+        assert result.stderr == ""
+
+
+@pytest.mark.unit
+class TestPrintHandlerResultStreaming:
+    """Tests for _print_handler_result with streaming behavior."""
+
+    def test_skips_reprinting_for_streamed_script_handler(self):
+        """Output is not re-printed for ScriptHandler with console."""
+        console = MagicMock()
+        bus = UnifiedEventBus(console=console)
+
+        handler = ScriptHandler(
+            {"type": "script", "script": "test.sh"},
+            console=console,
+        )
+        result = EventResult(
+            success=True,
+            stdout="already streamed line",
+            handler_name="test",
+        )
+
+        console.reset_mock()
+        bus._print_handler_result(handler, result)
+
+        # Should print summary but NOT re-print stdout
+        calls = [str(c) for c in console.print.call_args_list]
+        assert any("completed" in c for c in calls)
+        assert not any("already streamed line" in c for c in calls)
+
+    def test_skips_reprinting_stderr_for_streamed_script_handler(self):
+        """Stderr is not re-printed for failed ScriptHandler with console."""
+        console = MagicMock()
+        bus = UnifiedEventBus(console=console)
+
+        handler = ScriptHandler(
+            {"type": "script", "script": "test.sh"},
+            console=console,
+        )
+        result = EventResult(
+            success=False,
+            reason="Exit code: 1",
+            stdout="some output",
+            stderr="some error",
+            handler_name="test",
+        )
+
+        console.reset_mock()
+        bus._print_handler_result(handler, result)
+
+        calls = [str(c) for c in console.print.call_args_list]
+        assert any("failed" in c for c in calls)
+        assert not any("some output" in c for c in calls)
+        assert not any("some error" in c for c in calls)
+
+    def test_prints_output_for_non_script_handler(self):
+        """Output is still printed for non-script handlers."""
+        from infrafoundry.core.events.handlers.python import PythonHandler
+
+        console = MagicMock()
+        bus = UnifiedEventBus(console=console)
+
+        handler = PythonHandler({"type": "python", "module": "test"})
+        result = EventResult(
+            success=True,
+            stdout="python handler output",
+            handler_name="test",
+        )
+
+        console.reset_mock()
+        bus._print_handler_result(handler, result)
+
+        calls = [str(c) for c in console.print.call_args_list]
+        assert any("python handler output" in c for c in calls)
+
+    def test_prints_output_for_script_handler_without_console(self):
+        """Output is printed for ScriptHandler without console (no streaming)."""
+        console = MagicMock()
+        bus = UnifiedEventBus(console=console)
+
+        handler = ScriptHandler(
+            {"type": "script", "script": "test.sh"},
+            console=None,
+        )
+        result = EventResult(
+            success=True,
+            stdout="buffered output",
+            handler_name="test",
+        )
+
+        console.reset_mock()
+        bus._print_handler_result(handler, result)
+
+        calls = [str(c) for c in console.print.call_args_list]
+        assert any("buffered output" in c for c in calls)


### PR DESCRIPTION
## Description

Replace `subprocess.run` with `subprocess.Popen` and threaded stream readers in `ScriptHandler` so that stdout and stderr are printed to the Rich console line-by-line as the script runs, instead of being buffered until completion. This is critical for long-running event handlers (e.g., Ansible playbooks) where users need to see progress in real-time.

Addresses #342

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`src/infrafoundry/core/events/handlers/script.py`** — Replaced `subprocess.run` with `subprocess.Popen` plus two daemon threads that read stdout/stderr line-by-line. Added `_read_stream` helper that prints each line to the Rich console (with red styling for stderr) while also collecting lines for `EventResult`. Added optional `console` parameter to constructor.
- **`src/infrafoundry/core/events/bus.py`** — Pass `self.console` to `ScriptHandler` during instantiation. Skip re-printing stdout/stderr in `_print_handler_result` when the handler already streamed output to the console.
- **`tests/unit/test_events.py`** — Added 10 new tests covering: real-time stdout/stderr streaming, backward compatibility without console, timeout with partial output, empty output, and the skip-reprint logic in `_print_handler_result` for both script and non-script handlers.
- **`docs/development/event-system.md`** — Added "Real-Time Output Streaming" section documenting the behavior.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (10 tests in two new test classes)
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
