### PR TITLE
fix: use suffix matching for terraform_data address-to-name mapping

### DIFF
--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -348,7 +348,7 @@ class TerraformRunner(BaseRunner):
         }
 
         # Parse resource outcomes from JSON output
-        outcomes = self._parse_json_output(stdout_lines, tf_dir)
+        outcomes = self._parse_json_output(stdout_lines, tf_dir, target_resources)
         response["resource_outcomes"] = outcomes
         # Store JSON-safe version for audit logging
         response["resource_outcomes_summary"] = [o.to_dict() for o in outcomes]
@@ -393,7 +393,12 @@ class TerraformRunner(BaseRunner):
             if detail:
                 self.console.print(f"  [red]{detail}[/red]")
 
-    def _parse_json_output(self, stdout_lines: list[str], tf_dir: Path) -> list[ResourceOutcome]:
+    def _parse_json_output(
+        self,
+        stdout_lines: list[str],
+        tf_dir: Path,
+        resource_names: list[str] | None = None,
+    ) -> list[ResourceOutcome]:
         """Parse terraform JSON output lines into resource outcomes.
 
         Looks for ``apply_complete`` messages which indicate a resource
@@ -403,11 +408,13 @@ class TerraformRunner(BaseRunner):
         Args:
             stdout_lines: Lines of JSON output from terraform
             tf_dir: Terraform working directory (for address-to-name mapping)
+            resource_names: Optional list of known InfraFoundry resource names
+                for suffix-based address mapping
 
         Returns:
             List of ResourceOutcome objects
         """
-        address_to_name = self._build_address_to_name_map(tf_dir)
+        address_to_name = self._build_address_to_name_map(tf_dir, resource_names)
         outcomes: list[ResourceOutcome] = []
 
         for line in stdout_lines:
@@ -445,19 +452,28 @@ class TerraformRunner(BaseRunner):
 
         return outcomes
 
-    def _build_address_to_name_map(self, tf_dir: Path) -> dict[str, str]:
+    def _build_address_to_name_map(
+        self, tf_dir: Path, resource_names: list[str] | None = None
+    ) -> dict[str, str]:
         """Build a mapping from terraform resource addresses to resource names.
 
         Scans ``.tf`` files for ``resource`` blocks and maps each
-        ``type.tf_name`` address back to the original resource name
-        (converting underscores to dashes).
+        ``type.tf_name`` address back to the original resource name.
+        When *resource_names* is provided, suffix matching is used so that
+        prefixed terraform names (e.g. ``ova_vm_ontapcl_01``) are correctly
+        mapped back to their InfraFoundry name (``ontapcl-01``).
 
         Args:
             tf_dir: Terraform working directory
+            resource_names: Optional list of known InfraFoundry resource names
+                for suffix-based matching
 
         Returns:
             Dict mapping e.g. ``proxmox_vm.infra_web`` to ``infra-web``
         """
+        known_tf_names = (
+            {name.replace("-", "_") for name in resource_names} if resource_names else set()
+        )
         address_map: dict[str, str] = {}
         resource_pattern = re.compile(r'^resource\s+"([^"]+)"\s+"([^"]+)"')
 
@@ -470,13 +486,42 @@ class TerraformRunner(BaseRunner):
                             resource_type = match.group(1)
                             tf_name = match.group(2)
                             address = f"{resource_type}.{tf_name}"
-                            # Convert terraform name back to resource name
-                            resource_name = tf_name.replace("_", "-")
+                            # Resolve resource name using suffix matching
+                            resource_name = self._resolve_resource_name(tf_name, known_tf_names)
                             address_map[address] = resource_name
             except OSError:
                 continue
 
         return address_map
+
+    @staticmethod
+    def _resolve_resource_name(tf_name: str, known_tf_names: set[str]) -> str:
+        """Resolve a terraform resource name back to an InfraFoundry resource name.
+
+        Uses three strategies in order:
+        1. Exact match against known resource names
+        2. Suffix match for prefixed names (e.g. ``ova_vm_ontapcl_01`` → ``ontapcl-01``)
+        3. Fallback: full name conversion (underscores to dashes)
+
+        Args:
+            tf_name: Terraform resource name (e.g. ``ova_vm_ontapcl_01``)
+            known_tf_names: Known resource names in terraform form (underscores)
+
+        Returns:
+            InfraFoundry resource name (with dashes)
+        """
+        # 1. Exact match
+        if tf_name in known_tf_names:
+            return tf_name.replace("_", "-")
+
+        # 2. Suffix match (handles prefixed names like ova_vm_ontapcl_01)
+        if known_tf_names:
+            for known in known_tf_names:
+                if tf_name.endswith(f"_{known}"):
+                    return known.replace("_", "-")
+
+        # 3. Fallback: full name conversion
+        return tf_name.replace("_", "-")
 
     def _resolve_terraform_targets(self, tf_dir: Path, resource_names: list[str]) -> list[str]:
         """Resolve resource names to terraform resource addresses.

--- a/tests/unit/test_resource_lifecycle_events.py
+++ b/tests/unit/test_resource_lifecycle_events.py
@@ -241,6 +241,73 @@ class TestTerraformJsonParsing:
         assert len(outcomes) == 1
         assert outcomes[0].resource_name == "some-resource"
 
+    def test_build_address_map_suffix_match(self, tmp_path: Path) -> None:
+        """Prefixed terraform names map to resource names via suffix matching."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text(
+            'resource "terraform_data" "ova_vm_ontapcl_01" {\n'
+            "}\n"
+            'resource "terraform_data" "ova_vm_ontapcl_02" {\n'
+            "}\n"
+        )
+
+        runner = TerraformRunner()
+        name_map = runner._build_address_to_name_map(
+            tmp_path, resource_names=["ontapcl-01", "ontapcl-02"]
+        )
+
+        assert name_map == {
+            "terraform_data.ova_vm_ontapcl_01": "ontapcl-01",
+            "terraform_data.ova_vm_ontapcl_02": "ontapcl-02",
+        }
+
+    def test_build_address_map_exact_match(self, tmp_path: Path) -> None:
+        """Exact match takes priority when resource name matches directly."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text('resource "proxmox_virtual_environment_vm" "infra_web" {\n}\n')
+
+        runner = TerraformRunner()
+        name_map = runner._build_address_to_name_map(tmp_path, resource_names=["infra-web"])
+
+        assert name_map == {
+            "proxmox_virtual_environment_vm.infra_web": "infra-web",
+        }
+
+    def test_build_address_map_fallback_no_resource_names(self, tmp_path: Path) -> None:
+        """Without resource_names, falls back to full name conversion."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text('resource "terraform_data" "ova_vm_ontapcl_01" {\n}\n')
+
+        runner = TerraformRunner()
+        name_map = runner._build_address_to_name_map(tmp_path)
+
+        assert name_map == {
+            "terraform_data.ova_vm_ontapcl_01": "ova-vm-ontapcl-01",
+        }
+
+    def test_parse_json_output_with_resource_names(self, tmp_path: Path) -> None:
+        """End-to-end: prefixed terraform_data produces correct resource name."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text('resource "terraform_data" "ova_vm_ontapcl_01" {\n}\n')
+
+        runner = TerraformRunner()
+        json_lines = [
+            json.dumps(
+                {
+                    "type": "apply_complete",
+                    "hook": {
+                        "resource": {"addr": "terraform_data.ova_vm_ontapcl_01"},
+                        "action": "create",
+                    },
+                }
+            ),
+        ]
+        outcomes = runner._parse_json_output(json_lines, tmp_path, resource_names=["ontapcl-01"])
+
+        assert len(outcomes) == 1
+        assert outcomes[0].resource_name == "ontapcl-01"
+        assert outcomes[0].action == "create"
+
 
 # --- AnsibleHandler ---
 


### PR DESCRIPTION
## Description

`_build_address_to_name_map()` did a naive `tf_name.replace("_", "-")` to convert terraform names back to InfraFoundry resource names. For prefixed terraform names like `ova_vm_ontapcl_01` (from OVA templates), this produced `ova-vm-ontapcl-01` instead of the correct `ontapcl-01`, preventing `on_create` lifecycle events from firing.

Now uses suffix matching (consistent with `_resolve_terraform_targets`) to correctly map prefixed names back to resource names.

Addresses #396

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `terraform_runner.py`: Added `resource_names` parameter to `_build_address_to_name_map()` and `_parse_json_output()`. New `_resolve_resource_name()` static method with exact match → suffix match → fallback resolution.
- `test_resource_lifecycle_events.py`: 4 new tests for suffix match, exact match, fallback, and end-to-end JSON parsing with prefixed names.

## Testing

- [x] All existing tests pass
- [x] 4 new tests added

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings