### PR TITLE
fix: raise error when -r resource filter matches no resources

### DIFF
--- a/src/infrafoundry/cli/errors.py
+++ b/src/infrafoundry/cli/errors.py
@@ -333,6 +333,16 @@ ERROR_CATALOG: dict[str, ErrorInfo] = {
             "Verify data types match expected schema",
         ],
     ),
+    "IF-VALIDATION-005": ErrorInfo(
+        code="IF-VALIDATION-005",
+        title="Resource Filter Matched Nothing",
+        description="The -r resource filter did not match any available resources.",
+        suggestions=[
+            "Check spelling of the resource names passed to -r",
+            "Run 'foundry infra list --env <env>' to see available resources",
+            "Verify the resources exist in your configuration",
+        ],
+    ),
     # Dependency errors (IF-DEPENDENCY-XXX)
     "IF-DEPENDENCY-001": ErrorInfo(
         code="IF-DEPENDENCY-001",
@@ -530,6 +540,7 @@ _EXCEPTION_TO_CODE: dict[str, str] = {
     "ConnectivityValidationError": "IF-VALIDATION-002",
     "ReferenceValidationError": "IF-VALIDATION-003",
     "SchemaValidationError": "IF-VALIDATION-004",
+    "ResourceFilterError": "IF-VALIDATION-005",
     # Dependency errors
     "CircularDependencyError": "IF-DEPENDENCY-001",
     "MissingDependencyError": "IF-DEPENDENCY-002",

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -7,7 +7,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from infrafoundry.core.config.models import IaCTool
 from infrafoundry.core.events import EventManager, EventType
-from infrafoundry.core.exceptions import InfraFoundryError
+from infrafoundry.core.exceptions import InfraFoundryError, ResourceFilterError
 from infrafoundry.core.execution_planner import ExecutionPlanner
 from infrafoundry.core.protocols import Applyable, StateAware
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
@@ -63,6 +63,40 @@ class DeploymentExecutor:
             runner = self.runner_registry.create_runner(tool_name, console=self.console)
             if runner:
                 self.runners[tool_name] = runner
+
+    def _validate_resource_filter(
+        self,
+        resources_by_provider: dict[str, list[ResourceConfig]],
+        filter_set: set[str],
+    ) -> None:
+        """Validate that resource filter matches at least one resource.
+
+        Args:
+            resources_by_provider: Dict mapping provider names to resources
+            filter_set: Set of resource names to filter by
+
+        Raises:
+            ResourceFilterError: If no resources match the filter
+        """
+        all_resource_names: set[str] = set()
+        matched_names: set[str] = set()
+        for resources in resources_by_provider.values():
+            for r in resources:
+                all_resource_names.add(r.name)
+                if r.name in filter_set:
+                    matched_names.add(r.name)
+
+        unmatched = filter_set - matched_names
+        if not matched_names:
+            raise ResourceFilterError(
+                f"No resources matched filter: {', '.join(sorted(filter_set))}. "
+                f"Available resources: {', '.join(sorted(all_resource_names))}"
+            )
+        elif unmatched:
+            self.console.print(
+                f"[yellow]Warning: Some resources not found: "
+                f"{', '.join(sorted(unmatched))}[/yellow]"
+            )
 
     def _get_sorted_runners(self) -> list[tuple[str, BaseRunner]]:
         """Get runners sorted by priority, filtering by configured IaC tool.
@@ -120,6 +154,10 @@ class DeploymentExecutor:
 
         # Convert to set for O(1) lookups
         filter_set = set(resource_filter) if resource_filter else None
+
+        # Validate resource filter before proceeding
+        if filter_set:
+            self._validate_resource_filter(resources_by_provider, filter_set)
 
         # Sort providers using execution planner (forward order for apply)
         sorted_providers = self.execution_planner.sort_providers(
@@ -189,6 +227,10 @@ class DeploymentExecutor:
 
         # Convert to set for O(1) lookups
         filter_set = set(resource_filter) if resource_filter else None
+
+        # Validate resource filter before proceeding
+        if filter_set:
+            self._validate_resource_filter(resources_by_provider, filter_set)
 
         # Get execution batches from planner (forward order for apply)
         batches = self.execution_planner.plan_apply(resources_by_provider)

--- a/src/infrafoundry/core/exceptions.py
+++ b/src/infrafoundry/core/exceptions.py
@@ -157,6 +157,13 @@ class StateInconsistencyError(StateError):
     """State database is inconsistent."""
 
 
+# Resource Filter Errors
+
+
+class ResourceFilterError(InfraFoundryError):
+    """Raised when resource filter matches no resources."""
+
+
 # Deployment and Orchestration Errors
 
 
@@ -312,6 +319,8 @@ __all__ = [
     "ProviderInitializationError",
     "ProviderNotFoundError",
     "ReferenceValidationError",
+    # Resource Filter
+    "ResourceFilterError",
     "ResourceNotFoundError",
     "RollbackError",
     "SchemaValidationError",

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -14,6 +14,7 @@ from infrafoundry.core.dependencies import DependencyGraph
 from infrafoundry.core.deployment_executor import DeploymentExecutor
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import Event, EventManager, EventType
+from infrafoundry.core.exceptions import ResourceFilterError
 from infrafoundry.core.execution_planner import ExecutionPlanner
 from infrafoundry.core.hooks import HookManager
 from infrafoundry.core.notifications import NotificationManager
@@ -335,6 +336,25 @@ class Orchestrator:
                     original_count=original_count,
                 )
             )
+
+        # Validate resource filter results
+        if filter_set:
+            matched_names = {r.name for batch in batches for r in batch.resources}
+            unmatched = filter_set - matched_names
+            if not matched_names:
+                all_names = sorted(
+                    {r.name for resources in resources_by_provider.values() for r in resources}
+                )
+                raise ResourceFilterError(
+                    f"No resources matched filter: {', '.join(sorted(filter_set))}. "
+                    f"Available resources: {', '.join(all_names)}"
+                )
+            elif unmatched:
+                self.console.print(
+                    f"[yellow]Warning: Some resources not found: "
+                    f"{', '.join(sorted(unmatched))}[/yellow]"
+                )
+
         return batches
 
     def validate_resources(self, resources: list[ResourceConfig]) -> None:

--- a/tests/unit/test_deployment_executor.py
+++ b/tests/unit/test_deployment_executor.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from infrafoundry.core.config.models import IaCTool
 from infrafoundry.core.deployment_executor import DeploymentExecutor
 from infrafoundry.core.events import EventType
+from infrafoundry.core.exceptions import ResourceFilterError
 from infrafoundry.core.state import ResourceState
 
 
@@ -706,8 +709,6 @@ def test_apply_emits_runner_failed_on_exception():
         providers=providers,
     )
 
-    import pytest
-
     with pytest.raises(RuntimeError, match="terraform crashed"):
         executor.apply_single_provider(
             env_name="dev",
@@ -752,3 +753,104 @@ def test_apply_emits_runner_failed_on_exception():
         if call[0][0] == EventType.RUNNER_COMPLETED
     ]
     assert len(completed_calls) == 0
+
+
+def _make_executor(providers=None):
+    """Create a minimal DeploymentExecutor for resource filter tests."""
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = []
+    state_manager = MagicMock()
+    event_manager = MagicMock()
+
+    return DeploymentExecutor(
+        runner_registry=runner_registry,
+        state_manager=state_manager,
+        event_manager=event_manager,
+        providers=providers or {},
+    )
+
+
+def test_validate_resource_filter_zero_matches_raises():
+    """Zero resource filter matches raises ResourceFilterError."""
+    executor = _make_executor()
+    resources_by_provider = {
+        "proxmox": [_resource("vm1"), _resource("vm2")],
+    }
+
+    with pytest.raises(ResourceFilterError, match="No resources matched filter"):
+        executor._validate_resource_filter(resources_by_provider, {"nonexistent"})
+
+
+def test_validate_resource_filter_error_includes_names():
+    """Error message includes unmatched filter names and available resource names."""
+    executor = _make_executor()
+    resources_by_provider = {
+        "proxmox": [_resource("vm1"), _resource("vm2")],
+    }
+
+    with pytest.raises(ResourceFilterError) as exc_info:
+        executor._validate_resource_filter(resources_by_provider, {"nonexistent"})
+
+    error_msg = str(exc_info.value)
+    assert "nonexistent" in error_msg
+    assert "vm1" in error_msg
+    assert "vm2" in error_msg
+
+
+def test_validate_resource_filter_partial_match_warns():
+    """Partial match warns but does not raise."""
+    executor = _make_executor()
+    resources_by_provider = {
+        "proxmox": [_resource("vm1"), _resource("vm2")],
+    }
+
+    # Should not raise
+    executor._validate_resource_filter(resources_by_provider, {"vm1", "nonexistent"})
+
+
+def test_validate_resource_filter_full_match_succeeds():
+    """Full match does not raise or warn."""
+    executor = _make_executor()
+    resources_by_provider = {
+        "proxmox": [_resource("vm1"), _resource("vm2")],
+    }
+
+    # Should not raise
+    executor._validate_resource_filter(resources_by_provider, {"vm1", "vm2"})
+
+
+def test_apply_serial_raises_on_zero_filter_matches():
+    """apply_serial raises ResourceFilterError when filter matches nothing."""
+    providers = {"proxmox": MagicMock()}
+    executor = _make_executor(providers=providers)
+    resources_by_provider = {
+        "proxmox": [_resource("vm1")],
+    }
+
+    with pytest.raises(ResourceFilterError, match="No resources matched filter"):
+        executor.apply_serial(
+            env_name="dev",
+            deployment_id=1,
+            resources_by_provider=resources_by_provider,
+            resource_filter=["nonexistent"],
+            auto_approve=True,
+        )
+
+
+def test_apply_parallel_raises_on_zero_filter_matches():
+    """apply_parallel raises ResourceFilterError when filter matches nothing."""
+    providers = {"proxmox": MagicMock()}
+    executor = _make_executor(providers=providers)
+    resources_by_provider = {
+        "proxmox": [_resource("vm1")],
+    }
+
+    with pytest.raises(ResourceFilterError, match="No resources matched filter"):
+        executor.apply_parallel(
+            env_name="dev",
+            deployment_id=1,
+            resources_by_provider=resources_by_provider,
+            resource_filter=["nonexistent"],
+            auto_approve=True,
+            max_workers=2,
+        )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -9,7 +9,7 @@ import pytest
 
 from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.events import EventManager
-from infrafoundry.core.exceptions import SecretNotFoundError
+from infrafoundry.core.exceptions import ResourceFilterError, SecretNotFoundError
 from infrafoundry.core.notifications import NotificationManager
 from infrafoundry.core.orchestrator import Orchestrator, OrchestratorStrictConfig
 from infrafoundry.core.orchestrator_workflows import PlanOrchestrator
@@ -521,3 +521,95 @@ class TestPlanOrchestratorStrictMode:
         provider = SimpleNamespace(terraform_dir=tmp_path)
 
         workflow._export_secrets("proxmox", "dev", provider)
+
+
+class TestIterProviderBatchesResourceFilter:
+    """Tests for resource filter validation in _iter_provider_batches."""
+
+    def _make_orchestrator(self, tmp_path):
+        """Create a minimal Orchestrator for testing _iter_provider_batches."""
+        config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
+        config_manager.load_environment.return_value = None
+        config_manager.get_all_resources_all_providers.return_value = []
+        return Orchestrator(config_manager)
+
+    def _resource(self, name, provider="proxmox", type_="vm"):
+        from infrafoundry.core.provider import ResourceConfig
+
+        return ResourceConfig(name=name, provider=provider, type=type_, config={"id": name})
+
+    def test_no_filter_returns_all_batches(self, tmp_path):
+        """No resource filter returns all provider batches."""
+        orchestrator = self._make_orchestrator(tmp_path)
+        resources_by_provider = {
+            "proxmox": [self._resource("vm1"), self._resource("vm2")],
+        }
+
+        batches = orchestrator._iter_provider_batches(resources_by_provider, None)
+
+        assert len(batches) == 1
+        assert len(batches[0].resources) == 2
+
+    def test_full_match_returns_filtered_batches(self, tmp_path):
+        """Filter matching all names returns those resources without error."""
+        orchestrator = self._make_orchestrator(tmp_path)
+        resources_by_provider = {
+            "proxmox": [self._resource("vm1"), self._resource("vm2")],
+        }
+
+        batches = orchestrator._iter_provider_batches(resources_by_provider, ["vm1", "vm2"])
+
+        assert len(batches) == 1
+        assert {r.name for r in batches[0].resources} == {"vm1", "vm2"}
+
+    def test_zero_matches_raises_resource_filter_error(self, tmp_path):
+        """Filter matching zero resources raises ResourceFilterError."""
+        orchestrator = self._make_orchestrator(tmp_path)
+        resources_by_provider = {
+            "proxmox": [self._resource("vm1"), self._resource("vm2")],
+        }
+
+        with pytest.raises(ResourceFilterError, match="No resources matched filter"):
+            orchestrator._iter_provider_batches(resources_by_provider, ["nonexistent"])
+
+    def test_zero_matches_error_includes_available_names(self, tmp_path):
+        """Error message includes unmatched and available resource names."""
+        orchestrator = self._make_orchestrator(tmp_path)
+        resources_by_provider = {
+            "proxmox": [self._resource("vm1"), self._resource("vm2")],
+        }
+
+        with pytest.raises(ResourceFilterError, match="nonexistent") as exc_info:
+            orchestrator._iter_provider_batches(resources_by_provider, ["nonexistent"])
+
+        error_msg = str(exc_info.value)
+        assert "nonexistent" in error_msg
+        assert "vm1" in error_msg
+        assert "vm2" in error_msg
+
+    def test_partial_match_warns_but_succeeds(self, tmp_path, capsys):
+        """Partial filter match warns about unmatched names but returns results."""
+        orchestrator = self._make_orchestrator(tmp_path)
+        resources_by_provider = {
+            "proxmox": [self._resource("vm1"), self._resource("vm2")],
+        }
+
+        batches = orchestrator._iter_provider_batches(resources_by_provider, ["vm1", "nonexistent"])
+
+        assert len(batches) == 1
+        assert batches[0].resources[0].name == "vm1"
+
+    def test_partial_match_across_providers(self, tmp_path):
+        """Partial match works across multiple providers."""
+        orchestrator = self._make_orchestrator(tmp_path)
+        resources_by_provider = {
+            "proxmox": [self._resource("vm1", provider="proxmox")],
+            "opnsense": [self._resource("fw1", provider="opnsense", type_="firewall")],
+        }
+
+        batches = orchestrator._iter_provider_batches(resources_by_provider, ["vm1", "fw1"])
+
+        assert len(batches) == 2
+        all_names = {r.name for b in batches for r in b.resources}
+        assert all_names == {"vm1", "fw1"}


### PR DESCRIPTION
## Description

When using `infra plan/apply/destroy -r <name>`, if the resource names don't match any loaded resources, the command silently reports success without warning. This fix adds validation to raise a `ResourceFilterError` when zero resources match, and prints a warning when only some resources match (partial match).

Addresses #367

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement

## Changes Made

- Added `ResourceFilterError` exception to `src/infrafoundry/core/exceptions.py`
- Added validation in `_iter_provider_batches()` (orchestrator.py): zero matches raises error with available resource names, partial matches prints warning
- Added `_validate_resource_filter()` helper to `DeploymentExecutor` (deployment_executor.py), called from `apply_serial()` and `apply_parallel()`
- Added `IF-VALIDATION-005` error catalog entry in `cli/errors.py`
- Added 12 new tests covering zero match, partial match, full match, and no filter scenarios

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
