### PR TITLE
fix: skip non-matching packages and deduplicate resource filter

### DIFF
--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -411,7 +411,7 @@ class ConfigManager(PathBasedManager):
                     pkg_resources, _ = self._package_loader.load_package(
                         package_dir, effective_provider, env_name
                     )
-                    return [r.name for r in pkg_resources]
+                    return list(dict.fromkeys(r.name for r in pkg_resources))
 
         # Check env-root packages
         for package_dir in self._package_loader.discover_env_root_packages(env_name):
@@ -424,7 +424,7 @@ class ConfigManager(PathBasedManager):
                 pkg_resources, _ = self._package_loader.load_package(
                     package_dir, manifest.provider, env_name
                 )
-                return [r.name for r in pkg_resources]
+                return list(dict.fromkeys(r.name for r in pkg_resources))
 
         raise PackageNotFoundError(
             f"Package '{package_name}' not found in environment '{env_name}'"

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -217,6 +217,14 @@ class DeploymentExecutor:
             # Group by package for state isolation
             package_groups = self._group_by_package(resources, self.resource_package_map)
 
+            # When resource_filter is set, skip packages with no matching resources
+            if filter_set:
+                package_groups = [
+                    (pkg, res)
+                    for pkg, res in package_groups
+                    if any(r.name in filter_set for r in res)
+                ]
+
             for pkg_name, pkg_resources in package_groups:
                 if pkg_name is not None:
                     provider.set_package_context(pkg_name)

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -460,6 +460,15 @@ class PlanOrchestrator(HookExecutionMixin):
                     package_map = self._get_resource_package_map()
                     package_groups = self._group_by_package(generate_resources, package_map)
 
+                    # When resource_filter is set, skip packages with no matching resources
+                    if resource_filter:
+                        filter_set = set(resource_filter)
+                        package_groups = [
+                            (pkg, res)
+                            for pkg, res in package_groups
+                            if any(r.name in filter_set for r in res)
+                        ]
+
                     iac_tool = env_config.iac_tool if env_config else IaCTool.TERRAFORM
 
                     for pkg_name, pkg_resources in package_groups:
@@ -1068,6 +1077,15 @@ class DestroyOrchestrator(HookExecutionMixin):
                 # Group resources by package for state isolation
                 package_map = self._get_resource_package_map()
                 package_groups = PlanOrchestrator._group_by_package(resources, package_map)
+
+                # When resource_filter is set, skip packages with no matching resources
+                if resource_filter:
+                    filter_set = set(resource_filter)
+                    package_groups = [
+                        (pkg, res)
+                        for pkg, res in package_groups
+                        if any(r.name in filter_set for r in res)
+                    ]
 
                 for pkg_name, pkg_resources in package_groups:
                     if pkg_name is not None:


### PR DESCRIPTION
## Description

Fix three bugs in the package-based resource filtering:

1. **#378**: `resolve_package_filter()` returned duplicate resource names when a package had resources with the same name across different YAML files (e.g., `ontapcl-01` as both a VM and DHCP reservation). Fixed by deduplicating with `dict.fromkeys()`.

2. **#376**: `--package` flag processed ALL packages in the environment instead of only the targeted one. The per-package iteration in plan/apply/destroy workflows now skips package groups that have no resources matching the filter.

Addresses #376
Addresses #378

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `config_manager.py`: `resolve_package_filter()` deduplicates resource names
- `orchestrator_workflows.py`: Plan and destroy workflows skip package groups with no matching filtered resources
- `deployment_executor.py`: `apply_serial()` skips package groups with no matching filtered resources

## Testing

- [x] All existing tests pass
- [x] Manually tested: `foundry -c endavis-infra infra plan --env prod --package ontap-cluster` now only processes the ontap-cluster package

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings