### PR TITLE
feat: support resource-centric format in package loader

### DIFF
--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -215,14 +215,19 @@ class PackageLoader:
     ) -> list[ResourceConfig]:
         """Extract ResourceConfig objects from parsed YAML data.
 
-        Uses the same logic as ProviderCentricLoader.load_resources:
-        resource type is derived from the filename stem, and both
-        singular and plural key forms are checked.
+        Supports two formats:
+
+        1. **Resource-centric** (``resources:`` key): Each item declares its own
+           ``provider`` and ``type``. The parent provider is used as fallback.
+
+        2. **Provider-centric** (type-named key like ``ova_vms:``): Resource type
+           is derived from the filename stem. Individual items may override
+           ``provider`` via an optional ``provider`` field.
 
         Args:
             data: Parsed YAML data dictionary
             resource_file: Resource filename (e.g., 'vm.yaml')
-            provider: Provider name
+            provider: Default provider name (from parent directory)
 
         Returns:
             List of ResourceConfig objects
@@ -230,7 +235,11 @@ class PackageLoader:
         if not data:
             return []
 
-        # Extract resource type from filename (same logic as ProviderCentricLoader)
+        # Check for resource-centric format first
+        if "resources" in data and isinstance(data["resources"], list):
+            return self._parse_resource_centric(data["resources"], resource_file, provider)
+
+        # Provider-centric: extract resource type from filename
         stem = Path(resource_file).stem
         resource_type = stem.split("-")[0] if "-" in stem else stem
 
@@ -250,12 +259,44 @@ class PackageLoader:
             ResourceConfig(
                 name=item["name"],
                 type=resource_type,
-                provider=provider,
+                provider=item.get("provider", provider),
                 config=item,
             )
             for item in resource_list
             if isinstance(item, dict) and "name" in item
         ]
+
+    def _parse_resource_centric(
+        self, resources: list[Any], resource_file: str, default_provider: str
+    ) -> list[ResourceConfig]:
+        """Parse resource-centric format where each item has provider and type.
+
+        Args:
+            resources: List of resource dicts with provider, type, name, config
+            resource_file: Source filename (for error messages)
+            default_provider: Fallback provider if item lacks one
+
+        Returns:
+            List of ResourceConfig objects
+        """
+        result: list[ResourceConfig] = []
+        for item in resources:
+            if not isinstance(item, dict) or "name" not in item:
+                continue
+            if "type" not in item:
+                raise InvalidConfigurationError(
+                    f"Resource '{item.get('name', '?')}' in {resource_file} "
+                    f"uses resource-centric format but is missing 'type'"
+                )
+            result.append(
+                ResourceConfig(
+                    name=item["name"],
+                    type=item["type"],
+                    provider=item.get("provider", default_provider),
+                    config=item.get("config", item),
+                )
+            )
+        return result
 
     def _rewrite_event_scripts(
         self,

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -479,3 +479,159 @@ class TestLoadPackage:
 
         with pytest.raises(InvalidConfigurationError, match="not found"):
             loader.load_package(pkg_dir, "proxmox", "dev")
+
+
+class TestMultiProviderResources:
+    """Tests for multi-provider resource support in packages."""
+
+    def test_resource_centric_format(self, temp_dir):
+        """Resource-centric format with explicit provider and type per item."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "multi-provider",
+            "resources": ["resources.yaml"],
+        }
+        resource_content = """
+resources:
+  - provider: proxmox
+    type: ova_vm
+    name: ontap-node-01
+    config:
+      vmid: 220
+      target_node: pve1
+  - provider: opnsense
+    type: kea_reservation
+    name: ontap-node-01
+    config:
+      subnet_ref: opt1-infrastructure
+      ip_address: "192.168.10.201"
+"""
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "multi-provider",
+            manifest,
+            {"resources.yaml": resource_content},
+        )
+
+        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        assert len(resources) == 2
+        assert resources[0].provider == "proxmox"
+        assert resources[0].type == "ova_vm"
+        assert resources[0].name == "ontap-node-01"
+        assert resources[1].provider == "opnsense"
+        assert resources[1].type == "kea_reservation"
+
+    def test_resource_centric_default_provider(self, temp_dir):
+        """Resource-centric items without provider use parent provider."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "default-provider",
+            "resources": ["resources.yaml"],
+        }
+        resource_content = """
+resources:
+  - type: vm
+    name: web-01
+    config:
+      vmid: 100
+"""
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "default-provider",
+            manifest,
+            {"resources.yaml": resource_content},
+        )
+
+        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        assert len(resources) == 1
+        assert resources[0].provider == "proxmox"
+        assert resources[0].type == "vm"
+
+    def test_resource_centric_missing_type(self, temp_dir):
+        """Resource-centric item without type raises error."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "no-type",
+            "resources": ["resources.yaml"],
+        }
+        resource_content = """
+resources:
+  - provider: proxmox
+    name: bad-resource
+    config:
+      vmid: 100
+"""
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "no-type",
+            manifest,
+            {"resources.yaml": resource_content},
+        )
+
+        with pytest.raises(InvalidConfigurationError, match="missing 'type'"):
+            loader.load_package(pkg_dir, "proxmox", "dev")
+
+    def test_provider_centric_with_provider_override(self, temp_dir):
+        """Provider-centric format items can override provider."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "override",
+            "resources": ["vms.yaml"],
+        }
+        resource_content = """
+vms:
+  - name: vm-01
+    vmid: 100
+  - name: vm-02
+    vmid: 101
+    provider: esxi
+"""
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "override",
+            manifest,
+            {"vms.yaml": resource_content},
+        )
+
+        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        assert len(resources) == 2
+        assert resources[0].provider == "proxmox"
+        assert resources[1].provider == "esxi"
+
+    def test_resource_centric_with_variables(self, temp_dir):
+        """Resource-centric format works with Jinja2 variable rendering."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "templated",
+            "variables": {"node_name": "ontap-01", "vmid": 220},
+            "resources": ["resources.yaml"],
+        }
+        resource_content = """
+resources:
+  - provider: proxmox
+    type: ova_vm
+    name: "{{ node_name }}"
+    config:
+      vmid: {{ vmid }}
+"""
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "templated",
+            manifest,
+            {"resources.yaml": resource_content},
+        )
+
+        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        assert len(resources) == 1
+        assert resources[0].name == "ontap-01"
+        assert resources[0].config["vmid"] == 220


### PR DESCRIPTION
## Description

Add cross-provider resource support to `PackageLoader`. Resource files can now use a `resources:` key where each item declares its own `provider` and `type`, enabling packages to manage resources across multiple providers (e.g., OPNsense DHCP reservations inside a Proxmox package directory).

## Related Issue

Addresses #354

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `_parse_resource_centric()` method to `PackageLoader` for `resources:` key format
- Updated `_parse_resources_from_data()` to detect and dispatch resource-centric format
- Added provider override support in provider-centric format items
- Added `TestMultiProviderResources` test class with 5 tests covering both formats, defaults, errors, and Jinja2 templating

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes (full ONTAP cluster deployment with cross-provider DHCP resources)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings