### PR TITLE
fix: resolve destroy command double-prompting for confirmation

### DIFF
--- a/src/infrafoundry/cli/commands/infra/destroy.py
+++ b/src/infrafoundry/cli/commands/infra/destroy.py
@@ -28,14 +28,22 @@ def destroy(
 ) -> None:
     """Destroy infrastructure."""
 
-    def confirm_callback() -> bool:
-        return click.confirm("Are you sure you want to destroy?")
+    if not auto_approve:
+        resource_desc = f" (resources: {', '.join(resource)})" if resource else ""
+        console.warning(f"About to DESTROY infrastructure for environment: {env}{resource_desc}")
+        console.warning("This will permanently remove resources from your infrastructure.")
+
+        if not click.confirm("Are you sure you want to destroy?", default=False):
+            console.warning("Destroy cancelled.")
+            return
+
+        # User confirmed, so pass auto_approve=True to Terraform
+        auto_approve = True
 
     with OperationTimer() as timer:
         orchestrator.destroy(
             env,
             auto_approve=auto_approve,
             resource_filter=list(resource) if resource else None,
-            confirm_callback=confirm_callback,
         )
     console.success(f"Destroy complete! ({timer.elapsed_str})")

--- a/tests/unit/test_cli_destroy.py
+++ b/tests/unit/test_cli_destroy.py
@@ -22,23 +22,32 @@ def mock_orchestrator():
     return mock
 
 
-def test_destroy_basic(cli_runner, mock_orchestrator):
-    """Test basic destroy command (orchestrator handles confirmation)."""
+def test_destroy_confirms_then_auto_approves(cli_runner, mock_orchestrator):
+    """Test that confirming at CLI level passes auto_approve=True to orchestrator."""
     with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-        result = cli_runner.invoke(main, ["infra", "destroy", "--env", "test"])
+        result = cli_runner.invoke(main, ["infra", "destroy", "--env", "test"], input="y\n")
 
         assert result.exit_code == 0
         assert "Destroy complete!" in result.output
-        # Verify confirm_callback is passed
         call_args = mock_orchestrator.destroy.call_args
         assert call_args[0] == ("test",)
-        assert call_args[1]["auto_approve"] is False
+        assert call_args[1]["auto_approve"] is True
         assert call_args[1]["resource_filter"] is None
-        assert callable(call_args[1]["confirm_callback"])
+        assert "confirm_callback" not in call_args[1]
+
+
+def test_destroy_cancelled(cli_runner, mock_orchestrator):
+    """Test that declining confirmation cancels destroy."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "destroy", "--env", "test"], input="n\n")
+
+        assert result.exit_code == 0
+        assert "Destroy cancelled." in result.output
+        mock_orchestrator.destroy.assert_not_called()
 
 
 def test_destroy_with_auto_approve(cli_runner, mock_orchestrator):
-    """Test destroy command with auto-approve flag."""
+    """Test destroy command with auto-approve flag skips confirmation."""
     with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
         result = cli_runner.invoke(main, ["infra", "destroy", "--env", "test", "--auto-approve"])
 
@@ -59,6 +68,20 @@ def test_destroy_with_resource_filter(cli_runner, mock_orchestrator):
         assert result.exit_code == 0
         call_args = mock_orchestrator.destroy.call_args
         assert call_args[1]["resource_filter"] == ["vm-01", "vm-02"]
+
+
+def test_destroy_shows_resource_names_in_prompt(cli_runner, mock_orchestrator):
+    """Test that resource names are shown in the confirmation prompt."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "destroy", "--env", "test", "-r", "vm-01", "-r", "vm-02"],
+            input="y\n",
+        )
+
+        assert result.exit_code == 0
+        assert "vm-01" in result.output
+        assert "vm-02" in result.output
 
 
 def test_destroy_orchestrator_failure(cli_runner, mock_orchestrator):


### PR DESCRIPTION
## Description

The `infra destroy` command prompted twice — once at the InfraFoundry level via `confirm_callback`, then again at the Terraform level because `auto_approve` remained `False`. This made destroy unusable in non-interactive contexts without `--auto-approve`.

Fix moves confirmation to the CLI level (matching `apply.py`), setting `auto_approve=True` after the user confirms so Terraform receives `-auto-approve`.

## Related Issue

Addresses #349

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Replaced `confirm_callback` pattern with CLI-level confirmation in `destroy.py`
- After confirmation, `auto_approve` is set to `True` before passing to orchestrator
- Confirmation prompt now shows environment name and targeted resource names
- Updated tests to verify new behavior (confirm → auto_approve, cancel, resource display)

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings