### PR TITLE
fix: support on_create/on_destroy/on_update aliases and requires group events

### DIFF
--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -199,6 +199,31 @@ class DeploymentExecutor:
             )
             results[provider_name] = result
 
+        # Emit aggregate RESOURCE_CREATED event AFTER all providers complete.
+        # This ensures group handlers (requires: [...]) only fire once when
+        # all required resources exist across all providers.
+        all_created: list[str] = []
+        for result in results.values():
+            if isinstance(result, dict):
+                for tool_result in result.values():
+                    if isinstance(tool_result, dict):
+                        for outcome in tool_result.get("resource_outcomes", []):
+                            name = (
+                                outcome.get("resource_name", "")
+                                if isinstance(outcome, dict)
+                                else ""
+                            )
+                            action = outcome.get("action", "") if isinstance(outcome, dict) else ""
+                            if action == "create" and name:
+                                all_created.append(name)
+        if all_created:
+            self.event_manager.emit_event(
+                EventType.RESOURCE_CREATED,
+                env_name,
+                {"action": "create", "resources": all_created},
+                target_resources=all_created,
+            )
+
         return results
 
     def apply_parallel(
@@ -584,7 +609,9 @@ class DeploymentExecutor:
                     )
                     continue
 
-            # Emit the event so registered handlers execute
+            # Emit per-resource event for resource-level handlers.
+            # Pass only the single resource name as target so that group
+            # handlers with ``requires`` don't match individual emissions.
             event_type = (
                 EventType.RESOURCE_CREATED
                 if outcome.action == "create"
@@ -603,5 +630,9 @@ class DeploymentExecutor:
                 },
                 provider=provider_name,
                 resource=outcome.resource_name,
-                target_resources=resource_filter,
+                target_resources=[outcome.resource_name],
             )
+
+        # NOTE: Aggregate events for group handlers (requires: [...]) are NOT
+        # emitted here. They must be emitted after ALL providers complete to
+        # avoid firing before all required resources exist. See apply_serial().

--- a/src/infrafoundry/core/events/bus.py
+++ b/src/infrafoundry/core/events/bus.py
@@ -398,9 +398,17 @@ class UnifiedEventBus(BaseManager):
                 ],
             }
         """
+        # Map lifecycle shorthand names to EventType values
+        lifecycle_aliases: dict[str, str] = {
+            "on_create": EventType.RESOURCE_CREATED.value,
+            "on_destroy": EventType.RESOURCE_DELETED.value,
+            "on_update": EventType.RESOURCE_UPDATED.value,
+        }
+
         for event_name, handlers in events_config.items():
+            resolved_name = lifecycle_aliases.get(event_name.lower(), event_name.lower())
             try:
-                event_type = EventType(event_name.lower())
+                event_type = EventType(resolved_name)
             except ValueError:
                 self._log_warning(f"Unknown event type in config: {event_name}")
                 continue

--- a/src/infrafoundry/core/events/handlers/base.py
+++ b/src/infrafoundry/core/events/handlers/base.py
@@ -51,9 +51,10 @@ class BaseHandler(ABC):
         """Check whether this handler should fire for the given target resources.
 
         A handler fires if:
-        - It has no ``resources`` filter in its config (fires for all).
+        - It has no ``resources`` or ``requires`` filter (fires for all).
         - ``target_resources`` is None (no -r flag, all resources targeted).
-        - There is an intersection between handler resources and target resources.
+        - For ``resources``: intersection between handler and target resources.
+        - For ``requires``: ALL required resources must be in target resources.
 
         Args:
             target_resources: Resource names from the -r CLI filter, or None.
@@ -61,6 +62,14 @@ class BaseHandler(ABC):
         Returns:
             True if this handler should execute, False to skip.
         """
+        # Check 'requires' — ALL must be present (group event semantics)
+        required_resources = self.config.get("requires")
+        if required_resources:
+            if target_resources is None:
+                return True
+            return set(required_resources).issubset(set(target_resources))
+
+        # Check 'resources' — ANY intersection (filter semantics)
         handler_resources = self.config.get("resources")
         if not handler_resources:
             return True


### PR DESCRIPTION
## Description

Follow-up to PR #392. Package-level lifecycle events (`on_create`, `on_destroy`, `on_update`) weren't recognized by the event bus config loader — they need to be mapped to internal EventType values. Also adds `requires` field support for group events.

Addresses #390

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `bus.py`: Map `on_create` → `resource_created`, `on_destroy` → `resource_deleted`, `on_update` → `resource_updated` in config loader
- `base.py`: `matches_resources()` supports `requires` field — ALL required resources must be present (vs `resources` which needs any intersection)
- `deployment_executor.py`: Per-resource RESOURCE_CREATED events pass `[outcome.resource_name]` as target_resources (not full CLI filter) so group handlers don't match individual emissions

## Testing

- [x] All existing tests pass
- [x] Manually tested: ONTAP cluster deployed successfully with on_create group event