### PR TITLE
feat: add per-package terraform state isolation

### DIFF
--- a/docs/architecture/decisions/0006-packages-as-primary-resource-model.md
+++ b/docs/architecture/decisions/0006-packages-as-primary-resource-model.md
@@ -26,8 +26,11 @@ We will promote packages to the primary resource model in three phases:
 4. Emit deprecation warnings when loose resources (not in packages) are found.
 5. Add `PackageNotFoundError` exception for package resolution errors.
 
-### Phase 2 (future)
+### Phase 2 (this ADR, PR 2)
 - Per-package terraform state isolation: each package gets its own terraform working directory and state file.
+- `ProviderBase.set_package_context()` / `clear_package_context()` switch `terraform_dir` between `generated/{env}/terraform/{package}/` and the default `generated/{env}/terraform/{provider}/`.
+- Plan, apply, and destroy workflows group resources by package and process each group in its own terraform working directory.
+- Loose resources (not in any package) continue to use the per-provider directory.
 
 ### Phase 3 (future)
 - `--package` / `-p` CLI flag for `plan`/`apply`/`destroy` to target specific packages.

--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -187,6 +187,42 @@ Packages are discovered automatically during resource loading from two locations
    so they are not mistaken for provider directories
 4. Env-root packages must declare a `provider` field in the manifest
 
+## Per-Package State Isolation
+
+Each package gets its own terraform working directory and state file. When a
+package context is active, generated terraform files are written to
+`generated/{env}/terraform/{package-name}/` instead of the default
+`generated/{env}/terraform/{provider}/`.
+
+This means:
+
+- **Independent state:** Applying or destroying one package cannot affect
+  another package's terraform state.
+- **Targeted operations:** `plan`, `apply`, and `destroy` process each package
+  separately, running `terraform init`, `plan`, and `apply` within the
+  package-scoped directory.
+- **Loose resources** (not inside a package) continue to use the per-provider
+  directory `generated/{env}/terraform/{provider}/`.
+
+### Directory layout example
+
+```
+generated/prod/
+  terraform/
+    ontap-cluster/           # Package-scoped state
+      main.tf
+      .terraform/
+        terraform.tfstate
+    k8s-cluster/             # Another package
+      main.tf
+      .terraform/
+        terraform.tfstate
+    proxmox/                 # Loose resources (per-provider)
+      main.tf
+      .terraform/
+        terraform.tfstate
+```
+
 ## Loose Resource Deprecation
 
 !!! warning "Deprecated"

--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -294,6 +294,94 @@ class ConfigManager(PathBasedManager):
 
         return all_resources
 
+    def get_package_for_resource(self, env_name: str, resource_name: str) -> str | None:
+        """Return the package name that owns a resource, or None for loose resources.
+
+        Scans provider-scoped and env-root packages for a resource whose name
+        matches *resource_name*.
+
+        Args:
+            env_name: Environment name
+            resource_name: Resource name to look up
+
+        Returns:
+            Package name if the resource belongs to a package, None otherwise
+        """
+        # Check provider-scoped packages
+        discovered_providers = self.provider_centric.discover_providers(env_name)
+        for provider_name in discovered_providers:
+            for package_dir in self._package_loader.discover_packages(env_name, provider_name):
+                manifest = self._package_loader._parse_manifest(
+                    package_dir / PackageLoader.MANIFEST_FILENAME
+                )
+                effective_provider = manifest.provider or provider_name
+                pkg_resources, _ = self._package_loader.load_package(
+                    package_dir, effective_provider, env_name
+                )
+                for resource in pkg_resources:
+                    if resource.name == resource_name:
+                        return manifest.name
+
+        # Check env-root packages
+        for package_dir in self._package_loader.discover_env_root_packages(env_name):
+            manifest = self._package_loader._parse_manifest(
+                package_dir / PackageLoader.MANIFEST_FILENAME
+            )
+            if not manifest.provider:
+                continue
+            pkg_resources, _ = self._package_loader.load_package(
+                package_dir, manifest.provider, env_name
+            )
+            for resource in pkg_resources:
+                if resource.name == resource_name:
+                    return manifest.name
+
+        return None
+
+    def get_resource_package_map(self, env_name: str) -> dict[str, str]:
+        """Build a mapping of resource names to their owning package names.
+
+        This is more efficient than calling ``get_package_for_resource()``
+        in a loop because it loads each package only once.
+
+        Args:
+            env_name: Environment name
+
+        Returns:
+            Dict mapping resource names to package names. Loose resources
+            (not in any package) are omitted from the result.
+        """
+        resource_to_package: dict[str, str] = {}
+
+        # Provider-scoped packages
+        discovered_providers = self.provider_centric.discover_providers(env_name)
+        for provider_name in discovered_providers:
+            for package_dir in self._package_loader.discover_packages(env_name, provider_name):
+                manifest = self._package_loader._parse_manifest(
+                    package_dir / PackageLoader.MANIFEST_FILENAME
+                )
+                effective_provider = manifest.provider or provider_name
+                pkg_resources, _ = self._package_loader.load_package(
+                    package_dir, effective_provider, env_name
+                )
+                for resource in pkg_resources:
+                    resource_to_package[resource.name] = manifest.name
+
+        # Env-root packages
+        for package_dir in self._package_loader.discover_env_root_packages(env_name):
+            manifest = self._package_loader._parse_manifest(
+                package_dir / PackageLoader.MANIFEST_FILENAME
+            )
+            if not manifest.provider:
+                continue
+            pkg_resources, _ = self._package_loader.load_package(
+                package_dir, manifest.provider, env_name
+            )
+            for resource in pkg_resources:
+                resource_to_package[resource.name] = manifest.name
+
+        return resource_to_package
+
     def get_package_events(self) -> dict[str, list[dict[str, Any]]]:
         """Return accumulated package events from last resource load.
 

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -57,12 +57,42 @@ class DeploymentExecutor:
         # Create execution planner with configured provider order
         self.execution_planner = ExecutionPlanner(provider_order=provider_order)
 
+        # Resource-to-package mapping for per-package state isolation.
+        # Set by the orchestrator before apply_serial/apply_parallel calls.
+        self.resource_package_map: dict[str, str] = {}
+
         # Dynamically create all registered runners
         self.runners: dict[str, BaseRunner] = {}
         for tool_name in self.runner_registry.list_runners():
             runner = self.runner_registry.create_runner(tool_name, console=self.console)
             if runner:
                 self.runners[tool_name] = runner
+
+    @staticmethod
+    def _group_by_package(
+        resources: list[ResourceConfig],
+        package_map: dict[str, str],
+    ) -> list[tuple[str | None, list[ResourceConfig]]]:
+        """Split resources into (package_name, resources) groups.
+
+        Args:
+            resources: Resources to split
+            package_map: Mapping of resource name to package name
+
+        Returns:
+            List of (package_name_or_None, resources) tuples
+        """
+        groups: dict[str | None, list[ResourceConfig]] = {}
+        for resource in resources:
+            pkg = package_map.get(resource.name)
+            groups.setdefault(pkg, []).append(resource)
+
+        result: list[tuple[str | None, list[ResourceConfig]]] = []
+        for pkg_name in sorted(k for k in groups if k is not None):
+            result.append((pkg_name, groups[pkg_name]))
+        if None in groups:
+            result.append((None, groups[None]))
+        return result
 
     def _validate_resource_filter(
         self,
@@ -184,16 +214,32 @@ class DeploymentExecutor:
             # Set environment for provider to ensure correct output directory
             provider.set_environment(env_name)
 
-            result = self.apply_single_provider(
-                env_name=env_name,
-                deployment_id=deployment_id,
-                provider_name=provider_name,
-                provider=provider,
-                resources=resources,
-                auto_approve=auto_approve,
-                resource_filter=resource_filter,
-            )
-            results[provider_name] = result
+            # Group by package for state isolation
+            package_groups = self._group_by_package(resources, self.resource_package_map)
+
+            for pkg_name, pkg_resources in package_groups:
+                if pkg_name is not None:
+                    provider.set_package_context(pkg_name)
+                    self.console.print(
+                        f"  [dim]Package: {pkg_name} ({len(pkg_resources)} resources)[/dim]"
+                    )
+                else:
+                    provider.clear_package_context()
+
+                result = self.apply_single_provider(
+                    env_name=env_name,
+                    deployment_id=deployment_id,
+                    provider_name=provider_name,
+                    provider=provider,
+                    resources=pkg_resources,
+                    auto_approve=auto_approve,
+                    resource_filter=resource_filter,
+                )
+                result_key = f"{provider_name}/{pkg_name}" if pkg_name else provider_name
+                results[result_key] = result
+
+            # Restore provider context
+            provider.clear_package_context()
 
         return results
 
@@ -243,9 +289,9 @@ class DeploymentExecutor:
 
         # Process each batch sequentially
         for batch_idx, batch in enumerate(batches, 1):
-            batch_providers = []
-
             # Filter to providers we have registered and have matching resources
+            # Each entry is (provider_name, pkg_name_or_None, resources)
+            batch_items: list[tuple[str, str | None, list[ResourceConfig]]] = []
             for provider_name in batch.providers:
                 if provider_name not in self.providers:
                     continue
@@ -258,24 +304,33 @@ class DeploymentExecutor:
                     if not resources:
                         continue
 
-                batch_providers.append((provider_name, resources))
+                # Sub-group by package for state isolation
+                package_groups = self._group_by_package(resources, self.resource_package_map)
+                for pkg_name, pkg_resources in package_groups:
+                    batch_items.append((provider_name, pkg_name, pkg_resources))
 
-            if not batch_providers:
+            if not batch_items:
                 continue
 
             if len(batches) > 1:
+                unique_providers = sorted({p for p, _, _ in batch_items})
                 self.console.print(
-                    f"\n[dim]Batch {batch_idx}/{len(batches)}: "
-                    f"{', '.join(p[0] for p in batch_providers)}[/dim]"
+                    f"\n[dim]Batch {batch_idx}/{len(batches)}: {', '.join(unique_providers)}[/dim]"
                 )
 
-            # Run providers in this batch in parallel
+            # Run providers/packages in this batch in parallel
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                future_to_provider: dict[Any, str] = {}
+                future_to_label: dict[Any, str] = {}
 
-                for provider_name, resources in batch_providers:
+                for provider_name, pkg_name, pkg_resources in batch_items:
                     provider = self.providers[provider_name]
                     provider.set_environment(env_name)
+                    if pkg_name is not None:
+                        provider.set_package_context(pkg_name)
+                    else:
+                        provider.clear_package_context()
+
+                    label = f"{provider_name}/{pkg_name}" if pkg_name else provider_name
 
                     future = executor.submit(
                         self.apply_single_provider,
@@ -283,37 +338,35 @@ class DeploymentExecutor:
                         deployment_id=deployment_id,
                         provider_name=provider_name,
                         provider=provider,
-                        resources=resources,
+                        resources=pkg_resources,
                         auto_approve=auto_approve,
                         resource_filter=resource_filter,
                     )
-                    future_to_provider[future] = provider_name
+                    future_to_label[future] = label
 
                 # Collect results as they complete
                 with Progress(
                     SpinnerColumn(), TextColumn("[progress.description]{task.description}")
                 ) as progress:
                     task = progress.add_task(
-                        "[cyan]Applying providers...", total=len(future_to_provider)
+                        "[cyan]Applying providers...", total=len(future_to_label)
                     )
 
-                    for future in as_completed(future_to_provider):
-                        provider_name = future_to_provider[future]
+                    for future in as_completed(future_to_label):
+                        label = future_to_label[future]
                         try:
                             result = future.result()
-                            results[provider_name] = result
-                            self.console.print(f"[green]✓ {provider_name} completed[/green]")
+                            results[label] = result
+                            self.console.print(f"[green]✓ {label} completed[/green]")
                         except InfraFoundryError as e:
-                            self.console.print(f"[red]✗ {provider_name} failed: {e.message}[/red]")
+                            self.console.print(f"[red]✗ {label} failed: {e.message}[/red]")
                             if e.context:
                                 self.console.print(f"  Context: {e.context}", style="dim red")
-                            results[provider_name] = {"error": str(e)}
+                            results[label] = {"error": str(e)}
                         except Exception as e:
-                            self.console.print(
-                                f"[red]✗ {provider_name} failed (unexpected): {e}[/red]"
-                            )
+                            self.console.print(f"[red]✗ {label} failed (unexpected): {e}[/red]")
                             self.console.print(traceback.format_exc(), style="dim red")
-                            results[provider_name] = {"error": str(e)}
+                            results[label] = {"error": str(e)}
                         progress.update(task, advance=1)
 
         return results

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -149,6 +149,7 @@ class Orchestrator:
             get_runner_priorities=self.provider_registry.get_runner_priorities,
             hook_manager=self.hook_manager,
             load_environment=self.config_manager.load_environment,
+            get_resource_package_map=self._get_resource_package_map,
         )
         self.apply_orchestrator = ApplyOrchestrator(
             console=self.console,
@@ -172,6 +173,7 @@ class Orchestrator:
             get_current_user=self._get_current_user,
             hook_manager=self.hook_manager,
             load_environment=self.config_manager.load_environment,
+            get_resource_package_map=self._get_resource_package_map,
         )
         self.rollback_orchestrator = RollbackOrchestrator(
             console=self.console,
@@ -267,7 +269,24 @@ class Orchestrator:
         if isinstance(package_events, dict) and package_events and self.event_manager:
             self.event_manager.load_config(package_events)
 
+        # Build and cache resource-to-package mapping for state isolation.
+        # Fallback to empty dict if the method returns a non-dict (e.g. when
+        # ConfigManager is mocked in tests).
+        pkg_map = self.config_manager.get_resource_package_map(env_name)
+        self._resource_package_map: dict[str, str] = pkg_map if isinstance(pkg_map, dict) else {}
+
         return all_resources, resources_by_provider
+
+    def _get_resource_package_map(self) -> dict[str, str]:
+        """Return the cached resource-to-package mapping.
+
+        Built during ``_load_resources()`` and maps resource names to their
+        owning package names. Loose resources are absent from the mapping.
+
+        Returns:
+            Dict mapping resource names to package names
+        """
+        return getattr(self, "_resource_package_map", {})
 
     def _create_execution_planner(self, env_name: str) -> ExecutionPlanner:
         """Create an execution planner for an environment.
@@ -573,6 +592,9 @@ class Orchestrator:
                 provider_order=env_config.provider_order or None
             )
 
+        # Pass cached resource-to-package map for state isolation
+        self.deployment_executor.resource_package_map = self._get_resource_package_map()
+
         return self.deployment_executor.apply_serial(
             env_name, deployment_id, resources_by_provider, resource_filter, auto_approve
         )
@@ -597,6 +619,9 @@ class Orchestrator:
             self.deployment_executor.execution_planner = ExecutionPlanner(
                 provider_order=env_config.provider_order or None
             )
+
+        # Pass cached resource-to-package map for state isolation
+        self.deployment_executor.resource_package_map = self._get_resource_package_map()
 
         return self.deployment_executor.apply_parallel(
             env_name,

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -293,6 +293,7 @@ class PlanOrchestrator(HookExecutionMixin):
         get_runner_priorities: Callable[[str], dict[str, int]],
         hook_manager: HookManager | None = None,
         load_environment: Callable[[str], EnvironmentConfig | None] | None = None,
+        get_resource_package_map: Callable[[], dict[str, str]] | None = None,
     ) -> None:
         self.console = console
         self.state_manager = state_manager
@@ -310,6 +311,7 @@ class PlanOrchestrator(HookExecutionMixin):
         self._get_runner_priorities = get_runner_priorities
         self._hook_manager = hook_manager
         self._load_environment = load_environment
+        self._get_resource_package_map = get_resource_package_map or (lambda: {})
 
         # Dynamically create all registered runners
         self.runners: dict[str, BaseRunner] = {}
@@ -317,6 +319,37 @@ class PlanOrchestrator(HookExecutionMixin):
             runner = self.runner_registry.create_runner(tool_name, console=self.console)
             if runner:
                 self.runners[tool_name] = runner
+
+    @staticmethod
+    def _group_by_package(
+        resources: list[ResourceConfig],
+        package_map: dict[str, str],
+    ) -> list[tuple[str | None, list[ResourceConfig]]]:
+        """Split resources into (package_name, resources) groups.
+
+        Resources belonging to a package are grouped under the package name.
+        Loose resources (not in any package) are grouped under ``None``.
+        Package groups are returned first, then the loose group (if any).
+
+        Args:
+            resources: Resources to split
+            package_map: Mapping of resource name to package name
+
+        Returns:
+            List of (package_name_or_None, resources) tuples
+        """
+        groups: dict[str | None, list[ResourceConfig]] = {}
+        for resource in resources:
+            pkg = package_map.get(resource.name)
+            groups.setdefault(pkg, []).append(resource)
+
+        # Packages first (sorted for deterministic order), then loose
+        result: list[tuple[str | None, list[ResourceConfig]]] = []
+        for pkg_name in sorted(k for k in groups if k is not None):
+            result.append((pkg_name, groups[pkg_name]))
+        if None in groups:
+            result.append((None, groups[None]))
+        return result
 
     def _get_sorted_runners(
         self,
@@ -414,8 +447,6 @@ class PlanOrchestrator(HookExecutionMixin):
                     provider_results["dry_run"] = True
                 else:
                     provider.set_environment(env_name)
-                    provider.ensure_directories()
-                    self._export_secrets(provider_name, env_name, provider)
 
                     # Always generate with ALL resources to avoid terraform
                     # seeing filtered-out resources as deleted. The resource
@@ -425,79 +456,110 @@ class PlanOrchestrator(HookExecutionMixin):
                         all_provider_resources if resource_filter else provider_resources
                     )
 
+                    # Split resources by package for state isolation
+                    package_map = self._get_resource_package_map()
+                    package_groups = self._group_by_package(generate_resources, package_map)
+
                     iac_tool = env_config.iac_tool if env_config else IaCTool.TERRAFORM
-                    for tool_name, runner in self._get_sorted_runners(runner_priorities, iac_tool):
-                        generate_method = getattr(provider, f"generate_{tool_name}", None)
-                        if generate_method and callable(generate_method):
-                            if not isinstance(runner, Plannable):
-                                self.console.print(
-                                    f"  [dim]Skipping {tool_name}: does not support plan[/dim]"
-                                )
-                                continue
 
+                    for pkg_name, pkg_resources in package_groups:
+                        # Set or clear package context on the provider
+                        if pkg_name is not None:
+                            provider.set_package_context(pkg_name)
                             self.console.print(
-                                f"  [dim]Generating {tool_name} configuration...[/dim]"
+                                f"  [dim]Package: {pkg_name} ({len(pkg_resources)} resources)[/dim]"
                             )
-                            generate_method(generate_resources)
-                            self.console.print(f"  [dim]Running {tool_name} plan...[/dim]")
-
-                            starting_event: RunnerEventData = {
-                                "provider": provider_name,
-                                "runner": tool_name,
-                                "phase": "plan",
-                            }
-                            self.event_manager.emit_event(
-                                EventType.RUNNER_STARTING,
-                                env_name,
-                                starting_event,
-                                provider=provider_name,
-                                runner=tool_name,
-                                target_resources=resource_filter,
-                            )
-
-                            try:
-                                # Pass resource filter as target names for terraform
-                                runner_result = runner.plan(
-                                    provider,
-                                    target_resources=resource_filter if resource_filter else None,
-                                )
-                                provider_results[f"{tool_name}_plan"] = runner_result
-
-                                completed_event: RunnerEventData = {
-                                    "provider": provider_name,
-                                    "runner": tool_name,
-                                    "phase": "plan",
-                                    "success": True,
-                                }
-                                self.event_manager.emit_event(
-                                    EventType.RUNNER_COMPLETED,
-                                    env_name,
-                                    completed_event,
-                                    provider=provider_name,
-                                    runner=tool_name,
-                                    target_resources=resource_filter,
-                                )
-                            except Exception as exc:
-                                failed_event: RunnerEventData = {
-                                    "provider": provider_name,
-                                    "runner": tool_name,
-                                    "phase": "plan",
-                                    "error": str(exc),
-                                }
-                                self.event_manager.emit_event(
-                                    EventType.RUNNER_FAILED,
-                                    env_name,
-                                    failed_event,
-                                    provider=provider_name,
-                                    runner=tool_name,
-                                    target_resources=resource_filter,
-                                )
-                                raise
                         else:
-                            self.console.print(
-                                f"  [dim]Skipping {tool_name} for {provider_name}: "
-                                f"no generate_{tool_name} method[/dim]"
-                            )
+                            provider.clear_package_context()
+
+                        provider.ensure_directories()
+                        self._export_secrets(provider_name, env_name, provider)
+
+                        for tool_name, runner in self._get_sorted_runners(
+                            runner_priorities, iac_tool
+                        ):
+                            generate_method = getattr(provider, f"generate_{tool_name}", None)
+                            if generate_method and callable(generate_method):
+                                if not isinstance(runner, Plannable):
+                                    self.console.print(
+                                        f"  [dim]Skipping {tool_name}: does not support plan[/dim]"
+                                    )
+                                    continue
+
+                                self.console.print(
+                                    f"  [dim]Generating {tool_name} configuration...[/dim]"
+                                )
+                                generate_method(pkg_resources)
+                                self.console.print(f"  [dim]Running {tool_name} plan...[/dim]")
+
+                                starting_event: RunnerEventData = {
+                                    "provider": provider_name,
+                                    "runner": tool_name,
+                                    "phase": "plan",
+                                }
+                                self.event_manager.emit_event(
+                                    EventType.RUNNER_STARTING,
+                                    env_name,
+                                    starting_event,
+                                    provider=provider_name,
+                                    runner=tool_name,
+                                    target_resources=resource_filter,
+                                )
+
+                                try:
+                                    # Pass resource filter as target names
+                                    runner_result = runner.plan(
+                                        provider,
+                                        target_resources=(
+                                            resource_filter if resource_filter else None
+                                        ),
+                                    )
+                                    # Use package-qualified key when multiple groups
+                                    result_key = (
+                                        f"{tool_name}_plan_{pkg_name}"
+                                        if pkg_name
+                                        else f"{tool_name}_plan"
+                                    )
+                                    provider_results[result_key] = runner_result
+
+                                    completed_event: RunnerEventData = {
+                                        "provider": provider_name,
+                                        "runner": tool_name,
+                                        "phase": "plan",
+                                        "success": True,
+                                    }
+                                    self.event_manager.emit_event(
+                                        EventType.RUNNER_COMPLETED,
+                                        env_name,
+                                        completed_event,
+                                        provider=provider_name,
+                                        runner=tool_name,
+                                        target_resources=resource_filter,
+                                    )
+                                except Exception as exc:
+                                    failed_event: RunnerEventData = {
+                                        "provider": provider_name,
+                                        "runner": tool_name,
+                                        "phase": "plan",
+                                        "error": str(exc),
+                                    }
+                                    self.event_manager.emit_event(
+                                        EventType.RUNNER_FAILED,
+                                        env_name,
+                                        failed_event,
+                                        provider=provider_name,
+                                        runner=tool_name,
+                                        target_resources=resource_filter,
+                                    )
+                                    raise
+                            else:
+                                self.console.print(
+                                    f"  [dim]Skipping {tool_name} for {provider_name}: "
+                                    f"no generate_{tool_name} method[/dim]"
+                                )
+
+                    # Restore provider-scoped terraform_dir after processing
+                    provider.clear_package_context()
 
                 # Execute resource-level after_plan hooks
                 for resource in provider_resources:
@@ -891,6 +953,7 @@ class DestroyOrchestrator(HookExecutionMixin):
         get_current_user: Callable[[], str],
         hook_manager: HookManager | None = None,
         load_environment: Callable[[str], EnvironmentConfig | None] | None = None,
+        get_resource_package_map: Callable[[], dict[str, str]] | None = None,
     ) -> None:
         self.console = console
         self.state_manager = state_manager
@@ -902,6 +965,7 @@ class DestroyOrchestrator(HookExecutionMixin):
         self._get_current_user = get_current_user
         self._hook_manager = hook_manager
         self._load_environment = load_environment
+        self._get_resource_package_map = get_resource_package_map or (lambda: {})
 
         # Dynamically create all registered runners
         self.runners: dict[str, BaseRunner] = {}
@@ -1000,70 +1064,98 @@ class DestroyOrchestrator(HookExecutionMixin):
 
                 provider_results: dict[str, Any] = {}
                 active_iac = env_config.iac_tool.value if env_config else IaCTool.TERRAFORM.value
-                for tool_name, runner in self.runners.items():
-                    # Skip IaC runners that don't match the configured tool
-                    if tool_name in _IAC_TOOL_KEYS and tool_name != active_iac:
-                        continue
-                    if not isinstance(runner, Destroyable):
+
+                # Group resources by package for state isolation
+                package_map = self._get_resource_package_map()
+                package_groups = PlanOrchestrator._group_by_package(resources, package_map)
+
+                for pkg_name, pkg_resources in package_groups:
+                    if pkg_name is not None:
+                        provider.set_package_context(pkg_name)
                         self.console.print(
-                            f"  [dim]Skipping {tool_name}: does not support destroy[/dim]"
+                            f"  [dim]Package: {pkg_name} ({len(pkg_resources)} resources)[/dim]"
                         )
-                        continue
+                    else:
+                        provider.clear_package_context()
 
-                    self.console.print(f"  [dim]Running {tool_name} destroy...[/dim]")
+                    # Build resource filter for this package sub-group
+                    pkg_resource_names = [r.name for r in pkg_resources]
 
-                    starting_event: RunnerEventData = {
-                        "provider": provider_name,
-                        "runner": tool_name,
-                        "phase": "destroy",
-                    }
-                    self.event_manager.emit_event(
-                        EventType.RUNNER_STARTING,
-                        env_name,
-                        starting_event,
-                        provider=provider_name,
-                        runner=tool_name,
-                        target_resources=resource_filter,
-                    )
+                    for tool_name, runner in self.runners.items():
+                        # Skip IaC runners that don't match the configured tool
+                        if tool_name in _IAC_TOOL_KEYS and tool_name != active_iac:
+                            continue
+                        if not isinstance(runner, Destroyable):
+                            self.console.print(
+                                f"  [dim]Skipping {tool_name}: does not support destroy[/dim]"
+                            )
+                            continue
 
-                    try:
-                        runner_result = runner.destroy(
-                            provider,
-                            auto_approve=auto_approve,
-                            target_resources=resource_filter if resource_filter else None,
-                        )
-                        provider_results[tool_name] = runner_result
+                        self.console.print(f"  [dim]Running {tool_name} destroy...[/dim]")
 
-                        completed_event: RunnerEventData = {
+                        starting_event: RunnerEventData = {
                             "provider": provider_name,
                             "runner": tool_name,
                             "phase": "destroy",
-                            "success": True,
                         }
                         self.event_manager.emit_event(
-                            EventType.RUNNER_COMPLETED,
+                            EventType.RUNNER_STARTING,
                             env_name,
-                            completed_event,
+                            starting_event,
                             provider=provider_name,
                             runner=tool_name,
                             target_resources=resource_filter,
                         )
-                    except Exception as exc:
-                        failed_event: RunnerEventData = {
-                            "provider": provider_name,
-                            "runner": tool_name,
-                            "phase": "destroy",
-                            "error": str(exc),
-                        }
-                        self.event_manager.emit_event(
-                            EventType.RUNNER_FAILED,
-                            env_name,
-                            failed_event,
-                            provider=provider_name,
-                            runner=tool_name,
-                            target_resources=resource_filter,
-                        )
-                        raise
+
+                        try:
+                            # Use package-scoped resource names or original
+                            # filter as target names for terraform
+                            destroy_targets = (
+                                (resource_filter if resource_filter else pkg_resource_names)
+                                if pkg_name is not None
+                                else (resource_filter if resource_filter else None)
+                            )
+                            runner_result = runner.destroy(
+                                provider,
+                                auto_approve=auto_approve,
+                                target_resources=destroy_targets,
+                            )
+                            result_key = f"{tool_name}_{pkg_name}" if pkg_name else tool_name
+                            provider_results[result_key] = runner_result
+
+                            completed_event: RunnerEventData = {
+                                "provider": provider_name,
+                                "runner": tool_name,
+                                "phase": "destroy",
+                                "success": True,
+                            }
+                            self.event_manager.emit_event(
+                                EventType.RUNNER_COMPLETED,
+                                env_name,
+                                completed_event,
+                                provider=provider_name,
+                                runner=tool_name,
+                                target_resources=resource_filter,
+                            )
+                        except Exception as exc:
+                            failed_event: RunnerEventData = {
+                                "provider": provider_name,
+                                "runner": tool_name,
+                                "phase": "destroy",
+                                "error": str(exc),
+                            }
+                            self.event_manager.emit_event(
+                                EventType.RUNNER_FAILED,
+                                env_name,
+                                failed_event,
+                                provider=provider_name,
+                                runner=tool_name,
+                                target_resources=resource_filter,
+                            )
+                            raise
+
+                # Restore provider context after processing all packages
+                provider.clear_package_context()
 
                 self._finalize_destroyed_resources(env_name, provider_name, resource_ids)
 

--- a/src/infrafoundry/core/provider.py
+++ b/src/infrafoundry/core/provider.py
@@ -41,6 +41,7 @@ class ProviderBase(ABC):
         self.ansible_dir = output_dir / "ansible" / name
         self.pyinfra_dir = output_dir / "pyinfra" / name
         self._current_environment: str | None = None
+        self._current_package: str | None = None
 
     def set_environment(self, env_name: str) -> None:
         """Set the current environment and update output directories.
@@ -49,14 +50,53 @@ class ProviderBase(ABC):
         or generate_pyinfra() to ensure files are generated in the correct
         environment-specific directory.
 
+        Also clears any active package context so that subsequent calls
+        default to the per-provider directory layout.
+
         Args:
             env_name: Environment name (e.g., 'dev', 'staging', 'prod')
         """
         self._current_environment = env_name
+        self._current_package = None
         self.output_dir = self.base_output_dir / env_name
         self.terraform_dir = self.output_dir / "terraform" / self.name
         self.ansible_dir = self.output_dir / "ansible" / self.name
         self.pyinfra_dir = self.output_dir / "pyinfra" / self.name
+
+    def set_package_context(self, package_name: str) -> None:
+        """Set package context for isolated terraform state.
+
+        When a package context is active, ``terraform_dir`` points to a
+        package-scoped directory instead of the per-provider default.
+        This gives each package its own terraform working directory and
+        state file, so that applying or destroying one package cannot
+        affect another package's resources.
+
+        Must be called after ``set_environment()``.
+
+        Args:
+            package_name: Name of the infrastructure package
+
+        Raises:
+            RuntimeError: If called before set_environment()
+        """
+        if self._current_environment is None:
+            raise RuntimeError(
+                "set_package_context() requires set_environment() to be called first"
+            )
+        self._current_package = package_name
+        self.terraform_dir = self.output_dir / "terraform" / package_name
+
+    def clear_package_context(self) -> None:
+        """Clear the active package context and restore per-provider paths.
+
+        After this call, ``terraform_dir`` reverts to the standard
+        ``generated/{env}/terraform/{provider}/`` layout used for loose
+        resources.
+        """
+        self._current_package = None
+        if self._current_environment is not None:
+            self.terraform_dir = self.output_dir / "terraform" / self.name
 
     @abstractmethod
     def validate_config(self, config: dict[str, Any]) -> bool:

--- a/tests/unit/test_package_state_isolation.py
+++ b/tests/unit/test_package_state_isolation.py
@@ -1,0 +1,357 @@
+"""Unit tests for per-package terraform state isolation.
+
+Verifies that ``set_package_context()`` / ``clear_package_context()`` on
+``ProviderBase`` correctly switch the ``terraform_dir`` between package-scoped
+and provider-scoped paths, and that the orchestrator's package-grouping helpers
+correctly split resources by package.
+"""
+
+from pathlib import Path
+from typing import Any, override
+
+import pytest
+import yaml
+
+from infrafoundry.core.config.config_manager import ConfigManager
+from infrafoundry.core.deployment_executor import DeploymentExecutor
+from infrafoundry.core.orchestrator_workflows import PlanOrchestrator
+from infrafoundry.core.provider import ProviderBase, ResourceConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubProvider(ProviderBase):
+    """Minimal concrete provider for testing."""
+
+    @override
+    def validate_config(self, config: dict[str, Any]) -> bool:
+        return True
+
+    @override
+    def generate_terraform(self, resources: list[ResourceConfig]) -> None:
+        pass
+
+    @override
+    def generate_ansible(self, resources: list[ResourceConfig]) -> None:
+        pass
+
+    @override
+    def get_resource_types(self) -> list[str]:
+        return ["vm", "container"]
+
+
+def _make_resource(name: str, provider: str = "proxmox") -> ResourceConfig:
+    return ResourceConfig(name=name, type="vm", provider=provider, config={"name": name})
+
+
+def _create_env(base_dir: Path, env_name: str) -> Path:
+    env_dir = base_dir / env_name
+    env_dir.mkdir(parents=True, exist_ok=True)
+    (env_dir / "settings.yaml").write_text(f"name: {env_name}\n")
+    return env_dir
+
+
+def _create_package(
+    base_dir: Path,
+    env_name: str,
+    package_name: str,
+    manifest: dict[str, Any],
+    resource_files: dict[str, Any] | None = None,
+    provider: str | None = None,
+) -> Path:
+    if provider:
+        package_dir = base_dir / env_name / provider / package_name
+    else:
+        package_dir = base_dir / env_name / package_name
+    package_dir.mkdir(parents=True, exist_ok=True)
+    with open(package_dir / "infrafoundry.yml", "w") as f:
+        yaml.dump(manifest, f)
+    if resource_files:
+        for filename, content in resource_files.items():
+            resource_path = package_dir / filename
+            resource_path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, str):
+                resource_path.write_text(content)
+            else:
+                with open(resource_path, "w") as f:
+                    yaml.dump(content, f)
+    return package_dir
+
+
+def _create_loose_resources(
+    base_dir: Path, env_name: str, provider: str, filename: str, content: Any
+) -> Path:
+    provider_dir = base_dir / env_name / provider
+    provider_dir.mkdir(parents=True, exist_ok=True)
+    resource_path = provider_dir / filename
+    if isinstance(content, str):
+        resource_path.write_text(content)
+    else:
+        with open(resource_path, "w") as f:
+            yaml.dump(content, f)
+    return resource_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: ProviderBase.set_package_context / clear_package_context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetPackageContext:
+    """Tests for ProviderBase.set_package_context and clear_package_context."""
+
+    def test_set_package_context_updates_terraform_dir(self, tmp_path: Path) -> None:
+        """set_package_context sets terraform_dir to package-scoped path."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("prod")
+        provider.set_package_context("ontap-cluster")
+
+        expected = tmp_path / "output" / "prod" / "terraform" / "ontap-cluster"
+        assert provider.terraform_dir == expected
+
+    def test_clear_package_context_restores_provider_dir(self, tmp_path: Path) -> None:
+        """clear_package_context restores terraform_dir to per-provider path."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("prod")
+        provider.set_package_context("ontap-cluster")
+        provider.clear_package_context()
+
+        expected = tmp_path / "output" / "prod" / "terraform" / "proxmox"
+        assert provider.terraform_dir == expected
+
+    def test_without_package_context_uses_provider_dir(self, tmp_path: Path) -> None:
+        """Without package context, terraform_dir is the default provider path."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("prod")
+
+        expected = tmp_path / "output" / "prod" / "terraform" / "proxmox"
+        assert provider.terraform_dir == expected
+
+    def test_package_dir_is_env_scoped(self, tmp_path: Path) -> None:
+        """Package terraform dir is under the environment's output directory."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("staging")
+        provider.set_package_context("k8s-cluster")
+
+        assert "staging" in str(provider.terraform_dir)
+        assert "k8s-cluster" in str(provider.terraform_dir)
+
+    def test_set_environment_clears_package_context(self, tmp_path: Path) -> None:
+        """Calling set_environment resets any active package context."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("prod")
+        provider.set_package_context("ontap-cluster")
+        provider.set_environment("staging")
+
+        assert provider._current_package is None
+        expected = tmp_path / "output" / "staging" / "terraform" / "proxmox"
+        assert provider.terraform_dir == expected
+
+    def test_two_packages_get_separate_dirs(self, tmp_path: Path) -> None:
+        """Two different packages produce distinct terraform directories."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("prod")
+
+        provider.set_package_context("ontap-cluster")
+        dir_a = provider.terraform_dir
+
+        provider.set_package_context("k8s-cluster")
+        dir_b = provider.terraform_dir
+
+        assert dir_a != dir_b
+        assert dir_a.name == "ontap-cluster"
+        assert dir_b.name == "k8s-cluster"
+
+    def test_set_package_context_without_environment_raises(self, tmp_path: Path) -> None:
+        """set_package_context raises RuntimeError without set_environment first."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        with pytest.raises(RuntimeError, match="set_environment"):
+            provider.set_package_context("my-pkg")
+
+    def test_clear_without_prior_set_is_safe(self, tmp_path: Path) -> None:
+        """clear_package_context is a no-op when no package context is active."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("prod")
+        provider.clear_package_context()  # should not raise
+
+        expected = tmp_path / "output" / "prod" / "terraform" / "proxmox"
+        assert provider.terraform_dir == expected
+
+    def test_ensure_directories_creates_package_dir(self, tmp_path: Path) -> None:
+        """ensure_directories creates the package-scoped terraform directory."""
+        provider = _StubProvider("proxmox", tmp_path / "config", tmp_path / "output")
+        provider.set_environment("prod")
+        provider.set_package_context("my-pkg")
+        provider.ensure_directories()
+
+        assert provider.terraform_dir.exists()
+        assert provider.terraform_dir == tmp_path / "output" / "prod" / "terraform" / "my-pkg"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _group_by_package helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGroupByPackage:
+    """Tests for PlanOrchestrator._group_by_package and DeploymentExecutor._group_by_package."""
+
+    def test_all_loose_resources(self) -> None:
+        """When no package map, all resources go to the None group."""
+        resources = [_make_resource("vm-1"), _make_resource("vm-2")]
+        groups = PlanOrchestrator._group_by_package(resources, {})
+        assert len(groups) == 1
+        pkg_name, pkg_resources = groups[0]
+        assert pkg_name is None
+        assert len(pkg_resources) == 2
+
+    def test_all_packaged_resources(self) -> None:
+        """When all resources are in packages, no None group is produced."""
+        resources = [_make_resource("vm-1"), _make_resource("vm-2")]
+        pkg_map = {"vm-1": "pkg-a", "vm-2": "pkg-a"}
+        groups = PlanOrchestrator._group_by_package(resources, pkg_map)
+        assert len(groups) == 1
+        assert groups[0][0] == "pkg-a"
+        assert len(groups[0][1]) == 2
+
+    def test_mixed_packages_and_loose(self) -> None:
+        """Mixed resources are split into package groups and a loose group."""
+        resources = [
+            _make_resource("vm-1"),
+            _make_resource("vm-2"),
+            _make_resource("vm-3"),
+        ]
+        pkg_map = {"vm-1": "pkg-a", "vm-2": "pkg-b"}
+        groups = PlanOrchestrator._group_by_package(resources, pkg_map)
+
+        # Should have 3 groups: pkg-a, pkg-b, None
+        assert len(groups) == 3
+        names = [g[0] for g in groups]
+        assert names == ["pkg-a", "pkg-b", None]
+
+    def test_packages_sorted_deterministically(self) -> None:
+        """Package groups are sorted alphabetically for deterministic execution."""
+        resources = [
+            _make_resource("vm-1"),
+            _make_resource("vm-2"),
+            _make_resource("vm-3"),
+        ]
+        pkg_map = {"vm-1": "zzz-pkg", "vm-2": "aaa-pkg", "vm-3": "mmm-pkg"}
+        groups = PlanOrchestrator._group_by_package(resources, pkg_map)
+        names = [g[0] for g in groups]
+        assert names == ["aaa-pkg", "mmm-pkg", "zzz-pkg"]
+
+    def test_deployment_executor_group_matches_plan(self) -> None:
+        """DeploymentExecutor._group_by_package produces identical results."""
+        resources = [_make_resource("vm-1"), _make_resource("vm-2")]
+        pkg_map = {"vm-1": "pkg-a"}
+        plan_groups = PlanOrchestrator._group_by_package(resources, pkg_map)
+        exec_groups = DeploymentExecutor._group_by_package(resources, pkg_map)
+        assert plan_groups == exec_groups
+
+    def test_empty_resources(self) -> None:
+        """Empty resource list produces no groups."""
+        groups = PlanOrchestrator._group_by_package([], {})
+        assert groups == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: ConfigManager.get_package_for_resource / get_resource_package_map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConfigManagerPackageMap:
+    """Tests for ConfigManager.get_package_for_resource and get_resource_package_map."""
+
+    def test_get_package_for_resource_in_provider_scoped_package(self, temp_dir: Path) -> None:
+        """Resource in a provider-scoped package returns the package name."""
+        _create_env(temp_dir, "dev")
+        _create_package(
+            temp_dir,
+            "dev",
+            "my-cluster",
+            {"name": "my-cluster", "resources": ["vm.yaml"]},
+            resource_files={
+                "vm.yaml": {"vm": [{"name": "node-01"}]},
+            },
+            provider="proxmox",
+        )
+        cm = ConfigManager(temp_dir)
+        assert cm.get_package_for_resource("dev", "node-01") == "my-cluster"
+
+    def test_get_package_for_resource_in_env_root_package(self, temp_dir: Path) -> None:
+        """Resource in an env-root package returns the package name."""
+        _create_env(temp_dir, "dev")
+        _create_package(
+            temp_dir,
+            "dev",
+            "my-cluster",
+            {"name": "my-cluster", "provider": "proxmox", "resources": ["vm.yaml"]},
+            resource_files={
+                "vm.yaml": {"vm": [{"name": "node-01"}]},
+            },
+        )
+        cm = ConfigManager(temp_dir)
+        assert cm.get_package_for_resource("dev", "node-01") == "my-cluster"
+
+    def test_get_package_for_resource_loose_returns_none(self, temp_dir: Path) -> None:
+        """Loose resource not in any package returns None."""
+        _create_env(temp_dir, "dev")
+        _create_loose_resources(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "vm.yaml",
+            {"vm": [{"name": "standalone-vm"}]},
+        )
+        cm = ConfigManager(temp_dir)
+        assert cm.get_package_for_resource("dev", "standalone-vm") is None
+
+    def test_get_resource_package_map_includes_all_packages(self, temp_dir: Path) -> None:
+        """get_resource_package_map returns all package resources."""
+        _create_env(temp_dir, "dev")
+        _create_package(
+            temp_dir,
+            "dev",
+            "cluster-a",
+            {"name": "cluster-a", "provider": "proxmox", "resources": ["vm.yaml"]},
+            resource_files={
+                "vm.yaml": {"vm": [{"name": "vm-a1"}, {"name": "vm-a2"}]},
+            },
+        )
+        _create_package(
+            temp_dir,
+            "dev",
+            "cluster-b",
+            {"name": "cluster-b", "resources": ["vm.yaml"]},
+            resource_files={
+                "vm.yaml": {"vm": [{"name": "vm-b1"}]},
+            },
+            provider="proxmox",
+        )
+        cm = ConfigManager(temp_dir)
+        pkg_map = cm.get_resource_package_map("dev")
+        assert pkg_map == {
+            "vm-a1": "cluster-a",
+            "vm-a2": "cluster-a",
+            "vm-b1": "cluster-b",
+        }
+
+    def test_get_resource_package_map_excludes_loose_resources(self, temp_dir: Path) -> None:
+        """Loose resources are not included in the package map."""
+        _create_env(temp_dir, "dev")
+        _create_loose_resources(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "vm.yaml",
+            {"vm": [{"name": "loose-vm"}]},
+        )
+        cm = ConfigManager(temp_dir)
+        pkg_map = cm.get_resource_package_map("dev")
+        assert "loose-vm" not in pkg_map


### PR DESCRIPTION
## Description

Per-package terraform state isolation (PR 2 of 3 for #357). Each infrastructure package now gets its own terraform working directory and state file at `generated/{env}/terraform/{package-name}/`, so applying or destroying one package cannot affect another package's terraform state. Loose resources continue to use the per-provider directory.

Addresses #357

## Related Issue

Addresses #357

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `ProviderBase`: added `set_package_context()` / `clear_package_context()` to switch `terraform_dir` between package-scoped and provider-scoped paths
- `ConfigManager`: added `get_package_for_resource()` and `get_resource_package_map()` to map resource names to their owning package
- `DeploymentExecutor`: added `_group_by_package()` helper; `apply_serial` and `apply_parallel` now group resources by package and process each group in its own terraform directory
- `PlanOrchestrator`: added `_group_by_package()`; plan workflow groups by package, sets/clears package context, and calls `ensure_directories()` per group
- `DestroyOrchestrator`: destroy workflow groups by package with per-package state isolation
- `Orchestrator`: threads `get_resource_package_map` callback through plan/destroy orchestrators and passes cached map to `DeploymentExecutor`
- ADR 0006 updated with Phase 2 implementation details
- Documentation updated with per-package state isolation section

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (20 tests in `test_package_state_isolation.py`)
- [ ] Manually tested the changes

New test file covers:
- `set_package_context` / `clear_package_context` path switching (9 tests)
- `_group_by_package` helper for plan and deploy (6 tests)
- `ConfigManager.get_package_for_resource` and `get_resource_package_map` (5 tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is PR 2 of 3 for issue #357 (packages as primary resource model):
- **PR 1** (merged as #373): Package model foundation with env-root discovery, provider field, deprecation warnings
- **PR 2** (this): Per-package terraform state isolation
- **PR 3** (next): `--package` / `-p` CLI flag for targeted package operations
