### PR TITLE
fix: example scripts read secrets.yaml for SOPS-encrypted package variables

### DIFF
--- a/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-initial-setup.py
+++ b/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-initial-setup.py
@@ -27,12 +27,31 @@ DEFAULT_PASSWORD = "admin"
 
 
 def load_config() -> dict:
-    """Load variables from infrafoundry.yml."""
+    """Load variables from infrafoundry.yml, merging secrets.yaml if present."""
+    import subprocess
+
     script_dir = Path(__file__).resolve().parent
-    config_path = script_dir.parent / "infrafoundry.yml"
+    package_dir = script_dir.parent
+    config_path = package_dir / "infrafoundry.yml"
     with open(config_path) as f:
         data = yaml.safe_load(f)
-    return data.get("variables", {})
+    variables = data.get("variables", {})
+
+    # Merge SOPS-encrypted secrets.yaml if it exists
+    secrets_path = package_dir / "secrets.yaml"
+    if secrets_path.exists():
+        raw = secrets_path.read_text()
+        if "sops:" in raw and "ENC[AES256_GCM," in raw:
+            result = subprocess.run(
+                ["sops", "--decrypt", str(secrets_path)],
+                capture_output=True, text=True, check=True,
+            )
+            secrets = yaml.safe_load(result.stdout) or {}
+        else:
+            secrets = yaml.safe_load(raw) or {}
+        variables.update(secrets.get("variables", {}))
+
+    return variables
 
 
 def save_option(base_url: str, name: str, value: str | int | bool, auth: tuple) -> bool:

--- a/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-post-terraform.sh
+++ b/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-post-terraform.sh
@@ -17,12 +17,27 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Read variables from infrafoundry.yml
+# Read variables from infrafoundry.yml + secrets.yaml
 eval "$(python3 -c "
-import sys, yaml
+import subprocess, sys, yaml
+from pathlib import Path
+
 with open('${PACKAGE_DIR}/infrafoundry.yml') as f:
     data = yaml.safe_load(f)
 v = data.get('variables', {})
+
+# Merge secrets.yaml if it exists (SOPS-encrypted)
+secrets_path = Path('${PACKAGE_DIR}/secrets.yaml')
+if secrets_path.exists():
+    raw = secrets_path.read_text()
+    if 'sops:' in raw and 'ENC[AES256_GCM,' in raw:
+        result = subprocess.run(['sops', '--decrypt', str(secrets_path)],
+                                capture_output=True, text=True, check=True)
+        secrets = yaml.safe_load(result.stdout) or {}
+    else:
+        secrets = yaml.safe_load(raw) or {}
+    v.update(secrets.get('variables', {}))
+
 for k, val in v.items():
     print(f'{k}={val}')
 ")"

--- a/example-config/envs/dev/proxmox/ontap-cluster/scripts/ontap-post-terraform.sh
+++ b/example-config/envs/dev/proxmox/ontap-cluster/scripts/ontap-post-terraform.sh
@@ -36,12 +36,25 @@ INVENTORY="${PACKAGE_DIR}/.generated-inventory.yml"
 VARS_FILE="${PACKAGE_DIR}/.generated-vars.json"
 
 python3 -c "
-import json, sys, yaml
+import json, subprocess, sys, yaml
+from pathlib import Path
 
 with open(sys.argv[1]) as f:
     data = yaml.safe_load(f)
 
 v = data.get('variables', {})
+
+# Merge secrets.yaml if it exists (SOPS-encrypted)
+secrets_path = Path(sys.argv[1]).parent / 'secrets.yaml'
+if secrets_path.exists():
+    raw = secrets_path.read_text()
+    if 'sops:' in raw and 'ENC[AES256_GCM,' in raw:
+        result = subprocess.run(['sops', '--decrypt', str(secrets_path)],
+                                capture_output=True, text=True, check=True)
+        secrets = yaml.safe_load(result.stdout) or {}
+    else:
+        secrets = yaml.safe_load(raw) or {}
+    v.update(secrets.get('variables', {}))
 
 # Build host lookup from target names
 host_lookup = {}


### PR DESCRIPTION
## Description

Example package scripts read `infrafoundry.yml` directly at runtime, bypassing the framework's `secrets.yaml` merge. When passwords are moved to SOPS-encrypted `secrets.yaml`, scripts fail because variables are missing.

Updated all three example scripts to detect, decrypt, and merge `secrets.yaml` before using variables.

Addresses #411

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `ontap-cluster/scripts/ontap-post-terraform.sh` — Merge `secrets.yaml` into vars before generating Ansible inventory
- `aiqum/scripts/aiqum-post-terraform.sh` — Merge `secrets.yaml` into shell vars via eval
- `aiqum/scripts/aiqum-initial-setup.py` — Merge `secrets.yaml` in `load_config()`

## Testing

- [x] Manually tested: ONTAP cluster deployed successfully with password in SOPS-encrypted `secrets.yaml`

## Checklist

- [x] My code follows the code style of this project
- [x] My changes generate no new warnings