### PR TITLE
feat: add --package/-p CLI flag for plan, apply, and destroy

### DIFF
--- a/docs/architecture/decisions/0006-packages-as-primary-resource-model.md
+++ b/docs/architecture/decisions/0006-packages-as-primary-resource-model.md
@@ -32,9 +32,10 @@ We will promote packages to the primary resource model in three phases:
 - Plan, apply, and destroy workflows group resources by package and process each group in its own terraform working directory.
 - Loose resources (not in any package) continue to use the per-provider directory.
 
-### Phase 3 (future)
+### Phase 3 (this ADR, PR 3)
 - `--package` / `-p` CLI flag for `plan`/`apply`/`destroy` to target specific packages.
-- `resolve_package_filter()` for CLI integration.
+- `resolve_package_filter()` in `ConfigManager` resolves a package name to its resource names for CLI integration.
+- `--package` and `--resource` are mutually exclusive.
 
 ### Env-root packages
 

--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -223,6 +223,29 @@ generated/prod/
         terraform.tfstate
 ```
 
+## Targeting Packages from the CLI
+
+Use the `--package` / `-p` flag on `plan`, `apply`, and `destroy` to target all
+resources in a specific package:
+
+```bash
+# Plan only the ontap-cluster package
+infra plan --env prod --package ontap-cluster
+
+# Apply a package (short flag)
+infra apply --env prod -p ontap-cluster --auto-approve
+
+# Destroy a package
+infra destroy --env prod -p ontap-cluster
+```
+
+The `--package` flag resolves the package name to the list of resource names
+declared in its manifest and passes them as a resource filter to the orchestrator.
+
+!!! note
+    `--package` (`-p`) and `--resource` (`-r`) are mutually exclusive. Use one
+    or the other, not both.
+
 ## Loose Resource Deprecation
 
 !!! warning "Deprecated"

--- a/docs/usage/cli-reference.md
+++ b/docs/usage/cli-reference.md
@@ -56,9 +56,9 @@ infra destroy --env dev --auto-approve
   - `infra history [--env <env>]` — view deployment history.
   - `infra diff --env-a <env1> --env-b <env2> [--provider ...] [--verbose]` — compare configurations between two environments.
 - **Plan/Apply/Destroy**
-  - `infra plan --env <env> [--resource ...] [--dry-run]`
-  - `infra apply --env <env> [--resource ...] [--auto-approve]`
-  - `infra destroy --env <env> [--resource ...] [--auto-approve]`
+  - `infra plan --env <env> [--resource ...] [--package <name>] [--dry-run]`
+  - `infra apply --env <env> [--resource ...] [--package <name>] [--auto-approve]`
+  - `infra destroy --env <env> [--resource ...] [--package <name>] [--auto-approve]`
   - `infra reset --env <env> --provider <provider> --component <component> [--auto-approve]` — completely remove component configuration from provider for clean reapply.
 - **Rollback and Recovery**
   - `infra rollback-points --env <env> [--limit <n>]` — list available rollback points for an environment.
@@ -95,6 +95,13 @@ infra destroy --env dev --auto-approve
   infra plan --env dev --resource vm-01 --resource vm-02
   infra apply --env dev --resource vm-01 --auto-approve
   ```
+- **Target an entire package:**
+  ```bash
+  infra plan --env dev --package ontap-cluster
+  infra apply --env dev -p ontap-cluster --auto-approve
+  infra destroy --env dev -p ontap-cluster
+  ```
+  Note: `--package` (`-p`) and `--resource` (`-r`) are mutually exclusive.
 - **Rollback to previous deployment:**
   ```bash
   # View deployment history to find deployment ID

--- a/src/infrafoundry/cli/commands/infra/apply.py
+++ b/src/infrafoundry/cli/commands/infra/apply.py
@@ -19,6 +19,12 @@ from ...utils import console
     help="Specific resource name(s) to target (can be used multiple times)",
 )
 @click.option(
+    "--package",
+    "-p",
+    "package_name",
+    help="Target a specific package by name (mutually exclusive with -r)",
+)
+@click.option(
     "--parallel",
     is_flag=True,
     help="Apply providers in parallel (experimental)",
@@ -36,13 +42,28 @@ def apply(
     env: str,
     auto_approve: bool,
     resource: tuple[str, ...],
+    package_name: str | None,
     parallel: bool,
     max_workers: int,
 ) -> None:
     """Apply infrastructure changes."""
+    if package_name and resource:
+        raise click.UsageError("--package and --resource are mutually exclusive")
+
+    resource_filter: list[str] | None = None
+    if package_name:
+        resource_filter = orchestrator.config_manager.resolve_package_filter(env, package_name)
+    elif resource:
+        resource_filter = list(resource)
+
     # If not auto-approve, ask for confirmation at InfraFoundry level
     if not auto_approve:
-        resource_desc = f" (resources: {', '.join(resource)})" if resource else ""
+        if package_name:
+            resource_desc = f" (package: {package_name})"
+        elif resource:
+            resource_desc = f" (resources: {', '.join(resource)})"
+        else:
+            resource_desc = ""
         console.warning(f"About to apply infrastructure for environment: {env}{resource_desc}")
         console.warning("This will make real changes to your infrastructure.")
 
@@ -57,7 +78,7 @@ def apply(
         orchestrator.apply(
             env,
             auto_approve=auto_approve,
-            resource_filter=list(resource) if resource else None,
+            resource_filter=resource_filter,
             parallel=parallel,
             max_workers=max_workers,
         )

--- a/src/infrafoundry/cli/commands/infra/destroy.py
+++ b/src/infrafoundry/cli/commands/infra/destroy.py
@@ -18,6 +18,12 @@ from ...utils import console
     multiple=True,
     help="Specific resource name(s) to target (can be used multiple times)",
 )
+@click.option(
+    "--package",
+    "-p",
+    "package_name",
+    help="Target a specific package by name (mutually exclusive with -r)",
+)
 @with_orchestrator("Destroy failed")
 def destroy(
     _ctx: click.Context,
@@ -25,11 +31,25 @@ def destroy(
     env: str,
     auto_approve: bool,
     resource: tuple[str, ...],
+    package_name: str | None,
 ) -> None:
     """Destroy infrastructure."""
+    if package_name and resource:
+        raise click.UsageError("--package and --resource are mutually exclusive")
+
+    resource_filter: list[str] | None = None
+    if package_name:
+        resource_filter = orchestrator.config_manager.resolve_package_filter(env, package_name)
+    elif resource:
+        resource_filter = list(resource)
 
     if not auto_approve:
-        resource_desc = f" (resources: {', '.join(resource)})" if resource else ""
+        if package_name:
+            resource_desc = f" (package: {package_name})"
+        elif resource:
+            resource_desc = f" (resources: {', '.join(resource)})"
+        else:
+            resource_desc = ""
         console.warning(f"About to DESTROY infrastructure for environment: {env}{resource_desc}")
         console.warning("This will permanently remove resources from your infrastructure.")
 
@@ -44,6 +64,6 @@ def destroy(
         orchestrator.destroy(
             env,
             auto_approve=auto_approve,
-            resource_filter=list(resource) if resource else None,
+            resource_filter=resource_filter,
         )
     console.success(f"Destroy complete! ({timer.elapsed_str})")

--- a/src/infrafoundry/cli/commands/infra/plan.py
+++ b/src/infrafoundry/cli/commands/infra/plan.py
@@ -19,6 +19,12 @@ from ...utils import console
     help="Specific resource name(s) to target (can be used multiple times)",
 )
 @click.option(
+    "--package",
+    "-p",
+    "package_name",
+    help="Target a specific package by name (mutually exclusive with -r)",
+)
+@click.option(
     "--enforce-policies",
     is_flag=True,
     help="Enforce policy checks (block on violations)",
@@ -30,14 +36,24 @@ def plan(
     env: str,
     dry_run: bool,
     resource: tuple[str, ...],
+    package_name: str | None,
     enforce_policies: bool,
 ) -> None:
     """Plan infrastructure changes."""
+    if package_name and resource:
+        raise click.UsageError("--package and --resource are mutually exclusive")
+
+    resource_filter: list[str] | None = None
+    if package_name:
+        resource_filter = orchestrator.config_manager.resolve_package_filter(env, package_name)
+    elif resource:
+        resource_filter = list(resource)
+
     with OperationTimer() as timer:
         orchestrator.plan(
             env,
             dry_run=dry_run,
-            resource_filter=list(resource) if resource else None,
+            resource_filter=resource_filter,
             enforce_policies=enforce_policies,
         )
 

--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -12,7 +12,7 @@ from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
 from infrafoundry.core.config.resource_centric_loader import ResourceCentricLoader
-from infrafoundry.core.exceptions import InvalidConfigurationError
+from infrafoundry.core.exceptions import InvalidConfigurationError, PackageNotFoundError
 from infrafoundry.core.provider import ResourceConfig
 
 
@@ -381,6 +381,54 @@ class ConfigManager(PathBasedManager):
                 resource_to_package[resource.name] = manifest.name
 
         return resource_to_package
+
+    def resolve_package_filter(self, env_name: str, package_name: str) -> list[str]:
+        """Resolve a package name to a list of resource names.
+
+        Searches both provider-scoped and env-root packages for a package
+        whose manifest name matches *package_name*, then returns the names
+        of all resources declared by that package.
+
+        Args:
+            env_name: Environment name
+            package_name: Package name to resolve
+
+        Returns:
+            List of resource names belonging to the package
+
+        Raises:
+            PackageNotFoundError: If no package with the given name is found
+        """
+        # Check provider-scoped packages
+        discovered_providers = self.provider_centric.discover_providers(env_name)
+        for provider_name in discovered_providers:
+            for package_dir in self._package_loader.discover_packages(env_name, provider_name):
+                manifest = self._package_loader._parse_manifest(
+                    package_dir / PackageLoader.MANIFEST_FILENAME
+                )
+                if manifest.name == package_name:
+                    effective_provider = manifest.provider or provider_name
+                    pkg_resources, _ = self._package_loader.load_package(
+                        package_dir, effective_provider, env_name
+                    )
+                    return [r.name for r in pkg_resources]
+
+        # Check env-root packages
+        for package_dir in self._package_loader.discover_env_root_packages(env_name):
+            manifest = self._package_loader._parse_manifest(
+                package_dir / PackageLoader.MANIFEST_FILENAME
+            )
+            if manifest.name == package_name:
+                if not manifest.provider:
+                    continue
+                pkg_resources, _ = self._package_loader.load_package(
+                    package_dir, manifest.provider, env_name
+                )
+                return [r.name for r in pkg_resources]
+
+        raise PackageNotFoundError(
+            f"Package '{package_name}' not found in environment '{env_name}'"
+        )
 
     def get_package_events(self) -> dict[str, list[dict[str, Any]]]:
         """Return accumulated package events from last resource load.

--- a/tests/unit/test_package_filter.py
+++ b/tests/unit/test_package_filter.py
@@ -1,0 +1,329 @@
+"""Unit tests for the --package / -p CLI flag and resolve_package_filter."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from infrafoundry.cli.main import main
+from infrafoundry.core.config.config_manager import ConfigManager
+from infrafoundry.core.exceptions import PackageNotFoundError
+from infrafoundry.core.orchestrator import Orchestrator
+
+
+@pytest.fixture
+def cli_runner():
+    """Fixture for invoking CLI commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_orchestrator():
+    """Mock orchestrator for testing."""
+    mock = Mock(spec=Orchestrator)
+    mock.config_manager = Mock(spec=ConfigManager)
+    return mock
+
+
+# --- resolve_package_filter unit tests ---
+
+
+class TestResolvePackageFilter:
+    """Tests for ConfigManager.resolve_package_filter."""
+
+    def test_known_package_resolves_to_resource_names(self, tmp_path: Path):
+        """Known package resolves to correct resource names."""
+        # Set up env with a provider-scoped package
+        env_dir = tmp_path / "test-env"
+        provider_dir = env_dir / "proxmox"
+        pkg_dir = provider_dir / "my-cluster"
+        pkg_dir.mkdir(parents=True)
+
+        # Create settings.yaml
+        (env_dir / "settings.yaml").write_text("iac_tool: terraform\n")
+
+        # Create manifest
+        (pkg_dir / "infrafoundry.yml").write_text("name: my-cluster\nresources:\n  - vm.yaml\n")
+
+        # Create resource file
+        (pkg_dir / "vm.yaml").write_text(
+            "vm:\n  - name: cluster-node1\n    cores: 2\n  - name: cluster-node2\n    cores: 2\n"
+        )
+
+        cm = ConfigManager(base_dir=tmp_path)
+        result = cm.resolve_package_filter("test-env", "my-cluster")
+
+        assert sorted(result) == ["cluster-node1", "cluster-node2"]
+
+    def test_unknown_package_raises_error(self, tmp_path: Path):
+        """Unknown package raises PackageNotFoundError."""
+        env_dir = tmp_path / "test-env"
+        env_dir.mkdir(parents=True)
+        (env_dir / "settings.yaml").write_text("iac_tool: terraform\n")
+
+        cm = ConfigManager(base_dir=tmp_path)
+
+        with pytest.raises(PackageNotFoundError, match="nonexistent"):
+            cm.resolve_package_filter("test-env", "nonexistent")
+
+    def test_package_with_multiple_resources(self, tmp_path: Path):
+        """Package with multiple resource files resolves all resource names."""
+        env_dir = tmp_path / "test-env"
+        provider_dir = env_dir / "proxmox"
+        pkg_dir = provider_dir / "big-cluster"
+        pkg_dir.mkdir(parents=True)
+
+        (env_dir / "settings.yaml").write_text("iac_tool: terraform\n")
+        (pkg_dir / "infrafoundry.yml").write_text(
+            "name: big-cluster\nresources:\n  - vm.yaml\n  - network.yaml\n"
+        )
+        (pkg_dir / "vm.yaml").write_text(
+            "vm:\n  - name: vm-a\n    cores: 2\n  - name: vm-b\n    cores: 2\n"
+        )
+        (pkg_dir / "network.yaml").write_text("network:\n  - name: net-a\n    bridge: vmbr0\n")
+
+        cm = ConfigManager(base_dir=tmp_path)
+        result = cm.resolve_package_filter("test-env", "big-cluster")
+
+        assert sorted(result) == ["net-a", "vm-a", "vm-b"]
+
+    def test_env_root_package_resolves(self, tmp_path: Path):
+        """Env-root package (with provider field) resolves correctly."""
+        env_dir = tmp_path / "test-env"
+        pkg_dir = env_dir / "standalone-pkg"
+        pkg_dir.mkdir(parents=True)
+
+        (env_dir / "settings.yaml").write_text("iac_tool: terraform\n")
+        (pkg_dir / "infrafoundry.yml").write_text(
+            "name: standalone-pkg\nprovider: proxmox\nresources:\n  - vm.yaml\n"
+        )
+        (pkg_dir / "vm.yaml").write_text("vm:\n  - name: standalone-vm\n    cores: 4\n")
+
+        cm = ConfigManager(base_dir=tmp_path)
+        result = cm.resolve_package_filter("test-env", "standalone-pkg")
+
+        assert result == ["standalone-vm"]
+
+
+# --- CLI mutual exclusivity tests ---
+
+
+class TestPackageResourceMutualExclusivity:
+    """Tests for --package and --resource mutual exclusivity."""
+
+    def test_plan_package_and_resource_mutually_exclusive(self, cli_runner, mock_orchestrator):
+        """Plan rejects --package and --resource together."""
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                ["infra", "plan", "--env", "test", "-p", "my-pkg", "-r", "vm-01"],
+            )
+
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output
+
+    def test_apply_package_and_resource_mutually_exclusive(self, cli_runner, mock_orchestrator):
+        """Apply rejects --package and --resource together."""
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                [
+                    "infra",
+                    "apply",
+                    "--env",
+                    "test",
+                    "--auto-approve",
+                    "-p",
+                    "my-pkg",
+                    "-r",
+                    "vm-01",
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output
+
+    def test_destroy_package_and_resource_mutually_exclusive(self, cli_runner, mock_orchestrator):
+        """Destroy rejects --package and --resource together."""
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                [
+                    "infra",
+                    "destroy",
+                    "--env",
+                    "test",
+                    "--auto-approve",
+                    "-p",
+                    "my-pkg",
+                    "-r",
+                    "vm-01",
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output
+
+
+# --- CLI --package integration tests ---
+
+
+class TestPlanWithPackage:
+    """Tests for plan --package."""
+
+    def test_plan_with_package_resolves_filter(self, cli_runner, mock_orchestrator):
+        """Plan --package resolves package to resource filter."""
+        mock_orchestrator.config_manager.resolve_package_filter.return_value = [
+            "vm-01",
+            "vm-02",
+        ]
+
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(main, ["infra", "plan", "--env", "test", "-p", "my-cluster"])
+
+            assert result.exit_code == 0
+            mock_orchestrator.config_manager.resolve_package_filter.assert_called_once_with(
+                "test", "my-cluster"
+            )
+            mock_orchestrator.plan.assert_called_once_with(
+                "test",
+                dry_run=False,
+                resource_filter=["vm-01", "vm-02"],
+                enforce_policies=False,
+            )
+
+    def test_plan_with_unknown_package_fails(self, cli_runner, mock_orchestrator):
+        """Plan --package with unknown package raises error."""
+        mock_orchestrator.config_manager.resolve_package_filter.side_effect = PackageNotFoundError(
+            "Package 'bad-pkg' not found in environment 'test'"
+        )
+
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(main, ["infra", "plan", "--env", "test", "-p", "bad-pkg"])
+
+            assert result.exit_code == 1
+            assert "Package Not Found" in result.output
+
+
+class TestApplyWithPackage:
+    """Tests for apply --package."""
+
+    def test_apply_with_package_resolves_filter(self, cli_runner, mock_orchestrator):
+        """Apply --package resolves package to resource filter."""
+        mock_orchestrator.config_manager.resolve_package_filter.return_value = [
+            "vm-01",
+        ]
+
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                [
+                    "infra",
+                    "apply",
+                    "--env",
+                    "test",
+                    "--auto-approve",
+                    "-p",
+                    "my-cluster",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_orchestrator.config_manager.resolve_package_filter.assert_called_once_with(
+                "test", "my-cluster"
+            )
+            mock_orchestrator.apply.assert_called_once_with(
+                "test",
+                auto_approve=True,
+                resource_filter=["vm-01"],
+                parallel=False,
+                max_workers=4,
+            )
+
+    def test_apply_with_package_shows_package_in_prompt(self, cli_runner, mock_orchestrator):
+        """Apply --package shows package name in confirmation prompt."""
+        mock_orchestrator.config_manager.resolve_package_filter.return_value = [
+            "vm-01",
+        ]
+
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                ["infra", "apply", "--env", "test", "-p", "my-cluster"],
+                input="y\n",
+            )
+
+            assert result.exit_code == 0
+            assert "package: my-cluster" in result.output
+
+
+class TestDestroyWithPackage:
+    """Tests for destroy --package."""
+
+    def test_destroy_with_package_resolves_filter(self, cli_runner, mock_orchestrator):
+        """Destroy --package resolves package to resource filter."""
+        mock_orchestrator.config_manager.resolve_package_filter.return_value = [
+            "vm-01",
+            "vm-02",
+        ]
+
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                [
+                    "infra",
+                    "destroy",
+                    "--env",
+                    "test",
+                    "--auto-approve",
+                    "-p",
+                    "my-cluster",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_orchestrator.config_manager.resolve_package_filter.assert_called_once_with(
+                "test", "my-cluster"
+            )
+            call_args = mock_orchestrator.destroy.call_args
+            assert call_args[1]["resource_filter"] == ["vm-01", "vm-02"]
+
+    def test_destroy_with_package_shows_package_in_prompt(self, cli_runner, mock_orchestrator):
+        """Destroy --package shows package name in confirmation prompt."""
+        mock_orchestrator.config_manager.resolve_package_filter.return_value = [
+            "vm-01",
+        ]
+
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                ["infra", "destroy", "--env", "test", "-p", "my-cluster"],
+                input="y\n",
+            )
+
+            assert result.exit_code == 0
+            assert "package: my-cluster" in result.output
+
+    def test_destroy_with_unknown_package_fails(self, cli_runner, mock_orchestrator):
+        """Destroy --package with unknown package raises error."""
+        mock_orchestrator.config_manager.resolve_package_filter.side_effect = PackageNotFoundError(
+            "Package 'bad-pkg' not found in environment 'test'"
+        )
+
+        with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+            result = cli_runner.invoke(
+                main,
+                [
+                    "infra",
+                    "destroy",
+                    "--env",
+                    "test",
+                    "--auto-approve",
+                    "-p",
+                    "bad-pkg",
+                ],
+            )
+
+            assert result.exit_code == 1
+            assert "Package Not Found" in result.output


### PR DESCRIPTION
## Description

Add `--package` / `-p` CLI flag to `plan`, `apply`, and `destroy` commands, enabling users to target all resources in a specific infrastructure package by name. This is the final PR (3 of 3) completing the packages-as-primary-resource-model feature.

The flag resolves a package name to its declared resource names via `ConfigManager.resolve_package_filter()` and passes them as a resource filter to the orchestrator.

Addresses #357

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Added `--package` / `-p` option to `plan`, `apply`, and `destroy` CLI commands
- Added `resolve_package_filter()` method to `ConfigManager` that searches provider-scoped and env-root packages by manifest name
- Enforced mutual exclusivity between `--package` and `--resource` flags
- Updated confirmation prompts to show package name when `--package` is used
- Updated ADR 0006 Phase 3 from "future" to "this ADR, PR 3"
- Updated `docs/configuration/infrastructure-packages.md` with CLI targeting section
- Updated `docs/usage/cli-reference.md` with `--package` in command signatures and examples

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

14 new tests in `tests/unit/test_package_filter.py`:
- `resolve_package_filter` unit tests (known package, unknown package, multiple resources, env-root package)
- Mutual exclusivity tests for plan, apply, destroy
- CLI integration tests for plan, apply, destroy with `--package` (filter resolution, confirmation prompts, unknown package errors)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

This is PR 3 of 3 for issue #357:
- **PR 1** (#373): Package model foundation with env-root discovery
- **PR 2** (#374): Per-package terraform state isolation
- **PR 3** (this): `--package` / `-p` CLI flag
