### PR TITLE
feat: support resource-scoped event handlers in package manifests

### DIFF
--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -50,7 +50,15 @@ events:
     - type: script
       script: scripts/cluster-setup.sh
       timeout: 300
+      resources:
+        - lab-ontap-node1
+        - lab-ontap-node2
 ```
+
+Handlers with a `resources` list only fire when those resources are targeted by
+the `-r` CLI filter. Omit `resources` to fire on every invocation. See the
+[Resource-Scoped Event Handlers](../development/event-system.md#resource-scoped-event-handlers)
+section for details.
 
 ### Fields
 

--- a/docs/development/event-system.md
+++ b/docs/development/event-system.md
@@ -74,6 +74,7 @@ events:
 | `INFRAFOUNDRY_PHASE` | `data.phase` is set (`plan`, `apply`, or `destroy`) |
 | `INFRAFOUNDRY_CONFIG_DIR` | Always |
 | `INFRAFOUNDRY_DEPLOYMENT_ID` | `context.deployment_id` is set |
+| `INFRAFOUNDRY_TARGET_RESOURCES` | `-r` filter is active (comma-separated list) |
 
 **Example:** Run an Ansible playbook after Terraform finishes for a specific provider:
 
@@ -123,6 +124,29 @@ Script handlers stream stdout and stderr to the console in real-time, line by li
       data={"policy": "strict-naming", "resource": "vm-01"}
   )
   ```
+
+## Resource-Scoped Event Handlers
+
+Event handlers can be scoped to specific resources using the `resources` field.
+When the `-r` CLI filter is active, only handlers whose `resources` list overlaps
+with the targeted resources will fire. Handlers without a `resources` field always
+fire regardless of the `-r` filter.
+
+```yaml
+events:
+  AFTER_APPLY:
+    - type: script
+      script: scripts/cluster-setup.sh
+      resources:
+        - ontap-node1
+        - ontap-node2
+```
+
+In this example, the script only runs when `ontap-node1` or `ontap-node2` is among
+the resources targeted by `-r`. If no `-r` filter is used, all handlers fire.
+
+Scripts receive the targeted resource names as a comma-separated list in the
+`INFRAFOUNDRY_TARGET_RESOURCES` environment variable when the `-r` filter is active.
 
 ## Package Events
 

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -322,6 +322,7 @@ class DeploymentExecutor:
                 EventType.RESOURCE_CREATING,
                 env_name,
                 creating_event,
+                target_resources=resource_filter,
             )
 
         runner_results: dict[str, Any] = {}
@@ -345,6 +346,7 @@ class DeploymentExecutor:
                 starting_event,
                 provider=provider_name,
                 runner=tool_name,
+                target_resources=resource_filter,
             )
 
             try:
@@ -369,6 +371,7 @@ class DeploymentExecutor:
                     completed_event,
                     provider=provider_name,
                     runner=tool_name,
+                    target_resources=resource_filter,
                 )
             except Exception as exc:
                 failed_event: RunnerEventData = {
@@ -383,6 +386,7 @@ class DeploymentExecutor:
                     failed_event,
                     provider=provider_name,
                     runner=tool_name,
+                    target_resources=resource_filter,
                 )
                 raise
 
@@ -416,6 +420,7 @@ class DeploymentExecutor:
                     EventType.RESOURCE_CREATED,
                     env_name,
                     created_event,
+                    target_resources=resource_filter,
                 )
 
         return runner_results

--- a/src/infrafoundry/core/events/bus.py
+++ b/src/infrafoundry/core/events/bus.py
@@ -230,6 +230,12 @@ class UnifiedEventBus(BaseManager):
 
         # Execute registered handlers
         for handler in self._handlers[event_type]:
+            if not handler.matches_resources(context.target_resources):
+                self._log_debug(
+                    f"Skipping handler {handler.name}: "
+                    f"no resource match for {context.target_resources}"
+                )
+                continue
             result = self._execute_handler(handler, context, results)
             results.append(result)
             self._print_handler_result(handler, result)

--- a/src/infrafoundry/core/events/context.py
+++ b/src/infrafoundry/core/events/context.py
@@ -27,6 +27,7 @@ class EventContext:
         runner: Runner name if applicable (e.g., "terraform")
         deployment_id: Deployment ID if in a deployment context
         plan_output: Plan output data if available
+        target_resources: Resource names targeted by -r filter (None = all)
         previous_results: Results from previous handlers in chain
     """
 
@@ -38,6 +39,7 @@ class EventContext:
     runner: str | None = None
     deployment_id: int | None = None
     plan_output: dict[str, Any] | None = None
+    target_resources: list[str] | None = None
     previous_results: list["EventResult"] = field(default_factory=list)
 
     def __repr__(self) -> str:

--- a/src/infrafoundry/core/events/handlers/base.py
+++ b/src/infrafoundry/core/events/handlers/base.py
@@ -47,5 +47,26 @@ class BaseHandler(ABC):
         """
         ...
 
+    def matches_resources(self, target_resources: list[str] | None) -> bool:
+        """Check whether this handler should fire for the given target resources.
+
+        A handler fires if:
+        - It has no ``resources`` filter in its config (fires for all).
+        - ``target_resources`` is None (no -r flag, all resources targeted).
+        - There is an intersection between handler resources and target resources.
+
+        Args:
+            target_resources: Resource names from the -r CLI filter, or None.
+
+        Returns:
+            True if this handler should execute, False to skip.
+        """
+        handler_resources = self.config.get("resources")
+        if not handler_resources:
+            return True
+        if target_resources is None:
+            return True
+        return bool(set(handler_resources) & set(target_resources))
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name})"

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -251,6 +251,9 @@ class ScriptHandler(BaseHandler):
         if context.deployment_id:
             env["INFRAFOUNDRY_DEPLOYMENT_ID"] = str(context.deployment_id)
 
+        if context.target_resources:
+            env["INFRAFOUNDRY_TARGET_RESOURCES"] = ",".join(context.target_resources)
+
         # Add custom environment variables from config
         custom_env = self.config.get("env", {})
         for key, value in custom_env.items():

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -361,6 +361,7 @@ class PlanOrchestrator(HookExecutionMixin):
             EventType.BEFORE_PLAN,
             env_name,
             {"deployment_id": deployment_id, "dry_run": dry_run},
+            target_resources=resource_filter,
         )
 
         results: dict[str, Any] = {}
@@ -451,6 +452,7 @@ class PlanOrchestrator(HookExecutionMixin):
                                 starting_event,
                                 provider=provider_name,
                                 runner=tool_name,
+                                target_resources=resource_filter,
                             )
 
                             try:
@@ -473,6 +475,7 @@ class PlanOrchestrator(HookExecutionMixin):
                                     completed_event,
                                     provider=provider_name,
                                     runner=tool_name,
+                                    target_resources=resource_filter,
                                 )
                             except Exception as exc:
                                 failed_event: RunnerEventData = {
@@ -487,6 +490,7 @@ class PlanOrchestrator(HookExecutionMixin):
                                     failed_event,
                                     provider=provider_name,
                                     runner=tool_name,
+                                    target_resources=resource_filter,
                                 )
                                 raise
                         else:
@@ -509,6 +513,7 @@ class PlanOrchestrator(HookExecutionMixin):
                 EventType.AFTER_PLAN,
                 env_name,
                 {"deployment_id": deployment_id, "results": results},
+                target_resources=resource_filter,
             )
         except Exception as exc:
             self.state_manager.update_deployment_status(
@@ -518,6 +523,7 @@ class PlanOrchestrator(HookExecutionMixin):
                 EventType.PLAN_FAILED,
                 env_name,
                 {"deployment_id": deployment_id, "error": str(exc)},
+                target_resources=resource_filter,
             )
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
             raise
@@ -756,6 +762,7 @@ class ApplyOrchestrator(HookExecutionMixin):
             EventType.BEFORE_APPLY,
             env_name,
             {"deployment_id": deployment_id, "auto_approve": auto_approve},
+            target_resources=resource_filter,
         )
 
         results: dict[str, Any] = {}
@@ -817,6 +824,7 @@ class ApplyOrchestrator(HookExecutionMixin):
                 EventType.AFTER_APPLY,
                 env_name,
                 {"deployment_id": deployment_id, "results": results},
+                target_resources=resource_filter,
             )
         except Exception as exc:
             self.state_manager.update_deployment_status(
@@ -826,6 +834,7 @@ class ApplyOrchestrator(HookExecutionMixin):
                 EventType.APPLY_FAILED,
                 env_name,
                 {"deployment_id": deployment_id, "error": str(exc)},
+                target_resources=resource_filter,
             )
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
             raise
@@ -924,6 +933,7 @@ class DestroyOrchestrator(HookExecutionMixin):
             EventType.BEFORE_DESTROY,
             env_name,
             {"deployment_id": deployment_id, "auto_approve": auto_approve},
+            target_resources=resource_filter,
         )
 
         results: dict[str, Any] = {}
@@ -1013,6 +1023,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                         starting_event,
                         provider=provider_name,
                         runner=tool_name,
+                        target_resources=resource_filter,
                     )
 
                     try:
@@ -1035,6 +1046,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                             completed_event,
                             provider=provider_name,
                             runner=tool_name,
+                            target_resources=resource_filter,
                         )
                     except Exception as exc:
                         failed_event: RunnerEventData = {
@@ -1049,6 +1061,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                             failed_event,
                             provider=provider_name,
                             runner=tool_name,
+                            target_resources=resource_filter,
                         )
                         raise
 
@@ -1068,6 +1081,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                 EventType.AFTER_DESTROY,
                 env_name,
                 {"deployment_id": deployment_id, "results": results},
+                target_resources=resource_filter,
             )
         except Exception as exc:
             self.state_manager.update_deployment_status(
@@ -1077,6 +1091,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                 EventType.DESTROY_FAILED,
                 env_name,
                 {"deployment_id": deployment_id, "error": str(exc)},
+                target_resources=resource_filter,
             )
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
             raise

--- a/tests/unit/test_deployment_executor.py
+++ b/tests/unit/test_deployment_executor.py
@@ -84,6 +84,7 @@ def test_apply_serial_orders_providers_and_tracks_states():
             "name": "fw",
             "terraform_id": None,
         },
+        target_resources=None,
     )
     assert any(
         call_args[0][0] == EventType.RESOURCE_CREATED
@@ -651,7 +652,11 @@ def test_apply_emits_runner_starting_and_completed():
         "runner": "terraform",
         "phase": "apply",
     }
-    assert starting_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+    assert starting_calls[0][1] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "target_resources": None,
+    }
 
     assert completed_calls[0][0][2] == {
         "provider": "proxmox",
@@ -659,7 +664,11 @@ def test_apply_emits_runner_starting_and_completed():
         "phase": "apply",
         "success": True,
     }
-    assert completed_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+    assert completed_calls[0][1] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "target_resources": None,
+    }
 
     # Verify ordering: STARTING before apply, COMPLETED after
     all_call_types = [call[0][0] for call in event_manager.emit_event.call_args_list]
@@ -730,7 +739,11 @@ def test_apply_emits_runner_failed_on_exception():
         "phase": "apply",
         "error": "terraform crashed",
     }
-    assert failed_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+    assert failed_calls[0][1] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "target_resources": None,
+    }
 
     # RUNNER_COMPLETED should NOT have been emitted
     completed_calls = [

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -77,10 +77,16 @@ def test_plan_orchestrator_dry_run_skips_generation(console):
     providers["proxmox"].ensure_directories.assert_not_called()
     state_manager.update_deployment_status.assert_called_with(1, DeploymentStatus.COMPLETED)
     event_manager.emit_event.assert_any_call(
-        EventType.BEFORE_PLAN, "dev", {"deployment_id": 1, "dry_run": True}
+        EventType.BEFORE_PLAN,
+        "dev",
+        {"deployment_id": 1, "dry_run": True},
+        target_resources=None,
     )
     event_manager.emit_event.assert_any_call(
-        EventType.AFTER_PLAN, "dev", {"deployment_id": 1, "results": result}
+        EventType.AFTER_PLAN,
+        "dev",
+        {"deployment_id": 1, "results": result},
+        target_resources=None,
     )
 
 
@@ -326,7 +332,11 @@ def test_plan_emits_runner_starting_and_completed(console):
         "runner": "terraform",
         "phase": "plan",
     }
-    assert starting_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+    assert starting_calls[0][1] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "target_resources": None,
+    }
     assert completed_calls[0][0][2] == {
         "provider": "proxmox",
         "runner": "terraform",
@@ -398,7 +408,11 @@ def test_destroy_emits_runner_starting_and_completed(console):
         "runner": "terraform",
         "phase": "destroy",
     }
-    assert starting_calls[0][1] == {"provider": "proxmox", "runner": "terraform"}
+    assert starting_calls[0][1] == {
+        "provider": "proxmox",
+        "runner": "terraform",
+        "target_resources": None,
+    }
     assert completed_calls[0][0][2] == {
         "provider": "proxmox",
         "runner": "terraform",

--- a/tests/unit/test_unified_event_bus.py
+++ b/tests/unit/test_unified_event_bus.py
@@ -1,5 +1,6 @@
 """Tests for the unified event bus."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -315,3 +316,200 @@ class TestBackwardCompatibility:
         event = callback.call_args[0][0]
         assert event.context.provider == "proxmox"
         assert event.context.data["drift"] is True
+
+
+class TestBaseHandlerMatchesResources:
+    """Tests for BaseHandler.matches_resources()."""
+
+    def _make_handler(self, config: dict[str, Any]) -> Any:
+        """Create a concrete handler subclass for testing."""
+        from infrafoundry.core.events.handlers.base import BaseHandler
+
+        class StubHandler(BaseHandler):
+            def execute(self, context: EventContext) -> EventResult:
+                return EventResult(success=True, handler_name=self.name)
+
+            def validate_config(self) -> list[str]:
+                return []
+
+        return StubHandler(config)
+
+    def test_no_config_filter_returns_true(self) -> None:
+        """Handler without resources config fires for any target."""
+        handler = self._make_handler({"name": "no-filter"})
+        assert handler.matches_resources(["res-a", "res-b"]) is True
+
+    def test_no_target_resources_returns_true(self) -> None:
+        """Handler with resources config fires when target is None (no -r)."""
+        handler = self._make_handler({"name": "filtered", "resources": ["res-a"]})
+        assert handler.matches_resources(None) is True
+
+    def test_intersection_returns_true(self) -> None:
+        """Handler fires when target_resources overlaps handler resources."""
+        handler = self._make_handler({"name": "filtered", "resources": ["res-a", "res-b"]})
+        assert handler.matches_resources(["res-b", "res-c"]) is True
+
+    def test_no_intersection_returns_false(self) -> None:
+        """Handler skipped when no overlap between handler and target resources."""
+        handler = self._make_handler({"name": "filtered", "resources": ["res-a"]})
+        assert handler.matches_resources(["res-x", "res-y"]) is False
+
+    def test_empty_config_resources_returns_true(self) -> None:
+        """Empty resources list treated as no filter (fires for all)."""
+        handler = self._make_handler({"name": "empty-filter", "resources": []})
+        assert handler.matches_resources(["res-a"]) is True
+
+    def test_empty_target_resources_returns_true(self) -> None:
+        """Empty target list has no overlap, but empty handler list fires."""
+        handler = self._make_handler({"name": "no-filter"})
+        assert handler.matches_resources([]) is True
+
+
+class TestResourceFilteredEmit:
+    """Tests for resource-scoped filtering in emit()."""
+
+    def test_filtered_handler_skipped_unfiltered_fires(self) -> None:
+        """Only matching handlers execute when target_resources is set."""
+        bus = UnifiedEventBus()
+
+        with patch("importlib.import_module") as mock_import:
+            call_count: dict[str, int] = {"ontap": 0, "aiqum": 0}
+
+            def make_result(name: str) -> EventResult:
+                call_count[name] += 1
+                return EventResult(success=True, handler_name=name)
+
+            # Two separate modules for two handlers
+            ontap_module = MagicMock()
+            ontap_module.handle = MagicMock(side_effect=lambda ctx: make_result("ontap"))
+
+            aiqum_module = MagicMock()
+            aiqum_module.handle = MagicMock(side_effect=lambda ctx: make_result("aiqum"))
+
+            def import_side_effect(module_name: str) -> MagicMock:
+                if module_name == "hooks.ontap":
+                    return ontap_module
+                return aiqum_module
+
+            mock_import.side_effect = import_side_effect
+
+            # Handler scoped to ontap resources
+            bus.register_handler(
+                EventType.AFTER_APPLY,
+                {
+                    "type": "python",
+                    "module": "hooks.ontap",
+                    "name": "ontap-handler",
+                    "resources": ["ontapcl-01", "ontapcl-02"],
+                },
+            )
+
+            # Handler scoped to aiqum resources
+            bus.register_handler(
+                EventType.AFTER_APPLY,
+                {
+                    "type": "python",
+                    "module": "hooks.aiqum",
+                    "name": "aiqum-handler",
+                    "resources": ["aiqum-console"],
+                },
+            )
+
+            # Emit targeting only ontap resources
+            ctx = EventContext(
+                EventType.AFTER_APPLY,
+                "prod",
+                target_resources=["ontapcl-01", "ontapcl-02"],
+            )
+            results = bus.emit(ctx)
+
+            # Only ontap handler should have fired
+            assert len(results) == 1
+            assert results[0].handler_name == "ontap-handler"
+            assert call_count["ontap"] == 1
+            assert call_count["aiqum"] == 0
+
+    def test_handler_without_filter_fires_regardless(self) -> None:
+        """Handler with no resources config fires for any target_resources."""
+        bus = UnifiedEventBus()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.handle = MagicMock(
+                return_value=EventResult(success=True, handler_name="global")
+            )
+            mock_import.return_value = mock_module
+
+            bus.register_handler(
+                EventType.AFTER_APPLY,
+                {"type": "python", "module": "hooks.global", "name": "global-handler"},
+            )
+
+            ctx = EventContext(
+                EventType.AFTER_APPLY,
+                "prod",
+                target_resources=["res-a"],
+            )
+            results = bus.emit(ctx)
+
+            assert len(results) == 1
+            assert results[0].handler_name == "global-handler"
+
+    def test_config_loading_preserves_resources_field(self) -> None:
+        """Resources field in handler config is preserved through load_config."""
+        bus = UnifiedEventBus()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.handle = MagicMock(return_value=EventResult(success=True))
+            mock_import.return_value = mock_module
+
+            bus.load_config(
+                {
+                    "after_apply": [
+                        {
+                            "type": "python",
+                            "module": "hooks.scoped",
+                            "resources": ["res-a", "res-b"],
+                        },
+                    ],
+                }
+            )
+
+            handlers = bus._handlers[EventType.AFTER_APPLY]
+            assert len(handlers) == 1
+            assert handlers[0].config["resources"] == ["res-a", "res-b"]
+
+
+class TestEventContextTargetResources:
+    """Tests for target_resources field on EventContext."""
+
+    def test_default_is_none(self) -> None:
+        """target_resources defaults to None."""
+        ctx = EventContext(EventType.BEFORE_PLAN, "dev")
+        assert ctx.target_resources is None
+
+    def test_set_via_constructor(self) -> None:
+        """target_resources can be set via constructor."""
+        ctx = EventContext(
+            EventType.BEFORE_PLAN,
+            "dev",
+            target_resources=["res-a", "res-b"],
+        )
+        assert ctx.target_resources == ["res-a", "res-b"]
+
+    def test_emit_event_passes_target_resources(self) -> None:
+        """emit_event convenience method passes target_resources to context."""
+        bus = UnifiedEventBus()
+        callback = MagicMock()
+        bus.subscribe(EventType.BEFORE_APPLY, callback)
+
+        bus.emit_event(
+            EventType.BEFORE_APPLY,
+            "prod",
+            target_resources=["res-a"],
+        )
+
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.context.target_resources == ["res-a"]


### PR DESCRIPTION
## Description

Add resource-scoped event handlers so that package manifest events can declare
which resources they apply to via a `resources` list. When the `-r` CLI filter
is active, only handlers whose resource list overlaps with the targeted resources
will fire. Handlers without a `resources` field always fire (backward compatible).

Addresses #363

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `BaseHandler.matches_resources()` — new method that checks whether a handler's `resources` config overlaps with `target_resources`
- `EventContext.target_resources` — new field carrying the `-r` filter resource names (None = all)
- `UnifiedEventBus.emit()` — skips handlers that don't match the target resources
- `ScriptHandler` — exposes `INFRAFOUNDRY_TARGET_RESOURCES` env var (comma-separated) to scripts
- `DeploymentExecutor` and `OrchestratorWorkflows` — pass `target_resources` through `emit_event` calls
- Documentation updated for the new `resources` handler field, `INFRAFOUNDRY_TARGET_RESOURCES` env var, and resource-scoped handler behavior

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
  - 12 new tests in `test_unified_event_bus.py` covering resource filtering (match, no-match, no-filter, handler-without-resources, multiple handlers, empty lists)
  - Updated `test_deployment_executor.py` and `test_orchestrator_workflows_unit.py` for new `target_resources` kwarg
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
