### PR TITLE
docs: update example scripts to use INFRAFOUNDRY_VAR_* env vars

### DIFF
--- a/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-initial-setup.py
+++ b/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-initial-setup.py
@@ -27,7 +27,19 @@ DEFAULT_PASSWORD = "admin"
 
 
 def load_config() -> dict:
-    """Load variables from infrafoundry.yml."""
+    """Load package variables from environment or infrafoundry.yml.
+
+    Prefers INFRAFOUNDRY_PACKAGE_VARS env var (set by ScriptHandler)
+    and falls back to reading infrafoundry.yml for standalone usage.
+    """
+    import json
+    import os
+
+    env_vars = os.environ.get("INFRAFOUNDRY_PACKAGE_VARS")
+    if env_vars:
+        return json.loads(env_vars)
+
+    # Fallback: read from infrafoundry.yml
     script_dir = Path(__file__).resolve().parent
     config_path = script_dir.parent / "infrafoundry.yml"
     with open(config_path) as f:

--- a/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-post-terraform.sh
+++ b/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-post-terraform.sh
@@ -7,6 +7,10 @@
 # All remote commands run through the ansible jumphost since the SSH key
 # for the AIQUM VM only exists there.
 #
+# Package variables (including secrets) are injected by InfraFoundry as:
+#   INFRAFOUNDRY_PACKAGE_VARS  - JSON string of all package variables
+#   INFRAFOUNDRY_VAR_<key>     - Individual variables
+#
 # Prerequisites:
 # - Rocky 9 VM created and booted with cloud-init
 # - AIQUM RPM available at a web server (set aiqum_url_base in infrafoundry.yml)
@@ -17,8 +21,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Read variables from infrafoundry.yml
-eval "$(python3 -c "
+# Read variables from INFRAFOUNDRY_PACKAGE_VARS or fall back to infrafoundry.yml
+if [ -n "${INFRAFOUNDRY_PACKAGE_VARS:-}" ]; then
+    eval "$(python3 -c "
+import json, os
+v = json.loads(os.environ['INFRAFOUNDRY_PACKAGE_VARS'])
+for k, val in v.items():
+    print(f'{k}={val}')
+")"
+else
+    eval "$(python3 -c "
 import sys, yaml
 with open('${PACKAGE_DIR}/infrafoundry.yml') as f:
     data = yaml.safe_load(f)
@@ -26,6 +38,7 @@ v = data.get('variables', {})
 for k, val in v.items():
     print(f'{k}={val}')
 ")"
+fi
 
 JUMPHOST="${jumphost:-ansible@ansible.example.com}"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"

--- a/example-config/envs/dev/proxmox/ontap-cluster/ontap-lab-cluster-setup.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/ontap-lab-cluster-setup.yml
@@ -4,27 +4,27 @@
 # Creates cluster on node 01, joins node 02, then configures via REST API.
 # Run AFTER serial setup (ontap-lab-serial-setup.yml).
 #
-# All variables are passed as extra-vars from infrafoundry.yml
-# by the ontap-post-terraform.sh event handler script.
+# All variables are read from INFRAFOUNDRY_VAR_* environment variables
+# set by the InfraFoundry framework (includes merged secrets from secrets.yaml).
 
 - name: Create ONTAP cluster on node 01
-  hosts: "{{ node01_target }}"
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_target') }}"
   gather_facts: false
   become: true
   roles:
     - role: ontap-cluster-setup
       vars:
-        ontap_vmid: "{{ node01_vmid }}"
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_vmid') }}"
         ontap_cluster_create: true
-        ontap_cluster_name: "{{ cluster_name }}"
-        ontap_cluster_mgmt_ip: "{{ cluster_mgmt_ip }}"
-        ontap_cluster_mgmt_mask: "{{ cluster_mgmt_mask }}"
-        ontap_cluster_mgmt_gateway: "{{ cluster_mgmt_gateway }}"
-        ontap_node_mgmt_ip: "{{ node01_mgmt_ip }}"
-        ontap_node_mgmt_mask: "{{ node_mgmt_mask }}"
-        ontap_node_mgmt_gateway: "{{ node_mgmt_gateway }}"
-        ontap_password: "{{ ontap_password }}"
-        ontap_dns_domain: "{{ dns_domain }}"
+        ontap_cluster_name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_name') }}"
+        ontap_cluster_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}"
+        ontap_cluster_mgmt_mask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_mask') }}"
+        ontap_cluster_mgmt_gateway: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_gateway') }}"
+        ontap_node_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_mgmt_ip') }}"
+        ontap_node_mgmt_mask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_mask') }}"
+        ontap_node_mgmt_gateway: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_gateway') }}"
+        ontap_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
+        ontap_dns_domain: "{{ lookup('env', 'INFRAFOUNDRY_VAR_dns_domain') }}"
 
 - name: Discover cluster interconnect IP from node 01
   hosts: ontap_cluster
@@ -33,9 +33,9 @@
   tasks:
     - name: Query cluster network interfaces
       ansible.builtin.uri:
-        url: "https://{{ cluster_mgmt_ip }}/api/network/ip/interfaces?ipspace.name=Cluster&fields=ip.address"
+        url: "https://{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}/api/network/ip/interfaces?ipspace.name=Cluster&fields=ip.address"
         user: "admin"
-        password: "{{ ontap_password }}"
+        password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
         validate_certs: false
         force_basic_auth: true
       register: cluster_interfaces
@@ -49,19 +49,19 @@
         msg: "Cluster interconnect IP for join: {{ ontap_cluster_interconnect_ip }}"
 
 - name: Join ONTAP node 02 to cluster
-  hosts: "{{ node02_target }}"
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_target') }}"
   gather_facts: false
   become: true
   roles:
     - role: ontap-cluster-setup
       vars:
-        ontap_vmid: "{{ node02_vmid }}"
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_vmid') }}"
         ontap_cluster_create: false
         ontap_cluster_join_ip: "{{ hostvars['ontap-cluster']['ontap_cluster_interconnect_ip'] }}"
-        ontap_node_mgmt_ip: "{{ node02_mgmt_ip }}"
-        ontap_node_mgmt_mask: "{{ node_mgmt_mask }}"
-        ontap_node_mgmt_gateway: "{{ node_mgmt_gateway }}"
-        ontap_password: "{{ ontap_password }}"
+        ontap_node_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_mgmt_ip') }}"
+        ontap_node_mgmt_mask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_mask') }}"
+        ontap_node_mgmt_gateway: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_gateway') }}"
+        ontap_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
 
 - name: Configure ONTAP cluster (aggregates, SVMs, LIFs)
   hosts: ontap_cluster
@@ -70,32 +70,32 @@
   roles:
     - role: ontap-post-cluster
       vars:
-        ontap_cluster_mgmt_ip: "{{ cluster_mgmt_ip }}"
+        ontap_cluster_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}"
         ontap_admin_user: "admin"
-        ontap_admin_password: "{{ ontap_password }}"
+        ontap_admin_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
         ontap_validate_certs: false
         ontap_dns:
-          - vserver: "{{ svm_name }}"
+          - vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
             domains:
-              - "{{ dns_domain }}"
+              - "{{ lookup('env', 'INFRAFOUNDRY_VAR_dns_domain') }}"
             nameservers:
-              - "{{ dns_nameserver }}"
+              - "{{ lookup('env', 'INFRAFOUNDRY_VAR_dns_nameserver') }}"
         ontap_ntp_servers:
-          - "{{ ntp_server }}"
+          - "{{ lookup('env', 'INFRAFOUNDRY_VAR_ntp_server') }}"
         ontap_lifs:
-          - name: "{{ svm_name }}_lif1"
-            vserver: "{{ svm_name }}"
+          - name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}_lif1"
+            vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
             role: data
             protocol: nfs
             node_index: 0
             home_port: e0d
-            address: "{{ data_lif1_ip }}"
-            netmask: "{{ data_lif_mask }}"
-          - name: "{{ svm_name }}_lif2"
-            vserver: "{{ svm_name }}"
+            address: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif1_ip') }}"
+            netmask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif_mask') }}"
+          - name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}_lif2"
+            vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
             role: data
             protocol: nfs
             node_index: 1
             home_port: e0d
-            address: "{{ data_lif2_ip }}"
-            netmask: "{{ data_lif_mask }}"
+            address: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif2_ip') }}"
+            netmask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif_mask') }}"

--- a/example-config/envs/dev/proxmox/ontap-cluster/ontap-lab-serial-setup.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/ontap-lab-serial-setup.yml
@@ -4,8 +4,8 @@
 # Sets serial console as primary and optionally assigns unique serial/sysid.
 # Must run on first boot BEFORE ONTAP initializes disks.
 #
-# All variables are passed as extra-vars from infrafoundry.yml
-# by the ontap-post-terraform.sh event handler script.
+# All variables are read from INFRAFOUNDRY_VAR_* environment variables
+# set by the InfraFoundry framework.
 
 - name: Install dependencies on Proxmox hosts
   hosts: proxmox_hosts
@@ -23,22 +23,22 @@
 
 # Node 01: set serial console as primary (keep default serial/sysid)
 - name: Configure serial console on ONTAP node 01
-  hosts: "{{ node01_target }}"
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_target') }}"
   gather_facts: false
   become: true
   roles:
     - role: ontap-serial-setup
       vars:
-        ontap_vmid: "{{ node01_vmid }}"
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_vmid') }}"
 
 # Node 02: set serial console + unique serial/sysid
 - name: Configure serial console and sysid on ONTAP node 02
-  hosts: "{{ node02_target }}"
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_target') }}"
   gather_facts: false
   become: true
   roles:
     - role: ontap-serial-setup
       vars:
-        ontap_vmid: "{{ node02_vmid }}"
-        ontap_serial_number: "{{ node02_serial_number }}"
-        ontap_sysid: "{{ node02_sysid }}"
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_vmid') }}"
+        ontap_serial_number: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_serial_number') }}"
+        ontap_sysid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_sysid') }}"

--- a/example-config/envs/dev/proxmox/ontap-cluster/scripts/ontap-post-terraform.sh
+++ b/example-config/envs/dev/proxmox/ontap-cluster/scripts/ontap-post-terraform.sh
@@ -4,50 +4,51 @@
 # Triggered by on_create resource lifecycle event after both ONTAP VMs are created.
 # Runs the full ONTAP lab playbook: serial setup, cluster create, join, post-config.
 #
-# All configuration is read from infrafoundry.yml — no other files need editing.
-# The script generates a dynamic Ansible inventory and extra-vars from
-# the infrafoundry.yml variables section.
+# All variables are provided by the framework via INFRAFOUNDRY_VAR_* env vars.
+# Ansible playbooks read variables directly from the environment via lookup('env', ...).
+# The script only generates a dynamic inventory (host mappings).
 #
 # Environment variables (injected by ScriptHandler):
-#   INFRAFOUNDRY_EVENT    - event type (e.g., "resource_created")
-#   INFRAFOUNDRY_RESOURCE - resource name (if per-resource event)
-#   INFRAFOUNDRY_ENV      - environment name (e.g., "prod")
-#   INFRAFOUNDRY_PROVIDER - provider name (if set)
-#   INFRAFOUNDRY_CONFIG_DIR - path to envs/<env>/
+#   INFRAFOUNDRY_PACKAGE_VARS - JSON string of all package variables (including secrets)
+#   INFRAFOUNDRY_VAR_<key>    - Individual package variables
+#   INFRAFOUNDRY_EVENT        - event type (e.g., "resource_created")
+#   INFRAFOUNDRY_ENV          - environment name (e.g., "prod")
+#   INFRAFOUNDRY_CONFIG_DIR   - path to envs/<env>/
 
 set -euo pipefail
 
 # Script lives in ontap-cluster/scripts/, so package dir is one level up
 PACKAGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-MANIFEST="${PACKAGE_DIR}/infrafoundry.yml"
 PLAYBOOK="${PACKAGE_DIR}/ontap-lab-playbook.yml"
 
 # Verify required files exist
-for f in "$MANIFEST" "$PLAYBOOK"; do
-    if [ ! -f "$f" ]; then
-        echo "ERROR: Required file not found: $f"
-        exit 1
-    fi
-done
+if [ ! -f "$PLAYBOOK" ]; then
+    echo "ERROR: Playbook not found: $PLAYBOOK"
+    exit 1
+fi
 
-# Generate Ansible inventory and extra-vars from infrafoundry.yml
-echo "Generating Ansible configuration from infrafoundry.yml..."
+# Generate Ansible inventory from package variables
+echo "Generating Ansible inventory from environment variables..."
 INVENTORY="${PACKAGE_DIR}/.generated-inventory.yml"
-VARS_FILE="${PACKAGE_DIR}/.generated-vars.json"
 
 python3 -c "
-import json, sys, yaml
+import json, os, sys, yaml
 
-with open(sys.argv[1]) as f:
-    data = yaml.safe_load(f)
-
-v = data.get('variables', {})
+# Read variables from INFRAFOUNDRY_PACKAGE_VARS env var (set by framework)
+vars_json = os.environ.get('INFRAFOUNDRY_PACKAGE_VARS')
+if vars_json:
+    v = json.loads(vars_json)
+else:
+    # Fallback: read from infrafoundry.yml directly (for manual runs)
+    print('Warning: INFRAFOUNDRY_PACKAGE_VARS not set, reading from infrafoundry.yml')
+    with open(sys.argv[1]) as f:
+        data = yaml.safe_load(f)
+    v = data.get('variables', {})
 
 # Build host lookup from target names
 host_lookup = {}
 for key in v:
     if key.endswith('_host') and key.startswith('pve'):
-        # e.g., pve1_host -> pve1
         host_lookup[key.replace('_host', '')] = v[key]
 
 # Build proxmox_hosts inventory — handle both nodes on same host
@@ -93,11 +94,8 @@ inventory = {
 
 with open(sys.argv[2], 'w') as f:
     yaml.dump(inventory, f, default_flow_style=False)
-
-with open(sys.argv[3], 'w') as f:
-    json.dump(v, f)
-" "$MANIFEST" "$INVENTORY" "$VARS_FILE"
+" "${PACKAGE_DIR}/infrafoundry.yml" "$INVENTORY"
 
 echo "Running ONTAP lab cluster setup playbook..."
 cd "$PACKAGE_DIR"
-ansible-playbook -i "$INVENTORY" "$PLAYBOOK" -e "@${VARS_FILE}" -v
+ansible-playbook -i "$INVENTORY" "$PLAYBOOK" -v


### PR DESCRIPTION
## Description

Updates example package scripts to read variables from `INFRAFOUNDRY_VAR_*` environment variables instead of re-parsing `infrafoundry.yml` and `secrets.yaml` files. Follow-up to #413.

## Type of Change

- [x] Documentation update

## Changes Made

### ontap-cluster
- `ontap-lab-cluster-setup.yml` — All variables via `lookup('env', 'INFRAFOUNDRY_VAR_*')`
- `ontap-lab-serial-setup.yml` — Same
- `scripts/ontap-post-terraform.sh` — Reads from `INFRAFOUNDRY_PACKAGE_VARS` env var, only generates inventory (no vars file)

### aiqum
- `scripts/aiqum-post-terraform.sh` — Reads from `INFRAFOUNDRY_VAR_*` env vars directly
- `scripts/aiqum-initial-setup.py` — `load_config()` reads from `INFRAFOUNDRY_PACKAGE_VARS` with fallback

## Testing

- [x] Manual: ONTAP cluster deployed successfully with env var approach
- [x] Manual: AIQUM deployed successfully with env var approach
- [x] No plaintext secrets on disk

## Checklist

- [x] My code follows the code style of this project
- [x] My changes generate no new warnings