### PR TITLE
feat: add per-package secrets.yaml with SOPS decryption

### DIFF
--- a/docs/architecture/secrets-architecture.md
+++ b/docs/architecture/secrets-architecture.md
@@ -125,6 +125,7 @@ After successful rotation:
 
 - [Age Key Management Best Practices](../guides/age-key-management.md)
 - [Per-Environment Credentials](../configuration/per-environment-credentials.md)
+- [Per-Package Secrets](../configuration/infrastructure-packages.md#per-package-secrets)
 - [Configuration Guide](../configuration/overview.md)
 - [Validation and Pre-Flight Checks](../usage/validation.md)
 

--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -26,6 +26,7 @@ envs/dev/
     vm.yaml                    # Regular provider resources (deprecated)
     ontap-cluster/             # Infrastructure package
       infrafoundry.yml         # Package manifest
+      secrets.yaml             # Per-package secrets (SOPS-encrypted)
       vm.yaml                  # Resource template (Jinja2)
       network.yaml             # Resource template (Jinja2)
       scripts/
@@ -144,6 +145,64 @@ vm:
 - After rendering, the result must be valid YAML
 - Resource type is derived from the filename (same as regular provider resources)
 - Both singular (`vm`) and plural (`vms`) keys are supported
+
+## Per-Package Secrets
+
+Packages can include a `secrets.yaml` file alongside the manifest. This file holds
+sensitive variables (passwords, API tokens, etc.) that should not be stored in
+plaintext in `infrafoundry.yml`.
+
+### How It Works
+
+1. Place a `secrets.yaml` file in the package directory next to `infrafoundry.yml`
+2. Encrypt it with SOPS: `sops --encrypt --in-place secrets.yaml`
+3. During loading, InfraFoundry automatically detects SOPS encryption and decrypts
+4. Variables under the `variables` key are merged into the manifest variables
+5. Secret variables **override** same-named variables from `infrafoundry.yml`
+
+### Format
+
+```yaml
+# secrets.yaml (encrypt with SOPS before committing)
+variables:
+  ontap_password: "my-secret-password"
+  api_token: "tok-abc123"
+```
+
+### Merge Behavior
+
+- Variables from `secrets.yaml` are merged into the manifest's `variables` dict
+- If a key exists in both `infrafoundry.yml` and `secrets.yaml`, the secret value wins
+- Templates can reference secret variables the same way as regular variables
+- If `secrets.yaml` is absent, the package loads normally with no changes
+
+### Example
+
+**`infrafoundry.yml`:**
+```yaml
+name: ontap-cluster
+variables:
+  cluster_name: lab-ontap
+  ontap_password: "changeme"    # safe default, overridden by secrets
+
+resources:
+  - vm.yaml
+```
+
+**`secrets.yaml`** (SOPS-encrypted at rest):
+```yaml
+variables:
+  ontap_password: "real-secret-from-vault"
+```
+
+After merging, templates see `ontap_password` as `"real-secret-from-vault"`.
+
+### Best Practices
+
+- Keep only sensitive values in `secrets.yaml`; put everything else in `infrafoundry.yml`
+- Always encrypt `secrets.yaml` with SOPS before committing
+- Add a `secrets.yaml.example` file with placeholder values for documentation
+- Use `.gitignore` or `.sops.yaml` rules to prevent accidental plaintext commits
 
 ## Package Events
 
@@ -332,6 +391,8 @@ envs/dev/
   proxmox/
     ontap-cluster/
       infrafoundry.yml
+      secrets.yaml               # SOPS-encrypted secrets (optional)
+      secrets.yaml.example       # Placeholder for documentation
       vm.yaml
       scripts/
         cluster-setup.sh

--- a/example-config/envs/dev/proxmox/ontap-cluster/secrets.yaml.example
+++ b/example-config/envs/dev/proxmox/ontap-cluster/secrets.yaml.example
@@ -1,0 +1,11 @@
+# Per-package secrets — SOPS-encrypted at rest.
+#
+# Copy this file to secrets.yaml and encrypt with SOPS:
+#   cp secrets.yaml.example secrets.yaml
+#   sops --encrypt --in-place secrets.yaml
+#
+# Variables listed here override same-named variables in infrafoundry.yml.
+# Only sensitive values belong here; keep everything else in infrafoundry.yml.
+
+variables:
+  ontap_password: "changeme123"

--- a/src/infrafoundry/core/config/__init__.py
+++ b/src/infrafoundry/core/config/__init__.py
@@ -15,6 +15,7 @@ from infrafoundry.core.config.models import EnvironmentConfig, IaCTool, PackageM
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
 from infrafoundry.core.config.resource_centric_loader import ResourceCentricLoader
+from infrafoundry.core.config.sops import load_yaml_with_sops
 
 __all__ = [
     "AzureBackendConfig",
@@ -33,4 +34,5 @@ __all__ = [
     "S3BackendConfig",
     "SSHConfig",
     "TerraformCloudBackendConfig",
+    "load_yaml_with_sops",
 ]

--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -1,7 +1,6 @@
 """Refactored configuration manager - coordinates between loaders."""
 
 import os
-import subprocess  # nosec B404 - needed for SOPS decryption
 import warnings
 from pathlib import Path
 from typing import Any
@@ -13,6 +12,7 @@ from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
 from infrafoundry.core.config.resource_centric_loader import ResourceCentricLoader
+from infrafoundry.core.config.sops import load_yaml_with_sops
 from infrafoundry.core.exceptions import InvalidConfigurationError, PackageNotFoundError
 from infrafoundry.core.provider import ResourceConfig
 
@@ -104,9 +104,8 @@ class ConfigManager(PathBasedManager):
     def _load_yaml_with_sops(file_path: Path) -> dict[str, Any]:
         """Load a YAML file, decrypting with SOPS if encrypted.
 
-        Detects SOPS encryption by checking for the ``sops`` metadata key
-        in the file content. If found, runs ``sops --decrypt`` to get
-        plaintext YAML before parsing.
+        Delegates to the shared :func:`~infrafoundry.core.config.sops.load_yaml_with_sops`
+        utility.
 
         Args:
             file_path: Path to the YAML file.
@@ -114,19 +113,7 @@ class ConfigManager(PathBasedManager):
         Returns:
             Parsed YAML data as a dictionary.
         """
-        with open(file_path) as f:
-            raw = f.read()
-
-        if "sops:" in raw and "ENC[AES256_GCM," in raw:
-            result = subprocess.run(  # nosec B603 B607 - trusted sops command
-                ["sops", "--decrypt", str(file_path)],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            return yaml.safe_load(result.stdout) or {}
-
-        return yaml.safe_load(raw) or {}
+        return load_yaml_with_sops(file_path)
 
     def load_resources(
         self, env_name: str, provider: str, resource_file: str

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -14,6 +14,7 @@ import jinja2
 import yaml
 
 from infrafoundry.core.config.models import PackageManifest
+from infrafoundry.core.config.sops import load_yaml_with_sops
 from infrafoundry.core.exceptions import InvalidConfigurationError
 from infrafoundry.core.provider import ResourceConfig
 
@@ -144,6 +145,19 @@ class PackageLoader:
         """
         manifest_path = package_dir / self.MANIFEST_FILENAME
         manifest = self._parse_manifest(manifest_path)
+
+        # Load and merge secrets if secrets.yaml exists
+        secrets_path = package_dir / "secrets.yaml"
+        if secrets_path.exists():
+            secrets_data = load_yaml_with_sops(secrets_path)
+            secret_vars = secrets_data.get("variables", {})
+            if secret_vars:
+                manifest.variables.update(secret_vars)
+                logger.info(
+                    "Loaded %d secret variable(s) from %s",
+                    len(secret_vars),
+                    secrets_path.name,
+                )
 
         # Use manifest provider with fallback to directory-inferred provider
         effective_provider = manifest.provider or provider

--- a/src/infrafoundry/core/config/sops.py
+++ b/src/infrafoundry/core/config/sops.py
@@ -1,0 +1,39 @@
+"""Shared SOPS decryption utility for YAML files.
+
+Provides a standalone function to load YAML files with automatic SOPS
+decryption, used by both ConfigManager and PackageLoader.
+"""
+
+import subprocess  # nosec B404 - needed for SOPS decryption
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_yaml_with_sops(file_path: Path) -> dict[str, Any]:
+    """Load a YAML file, decrypting with SOPS if encrypted.
+
+    Detects SOPS encryption by checking for the ``sops`` metadata key
+    and ``ENC[AES256_GCM,`` markers in the file content. If found,
+    runs ``sops --decrypt`` to get plaintext YAML before parsing.
+
+    Args:
+        file_path: Path to the YAML file.
+
+    Returns:
+        Parsed YAML data as a dictionary.
+    """
+    with open(file_path) as f:
+        raw = f.read()
+
+    if "sops:" in raw and "ENC[AES256_GCM," in raw:
+        result = subprocess.run(  # nosec B603 B607 - trusted sops command
+            ["sops", "--decrypt", str(file_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return yaml.safe_load(result.stdout) or {}
+
+    return yaml.safe_load(raw) or {}

--- a/tests/test_package_loader.py
+++ b/tests/test_package_loader.py
@@ -2,8 +2,10 @@
 
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
+import yaml
 
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.provider import ResourceConfig
@@ -165,3 +167,192 @@ class TestParseResourcesFromData:
         """Empty data returns empty list."""
         result = loader._parse_resources_from_data({}, "vm.yaml", "proxmox")
         assert result == []
+
+
+def _create_package(
+    tmp_path: Path,
+    manifest_data: dict[str, Any],
+    resource_data: dict[str, Any] | None = None,
+    secrets_data: dict[str, Any] | None = None,
+) -> Path:
+    """Helper to create a package directory with manifest, resource, and optional secrets.
+
+    Args:
+        tmp_path: Temporary directory root (used as base_dir/env/provider/).
+        manifest_data: Data for infrafoundry.yml.
+        resource_data: Data for the resource file (vm.yaml by default).
+        secrets_data: If provided, written to secrets.yaml.
+
+    Returns:
+        Path to the package directory.
+    """
+    env_dir = tmp_path / "test-env"
+    provider_dir = env_dir / "proxmox"
+    package_dir = provider_dir / manifest_data.get("name", "test-pkg")
+    package_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write manifest
+    manifest_path = package_dir / "infrafoundry.yml"
+    manifest_path.write_text(yaml.dump(manifest_data))
+
+    # Write resource file
+    if resource_data is not None:
+        for res_file in manifest_data.get("resources", []):
+            (package_dir / res_file).write_text(yaml.dump(resource_data))
+
+    # Write secrets file
+    if secrets_data is not None:
+        secrets_path = package_dir / "secrets.yaml"
+        secrets_path.write_text(yaml.dump(secrets_data))
+
+    return package_dir
+
+
+class TestPackageSecrets:
+    """Tests for per-package secrets.yaml loading and merging."""
+
+    def test_secrets_merged_into_manifest_variables(self, tmp_path: Path) -> None:
+        """Secret variables from secrets.yaml are merged into manifest variables."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"public_var": "public-value", "db_host": "localhost"},
+            "resources": ["vm.yaml"],
+        }
+        resource = {"vm": [{"name": "test-vm", "host": "{{ db_host }}"}]}
+        secrets = {"variables": {"db_password": "secret123"}}
+
+        package_dir = _create_package(tmp_path, manifest, resource, secrets)
+        loader = PackageLoader(tmp_path)
+
+        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+
+        assert len(resources) == 1
+        # The secret variable was available during rendering (no UndefinedError)
+
+    def test_secrets_override_manifest_variables(self, tmp_path: Path) -> None:
+        """Secret variables override same-named variables from infrafoundry.yml."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"password": "plaintext-default", "host": "localhost"},
+            "resources": ["vm.yaml"],
+        }
+        resource = {"vm": [{"name": "test-vm", "pass": "{{ password }}"}]}
+        secrets = {"variables": {"password": "encrypted-secret"}}
+
+        package_dir = _create_package(tmp_path, manifest, resource, secrets)
+        loader = PackageLoader(tmp_path)
+
+        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+
+        assert len(resources) == 1
+        assert resources[0].config["pass"] == "encrypted-secret"
+
+    def test_package_without_secrets_works_unchanged(self, tmp_path: Path) -> None:
+        """Package without secrets.yaml loads normally with no errors."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"host": "localhost"},
+            "resources": ["vm.yaml"],
+        }
+        resource = {"vm": [{"name": "test-vm", "host": "{{ host }}"}]}
+
+        package_dir = _create_package(tmp_path, manifest, resource, secrets_data=None)
+        loader = PackageLoader(tmp_path)
+
+        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+
+        assert len(resources) == 1
+        assert resources[0].config["host"] == "localhost"
+
+    def test_empty_secrets_yaml_does_not_break(self, tmp_path: Path) -> None:
+        """Empty secrets.yaml (no variables key) doesn't cause errors."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"host": "localhost"},
+            "resources": ["vm.yaml"],
+        }
+        resource = {"vm": [{"name": "test-vm", "host": "{{ host }}"}]}
+        secrets: dict[str, Any] = {}
+
+        package_dir = _create_package(tmp_path, manifest, resource, secrets)
+        # Write truly empty file (yaml.dump({}) writes "{}\n", safe_load returns {})
+        (package_dir / "secrets.yaml").write_text("")
+        loader = PackageLoader(tmp_path)
+
+        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+
+        assert len(resources) == 1
+        assert resources[0].config["host"] == "localhost"
+
+    def test_secrets_missing_variables_key_does_not_break(self, tmp_path: Path) -> None:
+        """secrets.yaml without a 'variables' key doesn't cause errors."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"host": "localhost"},
+            "resources": ["vm.yaml"],
+        }
+        resource = {"vm": [{"name": "test-vm", "host": "{{ host }}"}]}
+        secrets = {"description": "no variables here"}
+
+        package_dir = _create_package(tmp_path, manifest, resource, secrets)
+        loader = PackageLoader(tmp_path)
+
+        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+
+        assert len(resources) == 1
+        assert resources[0].config["host"] == "localhost"
+
+    def test_sops_encrypted_secrets_are_decrypted(self, tmp_path: Path) -> None:
+        """SOPS-encrypted secrets.yaml triggers sops --decrypt subprocess."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"host": "localhost"},
+            "resources": ["vm.yaml"],
+        }
+        resource = {"vm": [{"name": "test-vm", "host": "{{ host }}"}]}
+
+        package_dir = _create_package(tmp_path, manifest, resource, secrets_data=None)
+
+        # Write a fake SOPS-encrypted file
+        sops_content = (
+            "variables:\n    password: ENC[AES256_GCM,data:abc123]\nsops:\n    version: 3.7.3\n"
+        )
+        (package_dir / "secrets.yaml").write_text(sops_content)
+
+        # Mock subprocess.run to simulate sops --decrypt
+        decrypted_yaml = "variables:\n  password: decrypted-secret\n"
+        mock_result = type("Result", (), {"stdout": decrypted_yaml, "returncode": 0})()
+
+        with patch(
+            "infrafoundry.core.config.sops.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            loader = PackageLoader(tmp_path)
+            _resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert call_args[0][0] == ["sops", "--decrypt", str(package_dir / "secrets.yaml")]
+
+    def test_secret_variables_available_in_rendered_templates(self, tmp_path: Path) -> None:
+        """Variables from secrets are used when rendering resource templates."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"host": "db.local", "port": "5432"},
+            "resources": ["vm.yaml"],
+        }
+        # Template uses a variable only defined in secrets
+        resource_content = (
+            "vm:\n  - name: test-vm\n    host: {{ host }}\n    password: {{ db_password }}\n"
+        )
+        secrets = {"variables": {"db_password": "super-secret"}}
+
+        package_dir = _create_package(tmp_path, manifest, secrets_data=secrets, resource_data=None)
+        # Write raw template (not via yaml.dump, to preserve Jinja2 syntax)
+        (package_dir / "vm.yaml").write_text(resource_content)
+
+        loader = PackageLoader(tmp_path)
+        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+
+        assert len(resources) == 1
+        assert resources[0].config["password"] == "super-secret"
+        assert resources[0].config["host"] == "db.local"

--- a/tests/test_sops.py
+++ b/tests/test_sops.py
@@ -1,0 +1,84 @@
+"""Tests for the shared SOPS decryption utility."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from infrafoundry.core.config.sops import load_yaml_with_sops
+
+
+class TestLoadYamlWithSops:
+    """Tests for load_yaml_with_sops function."""
+
+    def test_plain_yaml_loaded_directly(self, tmp_path: Path) -> None:
+        """Plain YAML files are loaded without calling sops."""
+        yaml_file = tmp_path / "plain.yaml"
+        yaml_file.write_text("key: value\nnested:\n  foo: bar\n")
+
+        result = load_yaml_with_sops(yaml_file)
+
+        assert result == {"key": "value", "nested": {"foo": "bar"}}
+
+    def test_empty_file_returns_empty_dict(self, tmp_path: Path) -> None:
+        """Empty YAML file returns empty dict."""
+        yaml_file = tmp_path / "empty.yaml"
+        yaml_file.write_text("")
+
+        result = load_yaml_with_sops(yaml_file)
+
+        assert result == {}
+
+    def test_sops_encrypted_file_triggers_decrypt(self, tmp_path: Path) -> None:
+        """Files with SOPS markers trigger sops --decrypt subprocess call."""
+        yaml_file = tmp_path / "encrypted.yaml"
+        sops_content = "key: ENC[AES256_GCM,data:abc123]\nsops:\n    version: 3.7.3\n"
+        yaml_file.write_text(sops_content)
+
+        decrypted_yaml = "key: decrypted-value\n"
+        mock_result = type("Result", (), {"stdout": decrypted_yaml, "returncode": 0})()
+
+        with patch(
+            "infrafoundry.core.config.sops.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            result = load_yaml_with_sops(yaml_file)
+
+        mock_run.assert_called_once_with(
+            ["sops", "--decrypt", str(yaml_file)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result == {"key": "decrypted-value"}
+
+    def test_file_with_only_sops_marker_not_encrypted(self, tmp_path: Path) -> None:
+        """File with 'sops:' but no ENC marker is treated as plain YAML."""
+        yaml_file = tmp_path / "not-encrypted.yaml"
+        yaml_file.write_text("sops:\n  note: 'this is not actually encrypted'\n")
+
+        with patch("infrafoundry.core.config.sops.subprocess.run") as mock_run:
+            result = load_yaml_with_sops(yaml_file)
+
+        mock_run.assert_not_called()
+        assert result == {"sops": {"note": "this is not actually encrypted"}}
+
+    def test_file_with_only_enc_marker_not_encrypted(self, tmp_path: Path) -> None:
+        """File with ENC marker but no 'sops:' key is treated as plain YAML."""
+        yaml_file = tmp_path / "not-encrypted.yaml"
+        yaml_file.write_text("key: 'ENC[AES256_GCM,data:abc]'\n")
+
+        with patch("infrafoundry.core.config.sops.subprocess.run") as mock_run:
+            result = load_yaml_with_sops(yaml_file)
+
+        mock_run.assert_not_called()
+        assert result == {"key": "ENC[AES256_GCM,data:abc]"}
+
+    def test_sops_decrypt_returns_empty_yaml(self, tmp_path: Path) -> None:
+        """SOPS decryption that returns empty content returns empty dict."""
+        yaml_file = tmp_path / "encrypted.yaml"
+        yaml_file.write_text("key: ENC[AES256_GCM,data:x]\nsops:\n  v: 1\n")
+
+        mock_result = type("Result", (), {"stdout": "", "returncode": 0})()
+
+        with patch("infrafoundry.core.config.sops.subprocess.run", return_value=mock_result):
+            result = load_yaml_with_sops(yaml_file)
+
+        assert result == {}


### PR DESCRIPTION
## Description

Add support for per-package `secrets.yaml` files with automatic SOPS decryption. Packages can now include a `secrets.yaml` alongside `infrafoundry.yml` to store sensitive variables (passwords, API tokens) encrypted at rest. During package loading, secret variables are merged into the manifest variables, overriding same-named keys.

Addresses #409

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Extract shared `load_yaml_with_sops()` into `src/infrafoundry/core/config/sops.py` so both `ConfigManager` and `PackageLoader` reuse one SOPS decryption path
- Update `PackageLoader.load_package()` to detect and load `secrets.yaml`, merging secret variables into the manifest before template rendering
- Refactor `ConfigManager._load_yaml_with_sops()` to delegate to the shared utility
- Export `load_yaml_with_sops` from `infrafoundry.core.config`
- Add `tests/test_sops.py` with 6 tests covering plain YAML, empty files, SOPS detection, and edge cases
- Add 7 tests to `tests/test_package_loader.py` covering secret merging, overrides, missing/empty secrets, SOPS decryption, and template rendering with secret variables
- Add `example-config/envs/dev/proxmox/ontap-cluster/secrets.yaml.example` as a reference
- Update `docs/configuration/infrastructure-packages.md` with Per-Package Secrets section
- Add cross-reference from `docs/architecture/secrets-architecture.md`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

`doit check` passes (format, lint, type-check, security, spell-check, tests).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
