### PR TITLE
fix: prevent group event handlers from firing per-resource

### DIFF
--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -519,7 +519,7 @@ class DeploymentExecutor:
                     EventType.RESOURCE_CREATED,
                     env_name,
                     created_event,
-                    target_resources=resource_filter,
+                    target_resources=[resource.name],
                 )
 
         # Fire resource lifecycle events based on IaC outcomes


### PR DESCRIPTION
## Description

The pre-existing RESOURCE_CREATED emission in `apply_single_provider()` passed the full CLI `resource_filter` as `target_resources`. This caused group handlers with `requires: [ontapcl-01, ontapcl-02]` to match individual per-resource events (since the filter contained both names), firing the handler 5 times (once per DHCP reservation) before VMs existed.

Now passes `[resource.name]` so group handlers only match the aggregate emission after all providers complete.

Addresses #394

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `deployment_executor.py`: Changed `target_resources=resource_filter` to `target_resources=[resource.name]` in the per-resource RESOURCE_CREATED emission (line 522)

## Testing

- [x] All existing tests pass
- [x] Manually tested: ONTAP deploy — zero premature handler fires during opnsense phase