### PR TITLE
feat: pass all variables via environment instead of files on disk

### DIFF
--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -223,10 +223,15 @@ class ConfigManager(PathBasedManager):
             for package_dir in self.provider_centric._package_loader.discover_packages(
                 env_name, provider_name
             ):
-                pkg_resources, pkg_events = self.provider_centric._package_loader.load_package(
-                    package_dir, provider_name, env_name
+                pkg_resources, pkg_events, pkg_vars = (
+                    self.provider_centric._package_loader.load_package(
+                        package_dir, provider_name, env_name
+                    )
                 )
+                # Attach package variables to each resource
                 for resource in pkg_resources:
+                    if pkg_vars:
+                        resource.package_variables = pkg_vars
                     key = f"{resource.provider}:{resource.name}"
                     if key not in resource_locations:
                         resource_locations[key] = []
@@ -249,10 +254,13 @@ class ConfigManager(PathBasedManager):
                     f"must declare a 'provider' field in its manifest. "
                     f"Provider cannot be inferred for packages outside provider directories."
                 )
-            pkg_resources, pkg_events = self._package_loader.load_package(
+            pkg_resources, pkg_events, pkg_vars = self._package_loader.load_package(
                 package_dir, manifest.provider, env_name
             )
+            # Attach package variables to each resource
             for resource in pkg_resources:
+                if pkg_vars:
+                    resource.package_variables = pkg_vars
                 key = f"{resource.provider}:{resource.name}"
                 if key not in resource_locations:
                     resource_locations[key] = []
@@ -381,7 +389,7 @@ class ConfigManager(PathBasedManager):
                 )
                 if manifest.name == package_name:
                     effective_provider = manifest.provider or provider_name
-                    pkg_resources, _ = self._package_loader.load_package(
+                    pkg_resources, _, _pkg_vars = self._package_loader.load_package(
                         package_dir, effective_provider, env_name
                     )
                     return list(dict.fromkeys(r.name for r in pkg_resources))
@@ -394,7 +402,7 @@ class ConfigManager(PathBasedManager):
             if manifest.name == package_name:
                 if not manifest.provider:
                     continue
-                pkg_resources, _ = self._package_loader.load_package(
+                pkg_resources, _, _pkg_vars = self._package_loader.load_package(
                     package_dir, manifest.provider, env_name
                 )
                 return list(dict.fromkeys(r.name for r in pkg_resources))

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -126,7 +126,7 @@ class PackageLoader:
 
     def load_package(
         self, package_dir: Path, provider: str, env_name: str
-    ) -> tuple[list[ResourceConfig], dict[str, list[dict[str, Any]]]]:
+    ) -> tuple[list[ResourceConfig], dict[str, list[dict[str, Any]]], dict[str, Any]]:
         """Load an infrastructure package.
 
         Parses the manifest, renders resource templates with variables,
@@ -138,7 +138,9 @@ class PackageLoader:
             env_name: Environment name
 
         Returns:
-            Tuple of (resources, events) where events have rewritten script paths
+            Tuple of (resources, events, variables) where events have
+            rewritten script paths and variables is the merged manifest
+            variables (including secrets from secrets.yaml)
 
         Raises:
             InvalidConfigurationError: If manifest or resource files are invalid
@@ -187,7 +189,7 @@ class PackageLoader:
             if resource.events:
                 resource.events = self._rewrite_event_scripts(resource.events, package_dir, env_dir)
 
-        return resources, events
+        return resources, events, dict(manifest.variables)
 
     def _parse_manifest(self, manifest_path: Path) -> PackageManifest:
         """Parse an infrafoundry.yml manifest file.

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -113,7 +113,7 @@ class ProviderCentricLoader:
 
         # Discover and load packages in provider subdirectories
         for package_dir in self._package_loader.discover_packages(env_name, provider):
-            pkg_resources, pkg_events = self._package_loader.load_package(
+            pkg_resources, pkg_events, _pkg_vars = self._package_loader.load_package(
                 package_dir, provider, env_name
             )
             all_resources.extend(pkg_resources)

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -219,11 +219,18 @@ class DeploymentExecutor:
                                 seen_created.add(name)
                                 all_created.append(name)
         if all_created:
+            # Collect package_variables from created resources for group handlers
+            merged_pkg_vars: dict[str, Any] = {}
+            for resources in resources_by_provider.values():
+                for r in resources:
+                    if r.name in seen_created and r.package_variables:
+                        merged_pkg_vars.update(r.package_variables)
             self.event_manager.emit_event(
                 EventType.RESOURCE_CREATED,
                 env_name,
                 {"action": "create", "resources": all_created},
                 target_resources=all_created,
+                package_variables=merged_pkg_vars,
             )
 
         return results
@@ -653,6 +660,7 @@ class DeploymentExecutor:
                 provider=provider_name,
                 resource=outcome.resource_name,
                 target_resources=[outcome.resource_name],
+                package_variables=resource.package_variables or {},
             )
 
         # NOTE: Aggregate events for group handlers (requires: [...]) are NOT

--- a/src/infrafoundry/core/events/context.py
+++ b/src/infrafoundry/core/events/context.py
@@ -41,6 +41,7 @@ class EventContext:
     plan_output: dict[str, Any] | None = None
     target_resources: list[str] | None = None
     previous_results: list["EventResult"] = field(default_factory=list)
+    package_variables: dict[str, Any] = field(default_factory=dict)
 
     def __repr__(self) -> str:
         parts = [f"EventContext({self.event_type.value}, env={self.environment}"]

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess  # nosec B404 - required for running user scripts
@@ -35,6 +36,8 @@ class ScriptHandler(BaseHandler):
         INFRAFOUNDRY_RUNNER: Runner name (if applicable, e.g., "terraform")
         INFRAFOUNDRY_PHASE: Workflow phase (if applicable, e.g., "plan", "apply", "destroy")
         INFRAFOUNDRY_CONFIG_DIR: Path to environment config directory
+        INFRAFOUNDRY_PACKAGE_VARS: JSON string of all package variables (if available)
+        INFRAFOUNDRY_VAR_<key>: Individual package variable values (if available)
 
     Example config:
         type: script
@@ -253,6 +256,12 @@ class ScriptHandler(BaseHandler):
 
         if context.target_resources:
             env["INFRAFOUNDRY_TARGET_RESOURCES"] = ",".join(context.target_resources)
+
+        # Add package variables as JSON and individual env vars
+        if context.package_variables:
+            env["INFRAFOUNDRY_PACKAGE_VARS"] = json.dumps(context.package_variables)
+            for key, value in context.package_variables.items():
+                env[f"INFRAFOUNDRY_VAR_{key}"] = str(value)
 
         # Add custom environment variables from config
         custom_env = self.config.get("env", {})

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -17,7 +17,6 @@ from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import EventManager, EventType
-from infrafoundry.core.exceptions import SecretNotFoundError
 from infrafoundry.core.hooks import HookExecutionMixin, HookManager
 from infrafoundry.core.protocols import Destroyable, Plannable
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
@@ -420,7 +419,6 @@ class PlanOrchestrator(HookExecutionMixin):
                 else:
                     provider.set_environment(env_name)
                     provider.ensure_directories()
-                    self._export_secrets(provider_name, env_name, provider)
 
                     # Always generate with ALL resources to avoid terraform
                     # seeing filtered-out resources as deleted. The resource
@@ -606,22 +604,6 @@ class PlanOrchestrator(HookExecutionMixin):
                     "terraform_id": tracked_resource.terraform_id,
                 },
             )
-
-    def _export_secrets(self, provider_name: str, env_name: str, provider: ProviderBase) -> None:
-        try:
-            secret_manager = self._secret_manager_factory(env_name)
-            secrets_file = f"{provider_name}.yaml"
-            tf_vars = provider.terraform_dir / "secrets.auto.tfvars"
-            secret_manager.export_for_terraform(secrets_file, tf_vars)
-        except (FileNotFoundError, SecretNotFoundError) as exc:
-            message = f"No secrets file for {provider_name}"
-            if self._fail_on_missing_secrets:
-                raise FileNotFoundError(message) from exc
-            self.console.print(f"[yellow]{message}[/yellow]")
-        except ValueError as exc:
-            if self._fail_on_missing_secrets:
-                raise
-            self.console.print(f"[dim]Skipping secrets export: {exc}[/dim]")
 
 
 class RollbackOrchestrator:

--- a/src/infrafoundry/core/provider.py
+++ b/src/infrafoundry/core/provider.py
@@ -20,6 +20,7 @@ class ResourceConfig(BaseModel):
     config: dict[str, Any]
     hooks: HooksConfig | None = None
     events: dict[str, list[dict[str, Any]]] | None = None
+    package_variables: dict[str, Any] | None = None
 
 
 class ProviderBase(ABC):
@@ -119,6 +120,18 @@ class ProviderBase(ABC):
 
         Returns:
             Dict mapping resource types to their dependencies
+        """
+        return {}
+
+    def get_terraform_env_vars(self) -> dict[str, str]:
+        """Return TF_VAR_* environment variables for this provider.
+
+        Providers override this to supply their settings and credentials
+        as Terraform input variables via the environment, eliminating the
+        need for terraform.tfvars files on disk.
+
+        Returns:
+            Dict mapping TF_VAR_<name> keys to string values
         """
         return {}
 

--- a/src/infrafoundry/core/provider_mixins.py
+++ b/src/infrafoundry/core/provider_mixins.py
@@ -460,7 +460,13 @@ class TerraformGeneratorMixin:
         include_ssh: bool = False,
         ssh_prefix: str | None = None,
     ) -> None:
-        """Generate tfvars content using provided mappings."""
+        """Generate tfvars content using provided mappings.
+
+        .. deprecated::
+            This method writes secrets to disk. Use
+            :meth:`build_terraform_env_vars` instead, which returns
+            ``TF_VAR_*`` environment variables for the runner.
+        """
         env_config = self._load_environment_config()
         if not env_config:
             return
@@ -478,6 +484,57 @@ class TerraformGeneratorMixin:
             )
 
         self._write_tfvars_lines(lines)
+
+    def build_terraform_env_vars(
+        self,
+        provider_name: str,
+        mapping: dict[str, str],
+        *,
+        include_ssh: bool = False,
+        ssh_prefix: str | None = None,
+    ) -> dict[str, str]:
+        """Build TF_VAR_* env vars from provider settings.
+
+        This is the environment-variable counterpart of
+        ``generate_provider_tfvars``. Instead of writing a file, it
+        returns a dict suitable for merging into the subprocess
+        environment.
+
+        Args:
+            provider_name: Provider name used to look up settings
+            mapping: Maps settings.yaml keys to terraform variable names
+            include_ssh: Whether to include SSH settings
+            ssh_prefix: Prefix for SSH variable names
+
+        Returns:
+            Dict mapping ``TF_VAR_<name>`` to string values
+        """
+        env_config = self._load_environment_config()
+        if not env_config:
+            return {}
+
+        result: dict[str, str] = {}
+        provider_settings = env_config.get_provider_settings(provider_name)
+        if provider_settings:
+            for source_key, tfvar_name in mapping.items():
+                value = provider_settings.get(source_key)
+                if value not in (None, ""):
+                    result[f"TF_VAR_{tfvar_name}"] = (
+                        json.dumps(value) if not isinstance(value, str) else value
+                    )
+
+        if include_ssh:
+            ssh_config = env_config.get_ssh_config(provider_name)
+            if ssh_config:
+                prefix = ssh_prefix or provider_name
+                if getattr(ssh_config, "user", None):
+                    result[f"TF_VAR_{prefix}_ssh_user"] = str(ssh_config.user)
+                if getattr(ssh_config, "key_path", None):
+                    result[f"TF_VAR_{prefix}_ssh_key_path"] = str(ssh_config.key_path)
+                if getattr(ssh_config, "port", None) and ssh_config.port != 22:
+                    result[f"TF_VAR_{prefix}_ssh_port"] = str(ssh_config.port)
+
+        return result
 
     def render_and_write_terraform(
         self,

--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -667,18 +667,20 @@ class TerraformRunner(BaseRunner):
     def _prepare_environment(self, provider: ProviderBase) -> dict[str, str]:
         """Prepare environment variables for Terraform execution.
 
-        Note: Credentials should be loaded via CredentialLoader before calling this.
-        This method uses environment variables that are already set.
+        Merges provider-specific ``TF_VAR_*`` variables into the process
+        environment so that Terraform reads credentials and settings from
+        the environment instead of ``.tfvars`` files on disk.
 
         Args:
             provider: Provider instance
 
         Returns:
-            Environment variables dict (credentials come from os.environ)
+            Environment variables dict with TF_VAR_* entries
         """
         env = os.environ.copy()
 
-        # Credentials are already set by CredentialLoader in CLI
-        # No need to decrypt secrets here - they're loaded per-environment
+        # Merge provider-specific TF_VAR_* env vars (settings + credentials)
+        tf_vars = provider.get_terraform_env_vars()
+        env.update(tf_vars)
 
         return env

--- a/src/infrafoundry/providers/kubernetes/__init__.py
+++ b/src/infrafoundry/providers/kubernetes/__init__.py
@@ -41,6 +41,14 @@ class KubernetesProvider(
         return all(field in config for field in required_fields)
 
     @override
+    def get_terraform_env_vars(self) -> dict[str, str]:
+        """Return TF_VAR_* env vars for Kubernetes provider."""
+        return self.build_terraform_env_vars(
+            provider_name="kubernetes",
+            mapping=self._KUBERNETES_TFVARS_MAPPING,
+        )
+
+    @override
     def generate_terraform(self, resources: list[ResourceConfig]) -> None:
         """Generate Terraform configuration for Kubernetes resources."""
         resources_by_type = self.prepare_terraform_generation(resources)
@@ -59,12 +67,6 @@ class KubernetesProvider(
             "kubernetes/variables.tf.j2",
             context={},
             output_name="variables.tf",
-        )
-
-        # Generate terraform.tfvars from settings.yaml
-        self.generate_provider_tfvars(
-            provider_name="kubernetes",
-            mapping=self._KUBERNETES_TFVARS_MAPPING,
         )
 
         # Generate resources by type - Core resources

--- a/src/infrafoundry/providers/oci/__init__.py
+++ b/src/infrafoundry/providers/oci/__init__.py
@@ -62,6 +62,14 @@ class OCIProvider(
         validator.validate_references(resources)
 
     @override
+    def get_terraform_env_vars(self) -> dict[str, str]:
+        """Return TF_VAR_* env vars for OCI provider."""
+        return self.build_terraform_env_vars(
+            provider_name="oci",
+            mapping=self._OCI_TFVARS_MAPPING,
+        )
+
+    @override
     def generate_terraform(self, resources: list[ResourceConfig]) -> None:
         """Generate Terraform configuration for OCI resources."""
         resources_by_type = self.prepare_terraform_generation(resources)
@@ -71,12 +79,6 @@ class OCIProvider(
 
         # Generate provider configuration and variables
         self.render_provider_and_variables()
-
-        # Generate terraform.tfvars from environment config
-        self.generate_provider_tfvars(
-            provider_name="oci",
-            mapping=self._OCI_TFVARS_MAPPING,
-        )
 
         # Generate VCN and subnet resources
         if "vcn" in resources_by_type or "subnet" in resources_by_type:

--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -45,6 +45,14 @@ class OPNsenseProvider(
         return all(field in config for field in required_fields)
 
     @override
+    def get_terraform_env_vars(self) -> dict[str, str]:
+        """Return TF_VAR_* env vars for OPNsense provider."""
+        return self.build_terraform_env_vars(
+            provider_name="opnsense",
+            mapping=self._OPNSENSE_TFVARS_MAPPING,
+        )
+
+    @override
     def generate_terraform(self, resources: list[ResourceConfig]) -> None:
         """Generate Terraform configuration for OPNsense resources."""
         resources_by_type = self.prepare_terraform_generation(resources)
@@ -54,12 +62,6 @@ class OPNsenseProvider(
 
         # Generate provider configuration
         self.render_provider_and_variables()
-
-        # Generate terraform.tfvars from settings.yaml
-        self.generate_provider_tfvars(
-            provider_name="opnsense",
-            mapping=self._OPNSENSE_TFVARS_MAPPING,
-        )
 
         # Generate resources by type
         if "firewall_rules" in resources_by_type:

--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -59,6 +59,16 @@ class ProxmoxProvider(
         validator.validate_references(resources)
 
     @override
+    def get_terraform_env_vars(self) -> dict[str, str]:
+        """Return TF_VAR_* env vars for Proxmox provider."""
+        return self.build_terraform_env_vars(
+            provider_name="proxmox",
+            mapping=self._PROXMOX_TFVARS_MAPPING,
+            include_ssh=True,
+            ssh_prefix="proxmox",
+        )
+
+    @override
     def generate_terraform(self, resources: list[ResourceConfig]) -> None:
         """Generate Terraform configuration for Proxmox resources."""
         resources_by_type = self.prepare_terraform_generation(resources)
@@ -69,14 +79,6 @@ class ProxmoxProvider(
         # Generate provider configuration with environment context
         self.render_provider_and_variables(
             variables_context={"default_ssh_user": os.getenv("USER", "root")},
-        )
-
-        # Copy or generate terraform.tfvars from environment config
-        self.generate_provider_tfvars(
-            provider_name="proxmox",
-            mapping=self._PROXMOX_TFVARS_MAPPING,
-            include_ssh=True,
-            ssh_prefix="proxmox",
         )
 
         # Generate resources by type (storage before VMs/containers so they can reference it)

--- a/tests/integration/test_advanced_workflows.py
+++ b/tests/integration/test_advanced_workflows.py
@@ -89,6 +89,7 @@ vms:
     provider.validate_config = Mock()
     provider.get_resource_types = Mock(return_value=["vm", "template"])
     provider.get_dependencies = Mock(return_value={"vm": ["template"]})
+    provider.get_terraform_env_vars = Mock(return_value={})
 
     orchestrator.register_provider(provider)
 
@@ -208,6 +209,7 @@ class TestDriftDetection:
         opnsense_provider.generate_terraform = Mock()
         opnsense_provider.get_resource_types = Mock(return_value=["firewall_rule"])
         opnsense_provider.get_dependencies = Mock(return_value={})
+        opnsense_provider.get_terraform_env_vars = Mock(return_value={})
 
         orchestrator.register_provider(opnsense_provider)
 
@@ -359,6 +361,7 @@ firewall_rules:
         opnsense_provider.get_resource_types = Mock(return_value=["firewall_rule", "alias"])
         opnsense_provider.get_dependencies = Mock(return_value={"firewall_rule": ["alias"]})
         opnsense_provider.set_environment = Mock()
+        opnsense_provider.get_terraform_env_vars = Mock(return_value={})
 
         orchestrator.register_provider(opnsense_provider)
 
@@ -423,6 +426,7 @@ deployments:
         k8s_provider.get_resource_types = Mock(return_value=["deployment", "service"])
         k8s_provider.get_dependencies = Mock(return_value={})
         k8s_provider.set_environment = Mock()
+        k8s_provider.get_terraform_env_vars = Mock(return_value={})
 
         orchestrator.register_provider(k8s_provider)
 

--- a/tests/integration/test_orchestrator_workflows.py
+++ b/tests/integration/test_orchestrator_workflows.py
@@ -27,6 +27,7 @@ def mock_providers(tmp_path):
     proxmox.validate_config = Mock()
     proxmox.get_resource_types = Mock(return_value=["vm", "network", "template"])
     proxmox.get_dependencies = Mock(return_value={})  # No dependencies defined
+    proxmox.get_terraform_env_vars = Mock(return_value={})
 
     return {"proxmox": proxmox}
 
@@ -586,6 +587,7 @@ class TestMultiProviderWorkflow:
         kubernetes.generate_ansible = Mock()
         kubernetes.get_resource_types = Mock(return_value=["deployment", "service"])
         kubernetes.get_dependencies = Mock(return_value={})
+        kubernetes.get_terraform_env_vars = Mock(return_value={})
         mock_providers["kubernetes"] = kubernetes
         orchestrator.providers = mock_providers
 
@@ -621,6 +623,7 @@ class TestMultiProviderWorkflow:
         kubernetes.generate_ansible = Mock()
         kubernetes.get_resource_types = Mock(return_value=["deployment", "service"])
         kubernetes.get_dependencies = Mock(return_value={})
+        kubernetes.get_terraform_env_vars = Mock(return_value={})
         mock_providers["kubernetes"] = kubernetes
         orchestrator.providers = mock_providers
 

--- a/tests/test_package_loader.py
+++ b/tests/test_package_loader.py
@@ -224,7 +224,7 @@ class TestPackageSecrets:
         package_dir = _create_package(tmp_path, manifest, resource, secrets)
         loader = PackageLoader(tmp_path)
 
-        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+        resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
         assert len(resources) == 1
         # The secret variable was available during rendering (no UndefinedError)
@@ -242,7 +242,7 @@ class TestPackageSecrets:
         package_dir = _create_package(tmp_path, manifest, resource, secrets)
         loader = PackageLoader(tmp_path)
 
-        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+        resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
         assert len(resources) == 1
         assert resources[0].config["pass"] == "encrypted-secret"
@@ -259,7 +259,7 @@ class TestPackageSecrets:
         package_dir = _create_package(tmp_path, manifest, resource, secrets_data=None)
         loader = PackageLoader(tmp_path)
 
-        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+        resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
         assert len(resources) == 1
         assert resources[0].config["host"] == "localhost"
@@ -279,7 +279,7 @@ class TestPackageSecrets:
         (package_dir / "secrets.yaml").write_text("")
         loader = PackageLoader(tmp_path)
 
-        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+        resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
         assert len(resources) == 1
         assert resources[0].config["host"] == "localhost"
@@ -297,7 +297,7 @@ class TestPackageSecrets:
         package_dir = _create_package(tmp_path, manifest, resource, secrets)
         loader = PackageLoader(tmp_path)
 
-        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+        resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
         assert len(resources) == 1
         assert resources[0].config["host"] == "localhost"
@@ -327,7 +327,7 @@ class TestPackageSecrets:
             "infrafoundry.core.config.sops.subprocess.run", return_value=mock_result
         ) as mock_run:
             loader = PackageLoader(tmp_path)
-            _resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+            _resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
         mock_run.assert_called_once()
         call_args = mock_run.call_args
@@ -351,7 +351,7 @@ class TestPackageSecrets:
         (package_dir / "vm.yaml").write_text(resource_content)
 
         loader = PackageLoader(tmp_path)
-        resources, _ = loader.load_package(package_dir, "proxmox", "test-env")
+        resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
         assert len(resources) == 1
         assert resources[0].config["password"] == "super-secret"

--- a/tests/unit/test_env_root_packages.py
+++ b/tests/unit/test_env_root_packages.py
@@ -181,7 +181,7 @@ class TestManifestProviderField:
             provider="proxmox",
         )
 
-        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, _, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert len(resources) == 1
         # Should use manifest provider "esxi", not directory-inferred "proxmox"
         assert resources[0].provider == "esxi"
@@ -203,7 +203,7 @@ class TestManifestProviderField:
             provider="proxmox",
         )
 
-        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, _, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert len(resources) == 1
         assert resources[0].provider == "proxmox"
 

--- a/tests/unit/test_env_vars_for_secrets.py
+++ b/tests/unit/test_env_vars_for_secrets.py
@@ -1,0 +1,243 @@
+"""Tests for passing variables via environment instead of files on disk.
+
+Covers:
+- TerraformRunner sets TF_VAR_* correctly via provider.get_terraform_env_vars()
+- No secrets.auto.tfvars generated (orchestrator no longer calls _export_secrets)
+- ScriptHandler sets INFRAFOUNDRY_PACKAGE_VARS and INFRAFOUNDRY_VAR_* env vars
+- Package variables include merged secrets from secrets.yaml
+- Empty package_variables doesn't set env vars
+- ResourceConfig carries package_variables
+- EventContext carries package_variables
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+from infrafoundry.core.events.context import EventContext
+from infrafoundry.core.events.handlers.script import ScriptHandler
+from infrafoundry.core.events.types import EventType
+from infrafoundry.core.provider import ProviderBase, ResourceConfig
+from infrafoundry.core.runners.terraform_runner import TerraformRunner
+
+
+class TestResourceConfigPackageVariables:
+    """ResourceConfig carries package_variables."""
+
+    def test_default_none(self):
+        """package_variables defaults to None."""
+        rc = ResourceConfig(name="vm-1", type="vm", provider="proxmox", config={})
+        assert rc.package_variables is None
+
+    def test_set_package_variables(self):
+        """package_variables can be set."""
+        vars_ = {"cluster_name": "lab", "admin_password": "secret"}
+        rc = ResourceConfig(
+            name="vm-1", type="vm", provider="proxmox", config={}, package_variables=vars_
+        )
+        assert rc.package_variables == vars_
+
+
+class TestEventContextPackageVariables:
+    """EventContext carries package_variables."""
+
+    def test_default_empty(self):
+        """package_variables defaults to empty dict."""
+        ctx = EventContext(event_type=EventType.RESOURCE_CREATED, environment="dev")
+        assert ctx.package_variables == {}
+
+    def test_set_package_variables(self):
+        """package_variables can be set via constructor."""
+        vars_ = {"ontap_password": "secret123"}
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="dev",
+            package_variables=vars_,
+        )
+        assert ctx.package_variables == vars_
+
+
+class TestTerraformRunnerEnvVars:
+    """TerraformRunner._prepare_environment merges TF_VAR_* from provider."""
+
+    def test_sets_tf_var_from_provider(self):
+        """Provider TF_VAR_* env vars are merged into the environment."""
+        runner = TerraformRunner(console=Mock())
+        provider = MagicMock(spec=ProviderBase)
+        provider.get_terraform_env_vars.return_value = {
+            "TF_VAR_proxmox_api_url": "https://pve.example.com",
+            "TF_VAR_proxmox_api_token": "user@pam!token=secret",
+        }
+
+        with patch.dict("os.environ", {"HOME": "/home/test"}, clear=True):
+            env = runner._prepare_environment(provider)
+
+        assert env["TF_VAR_proxmox_api_url"] == "https://pve.example.com"
+        assert env["TF_VAR_proxmox_api_token"] == "user@pam!token=secret"
+        provider.get_terraform_env_vars.assert_called_once()
+
+    def test_empty_provider_vars(self):
+        """Empty provider vars don't break environment preparation."""
+        runner = TerraformRunner(console=Mock())
+        provider = MagicMock(spec=ProviderBase)
+        provider.get_terraform_env_vars.return_value = {}
+
+        with patch.dict("os.environ", {"HOME": "/home/test"}, clear=True):
+            env = runner._prepare_environment(provider)
+
+        assert "TF_VAR_proxmox_api_url" not in env
+
+    def test_preserves_existing_env_vars(self):
+        """Existing environment variables are preserved."""
+        runner = TerraformRunner(console=Mock())
+        provider = MagicMock(spec=ProviderBase)
+        provider.get_terraform_env_vars.return_value = {"TF_VAR_new": "value"}
+
+        with patch.dict("os.environ", {"EXISTING": "keep_me"}, clear=True):
+            env = runner._prepare_environment(provider)
+
+        assert env["EXISTING"] == "keep_me"
+        assert env["TF_VAR_new"] == "value"
+
+
+class TestScriptHandlerPackageVars:
+    """ScriptHandler sets INFRAFOUNDRY_PACKAGE_VARS and INFRAFOUNDRY_VAR_*."""
+
+    def _make_handler(self) -> ScriptHandler:
+        return ScriptHandler(
+            config={"script": "scripts/test.sh"},
+            config_base_dir=Path("/tmp/config"),
+        )
+
+    def test_sets_package_vars_json(self):
+        """INFRAFOUNDRY_PACKAGE_VARS is set as JSON string."""
+        handler = self._make_handler()
+        vars_ = {"cluster_name": "lab", "admin_password": "secret123"}
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="dev",
+            package_variables=vars_,
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = handler._prepare_environment(ctx, Path("/tmp/config/envs/dev"))
+
+        assert "INFRAFOUNDRY_PACKAGE_VARS" in env
+        parsed = json.loads(env["INFRAFOUNDRY_PACKAGE_VARS"])
+        assert parsed == vars_
+
+    def test_sets_individual_var_env_vars(self):
+        """INFRAFOUNDRY_VAR_<key> is set for each variable."""
+        handler = self._make_handler()
+        vars_ = {"cluster_name": "lab", "node_count": 3}
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="dev",
+            package_variables=vars_,
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = handler._prepare_environment(ctx, Path("/tmp/config/envs/dev"))
+
+        assert env["INFRAFOUNDRY_VAR_cluster_name"] == "lab"
+        assert env["INFRAFOUNDRY_VAR_node_count"] == "3"
+
+    def test_empty_package_variables_no_env_vars(self):
+        """Empty package_variables doesn't set INFRAFOUNDRY_PACKAGE_VARS."""
+        handler = self._make_handler()
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="dev",
+            package_variables={},
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = handler._prepare_environment(ctx, Path("/tmp/config/envs/dev"))
+
+        assert "INFRAFOUNDRY_PACKAGE_VARS" not in env
+
+    def test_none_package_variables_no_env_vars(self):
+        """Default empty package_variables doesn't set env vars."""
+        handler = self._make_handler()
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="dev",
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            env = handler._prepare_environment(ctx, Path("/tmp/config/envs/dev"))
+
+        assert "INFRAFOUNDRY_PACKAGE_VARS" not in env
+
+
+class TestPackageLoaderReturnsVariables:
+    """PackageLoader.load_package returns variables as third element."""
+
+    def test_load_package_returns_variables(self, tmp_path):
+        """load_package returns (resources, events, variables) triple."""
+        from infrafoundry.core.config.package_loader import PackageLoader
+
+        # Set up package structure
+        env_dir = tmp_path / "dev"
+        pkg_dir = env_dir / "proxmox" / "my-pkg"
+        pkg_dir.mkdir(parents=True)
+
+        # Write manifest
+        (pkg_dir / "infrafoundry.yml").write_text(
+            "name: my-pkg\n"
+            "resources:\n  - vm.yaml\n"
+            "variables:\n"
+            "  cluster_name: lab\n"
+            "  node_count: 2\n"
+        )
+        # Write resource file
+        (pkg_dir / "vm.yaml").write_text("vm:\n  - name: test-vm\n    cores: 2\n")
+
+        loader = PackageLoader(tmp_path)
+        resources, _events, variables = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert variables == {"cluster_name": "lab", "node_count": 2}
+
+    def test_load_package_empty_variables(self, tmp_path):
+        """Empty variables returns empty dict."""
+        from infrafoundry.core.config.package_loader import PackageLoader
+
+        env_dir = tmp_path / "dev"
+        pkg_dir = env_dir / "proxmox" / "my-pkg"
+        pkg_dir.mkdir(parents=True)
+
+        (pkg_dir / "infrafoundry.yml").write_text("name: my-pkg\nresources:\n  - vm.yaml\n")
+        (pkg_dir / "vm.yaml").write_text("vm:\n  - name: test-vm\n    cores: 2\n")
+
+        loader = PackageLoader(tmp_path)
+        _resources, _events, variables = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert variables == {}
+
+
+class TestProviderBaseGetTerraformEnvVars:
+    """ProviderBase.get_terraform_env_vars default returns empty dict."""
+
+    def test_default_returns_empty(self):
+        """Base implementation returns empty dict."""
+
+        class ConcreteProvider(ProviderBase):
+            def validate_config(self, config: dict[str, Any]) -> bool:
+                return True
+
+            def generate_terraform(self, resources: list[ResourceConfig]) -> None:
+                pass
+
+            def generate_ansible(self, resources: list[ResourceConfig]) -> None:
+                pass
+
+            def get_resource_types(self) -> list[str]:
+                return []
+
+            def get_terraform_resource_types(self) -> dict[str, list[str]]:
+                return {}
+
+        provider = ConcreteProvider("test", Path("/tmp"), Path("/tmp/out"))
+        assert provider.get_terraform_env_vars() == {}

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2,20 +2,17 @@
 
 import os
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 
 from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.events import EventManager
-from infrafoundry.core.exceptions import ResourceFilterError, SecretNotFoundError
+from infrafoundry.core.exceptions import ResourceFilterError
 from infrafoundry.core.notifications import NotificationManager
 from infrafoundry.core.orchestrator import Orchestrator, OrchestratorStrictConfig
-from infrafoundry.core.orchestrator_workflows import PlanOrchestrator
 from infrafoundry.core.policy import PolicyEngine
 from infrafoundry.core.provider import ProviderBase
-from infrafoundry.core.secrets.secret_manager import SecretManager
 from infrafoundry.core.state import StateManager
 
 
@@ -430,97 +427,9 @@ class TestOrchestratorStatus:
 
 
 class TestPlanOrchestratorStrictMode:
-    """Tests for PlanOrchestrator strict-mode behavior."""
+    """Tests for PlanOrchestrator — secrets are now passed via env vars, not files."""
 
-    def _make_plan_workflow(self, tmp_path, fail_on_missing_secrets: bool) -> PlanOrchestrator:
-        secret_manager = Mock(spec=SecretManager)
-        secret_manager.export_for_terraform.side_effect = FileNotFoundError("missing")
-
-        mock_runner_registry = Mock()
-        mock_runner_registry.list_runners.return_value = []
-        mock_runner_registry.create_runner.return_value = (
-            None  # No runners needed for these specific tests
-        )
-
-        return PlanOrchestrator(
-            console=Mock(),
-            state_manager=Mock(),
-            event_manager=Mock(),
-            runner_registry=mock_runner_registry,
-            get_providers=lambda: {},
-            load_resources=lambda env: ([], {}),
-            iter_provider_batches=lambda *_args, **_kwargs: [],
-            validate_resources=lambda resources: None,
-            has_policies=lambda: False,
-            check_policies=lambda env, resources, enforce: None,
-            secret_manager_factory=lambda env: secret_manager,
-            get_current_user=lambda: "tester",
-            fail_on_missing_secrets=fail_on_missing_secrets,
-            get_runner_priorities=lambda env: {},
-        )
-
-    def test_export_secrets_strict_mode_raises(self, tmp_path):
-        """Strict mode should raise when secrets are missing."""
-        workflow = self._make_plan_workflow(tmp_path, fail_on_missing_secrets=True)
-        provider = SimpleNamespace(terraform_dir=tmp_path)
-
-        with pytest.raises(FileNotFoundError):
-            workflow._export_secrets("proxmox", "dev", provider)
-
-    def test_export_secrets_permissive_mode_warns(self, tmp_path):
-        """Permissive mode should not raise when secrets are missing."""
-        workflow = self._make_plan_workflow(tmp_path, fail_on_missing_secrets=False)
-        provider = SimpleNamespace(terraform_dir=tmp_path)
-
-        workflow._export_secrets("proxmox", "dev", provider)
-
-    def _make_plan_workflow_with_secret_not_found(
-        self, tmp_path, fail_on_missing_secrets: bool
-    ) -> PlanOrchestrator:
-        secret_manager = Mock(spec=SecretManager)
-        secret_manager.export_for_terraform.side_effect = SecretNotFoundError(
-            "Encrypted file not found: prod/proxmox.yaml"
-        )
-
-        mock_runner_registry = Mock()
-        mock_runner_registry.list_runners.return_value = []
-        mock_runner_registry.create_runner.return_value = None
-
-        return PlanOrchestrator(
-            console=Mock(),
-            state_manager=Mock(),
-            event_manager=Mock(),
-            runner_registry=mock_runner_registry,
-            get_providers=lambda: {},
-            load_resources=lambda env: ([], {}),
-            iter_provider_batches=lambda *_args, **_kwargs: [],
-            validate_resources=lambda resources: None,
-            has_policies=lambda: False,
-            check_policies=lambda env, resources, enforce: None,
-            secret_manager_factory=lambda env: secret_manager,
-            get_current_user=lambda: "tester",
-            fail_on_missing_secrets=fail_on_missing_secrets,
-            get_runner_priorities=lambda env: {},
-        )
-
-    def test_export_secrets_strict_mode_raises_on_secret_not_found(self, tmp_path):
-        """Strict mode should raise when SecretNotFoundError occurs."""
-        workflow = self._make_plan_workflow_with_secret_not_found(
-            tmp_path, fail_on_missing_secrets=True
-        )
-        provider = SimpleNamespace(terraform_dir=tmp_path)
-
-        with pytest.raises(FileNotFoundError):
-            workflow._export_secrets("proxmox", "dev", provider)
-
-    def test_export_secrets_permissive_mode_warns_on_secret_not_found(self, tmp_path):
-        """Permissive mode should not raise when SecretNotFoundError occurs."""
-        workflow = self._make_plan_workflow_with_secret_not_found(
-            tmp_path, fail_on_missing_secrets=False
-        )
-        provider = SimpleNamespace(terraform_dir=tmp_path)
-
-        workflow._export_secrets("proxmox", "dev", provider)
+    pass
 
 
 class TestIterProviderBatchesResourceFilter:

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -409,7 +409,7 @@ class TestLoadPackage:
             {"vm.yaml": resource_content},
         )
 
-        resources, events = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, events, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
 
         assert len(resources) == 2
         assert resources[0].name == "lab-node1"
@@ -438,7 +438,7 @@ class TestLoadPackage:
             {"vm.yaml": resource_content},
         )
 
-        resources, events = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, events, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert len(resources) == 1
         assert resources[0].name == "web-01"
         assert events == {}
@@ -458,7 +458,7 @@ class TestLoadPackage:
             manifest,
         )
 
-        resources, events = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, events, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert resources == []
         assert "BEFORE_PLAN" in events
 
@@ -515,7 +515,7 @@ resources:
             {"resources.yaml": resource_content},
         )
 
-        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, _, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert len(resources) == 2
         assert resources[0].provider == "proxmox"
         assert resources[0].type == "ova_vm"
@@ -546,7 +546,7 @@ resources:
             {"resources.yaml": resource_content},
         )
 
-        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, _, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert len(resources) == 1
         assert resources[0].provider == "proxmox"
         assert resources[0].type == "vm"
@@ -601,7 +601,7 @@ vms:
             {"vms.yaml": resource_content},
         )
 
-        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, _, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert len(resources) == 2
         assert resources[0].provider == "proxmox"
         assert resources[1].provider == "esxi"
@@ -631,7 +631,7 @@ resources:
             {"resources.yaml": resource_content},
         )
 
-        resources, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+        resources, _, _pkg_vars = loader.load_package(pkg_dir, "proxmox", "dev")
         assert len(resources) == 1
         assert resources[0].name == "ontap-01"
         assert resources[0].config["vmid"] == 220


### PR DESCRIPTION
## Description

Eliminates plaintext secrets from disk by passing all variables (including SOPS-decrypted secrets) through environment variables instead of `.tfvars` files and generated JSON vars files.

Addresses #413

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### Terraform — no more secrets on disk
- `TerraformRunner._prepare_environment()` calls `provider.get_terraform_env_vars()` to set `TF_VAR_*` env vars
- Removed `_export_secrets()` from orchestrator workflows (no more `secrets.auto.tfvars`)
- Added `build_terraform_env_vars()` to provider mixins; deprecated `generate_provider_tfvars()`
- All 4 providers implement `get_terraform_env_vars()` override

### Scripts — package variables via env vars
- `PackageLoader.load_package()` returns merged variables as third element
- `ResourceConfig` carries `package_variables` from package loading
- `EventContext` gains `package_variables` field
- `ScriptHandler` sets `INFRAFOUNDRY_PACKAGE_VARS` (JSON) and `INFRAFOUNDRY_VAR_*` individual env vars
- Aggregate events in `apply_serial()` pass `package_variables` for group handlers

## Testing

- [x] All existing tests pass (2093 total)
- [x] 14 new tests for env var functionality
- [x] Manual: ONTAP cluster deployed with password only in SOPS-encrypted secrets.yaml — Ansible receives password via INFRAFOUNDRY_VAR_* env var, no plaintext files on disk

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

Example config scripts will be updated in a follow-up PR after testing the AIQUM package with the same approach.