### PR TITLE
feat: add package model foundation with env-root discovery

### DIFF
--- a/docs/architecture/decisions/0006-packages-as-primary-resource-model.md
+++ b/docs/architecture/decisions/0006-packages-as-primary-resource-model.md
@@ -1,0 +1,72 @@
+# 6. Packages as Primary Resource Model
+
+**Date:** 2026-03-14
+**Status:** Accepted
+**Issue:** [#357](https://github.com/endavis/infrafoundry/issues/357)
+
+## Context
+
+Infrastructure packages (`infrafoundry.yml` manifest) proved to be a better resource model during the ONTAP cluster migration (#346). Packages provide self-contained, templated resource bundles with variables, event handlers, and clear boundaries. However, the current model treats packages as an optional feature nested under provider directories, and loose YAML resource files remain the default.
+
+This creates several issues:
+
+- **No isolation:** All resources for a provider share one terraform directory and state file, making targeted operations risky.
+- **No portability:** Resources can't be easily moved, backed up, or managed independently.
+- **Fragmented config:** Related resources are spread across multiple loose YAML files with no grouping mechanism.
+- **No templating for loose resources:** Only packages support Jinja2 variable substitution.
+
+## Decision
+
+We will promote packages to the primary resource model in three phases:
+
+### Phase 1 (this ADR)
+1. Add a `provider` field to `PackageManifest` for env-root packages.
+2. Support package discovery at the environment root (`envs/{env}/`), not just under provider directories.
+3. Skip directories containing `infrafoundry.yml` during provider discovery to avoid treating env-root packages as providers.
+4. Emit deprecation warnings when loose resources (not in packages) are found.
+5. Add `PackageNotFoundError` exception for package resolution errors.
+
+### Phase 2 (future)
+- Per-package terraform state isolation: each package gets its own terraform working directory and state file.
+
+### Phase 3 (future)
+- `--package` / `-p` CLI flag for `plan`/`apply`/`destroy` to target specific packages.
+- `resolve_package_filter()` for CLI integration.
+
+### Env-root packages
+
+Packages at the environment root (`envs/{env}/{package-name}/infrafoundry.yml`) must declare a `provider` field since there is no parent provider directory to infer from. Provider-scoped packages (`envs/{env}/{provider}/{package-name}/`) can optionally declare `provider` to override the directory-inferred value.
+
+### Loose resource deprecation
+
+Loose YAML resources (not inside a package directory) will:
+- Continue to work but emit a `DeprecationWarning`
+- Be phased out in a future release
+- Users should migrate them to packages with an `infrafoundry.yml` manifest
+
+## Consequences
+
+**Positive:**
+
+- **Clear boundaries:** Each package is a self-contained unit with explicit inputs (variables) and outputs (resources).
+- **Env-root placement:** Packages at the environment root are provider-agnostic, enabling multi-provider packages.
+- **Gradual migration:** Loose resources continue to work with deprecation warnings, giving users time to migrate.
+- **Foundation for isolation:** The `provider` field and env-root discovery lay the groundwork for per-package terraform state in Phase 2.
+
+**Negative:**
+
+- **Migration effort:** Existing environments with loose resources need to be restructured into packages.
+- **Provider field requirement:** Env-root packages must explicitly declare their provider, adding a mandatory field.
+- **Discovery complexity:** Provider discovery must now skip directories containing `infrafoundry.yml`.
+
+## Alternatives Considered
+
+1. **Keep packages as optional feature:** Rejected because loose resources lack templating, isolation, and grouping. Packages are strictly better.
+
+2. **Remove loose resources immediately:** Rejected because it would be a breaking change with no migration path. Deprecation warnings give users time to adopt packages.
+
+3. **Infer provider for env-root packages from resource content:** Rejected because resources may span multiple providers, and the manifest `provider` field serves as the default/primary provider for the package.
+
+## Documentation
+
+- [Infrastructure Packages](../../configuration/infrastructure-packages.md)

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -9,6 +9,8 @@ This directory contains Architecture Decision Records (ADRs) for InfraFoundry.
 - [0002-mixin-pattern-for-providers.md](0002-mixin-pattern-for-providers.md): Use Mixin Pattern for Provider Functionality
 - [0003-granular-event-types.md](0003-granular-event-types.md): Use Granular Lifecycle Event Types
 - [0004-protocol-based-runner-interfaces.md](0004-protocol-based-runner-interfaces.md): Use Protocol-Based Runner Interfaces for ISP Compliance
+- [0005-environment-lifecycle-hooks.md](0005-environment-lifecycle-hooks.md): Environment Lifecycle Hooks
+- [0006-packages-as-primary-resource-model.md](0006-packages-as-primary-resource-model.md): Packages as Primary Resource Model
 
 ---
 [Back to Table of Contents](../../index.md)

--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -2,21 +2,28 @@
 
 ## Overview
 
-Infrastructure packages are self-contained directories within a provider that bundle
-resource templates, variables, and event handlers into a single deployable unit.
-Instead of scattering configuration across `settings.yaml`, provider resource files,
-and scripts directories, a package keeps everything together.
+Infrastructure packages are self-contained directories that bundle resource templates,
+variables, and event handlers into a single deployable unit. Instead of scattering
+configuration across `settings.yaml`, provider resource files, and scripts directories,
+a package keeps everything together.
+
+Packages can be placed in two locations:
+
+- **Provider-scoped:** Under a provider directory (`envs/{env}/{provider}/{package}/`)
+- **Env-root:** Directly under the environment directory (`envs/{env}/{package}/`)
 
 ## Directory Structure
 
-A package is a subdirectory of a provider directory containing an `infrafoundry.yml`
-manifest file:
+### Provider-scoped packages
+
+A provider-scoped package is a subdirectory of a provider directory containing an
+`infrafoundry.yml` manifest file. The provider is inferred from the parent directory:
 
 ```
 envs/dev/
   settings.yaml
   proxmox/
-    vm.yaml                    # Regular provider resources
+    vm.yaml                    # Regular provider resources (deprecated)
     ontap-cluster/             # Infrastructure package
       infrafoundry.yml         # Package manifest
       vm.yaml                  # Resource template (Jinja2)
@@ -26,6 +33,26 @@ envs/dev/
       roles/
         ontap-config/          # Ansible role (excluded from scanning)
 ```
+
+### Env-root packages
+
+An env-root package sits directly under the environment directory rather than under
+a provider. Because there is no parent provider directory to infer from, env-root
+packages **must** declare a `provider` field in their manifest:
+
+```
+envs/dev/
+  settings.yaml
+  ontap-cluster/               # Env-root package
+    infrafoundry.yml           # Must include provider field
+    vm.yaml
+    network.yaml
+  proxmox/                     # Provider directory (no infrafoundry.yml)
+    vm.yaml
+```
+
+Env-root packages are discovered during resource loading and are skipped by provider
+discovery so they are not mistaken for provider directories.
 
 ## Package Manifest (`infrafoundry.yml`)
 
@@ -66,6 +93,7 @@ section for details.
 |:------|:-----|:---------|:------------|
 | `name` | string | Yes | Package identifier |
 | `description` | string | No | Human-readable description |
+| `provider` | string | Env-root: Yes, Provider-scoped: No | Target provider name. Required for env-root packages; optional override for provider-scoped packages. |
 | `variables` | dict | No | Key-value pairs for template rendering |
 | `resources` | list[string] | No | Resource template files to render and load |
 | `events` | dict | No | Event handlers (same format as `settings.yaml` events) |
@@ -140,13 +168,31 @@ Non-script handlers (webhook, python) are passed through unchanged.
 
 ## Package Discovery
 
-Packages are discovered automatically during resource loading:
+Packages are discovered automatically during resource loading from two locations:
+
+### Provider-scoped discovery
 
 1. Only **direct subdirectories** of provider directories are scanned (no recursion)
 2. A subdirectory is a package if it contains `infrafoundry.yml`
 3. The following directory names are **excluded** from scanning:
    `roles`, `tasks`, `handlers`, `defaults`, `vars`, `meta`, `files`, `templates`, `scripts`
 4. Packages are loaded in alphabetical order by directory name
+
+### Env-root discovery
+
+1. Direct subdirectories of `envs/{env}/` are scanned for `infrafoundry.yml`
+2. Directories named `resources` or `secrets` are excluded, along with the standard
+   exclusion list above
+3. Directories containing `infrafoundry.yml` are **skipped** during provider discovery
+   so they are not mistaken for provider directories
+4. Env-root packages must declare a `provider` field in the manifest
+
+## Loose Resource Deprecation
+
+!!! warning "Deprecated"
+    Loose resource files (YAML files not inside a package directory) are deprecated.
+    They will continue to work but emit `DeprecationWarning` messages. Migrate them
+    to packages with an `infrafoundry.yml` manifest.
 
 ## Loading Order
 
@@ -155,9 +201,10 @@ are registered with the event bus after all resources (from all providers) have
 been loaded. This means:
 
 1. Regular resources from `*.yaml` files in provider directories
-2. Package resources from subdirectories with `infrafoundry.yml`
-3. Resource-centric resources from `resources/*.yaml`
-4. Package events registered with the event bus
+2. Provider-scoped package resources from subdirectories with `infrafoundry.yml`
+3. Env-root package resources from `envs/{env}/{package}/infrafoundry.yml`
+4. Resource-centric resources from `resources/*.yaml`
+5. Package events registered with the event bus
 
 ## Duplicate Detection
 

--- a/src/infrafoundry/cli/errors.py
+++ b/src/infrafoundry/cli/errors.py
@@ -343,6 +343,17 @@ ERROR_CATALOG: dict[str, ErrorInfo] = {
             "Verify the resources exist in your configuration",
         ],
     ),
+    # Package errors (IF-PACKAGE-XXX)
+    "IF-PACKAGE-001": ErrorInfo(
+        code="IF-PACKAGE-001",
+        title="Package Not Found",
+        description="The specified infrastructure package was not found in the environment.",
+        suggestions=[
+            "Check the package name spelling",
+            "Run 'foundry infra list --env <env>' to see available packages",
+            "Verify the package directory contains an infrafoundry.yml manifest",
+        ],
+    ),
     # Dependency errors (IF-DEPENDENCY-XXX)
     "IF-DEPENDENCY-001": ErrorInfo(
         code="IF-DEPENDENCY-001",
@@ -541,6 +552,8 @@ _EXCEPTION_TO_CODE: dict[str, str] = {
     "ReferenceValidationError": "IF-VALIDATION-003",
     "SchemaValidationError": "IF-VALIDATION-004",
     "ResourceFilterError": "IF-VALIDATION-005",
+    # Package errors
+    "PackageNotFoundError": "IF-PACKAGE-001",
     # Dependency errors
     "CircularDependencyError": "IF-DEPENDENCY-001",
     "MissingDependencyError": "IF-DEPENDENCY-002",

--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -1,6 +1,7 @@
 """Refactored configuration manager - coordinates between loaders."""
 
 import os
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +9,7 @@ import yaml
 
 from infrafoundry.core.base_manager import PathBasedManager
 from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
+from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
 from infrafoundry.core.config.resource_centric_loader import ResourceCentricLoader
 from infrafoundry.core.exceptions import InvalidConfigurationError
@@ -52,6 +54,7 @@ class ConfigManager(PathBasedManager):
         # Initialize loaders
         self.provider_centric = ProviderCentricLoader(base_dir)
         self.resource_centric = ResourceCentricLoader(base_dir)
+        self._package_loader = PackageLoader(base_dir)
 
     def load_environment(self, env_name: str) -> EnvironmentConfig:
         """Load environment configuration.
@@ -168,6 +171,7 @@ class ConfigManager(PathBasedManager):
         """
         all_resources = []
         resource_locations: dict[str, list[str]] = {}  # Track where each resource is defined
+        loose_resource_files: list[str] = []  # Track loose resource files for deprecation
 
         # Discover and load from provider-centric directories
         discovered_providers = self.provider_centric.discover_providers(env_name)
@@ -189,6 +193,9 @@ class ConfigManager(PathBasedManager):
                     if key not in resource_locations:
                         resource_locations[key] = []
                     resource_locations[key].append(str(config_file))
+
+                if resources:
+                    loose_resource_files.append(str(config_file))
 
                 all_resources.extend(resources)
 
@@ -216,6 +223,32 @@ class ConfigManager(PathBasedManager):
                         handlers
                     )
 
+        # Load env-root packages (directories at envs/{env}/ with infrafoundry.yml)
+        for package_dir in self._package_loader.discover_env_root_packages(env_name):
+            manifest = self._package_loader._parse_manifest(
+                package_dir / PackageLoader.MANIFEST_FILENAME
+            )
+            if not manifest.provider:
+                raise InvalidConfigurationError(
+                    f"Env-root package '{manifest.name}' at {package_dir} "
+                    f"must declare a 'provider' field in its manifest. "
+                    f"Provider cannot be inferred for packages outside provider directories."
+                )
+            pkg_resources, pkg_events = self._package_loader.load_package(
+                package_dir, manifest.provider, env_name
+            )
+            for resource in pkg_resources:
+                key = f"{resource.provider}:{resource.name}"
+                if key not in resource_locations:
+                    resource_locations[key] = []
+                resource_locations[key].append(str(package_dir / "infrafoundry.yml"))
+
+            all_resources.extend(pkg_resources)
+            for event_type, handlers in pkg_events.items():
+                self.provider_centric._pending_package_events.setdefault(event_type, []).extend(
+                    handlers
+                )
+
         # Load from resource-centric files
         resources_dir = self.base_dir / env_name / "resources"
         if resources_dir.exists():
@@ -229,7 +262,21 @@ class ConfigManager(PathBasedManager):
                         resource_locations[key] = []
                     resource_locations[key].append(str(config_file))
 
+                if resources:
+                    loose_resource_files.append(str(config_file))
+
                 all_resources.extend(resources)
+
+        # Emit deprecation warnings for loose resources (not in packages)
+        if loose_resource_files:
+            file_list = ", ".join(loose_resource_files)
+            warnings.warn(
+                f"Loose resources (not in packages) are deprecated and will be "
+                f"removed in a future release. Migrate these files to infrastructure "
+                f"packages with an infrafoundry.yml manifest: {file_list}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Check for duplicate resource names
         duplicates = [

--- a/src/infrafoundry/core/config/models.py
+++ b/src/infrafoundry/core/config/models.py
@@ -129,6 +129,7 @@ class PackageManifest(BaseModel):
 
     name: str
     description: str | None = None
+    provider: str | None = None
     variables: dict[str, Any] = Field(default_factory=dict)
     resources: list[str] = Field(default_factory=list)
     events: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -49,6 +49,12 @@ class PackageLoader:
             "scripts",
         }
     )
+    ENV_ROOT_EXCLUDED_DIRS: frozenset[str] = frozenset(
+        {
+            "resources",
+            "secrets",
+        }
+    )
 
     def __init__(self, base_dir: Path) -> None:
         """Initialize package loader.
@@ -87,6 +93,36 @@ class PackageLoader:
 
         return packages
 
+    def discover_env_root_packages(self, env_name: str) -> list[Path]:
+        """Find subdirectories of an environment directory that contain a manifest.
+
+        Scans direct subdirectories of ``envs/{env}/`` for ``infrafoundry.yml``,
+        skipping directories in EXCLUDED_DIRS and ENV_ROOT_EXCLUDED_DIRS.
+        These are "env-root packages" that are not nested under a provider.
+
+        Args:
+            env_name: Environment name
+
+        Returns:
+            List of package directory paths, sorted by name
+        """
+        env_dir = self.base_dir / env_name
+        if not env_dir.exists():
+            return []
+
+        excluded = self.EXCLUDED_DIRS | self.ENV_ROOT_EXCLUDED_DIRS
+        packages: list[Path] = []
+        for item in sorted(env_dir.iterdir()):
+            if not item.is_dir():
+                continue
+            if item.name in excluded:
+                continue
+            manifest = item / self.MANIFEST_FILENAME
+            if manifest.exists():
+                packages.append(item)
+
+        return packages
+
     def load_package(
         self, package_dir: Path, provider: str, env_name: str
     ) -> tuple[list[ResourceConfig], dict[str, list[dict[str, Any]]]]:
@@ -109,11 +145,14 @@ class PackageLoader:
         manifest_path = package_dir / self.MANIFEST_FILENAME
         manifest = self._parse_manifest(manifest_path)
 
+        # Use manifest provider with fallback to directory-inferred provider
+        effective_provider = manifest.provider or provider
+
         logger.debug(
             "Loading package '%s' from %s (provider=%s, env=%s)",
             manifest.name,
             package_dir,
-            provider,
+            effective_provider,
             env_name,
         )
 
@@ -122,7 +161,7 @@ class PackageLoader:
         for resource_file in manifest.resources:
             resource_path = package_dir / resource_file
             data = self._render_resource_file(resource_path, manifest.variables)
-            parsed = self._parse_resources_from_data(data, resource_file, provider)
+            parsed = self._parse_resources_from_data(data, resource_file, effective_provider)
             resources.extend(parsed)
 
         # Rewrite event script paths

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -150,7 +150,13 @@ class ProviderCentricLoader:
 
         providers = set()
         for item in env_dir.iterdir():
-            if item.is_dir() and item.name not in ("resources", "secrets"):
-                providers.add(item.name)
+            if not item.is_dir():
+                continue
+            if item.name in ("resources", "secrets"):
+                continue
+            # Skip directories that are env-root packages (contain infrafoundry.yml)
+            if (item / PackageLoader.MANIFEST_FILENAME).exists():
+                continue
+            providers.add(item.name)
 
         return providers

--- a/src/infrafoundry/core/exceptions.py
+++ b/src/infrafoundry/core/exceptions.py
@@ -164,6 +164,13 @@ class ResourceFilterError(InfraFoundryError):
     """Raised when resource filter matches no resources."""
 
 
+# Package Errors
+
+
+class PackageNotFoundError(InfraFoundryError):
+    """Raised when a named package is not found in the environment."""
+
+
 # Deployment and Orchestration Errors
 
 
@@ -310,6 +317,8 @@ __all__ = [
     "MissingConfigurationError",
     "MissingCredentialError",
     "MissingDependencyError",
+    # Package
+    "PackageNotFoundError",
     # Policy
     "PolicyError",
     "PolicyNotFoundError",

--- a/tests/unit/test_env_root_packages.py
+++ b/tests/unit/test_env_root_packages.py
@@ -1,0 +1,438 @@
+"""Unit tests for env-root package discovery and integration."""
+
+import warnings
+
+import pytest
+import yaml
+
+from infrafoundry.core.config.config_manager import ConfigManager
+from infrafoundry.core.config.package_loader import PackageLoader
+from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
+from infrafoundry.core.exceptions import InvalidConfigurationError, PackageNotFoundError
+
+
+def _create_env(base_dir, env_name):
+    """Create a minimal environment directory with settings.yaml."""
+    env_dir = base_dir / env_name
+    env_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = env_dir / "settings.yaml"
+    settings_path.write_text(f"name: {env_name}\n")
+    return env_dir
+
+
+def _create_package(base_dir, env_name, package_name, manifest, resource_files=None, provider=None):
+    """Create a package directory structure.
+
+    Args:
+        base_dir: Base envs directory
+        env_name: Environment name
+        package_name: Package subdirectory name
+        manifest: Dict for infrafoundry.yml content
+        resource_files: Optional dict of filename -> content
+        provider: If set, create under provider subdir instead of env root
+    """
+    if provider:
+        package_dir = base_dir / env_name / provider / package_name
+    else:
+        package_dir = base_dir / env_name / package_name
+    package_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = package_dir / "infrafoundry.yml"
+    with open(manifest_path, "w") as f:
+        yaml.dump(manifest, f)
+
+    if resource_files:
+        for filename, content in resource_files.items():
+            resource_path = package_dir / filename
+            resource_path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, str):
+                resource_path.write_text(content)
+            else:
+                with open(resource_path, "w") as f:
+                    yaml.dump(content, f)
+
+    return package_dir
+
+
+def _create_loose_resources(base_dir, env_name, provider, resource_file, content):
+    """Create loose resource files under a provider directory."""
+    provider_dir = base_dir / env_name / provider
+    provider_dir.mkdir(parents=True, exist_ok=True)
+    resource_path = provider_dir / resource_file
+    if isinstance(content, str):
+        resource_path.write_text(content)
+    else:
+        with open(resource_path, "w") as f:
+            yaml.dump(content, f)
+    return resource_path
+
+
+@pytest.mark.unit
+class TestDiscoverEnvRootPackages:
+    """Tests for PackageLoader.discover_env_root_packages."""
+
+    def test_discovers_packages_at_env_root(self, temp_dir):
+        """Subdirectory of env root with infrafoundry.yml is discovered."""
+        loader = PackageLoader(temp_dir)
+        _create_env(temp_dir, "dev")
+        _create_package(temp_dir, "dev", "my-pkg", {"name": "my-pkg", "provider": "proxmox"})
+
+        packages = loader.discover_env_root_packages("dev")
+        assert len(packages) == 1
+        assert packages[0].name == "my-pkg"
+
+    def test_discovers_multiple_packages_sorted(self, temp_dir):
+        """Multiple packages are returned sorted by name."""
+        loader = PackageLoader(temp_dir)
+        _create_env(temp_dir, "dev")
+        _create_package(temp_dir, "dev", "zeta-pkg", {"name": "zeta", "provider": "proxmox"})
+        _create_package(temp_dir, "dev", "alpha-pkg", {"name": "alpha", "provider": "proxmox"})
+
+        packages = loader.discover_env_root_packages("dev")
+        names = [p.name for p in packages]
+        assert names == ["alpha-pkg", "zeta-pkg"]
+
+    def test_skips_excluded_dirs(self, temp_dir):
+        """Directories in EXCLUDED_DIRS and ENV_ROOT_EXCLUDED_DIRS are skipped."""
+        loader = PackageLoader(temp_dir)
+        _create_env(temp_dir, "dev")
+
+        # Create dirs that should be excluded
+        for excluded in ("resources", "secrets", "roles", "scripts"):
+            excluded_dir = temp_dir / "dev" / excluded
+            excluded_dir.mkdir(parents=True, exist_ok=True)
+            (excluded_dir / "infrafoundry.yml").write_text("name: excluded\n")
+
+        # Create valid package
+        _create_package(temp_dir, "dev", "valid-pkg", {"name": "valid", "provider": "proxmox"})
+
+        packages = loader.discover_env_root_packages("dev")
+        assert len(packages) == 1
+        assert packages[0].name == "valid-pkg"
+
+    def test_skips_dirs_without_manifest(self, temp_dir):
+        """Subdirectories without infrafoundry.yml are not discovered."""
+        loader = PackageLoader(temp_dir)
+        _create_env(temp_dir, "dev")
+        no_manifest_dir = temp_dir / "dev" / "plain-dir"
+        no_manifest_dir.mkdir(parents=True)
+        (no_manifest_dir / "some-file.yaml").write_text("key: value\n")
+
+        packages = loader.discover_env_root_packages("dev")
+        assert packages == []
+
+    def test_skips_files(self, temp_dir):
+        """Files at env root are not treated as packages."""
+        loader = PackageLoader(temp_dir)
+        _create_env(temp_dir, "dev")
+        (temp_dir / "dev" / "extra.yaml").write_text("key: value\n")
+
+        packages = loader.discover_env_root_packages("dev")
+        assert packages == []
+
+    def test_nonexistent_env(self, temp_dir):
+        """Non-existent environment returns empty list."""
+        loader = PackageLoader(temp_dir)
+        packages = loader.discover_env_root_packages("nonexistent")
+        assert packages == []
+
+
+@pytest.mark.unit
+class TestManifestProviderField:
+    """Tests for the provider field on PackageManifest."""
+
+    def test_manifest_provider_parsed(self, temp_dir):
+        """Provider field is parsed from manifest."""
+        loader = PackageLoader(temp_dir)
+        pkg_dir = temp_dir / "pkg"
+        pkg_dir.mkdir()
+        manifest_path = pkg_dir / "infrafoundry.yml"
+        manifest_path.write_text("name: my-pkg\nprovider: proxmox\n")
+
+        manifest = loader._parse_manifest(manifest_path)
+        assert manifest.provider == "proxmox"
+
+    def test_manifest_provider_defaults_to_none(self, temp_dir):
+        """Provider field defaults to None when not specified."""
+        loader = PackageLoader(temp_dir)
+        pkg_dir = temp_dir / "pkg"
+        pkg_dir.mkdir()
+        manifest_path = pkg_dir / "infrafoundry.yml"
+        manifest_path.write_text("name: my-pkg\n")
+
+        manifest = loader._parse_manifest(manifest_path)
+        assert manifest.provider is None
+
+    def test_manifest_provider_overrides_directory_inferred(self, temp_dir):
+        """Manifest provider overrides directory-inferred provider in load_package."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "my-pkg",
+            "provider": "esxi",
+            "resources": ["vm.yaml"],
+        }
+        resource_content = "vm:\n  - name: test-vm\n    cores: 2\n"
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "my-pkg",
+            manifest,
+            {"vm.yaml": resource_content},
+            provider="proxmox",
+        )
+
+        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        assert len(resources) == 1
+        # Should use manifest provider "esxi", not directory-inferred "proxmox"
+        assert resources[0].provider == "esxi"
+
+    def test_directory_inferred_provider_used_as_fallback(self, temp_dir):
+        """When manifest has no provider, directory-inferred provider is used."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "my-pkg",
+            "resources": ["vm.yaml"],
+        }
+        resource_content = "vm:\n  - name: test-vm\n    cores: 2\n"
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "my-pkg",
+            manifest,
+            {"vm.yaml": resource_content},
+            provider="proxmox",
+        )
+
+        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        assert len(resources) == 1
+        assert resources[0].provider == "proxmox"
+
+
+@pytest.mark.unit
+class TestDiscoverProvidersSkipsPackages:
+    """Tests for discover_providers() skipping env-root package dirs."""
+
+    def test_skips_directory_with_manifest(self, temp_dir):
+        """Directory containing infrafoundry.yml is not treated as a provider."""
+        loader = ProviderCentricLoader(temp_dir)
+        _create_env(temp_dir, "dev")
+
+        # Create a real provider directory
+        provider_dir = temp_dir / "dev" / "proxmox"
+        provider_dir.mkdir(parents=True)
+
+        # Create an env-root package (should be skipped)
+        _create_package(temp_dir, "dev", "my-pkg", {"name": "my-pkg", "provider": "proxmox"})
+
+        providers = loader.discover_providers("dev")
+        assert "proxmox" in providers
+        assert "my-pkg" not in providers
+
+    def test_provider_dir_without_manifest_still_discovered(self, temp_dir):
+        """Regular directories without infrafoundry.yml are still providers."""
+        loader = ProviderCentricLoader(temp_dir)
+        _create_env(temp_dir, "dev")
+
+        for name in ("proxmox", "opnsense"):
+            (temp_dir / "dev" / name).mkdir(parents=True)
+
+        providers = loader.discover_providers("dev")
+        assert providers == {"proxmox", "opnsense"}
+
+
+@pytest.mark.unit
+class TestEnvRootPackageIntegration:
+    """Tests for env-root packages in get_all_resources_all_providers."""
+
+    def test_env_root_packages_loaded(self, temp_dir):
+        """Env-root packages are loaded alongside provider-scoped resources."""
+        _create_env(temp_dir, "dev")
+
+        # Create provider-scoped loose resource
+        _create_loose_resources(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "vm.yaml",
+            {"vm": [{"name": "loose-vm", "cores": 2}]},
+        )
+
+        # Create env-root package
+        _create_package(
+            temp_dir,
+            "dev",
+            "my-pkg",
+            {"name": "my-pkg", "provider": "proxmox", "resources": ["vm.yaml"]},
+            {"vm.yaml": "vm:\n  - name: pkg-vm\n    cores: 4\n"},
+        )
+
+        manager = ConfigManager(base_dir=temp_dir)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            resources = manager.get_all_resources_all_providers("dev")
+
+        names = {r.name for r in resources}
+        assert "loose-vm" in names
+        assert "pkg-vm" in names
+
+    def test_env_root_package_without_provider_raises(self, temp_dir):
+        """Env-root package without provider field raises InvalidConfigurationError."""
+        _create_env(temp_dir, "dev")
+        _create_package(
+            temp_dir,
+            "dev",
+            "bad-pkg",
+            {"name": "bad-pkg", "resources": ["vm.yaml"]},
+            {"vm.yaml": "vm:\n  - name: test-vm\n"},
+        )
+
+        manager = ConfigManager(base_dir=temp_dir)
+        with pytest.raises(InvalidConfigurationError, match="must declare a 'provider' field"):
+            manager.get_all_resources_all_providers("dev")
+
+    def test_env_root_package_events_accumulated(self, temp_dir):
+        """Events from env-root packages are accumulated in package events."""
+        _create_env(temp_dir, "dev")
+        _create_package(
+            temp_dir,
+            "dev",
+            "my-pkg",
+            {
+                "name": "my-pkg",
+                "provider": "proxmox",
+                "events": {
+                    "AFTER_APPLY": [{"type": "script", "script": "scripts/setup.sh"}],
+                },
+            },
+        )
+
+        manager = ConfigManager(base_dir=temp_dir)
+        manager.get_all_resources_all_providers("dev")
+        events = manager.get_package_events()
+        assert "AFTER_APPLY" in events
+
+    def test_env_root_package_duplicate_name_detected(self, temp_dir):
+        """Duplicate resource names between env-root package and loose resources raise."""
+        _create_env(temp_dir, "dev")
+
+        # Create loose resource
+        _create_loose_resources(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "vm.yaml",
+            {"vm": [{"name": "dupe-vm", "cores": 2}]},
+        )
+
+        # Create env-root package with same resource name
+        _create_package(
+            temp_dir,
+            "dev",
+            "my-pkg",
+            {"name": "my-pkg", "provider": "proxmox", "resources": ["vm.yaml"]},
+            {"vm.yaml": "vm:\n  - name: dupe-vm\n    cores: 4\n"},
+        )
+
+        manager = ConfigManager(base_dir=temp_dir)
+        with pytest.raises(ValueError, match="Duplicate resource names"), warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            manager.get_all_resources_all_providers("dev")
+
+
+@pytest.mark.unit
+class TestLooseResourceDeprecationWarning:
+    """Tests for deprecation warnings on loose resources."""
+
+    def test_loose_resources_emit_deprecation_warning(self, temp_dir):
+        """Loose resource files trigger a DeprecationWarning."""
+        _create_env(temp_dir, "dev")
+        _create_loose_resources(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "vm.yaml",
+            {"vm": [{"name": "loose-vm", "cores": 2}]},
+        )
+
+        manager = ConfigManager(base_dir=temp_dir)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.get_all_resources_all_providers("dev")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 1
+        assert "Loose resources" in str(deprecation_warnings[0].message)
+        assert "deprecated" in str(deprecation_warnings[0].message)
+
+    def test_no_warning_when_only_packages(self, temp_dir):
+        """No deprecation warning when all resources are in packages."""
+        _create_env(temp_dir, "dev")
+        _create_package(
+            temp_dir,
+            "dev",
+            "my-pkg",
+            {"name": "my-pkg", "provider": "proxmox", "resources": ["vm.yaml"]},
+            {"vm.yaml": "vm:\n  - name: pkg-vm\n    cores: 4\n"},
+        )
+
+        manager = ConfigManager(base_dir=temp_dir)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.get_all_resources_all_providers("dev")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 0
+
+    def test_resource_centric_loose_files_emit_warning(self, temp_dir):
+        """Resource-centric loose files also trigger deprecation warning."""
+        _create_env(temp_dir, "dev")
+
+        # Create resource-centric file
+        resources_dir = temp_dir / "dev" / "resources"
+        resources_dir.mkdir(parents=True)
+        resource_file = resources_dir / "infra.yaml"
+        resource_file.write_text(
+            "resources:\n  - name: rc-vm\n    type: vm\n    provider: proxmox\n"
+        )
+
+        manager = ConfigManager(base_dir=temp_dir)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.get_all_resources_all_providers("dev")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 1
+
+    def test_no_warning_when_no_resources(self, temp_dir):
+        """No deprecation warning when environment has no resources at all."""
+        _create_env(temp_dir, "dev")
+
+        manager = ConfigManager(base_dir=temp_dir)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.get_all_resources_all_providers("dev")
+
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 0
+
+
+@pytest.mark.unit
+class TestPackageNotFoundError:
+    """Tests for PackageNotFoundError exception."""
+
+    def test_exception_exists_and_inherits(self):
+        """PackageNotFoundError exists and inherits from InfraFoundryError."""
+        from infrafoundry.core.exceptions import InfraFoundryError
+
+        error = PackageNotFoundError("test package not found")
+        assert isinstance(error, InfraFoundryError)
+        assert str(error) == "test package not found"
+
+    def test_exception_with_context(self):
+        """PackageNotFoundError accepts context dict."""
+        error = PackageNotFoundError(
+            "Package 'my-pkg' not found",
+            context={"env": "dev", "package": "my-pkg"},
+        )
+        assert error.context["env"] == "dev"
+        assert "my-pkg" in str(error)


### PR DESCRIPTION
## Description

Foundation for promoting packages to the primary resource model. This is PR 1 of 3 — it covers the package model changes and env-root discovery only. Per-package state isolation (PR 2) and `--package` CLI flag (PR 3) will follow in separate PRs.

Addresses #357

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Add `provider` field to `PackageManifest` for env-root packages that cannot infer provider from directory structure
- Add `discover_env_root_packages()` to `PackageLoader` for scanning `envs/{env}/` subdirectories
- Update `ConfigManager.get_all_resources_all_providers()` to load env-root packages and emit deprecation warnings for loose resource files
- Skip directories containing `infrafoundry.yml` during provider discovery to prevent env-root packages from being treated as providers
- Add `PackageNotFoundError` exception and `IF-PACKAGE-001` error catalog entry
- Create ADR 0006 documenting the packages-as-primary-resource-model decision
- Update infrastructure packages documentation with env-root placement, `provider` field, and deprecation notice
- Add 22 unit tests covering env-root discovery, provider field handling, deprecation warnings, and edge cases

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (22 tests in `tests/unit/test_env_root_packages.py`)
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

This is **PR 1 of 3** for issue #357:

1. **This PR:** Package model + env-root discovery foundation (ADR 0006, `provider` field, env-root discovery, loose resource deprecation)
2. **PR 2:** Per-package terraform state isolation
3. **PR 3:** `--package` / `-p` CLI flag for targeted operations
