### PR TITLE
refactor: replace null_resource template provisioners with native proxmox provider resources

### DIFF
--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -286,27 +286,16 @@ class ProxmoxProvider(
                 base[key] = value
 
     def _generate_templates_terraform(self, templates: list[ResourceConfig]) -> None:
-        """Generate Terraform for Proxmox templates."""
-        from urllib.parse import urlparse
+        """Generate Terraform for Proxmox templates.
 
-        from infrafoundry.core.config import ConfigManager
-
-        # Extract SSH hostname from API URL for templates that need it
-        ssh_hostname = None
-        if self._current_environment:
-            config_manager = ConfigManager(self.config_dir)
-            try:
-                env_config = config_manager.load_environment(self._current_environment)
-                provider_settings = env_config.get_provider_settings("proxmox")
-                if provider_settings and "api_url" in provider_settings:
-                    parsed = urlparse(provider_settings["api_url"])
-                    ssh_hostname = parsed.hostname
-            except FileNotFoundError:
-                pass
-
+        Uses native bpg/proxmox provider resources for download_image templates
+        (proxmox_virtual_environment_download_file + proxmox_virtual_environment_vm
+        with template=true). Clone-based templates use proxmox_virtual_environment_vm
+        with template=true directly.
+        """
         self.render_and_write_terraform(
             "proxmox/templates.tf.j2",
-            context={"templates": templates, "ssh_hostname": ssh_hostname},
+            context={"templates": templates},
             output_name="templates.tf",
         )
 

--- a/src/infrafoundry/providers/proxmox/templates/proxmox/templates.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/templates.tf.j2
@@ -1,133 +1,126 @@
 {% for template in templates %}
 # Template: {{ template.config.name }}
 {% if template.config.download_image is defined %}
-# Download image and create template from scratch using Proxmox API
-# Step 1: Download image to Proxmox storage via SSH
-# Note: Proxmox download_file provider only accepts ISOs, not disk images
-resource "null_resource" "download_image_{{ template.config.name | replace('-', '_') }}" {
-  provisioner "local-exec" {
-    command = <<-EOT
-      # Download and extract image via SSH in one operation
-      {% if template.config.download_image.extract is defined and template.config.download_image.extract %}
-      {% if template.config.download_image.filename.endswith('.xz') %}
-      {% set image_file = template.config.download_image.filename | replace('.xz', '') %}
-      ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_hostname if ssh_hostname else template.config.target_node }} "cd /var/lib/vz/template/iso && \
-        ([ -f {{ image_file }} ] || (wget -O {{ template.config.download_image.filename }} {{ template.config.download_image.url }} && xz -d {{ template.config.download_image.filename }}))"
-      {% elif template.config.download_image.filename.endswith('.gz') %}
-      {% set image_file = template.config.download_image.filename | replace('.gz', '') %}
-      ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_hostname if ssh_hostname else template.config.target_node }} "cd /var/lib/vz/template/iso && \
-        ([ -f {{ image_file }} ] || (wget -O {{ template.config.download_image.filename }} {{ template.config.download_image.url }} && gunzip {{ template.config.download_image.filename }}))"
-      {% endif %}
-      {% else %}
-      # Download without extraction
-      ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_hostname if ssh_hostname else template.config.target_node }} "cd /var/lib/vz/template/iso && \
-        [ -f {{ template.config.download_image.filename }} ] || wget -O {{ template.config.download_image.filename }} {{ template.config.download_image.url }}"
-      {% endif %}
-    EOT
-  }
-
-  triggers = {
-    url = "{{ template.config.download_image.url }}"
-    filename = "{{ template.config.download_image.filename }}"
-  }
+# Download cloud image and create template using native bpg/proxmox provider resources
+# Step 1: Download image to Proxmox storage via API
+resource "proxmox_virtual_environment_download_file" "cloud_image_{{ template.config.name | replace('-', '_') }}" {
+  content_type = "import"
+  datastore_id = "{{ template.config.disk.storage | default('local') }}"
+  node_name    = "{{ template.config.target_node }}"
+  url          = "{{ template.config.download_image.url }}"
+  file_name    = "{{ template.config.download_image.filename }}"
+{% if template.config.download_image.decompression is defined %}
+  decompression_algorithm = "{{ template.config.download_image.decompression }}"
+{% endif %}
 }
 
-# Step 2: Create VM using qm command via SSH
-resource "null_resource" "create_vm_{{ template.config.name | replace('-', '_') }}" {
-  depends_on = [null_resource.download_image_{{ template.config.name | replace('-', '_') }}]
+# Step 2: Create template VM with imported disk
+resource "proxmox_virtual_environment_vm" "template_{{ template.config.name | replace('-', '_') }}" {
+  name      = "{{ template.config.name }}"
+  node_name = "{{ template.config.target_node }}"
+  vm_id     = {{ template.config.vmid }}
+  template  = true
+  started   = false
+  on_boot   = false
 
-  provisioner "local-exec" {
-    command = <<-EOT
-      # Create VM using qm command
-      ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_hostname if ssh_hostname else template.config.target_node }} "qm create {{ template.config.vmid }} \
-        --name {{ template.config.name }} \
-        --memory {{ template.config.memory | default(2048) }} \
-        --cores {{ template.config.cores | default(2) }} \
-        {% if template.config.bios is defined %}--bios {{ template.config.bios }} \
-        {% endif %}{% if template.config.machine is defined %}--machine {{ template.config.machine }} \
-        {% endif %}--scsihw virtio-scsi-pci \
-        --net0 virtio,bridge={{ template.config.network.bridge | default('vmbr0') }}{% if template.config.network.tag is defined %},tag={{ template.config.network.tag }}{% endif %} \
-        --boot order=scsi0 \
-        --agent 1"
-    EOT
+  cpu {
+    cores   = {{ template.config.cores | default(2) }}
+    sockets = {{ template.config.sockets | default(1) }}
+{% if template.config.cpu_type is defined %}
+    type    = "{{ template.config.cpu_type }}"
+{% endif %}
   }
 
-  triggers = {
-    vmid = "{{ template.config.vmid }}"
-    name = "{{ template.config.name }}"
-  }
-}
-
-# Step 3: Import disk and configure cloud-init using qm commands
-resource "null_resource" "configure_vm_{{ template.config.name | replace('-', '_') }}" {
-  depends_on = [null_resource.create_vm_{{ template.config.name | replace('-', '_') }}]
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      {% if template.config.download_image.extract is defined and template.config.download_image.extract %}
-      {% set image_file = template.config.download_image.filename | replace('.xz', '') | replace('.gz', '') %}
-      {% else %}
-      {% set image_file = template.config.download_image.filename %}
-      {% endif %}
-
-      # Import disk and configure VM using qm commands
-      ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_hostname if ssh_hostname else template.config.target_node }} "
-        # Import disk
-        qm importdisk {{ template.config.vmid }} /var/lib/vz/template/iso/{{ image_file }} {{ template.config.disk.storage | default('local-lvm') }}
-
-        # Attach disk (parse unused0 from config to handle both LVM and NFS path formats)
-        DISK_PATH=\$(qm config {{ template.config.vmid }} | grep '^unused0:' | sed 's/^unused0: //')
-        qm set {{ template.config.vmid }} --scsi0 \$DISK_PATH
-
-        {% if template.config.efi_disk is defined %}
-        # Add EFI disk for UEFI boot
-        qm set {{ template.config.vmid }} --efidisk0 {{ template.config.efi_disk.storage | default(template.config.disk.storage) | default('local-lvm') }}:1,format=raw,efitype={{ template.config.efi_disk.type | default('4m') }},pre-enrolled-keys=0
-        {% endif %}
-
-        {% if template.config.cloud_init is defined and template.config.cloud_init %}
-        # Configure cloud-init
-        {% if template.config.ciuser is defined %}
-        qm set {{ template.config.vmid }} --ciuser {{ template.config.ciuser }}
-        {% endif %}
-        {% if template.config.sshkeys is defined %}
-        qm set {{ template.config.vmid }} --sshkeys \"{{ template.config.sshkeys | replace(' ', '%20') }}\"
-        {% endif %}
-        qm set {{ template.config.vmid }} --ipconfig0 ip=dhcp
-        {% endif %}
-      "
-    EOT
+  memory {
+    dedicated = {{ template.config.memory | default(2048) }}
   }
 
-  triggers = {
-    vmid = "{{ template.config.vmid }}"
+{% if template.config.agent is defined %}
+  agent {
+    enabled = {{ 'true' if template.config.agent else 'false' }}
   }
-}
+{% endif %}
 
-# Step 4: Convert VM to template using qm command
-resource "null_resource" "convert_to_template_{{ template.config.name | replace('-', '_') }}" {
-  depends_on = [null_resource.configure_vm_{{ template.config.name | replace('-', '_') }}]
+{% if template.config.bios is defined %}
+  bios = "{{ template.config.bios }}"
+{% endif %}
 
-  provisioner "local-exec" {
-    command = <<-EOT
-      # Convert to template
-      ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_hostname if ssh_hostname else template.config.target_node }} "qm template {{ template.config.vmid }}"
-    EOT
+{% if template.config.machine is defined %}
+  machine = "{{ template.config.machine }}"
+{% endif %}
+
+  disk {
+    datastore_id = "{{ template.config.disk.storage | default('local-lvm') }}"
+    import_from  = proxmox_virtual_environment_download_file.cloud_image_{{ template.config.name | replace('-', '_') }}.id
+    interface    = "scsi0"
+{% if template.config.disk.size is defined %}
+    size         = {{ template.config.disk.size | replace('G', '') }}
+{% endif %}
   }
 
-  triggers = {
-    vmid = "{{ template.config.vmid }}"
+  scsi_hardware = "virtio-scsi-pci"
+
+{% if template.config.efi_disk is defined %}
+  efi_disk {
+    datastore_id = "{{ template.config.efi_disk.storage | default(template.config.disk.storage) | default('local-lvm') }}"
+    type         = "{{ template.config.efi_disk.type | default('4m') }}"
+  }
+{% endif %}
+
+  network_device {
+    bridge = "{{ template.config.network.bridge | default('vmbr0') }}"
+{% if template.config.network.tag is defined %}
+    vlan_id = {{ template.config.network.tag }}
+{% endif %}
+  }
+
+{% if template.config.cloud_init is defined and template.config.cloud_init %}
+  initialization {
+{% if template.config.cloud_init_datastore is defined %}
+    datastore_id = "{{ template.config.cloud_init_datastore }}"
+{% endif %}
+    ip_config {
+      ipv4 {
+        address = "dhcp"
+      }
+    }
+{% if template.config.ciuser is defined %}
+    user_account {
+      username = "{{ template.config.ciuser }}"
+{% if template.config.sshkeys is defined %}
+      keys = [
+        "{{ template.config.sshkeys }}"
+      ]
+{% endif %}
+    }
+{% endif %}
+  }
+{% endif %}
+
+{% if template.config.description is defined %}
+  description = "{{ template.config.description }}"
+{% endif %}
+
+{% if template.config.tags is defined %}
+  tags = {{ template.config.tags | tojson }}
+{% endif %}
+
+  lifecycle {
+    prevent_destroy = {{ template.config.prevent_destroy | default(true) | tojson }}
   }
 }
 
 {% else %}
 # Create template from clone or manual creation
-# Note: VM will be converted to template after creation using local-exec provisioner
 resource "proxmox_virtual_environment_vm" "template_{{ template.config.name | replace('-', '_') }}" {
   name      = "{{ template.config.name }}"
   node_name = "{{ template.config.target_node }}"
   {% if template.config.vmid is defined %}
   vm_id     = {{ template.config.vmid }}
   {% endif %}
+  template  = true
+  started   = false
+  on_boot   = false
 
   {% if template.config.clone is defined %}
   # Clone from existing template/VM
@@ -182,10 +175,6 @@ resource "proxmox_virtual_environment_vm" "template_{{ template.config.name | re
   }
   {% endif %}
 
-  # Don't start the VM (templates should not run)
-  on_boot = false
-  started = false
-
   {% if template.config.cloud_init is defined and template.config.cloud_init %}
   # Cloud-init Configuration
   initialization {
@@ -220,27 +209,6 @@ resource "proxmox_virtual_environment_vm" "template_{{ template.config.name | re
     prevent_destroy = true
   }
   {% endif %}
-}
-
-# Convert VM to template using local-exec provisioner
-resource "null_resource" "convert_to_template_{{ template.config.name | replace('-', '_') }}" {
-  depends_on = [proxmox_virtual_environment_vm.template_{{ template.config.name | replace('-', '_') }}]
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      # Wait for VM to be fully created
-      sleep 5
-      # Convert to template via API using bpg provider auth
-      curl -k -X POST \
-        -H "Authorization: PVEAPIToken=$PROXMOX_VE_API_TOKEN" \
-        "$PROXMOX_VE_ENDPOINT/api2/json/nodes/{{ template.config.target_node }}/qemu/${proxmox_virtual_environment_vm.template_{{ template.config.name | replace('-', '_') }}.vm_id}/template"
-    EOT
-  }
-
-  # Trigger on changes to the VM
-  triggers = {
-    vm_id = proxmox_virtual_environment_vm.template_{{ template.config.name | replace('-', '_') }}.id
-  }
 }
 
 {% endif %}

--- a/tests/unit/test_provider_templates.py
+++ b/tests/unit/test_provider_templates.py
@@ -162,7 +162,7 @@ class TestProxmoxTemplates:
     def test_generate_template_terraform(
         self, provider: ProxmoxProvider, template_resource: ResourceConfig
     ) -> None:
-        """Test template Terraform generation."""
+        """Test template Terraform generation for clone-based template."""
         provider.generate_terraform([template_resource])
 
         templates_tf = provider.terraform_dir / "templates.tf"
@@ -172,8 +172,120 @@ class TestProxmoxTemplates:
         # Template generates "template_<name>" not normalized name
         assert "template_ubuntu" in content or "ubuntu" in content
         assert "ubuntu-22.04-template" in content
-        # Template flag may be represented differently in the new templates
-        assert "template" in content
+        # Clone-based templates use proxmox_virtual_environment_vm with template = true
+        assert 'resource "proxmox_virtual_environment_vm"' in content
+        assert "template  = true" in content
+        # Should NOT contain download_file resources
+        assert "proxmox_virtual_environment_download_file" not in content
+
+    def test_generate_download_image_template_terraform(self, provider: ProxmoxProvider) -> None:
+        """Test template Terraform generation for download_image-based template."""
+        template = ResourceConfig(
+            provider="proxmox",
+            type="template",
+            name="rocky9-template",
+            config={
+                "name": "rocky9-template",
+                "target_node": "pve1",
+                "vmid": 901,
+                "cores": 2,
+                "sockets": 1,
+                "memory": 2048,
+                "agent": True,
+                "cloud_init": True,
+                "ciuser": "rocky",
+                "disk": {"storage": "local-lvm", "size": "32G"},
+                "network": {"bridge": "vmbr0", "tag": 100},
+                "download_image": {
+                    "url": "https://example.com/Rocky-9-GenericCloud.qcow2.xz",
+                    "filename": "rocky-9-genericcloud.qcow2",
+                    "decompression": "xz",
+                },
+                "tags": ["template", "rocky"],
+                "description": "Rocky 9 cloud template",
+            },
+        )
+
+        provider.generate_terraform([template])
+
+        templates_tf = provider.terraform_dir / "templates.tf"
+        assert templates_tf.exists()
+
+        content = templates_tf.read_text()
+
+        # Should use native download_file resource
+        assert (
+            'resource "proxmox_virtual_environment_download_file" '
+            '"cloud_image_rocky9_template"' in content
+        )
+        assert 'content_type = "import"' in content
+        assert 'url          = "https://example.com/Rocky-9-GenericCloud.qcow2.xz"' in content
+        assert 'file_name    = "rocky-9-genericcloud.qcow2"' in content
+        assert 'decompression_algorithm = "xz"' in content
+
+        # Should use native VM resource with template = true
+        assert 'resource "proxmox_virtual_environment_vm" "template_rocky9_template"' in content
+        assert "template  = true" in content
+        assert "started   = false" in content
+        assert "vm_id     = 901" in content
+
+        # Check import_from references the download_file resource
+        assert (
+            "import_from  = proxmox_virtual_environment_download_file"
+            ".cloud_image_rocky9_template.id" in content
+        )
+
+        # Check cloud-init initialization block
+        assert "initialization {" in content
+        assert 'username = "rocky"' in content
+        assert "dhcp" in content
+
+        # Check network with VLAN
+        assert 'bridge = "vmbr0"' in content
+        assert "vlan_id = 100" in content
+
+        # Check tags and description
+        assert "rocky" in content
+        assert "Rocky 9 cloud template" in content
+
+        # Should NOT contain null_resource blocks
+        assert "null_resource" not in content
+
+    def test_generate_download_image_template_minimal(self, provider: ProxmoxProvider) -> None:
+        """Test download_image template with minimal config (no optional fields)."""
+        template = ResourceConfig(
+            provider="proxmox",
+            type="template",
+            name="minimal-dl",
+            config={
+                "name": "minimal-dl",
+                "target_node": "pve1",
+                "vmid": 900,
+                "disk": {"storage": "local"},
+                "network": {},
+                "download_image": {
+                    "url": "https://example.com/image.qcow2",
+                    "filename": "image.qcow2",
+                },
+            },
+        )
+
+        provider.generate_terraform([template])
+
+        content = (provider.terraform_dir / "templates.tf").read_text()
+
+        # Should have download_file without decompression
+        assert 'resource "proxmox_virtual_environment_download_file"' in content
+        assert "decompression_algorithm" not in content
+
+        # Should have VM resource with defaults
+        assert "template  = true" in content
+        assert "cores   = 2" in content  # default
+        assert "dedicated = 2048" in content  # default memory
+
+        # Should NOT have cloud-init, tags, description, or agent blocks
+        assert "initialization" not in content
+        assert "null_resource" not in content
 
     def test_generate_network_terraform(
         self, provider: ProxmoxProvider, network_resource: ResourceConfig


### PR DESCRIPTION
## Description

Replace `null_resource` with `local-exec` provisioner chains in Proxmox template generation with native `bpg/proxmox` provider resources. This eliminates SSH dependencies, reduces fragility, and leverages the provider's built-in API support for downloading cloud images and creating template VMs.

Addresses #366

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

- **Template (templates.tf.j2):** Replaced the 4-step `null_resource` SSH chain (download via SSH, create VM via `qm`, import disk via `qm`, convert to template via `qm`) with native provider resources:
  - `proxmox_virtual_environment_download_file` for cloud image downloads (supports `decompression_algorithm` instead of manual `xz`/`gunzip`)
  - `proxmox_virtual_environment_vm` with `template = true` and `import_from` for disk import
- **Template (clone path):** Replaced `null_resource` + `curl` template conversion with native `template = true` attribute on `proxmox_virtual_environment_vm`
- **Provider (__init__.py):** Removed SSH hostname extraction logic from `_generate_templates_terraform()` since SSH is no longer needed; the `ssh_hostname` context variable is removed
- **Config change:** `download_image.extract` replaced by `download_image.decompression` (maps to provider's `decompression_algorithm`)
- **Tests:** Added `test_generate_download_image_template_terraform` and `test_generate_download_image_template_minimal`; updated existing clone test assertions

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- No user-facing documentation exists for Proxmox templates yet, so no doc updates needed
- The `download_image.extract` boolean config key is replaced by `download_image.decompression` string key (e.g., `"xz"`, `"gz"`). This is a breaking change for existing template configs using `extract: true`
- The `ssh_hostname` and `proxmox_ssh_user` Terraform variables are no longer needed for template creation
- Issue #366 does not have the `needs-adr` label; no ADR is required
