### PR TITLE
docs: add README documentation to example packages

### DIFF
--- a/example-config/envs/dev/proxmox/aiqum/README.md
+++ b/example-config/envs/dev/proxmox/aiqum/README.md
@@ -1,0 +1,173 @@
+# AIQUM (Active IQ Unified Manager) on Rocky 9
+
+Deploys a Rocky Linux 9 VM from a cloud-init template, installs NetApp AIQUM
+via RPM with all prerequisites, completes the first-experience setup wizard
+via REST API, and adds the ONTAP cluster for monitoring.
+
+## Quick Start
+
+```bash
+# Deploy everything (VM, DHCP, AIQUM install, initial setup, cluster add)
+infra apply --env prod --package aiqum
+
+# Destroy everything
+infra destroy --env prod --package aiqum
+```
+
+## What It Does
+
+1. **Creates a Rocky 9 VM** cloned from template, with cloud-init (ansible user, DHCP networking, qemu-guest-agent)
+2. **Creates a DHCP reservation** on OPNsense
+3. **Runs automated post-deploy setup** via `on_create` event handler:
+   - Installs prerequisites (EPEL, MySQL 8.4 repo, 7-Zip, firewalld, wget)
+   - Opens firewall ports (443, 9443, 80, 8080, 56072, 56080, 56443)
+   - Downloads and installs AIQUM RPM (~1.9GB) from infra-web
+   - Completes the First Experience Wizard (FEW) via REST API:
+     - Configures email/SMTP notification
+     - Enables AutoSupport
+     - Changes admin password from default
+     - Enables API Gateway
+     - Adds ONTAP cluster as datasource
+     - Marks initial setup complete
+
+## Configuration
+
+**`infrafoundry.yml` is the only file you need to edit.** All other files
+derive their configuration from its `variables` section.
+
+### Variables Reference
+
+| Variable | Description | Example |
+|---|---|---|
+| **VM Configuration** | | |
+| `vm_name` | VM hostname | `aiqum` |
+| `vmid` | Proxmox VM ID | `222` |
+| `target_node` | Proxmox host | `pve1` |
+| `template_vmid` | Rocky 9 template VM ID | `901` |
+| `cores` | CPU cores | `4` |
+| `memory` | Memory in MB | `12288` |
+| `disk_size` | Disk size in GB | `150` |
+| `disk_storage` | Proxmox storage | `nas01` |
+| **Network** | | |
+| `mac_address` | VM MAC address | `` |
+| `ip_address` | VM IP (via DHCP reservation) | `192.168.1.50` |
+| `gateway` | Default gateway | `192.168.1.1` |
+| `dns_server` | DNS server | `192.168.1.1` |
+| `dhcp_subnet` | OPNsense Kea subnet reference | `opt1-infrastructure` |
+| **AIQUM** | | |
+| `aiqum_admin_user` | AIQUM admin username | `umadmin` |
+| `aiqum_admin_password` | AIQUM admin password (replaces default `admin`) | `CHANGE_ME` |
+| `aiqum_admin_email` | Admin email for notifications | `admin@example.com` |
+| **SMTP** | | |
+| `smtp_server` | SMTP relay server | `smtp.example.com` |
+| `smtp_port` | SMTP port | `2525` |
+| `smtp_user` | SMTP auth username | `aiqum` |
+| `smtp_password` | SMTP auth password | `CHANGE_ME` |
+| **ONTAP Cluster** | | |
+| `ontap_cluster_ip` | ONTAP cluster management IP | `192.168.1.220` |
+| `ontap_admin_user` | ONTAP admin username | `admin` |
+| `ontap_admin_password` | ONTAP admin password | `CHANGE_ME` |
+
+## Package Structure
+
+```
+aiqum/
+  infrafoundry.yml            # Main config — edit this
+  vm.yaml                     # VM definition (Jinja2 template)
+  dhcp.yaml                   # DHCP reservation (Jinja2 template)
+  scripts/
+    aiqum-post-terraform.sh   # on_create event handler (orchestrates everything)
+    aiqum-install-remote.sh   # RPM install script (runs on the VM)
+    aiqum-initial-setup.py    # First Experience Wizard automation (REST API)
+    capture-console.sh        # Utility to capture VM console output
+  docs/
+    full-deploy-output.txt    # Example output from a full deploy
+```
+
+## Files You Typically Edit
+
+| File | When to Edit |
+|---|---|
+| `infrafoundry.yml` | Always — all configuration lives here |
+| `vm.yaml` | Only if changing VM hardware (cores, memory, NICs) |
+| `dhcp.yaml` | Only if changing DHCP reservation settings |
+
+## Automation Flow
+
+```
+infra apply --package aiqum
+  |
+  +-- Terraform: Clone Rocky 9 template, resize disk to 150G
+  +-- Terraform: Upload cloud-init user-data (ansible user, DHCP, qemu-agent)
+  +-- Terraform: Create DHCP reservation on OPNsense
+  |
+  +-- on_create (resource: aiqum):
+       |
+       +-- aiqum-post-terraform.sh
+            |
+            +-- Phase 1: Wait for VM SSH (via ansible jumphost)
+            +-- Phase 2: Upload and run aiqum-install-remote.sh on VM
+            |    +-- Install wget, unzip
+            |    +-- Configure EPEL + MySQL 8.4 repos
+            |    +-- Install 7-Zip
+            |    +-- Configure firewall (all AIQUM ports)
+            |    +-- Download AIQUM RPM from infra-web (~1.9GB)
+            |    +-- Run pre_install_check.sh
+            |    +-- Install AIQUM RPM + 225 dependencies
+            +-- Phase 3: Wait for AIQUM web UI
+            +-- Phase 4: Run aiqum-initial-setup.py (FEW wizard)
+                 +-- Step 1: Configure email + SMTP
+                 +-- Step 2: Enable AutoSupport
+                 +-- Step 3: Change admin password
+                 +-- Step 4: Enable API Gateway
+                 +-- Step 5: Add ONTAP cluster
+                 +-- Step 6: Mark setup complete
+```
+
+## Prerequisites
+
+- Rocky 9 cloud-init template (VM ID 901) on Proxmox
+- AIQUM RPM and install scripts available at `http://your-web-server/applications/aiqum/`
+- SSH access to `ansible@ansible.example.com` (jumphost for VM access)
+- ONTAP cluster running and reachable (for cluster add step)
+
+## AIQUM RPM Source
+
+The RPM and related files must be available at:
+```
+http://your-web-server/applications/aiqum/
+  netapp-um-9.18-el9.x86_64.rpm    # Main RPM (~1.9GB)
+  pre_install_check.sh              # Prerequisite checker
+  install7zip.sh                    # 7-Zip installer
+```
+
+These are extracted from `ActiveIQUnifiedManager-9.18-el9.zip` downloaded from
+the NetApp Support site.
+
+## Firewall Ports
+
+AIQUM requires these ports open (configured automatically by the install script):
+
+| Port | Purpose |
+|---|---|
+| 443 | Web UI and REST API |
+| 9443 | Cluster agent communication (AMQP/websocket) |
+| 80 | HTTP redirect |
+| 8080 | Internal services |
+| 56072, 56080, 56443 | Acquisition unit communication |
+
+## Post-Deploy Access
+
+After a successful deploy:
+- **Web UI**: `https://<ip_address>/`
+- **Username**: value of `aiqum_admin_user` (default: `umadmin`)
+- **Password**: value of `aiqum_admin_password`
+
+## Troubleshooting
+
+- **VM not booting**: Check `cpu_type` — Rocky 9 requires `host` (not `kvm64`)
+- **Cloud-init not applied**: Snippet names must not include `.yaml` extension
+- **AIQUM install fails**: Check prerequisites — EPEL, MySQL 8.4 repo, and 7-Zip must be installed first
+- **Web UI shows setup wizard**: The `aiqum-initial-setup.py` script didn't complete; run it manually
+- **Cluster add fails**: Check firewall port 9443 is open; verify ONTAP cluster is reachable from the VM
+- **Stale data after redeploy**: NFS stale file handles can preserve old disk data; clean `/mnt/pve/<storage>/images/<vmid>/` on the Proxmox host before redeploying

--- a/example-config/envs/dev/proxmox/ontap-cluster/README.md
+++ b/example-config/envs/dev/proxmox/ontap-cluster/README.md
@@ -1,0 +1,171 @@
+# ONTAP Simulator 2-Node Cluster
+
+Deploys a 2-node NetApp ONTAP Simulator cluster on Proxmox, including DHCP
+reservations on OPNsense and fully automated cluster setup via Ansible.
+
+## Quick Start
+
+```bash
+# Deploy everything (VMs, DHCP, cluster setup)
+infra apply --env prod --package ontap-cluster
+
+# Destroy everything
+infra destroy --env prod --package ontap-cluster
+```
+
+## What It Does
+
+1. **Creates 2 ONTAP Simulator VMs** from an OVA on Proxmox
+2. **Creates DHCP reservations** on OPNsense (node mgmt, cluster mgmt, data LIFs)
+3. **Runs automated post-deploy setup** via `on_create` event handler:
+   - Serial console setup (first boot wizard, sysid assignment for node 02)
+   - Cluster create on node 01
+   - Cluster join on node 02
+   - Post-cluster config: SVM, data LIFs, DNS, NTP, aggregates
+
+## Configuration
+
+**`infrafoundry.yml` is the only file you need to edit.** All other files
+(playbooks, roles, templates) derive their configuration from its `variables`
+section.
+
+### Variables Reference
+
+| Variable | Description | Example |
+|---|---|---|
+| **VM Configuration** | | |
+| `node01_name` | Node 1 hostname | `ontapcl-01` |
+| `node02_name` | Node 2 hostname | `ontapcl-02` |
+| `node01_vmid` | Proxmox VM ID for node 1 | `220` |
+| `node02_vmid` | Proxmox VM ID for node 2 | `221` |
+| `node01_target` | Proxmox host for node 1 | `pve1` |
+| `node02_target` | Proxmox host for node 2 | `pve1` |
+| `ova_source` | Path to ONTAP Simulator OVA on Proxmox storage | `/mnt/pve/infra/appliances/ontap/9.18.1/vsim-...ova` |
+| `disk_storage` | Proxmox storage for VM disks | `nas01` |
+| **Proxmox Hosts** | | |
+| `pve1_host` | FQDN/IP of Proxmox host 1 | `192.168.1.10` |
+| `pve2_host` | FQDN/IP of Proxmox host 2 | `192.168.1.11` |
+| **Network** | | |
+| `bridge` | Proxmox network bridge | `vmbr0` |
+| `mgmt_vlan` | VLAN tag for management network | `10` |
+| **MAC Addresses** | | |
+| `node01_mgmt_mac` | Node 1 management NIC (e0c) | `` |
+| `node01_data_mac` | Node 1 data NIC (e0d) | `` |
+| `node02_mgmt_mac` | Node 2 management NIC (e0c) | `` |
+| `node02_data_mac` | Node 2 data NIC (e0d) | `` |
+| **Node 02 Identity** | | |
+| `node02_serial_number` | Serial number for node 2 (from OVA) | `4082368-50-7` |
+| `node02_sysid` | System ID for node 2 (from OVA) | `4082368507` |
+| **Cluster Configuration** | | |
+| `cluster_name` | ONTAP cluster name | `ontapcl` |
+| `cluster_mgmt_ip` | Cluster management LIF IP | `192.168.1.220` |
+| `cluster_mgmt_mask` | Cluster management subnet mask | `255.255.255.0` |
+| `cluster_mgmt_gateway` | Cluster management gateway | `192.168.1.1` |
+| `node01_mgmt_ip` | Node 1 management IP | `192.168.1.221` |
+| `node02_mgmt_ip` | Node 2 management IP | `192.168.1.222` |
+| `node_mgmt_mask` | Node management subnet mask | `255.255.255.0` |
+| `node_mgmt_gateway` | Node management gateway | `192.168.1.1` |
+| `ontap_password` | Admin password for ONTAP | `changeme123` |
+| `dns_domain` | DNS domain name | `lab.local` |
+| **Post-Cluster: SVM & Data LIFs** | | |
+| `svm_name` | Storage VM name | `svm_data` |
+| `data_lif1_ip` | Data LIF 1 IP (on node 1) | `192.168.1.230` |
+| `data_lif2_ip` | Data LIF 2 IP (on node 2) | `192.168.1.231` |
+| `data_lif_mask` | Data LIF subnet mask | `255.255.255.0` |
+| **DNS & NTP** | | |
+| `dns_nameserver` | DNS server IP | `192.168.1.1` |
+| `ntp_server` | NTP server IP | `192.168.1.1` |
+| **DHCP Reservations** | | |
+| `dhcp_subnet` | OPNsense Kea subnet reference | `opt1-infrastructure` |
+| `data_lif1_mac` | Data LIF 1 MAC for DHCP reservation | `bc:24:11:00:01:d1` |
+| `data_lif2_mac` | Data LIF 2 MAC for DHCP reservation | `bc:24:11:00:02:d2` |
+| `cluster_mgmt_mac` | Cluster mgmt MAC for DHCP reservation | `01:01:01:01:01:01` |
+
+## Package Structure
+
+```
+ontap-cluster/
+  infrafoundry.yml          # Main config — edit this
+  vm.yaml                   # VM definitions (Jinja2 template)
+  dhcp.yaml                 # DHCP reservations (Jinja2 template)
+  scripts/
+    ontap-post-terraform.sh # on_create event handler
+  ontap-lab-playbook.yml    # Master playbook (runs serial + cluster setup)
+  ontap-lab-serial-setup.yml  # First-boot serial console setup
+  ontap-lab-cluster-setup.yml # Cluster create/join/post-config
+  ansible.cfg               # Ansible settings
+  requirements.yml          # Ansible Galaxy requirements
+  roles/
+    ontap-serial-setup/     # First-boot wizard via expect scripts
+    ontap-cluster-setup/    # Cluster create + node join via expect
+    ontap-post-cluster/     # SVM, LIFs, DNS, NTP, aggregates via ONTAP REST
+  logs/                     # Expect script logs (auto-generated)
+```
+
+## Files You Typically Edit
+
+| File | When to Edit |
+|---|---|
+| `infrafoundry.yml` | Always — all configuration lives here |
+| `vm.yaml` | Only if changing VM hardware (cores, memory, NICs, disk bus) |
+| `dhcp.yaml` | Only if adding/removing DHCP reservations |
+
+## Network Layout
+
+Each ONTAP Simulator VM has 4 NICs:
+
+| NIC | Interface | Purpose |
+|---|---|---|
+| `net0` (e1000) | e0a | Cluster interconnect |
+| `net1` (e1000) | e0b | Cluster interconnect |
+| `net2` (e1000) | e0c | Node management (VLAN tagged) |
+| `net3` (e1000) | e0d | Data (VLAN tagged) |
+
+## Automation Flow
+
+```
+infra apply --package ontap-cluster
+  |
+  +-- Terraform: Create 2 OVA VMs on Proxmox
+  +-- Terraform: Create 5 DHCP reservations on OPNsense
+  |
+  +-- on_create (requires: ontapcl-01, ontapcl-02):
+       |
+       +-- ontap-post-terraform.sh
+            |
+            +-- Generate Ansible inventory from infrafoundry.yml
+            +-- ansible-playbook ontap-lab-playbook.yml
+                 |
+                 +-- ontap-serial-setup (expect: first-boot wizard)
+                 +-- ontap-cluster-setup (expect: cluster create + join)
+                 +-- ontap-post-cluster (REST API: SVM, LIFs, DNS, NTP)
+```
+
+## Prerequisites
+
+- ONTAP Simulator OVA extracted and accessible on Proxmox storage
+- Ansible installed with `netapp.ontap` collection (`ansible-galaxy install -r requirements.yml`)
+- `expect` available on the Proxmox host (for serial console automation)
+- SSH access to Proxmox hosts as root
+
+## Manual Playbook Runs
+
+If you need to re-run the Ansible playbooks without redeploying:
+
+```bash
+cd config-repo/envs/dev/proxmox/ontap-cluster/
+
+# Run the full setup
+./scripts/ontap-post-terraform.sh
+
+# Or run individual playbooks manually
+ansible-playbook -i .generated-inventory.yml ontap-lab-serial-setup.yml -e @.generated-vars.json -v
+ansible-playbook -i .generated-inventory.yml ontap-lab-cluster-setup.yml -e @.generated-vars.json -v
+```
+
+## Troubleshooting
+
+- **Logs**: Check `logs/` for expect script output from cluster create/join
+- **Serial console**: `ssh root@pve1 "qm terminal <vmid>"` to access ONTAP serial console
+- **Cluster status**: `ssh admin@<cluster_mgmt_ip>` then `cluster show`
+- **Node not joining**: Verify `node02_serial_number` and `node02_sysid` match the OVA


### PR DESCRIPTION
## Description

Adds README.md documentation to the ontap-cluster and aiqum example packages covering usage, configuration, package structure, automation flow, prerequisites, and troubleshooting. All values sanitized with generic placeholders.

## Type of Change

- [x] Documentation update

## Changes Made

- `example-config/envs/dev/proxmox/ontap-cluster/README.md` — Full package documentation
- `example-config/envs/dev/proxmox/aiqum/README.md` — Full package documentation

## Checklist

- [x] No sensitive data in example files
- [x] My changes generate no new warnings