### PR TITLE
fix: make ResourceOutcome JSON-serializable for audit logging

### DIFF
--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -502,6 +502,13 @@ class DeploymentExecutor:
             env_name, provider_name, resources, all_outcomes, resource_filter
         )
 
+        # Replace ResourceOutcome objects with JSON-safe dicts for audit logging
+        for result in runner_results.values():
+            if isinstance(result, dict) and "resource_outcomes" in result:
+                result["resource_outcomes"] = [
+                    o.to_dict() if hasattr(o, "to_dict") else o for o in result["resource_outcomes"]
+                ]
+
         return runner_results
 
     def _fire_resource_lifecycle_events(

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -1118,6 +1118,13 @@ class DestroyOrchestrator(HookExecutionMixin):
                 for resource in resources:
                     self._execute_resource_hooks(env_name, "after_destroy", resource, provider_name)
 
+                # Replace ResourceOutcome objects with JSON-safe dicts
+                for result in provider_results.values():
+                    if isinstance(result, dict) and "resource_outcomes" in result:
+                        result["resource_outcomes"] = [
+                            o.to_dict() if hasattr(o, "to_dict") else o
+                            for o in result["resource_outcomes"]
+                        ]
                 results[provider_name] = provider_results
 
             # Execute environment-level after_destroy hooks

--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -350,6 +350,8 @@ class TerraformRunner(BaseRunner):
         # Parse resource outcomes from JSON output
         outcomes = self._parse_json_output(stdout_lines, tf_dir)
         response["resource_outcomes"] = outcomes
+        # Store JSON-safe version for audit logging
+        response["resource_outcomes_summary"] = [o.to_dict() for o in outcomes]
 
         return response
 

--- a/src/infrafoundry/core/types.py
+++ b/src/infrafoundry/core/types.py
@@ -172,6 +172,10 @@ class ResourceOutcome:
     resource_name: str
     """Original resource name mapped back from the terraform address."""
 
+    def to_dict(self) -> dict[str, str]:
+        """Convert to JSON-serializable dict."""
+        return {"address": self.address, "action": self.action, "resource_name": self.resource_name}
+
 
 class RollbackResourceSnapshot(TypedDict):
     """Snapshot of a single resource for rollback purposes."""


### PR DESCRIPTION
## Description

`ResourceOutcome` dataclass objects from terraform `-json` output parsing are not JSON serializable. When they flow through to the audit log via event metadata, SQLAlchemy raises `TypeError: Object of type ResourceOutcome is not JSON serializable`.

Adds `to_dict()` method to `ResourceOutcome` and converts outcomes to dicts before they reach the audit system.

Addresses #390

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `types.py`: Added `to_dict()` to `ResourceOutcome`
- `deployment_executor.py`: Convert outcomes to dicts after lifecycle event firing
- `orchestrator_workflows.py`: Same for destroy workflow
- `terraform_runner.py`: Store JSON-safe summary alongside raw outcomes