### PR TITLE
fix: auto-load tfvars and upgrade lock file for multi-provider packages

### DIFF
--- a/src/infrafoundry/core/provider_mixins.py
+++ b/src/infrafoundry/core/provider_mixins.py
@@ -455,7 +455,7 @@ class TerraformGeneratorMixin:
 
         pkg = getattr(self, "_current_package", None)
         provider_name = getattr(self, "name", "unknown")
-        filename = f"terraform_{provider_name}.tfvars" if pkg else "terraform.tfvars"
+        filename = f"{provider_name}.auto.tfvars" if pkg else "terraform.tfvars"
         tfvars_path = Path(self.terraform_dir) / filename
         tfvars_path.write_text("".join(lines))
 

--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -100,7 +100,27 @@ class TerraformRunner(BaseRunner):
                 except (json.JSONDecodeError, FileNotFoundError):
                     pass
 
+            # Check if required_providers.tf has providers not in the lock file
             if not reconfigure:
+                lock_file = working_dir / ".terraform.lock.hcl"
+                req_providers_file = working_dir / "required_providers.tf"
+                if lock_file.exists() and req_providers_file.exists():
+                    lock_content = lock_file.read_text()
+                    req_content = req_providers_file.read_text()
+                    # Extract provider sources from required_providers.tf
+                    import re
+
+                    for source_match in re.finditer(r'source\s*=\s*"([^"]+)"', req_content):
+                        source = source_match.group(1)
+                        if source not in lock_content:
+                            upgrade = True
+                            self.console.print(
+                                f"[yellow]Provider {source} not in lock file, "
+                                f"running init -upgrade...[/yellow]"
+                            )
+                            break
+
+            if not (reconfigure or upgrade):
                 return {"success": True, "message": "Already initialized"}
 
         # Build init command using full path to terraform binary


### PR DESCRIPTION
## Description

Two fixes for per-package terraform state isolation with multi-provider packages:

1. **tfvars not auto-loaded**: Renamed `terraform_{name}.tfvars` to `{name}.auto.tfvars`. Terraform only auto-loads `terraform.tfvars` and `*.auto.tfvars` files.

2. **Lock file missing providers**: When the first provider inits, the lock file only contains that provider. When the second provider runs, terraform fails with "Inconsistent dependency lock file". Now the runner detects missing provider sources in the lock file and runs `terraform init -upgrade`.

Addresses #380

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `provider_mixins.py`: `_write_tfvars_lines()` uses `{name}.auto.tfvars` in package context
- `terraform_runner.py`: `initialize()` checks lock file against `required_providers.tf` and upgrades when providers are missing

## Testing

- [x] All existing tests pass
- [x] Manually tested: plan succeeds with auto-loaded tfvars and lock file upgrade