### PR TITLE
docs: update documentation for env-var secrets, lifecycle events, and removed tfvars

### DIFF
--- a/docs/architecture/events.md
+++ b/docs/architecture/events.md
@@ -90,10 +90,18 @@ Categorized event types for different lifecycle phases and operations.
    - `RESOURCE_DELETED`
    - `RESOURCE_FAILED`
 
-3. **Runner Events** - Runner lifecycle within a workflow
-   - `RUNNER_STARTING` - Emitted before a runner executes (plan, apply, destroy)
-   - `RUNNER_COMPLETED` - Emitted after a runner finishes successfully
+3. **Runner Events** - Runner lifecycle within a workflow *(deprecated)*
+   - `RUNNER_STARTING` - Emitted before a runner executes *(deprecated, use resource lifecycle events)*
+   - `RUNNER_COMPLETED` - Emitted after a runner finishes *(deprecated, use resource lifecycle events)*
    - `RUNNER_FAILED` - Emitted when a runner raises an exception
+
+4. **Resource Lifecycle Events** - Per-resource outcome-based events *(primary pattern)*
+   - `on_create` → `RESOURCE_CREATED` - Resource was newly created
+   - `on_update` → `RESOURCE_UPDATED` - Resource was modified in place
+   - `on_destroy` → `RESOURCE_DELETED` - Resource was destroyed
+   - Declared directly on resource definitions with `requires` for group dependencies
+   - Fire based on actual Terraform/OpenTofu outcomes, not runner completion
+   - Type-aware filtering via `get_terraform_resource_types()` prevents helper resources from firing events
 
 5. **Drift Events** - Configuration drift detection
    - `DRIFT_DETECTED`
@@ -186,7 +194,12 @@ Each event type includes specific data fields:
 }
 ```
 
-### Runner Events
+### Runner Events (Deprecated)
+
+!!! warning "Deprecated"
+    Runner events (`RUNNER_STARTING`, `RUNNER_COMPLETED`) are deprecated. Use resource
+    lifecycle events (`on_create`, `on_update`, `on_destroy`) instead. Runner events
+    continue to work but emit `DeprecationWarning` messages.
 
 ```python
 # RUNNER_STARTING / RUNNER_COMPLETED
@@ -202,6 +215,45 @@ Each event type includes specific data fields:
     "runner": "terraform",
     "error": "Command exited with code 1"
 }
+```
+
+### Resource Lifecycle Events (Primary Pattern)
+
+Resource lifecycle events fire based on the **actual outcome** of a Terraform apply
+or destroy. They are declared directly on resource definitions and replace the
+`RUNNER_COMPLETED` pattern.
+
+```yaml
+vm:
+  - name: ontapcl-01
+    cores: 4
+    memory: 16384
+    events:
+      on_create:
+        - type: script
+          name: serial-setup
+          script: scripts/ontap-serial-setup.sh
+          timeout: 600
+      on_update:
+        - type: webhook
+          url: "https://hooks.slack.com/..."
+      on_destroy:
+        - type: script
+          name: cleanup
+          script: scripts/ontap-cleanup.sh
+```
+
+Use `requires` to declare group dependencies:
+
+```yaml
+events:
+  on_create:
+    - type: script
+      name: cluster-init
+      script: scripts/cluster-init.sh
+      requires:
+        - ontap-node1
+        - ontap-node2
 ```
 
 ### Drift Events
@@ -405,4 +457,4 @@ Potential improvements:
 
 ---
 
-**Last Updated:** 2025-12-29
+**Last Updated:** 2026-03-18

--- a/docs/architecture/orchestrator-architecture.md
+++ b/docs/architecture/orchestrator-architecture.md
@@ -32,7 +32,7 @@ The Orchestrator is a thin coordinator that wires providers, runners, policy che
   - ConfigManager (resource loading/validation)
   - PolicyEngine (pre-deployment checks)
   - Dependency graph builder (ordering)
-  - SecretManager (exports for Terraform/Ansible)
+  - Provider credential mapping (credentials flow via `TF_VAR_*` env vars)
   - Providers (render Terraform/Ansible)
   - Runners via DeploymentExecutor (Terraform/Ansible execution)
   - StateManager (deployments/resources/events)
@@ -41,7 +41,7 @@ The Orchestrator is a thin coordinator that wires providers, runners, policy che
 - **Workflow outline:**
   1. Create deployment record; emit BEFORE event.
   2. Load/validate resources; check policies; group by provider.
-  3. Track resources in state; render Terraform/Ansible; export secrets.
+  3. Track resources in state; render Terraform/Ansible; credentials passed via `TF_VAR_*` env vars.
   4. Execute via runners; update state; emit AFTER or FAILED events.
 - **Provider registry:** Providers registered once; grouped resources dispatched per provider.
 
@@ -62,7 +62,6 @@ sequenceDiagram
     participant ConfigManager
     participant PolicyEngine
     participant Provider
-    participant SecretManager
     participant Runner
 
     User->>CLI: infra plan --env dev
@@ -95,8 +94,7 @@ sequenceDiagram
             PlanOrchestrator->>Provider: set_environment(env_name)
             PlanOrchestrator->>Provider: ensure_directories()
 
-            PlanOrchestrator->>SecretManager: export_for_terraform(secrets_file, tf_vars)
-            SecretManager-->>PlanOrchestrator: secrets exported
+            Note over PlanOrchestrator,Runner: Credentials passed via TF_VAR_* env vars
 
             loop for each runner (terraform, ansible, etc.)
                 PlanOrchestrator->>Provider: generate_{tool}(resources)
@@ -129,7 +127,6 @@ sequenceDiagram
     participant EventManager
     participant ConfigManager
     participant Provider
-    participant SecretManager
     participant Runner
 
     User->>CLI: infra apply --env dev
@@ -163,8 +160,7 @@ sequenceDiagram
 
             ApplyOrchestrator->>EventManager: emit_event(RESOURCE_APPLYING, env, resource_data)
 
-            ApplyOrchestrator->>SecretManager: export_for_terraform(secrets_file, tf_vars)
-            SecretManager-->>ApplyOrchestrator: secrets exported
+            Note over ApplyOrchestrator,Runner: Credentials passed via TF_VAR_* env vars
 
             loop for each runner (terraform, ansible, etc.)
                 ApplyOrchestrator->>Provider: generate_{tool}(resources)
@@ -284,7 +280,7 @@ sequenceDiagram
 
 ---
 
-Last updated: 2025-12-23
+Last updated: 2026-03-18
 
 
 ---

--- a/docs/architecture/secrets-architecture.md
+++ b/docs/architecture/secrets-architecture.md
@@ -121,6 +121,36 @@ After successful rotation:
 - **Rollback**: Automatic rollback to backup on any failure
 - **Dry-run mode**: Preview rotation without making changes
 
+## Secrets Transport: No Secrets on Disk
+
+InfraFoundry follows a **no-secrets-on-disk** approach for Terraform execution. Provider
+credentials and sensitive settings are never written to `.tfvars` files. Instead:
+
+1. **Provider credentials** from `settings.yaml` are mapped to `TF_VAR_*` environment
+   variables via each provider's `_CREDENTIAL_ENV_MAPPING` dict
+2. `TerraformRunner._prepare_environment()` calls `provider.get_terraform_env_vars()`
+   to build the full set of `TF_VAR_*` variables
+3. `build_terraform_env_vars()` in `provider_mixins.py` reads settings and returns the
+   `TF_VAR_*` dict
+4. These environment variables are passed to the Terraform process at runtime
+
+The deprecated `generate_provider_tfvars()` and `SecretManager.export_for_terraform()` /
+`_export_secrets()` methods have been removed from the orchestration workflow.
+
+### Per-Package Secrets
+
+Packages can include a `secrets.yaml` file alongside their `infrafoundry.yml` manifest.
+This file is SOPS-encrypted and automatically decrypted during package loading:
+
+- Variables from `secrets.yaml` merge into the manifest's `variables` dict
+- Secret values override same-named variables from `infrafoundry.yml`
+- Merged variables are exposed to scripts as `INFRAFOUNDRY_VAR_<KEY>` env vars
+  and as a JSON dict in `INFRAFOUNDRY_PACKAGE_VARS`
+- Scripts read configuration from env vars rather than re-parsing files
+
+See [Infrastructure Packages: Per-Package Secrets](../configuration/infrastructure-packages.md#per-package-secrets)
+for format and usage details.
+
 ## Related Documentation
 
 - [Age Key Management Best Practices](../guides/age-key-management.md)
@@ -140,7 +170,7 @@ After successful rotation:
 
 ---
 
-Last updated: 2025-12-27 19:30 GMT
+Last updated: 2026-03-18
 
 
 ---

--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -204,6 +204,33 @@ After merging, templates see `ontap_password` as `"real-secret-from-vault"`.
 - Add a `secrets.yaml.example` file with placeholder values for documentation
 - Use `.gitignore` or `.sops.yaml` rules to prevent accidental plaintext commits
 
+## Script Environment Variables
+
+When package event handlers run scripts, the `ScriptHandler` sets the following
+environment variables for the script to consume:
+
+| Variable | Description |
+|:---------|:-----------|
+| `INFRAFOUNDRY_VAR_<KEY>` | Individual package variable (key uppercased, e.g., `INFRAFOUNDRY_VAR_CLUSTER_NAME`) |
+| `INFRAFOUNDRY_PACKAGE_VARS` | JSON dict of all merged package variables (manifest + secrets.yaml) |
+| `INFRAFOUNDRY_ENV` | Environment name |
+| `INFRAFOUNDRY_PROVIDER` | Provider name |
+| `INFRAFOUNDRY_PACKAGE` | Package name |
+| `INFRAFOUNDRY_CONFIG_DIR` | Path to the environment config directory |
+
+Scripts should read configuration from these environment variables rather than
+re-parsing `infrafoundry.yml` or `secrets.yaml` directly:
+
+```bash
+#!/bin/bash
+# Read individual variables
+echo "Cluster: $INFRAFOUNDRY_VAR_CLUSTER_NAME"
+echo "Password available: ${INFRAFOUNDRY_VAR_ONTAP_PASSWORD:+yes}"
+
+# Or parse the full JSON
+echo "$INFRAFOUNDRY_PACKAGE_VARS" | jq '.cluster_name'
+```
+
 ## Package Events
 
 Events declared in the manifest follow the same format as
@@ -415,18 +442,9 @@ variables:
 
 resources:
   - vm.yaml
-
-events:
-  AFTER_APPLY:
-    - type: script
-      script: scripts/cluster-setup.sh
-      timeout: 300
-  BEFORE_DESTROY:
-    - type: script
-      script: scripts/cluster-teardown.sh
 ```
 
-**`vm.yaml`:**
+**`vm.yaml`** (using resource lifecycle events — the recommended pattern):
 ```yaml
 vm:
   - name: {{ cluster_name }}-node1
@@ -434,6 +452,19 @@ vm:
     memory: 16384
     network:
       - bridge: {{ mgmt_network }}
+    events:
+      on_create:
+        - type: script
+          name: cluster-setup
+          script: scripts/cluster-setup.sh
+          timeout: 300
+          requires:
+            - {{ cluster_name }}-node1
+            - {{ cluster_name }}-node2
+      on_destroy:
+        - type: script
+          name: cluster-teardown
+          script: scripts/cluster-teardown.sh
   - name: {{ cluster_name }}-node2
     cores: 4
     memory: 16384

--- a/docs/configuration/per-environment-credentials.md
+++ b/docs/configuration/per-environment-credentials.md
@@ -46,7 +46,7 @@ InfraFoundry automatically loads credentials for the environment you target with
 
 ## Configuration Details
 
-- **Automatic loading:** `infra ... --env <env>` decrypts `envs/{env}/settings.yaml`, extracts `provider_settings`, and exports provider environment variables (e.g., `PROXMOX_API_URL`, `OPNSENSE_API_KEY`).
+- **Automatic loading:** `infra ... --env <env>` decrypts `envs/{env}/settings.yaml`, extracts `provider_settings`, and maps credentials to `TF_VAR_*` environment variables via each provider's `_CREDENTIAL_ENV_MAPPING`. For example, `PROXMOX_API_URL` is mapped to `TF_VAR_proxmox_api_url`. No `.tfvars` files are written to disk.
 - **Recommended structure:**
   ```
   config-repo/
@@ -112,7 +112,7 @@ InfraFoundry automatically loads credentials for the environment you target with
 
 ---
 
-Last updated: 2025-12-23 14:19 GMT
+Last updated: 2026-03-18
 
 
 ---

--- a/docs/configuration/settings-file-structure.md
+++ b/docs/configuration/settings-file-structure.md
@@ -100,15 +100,16 @@ Each environment uses a single SOPS-encrypted `settings.yaml` to define metadata
     - **Proxmox authentication:** Supports two methods:
       - Single token: `api_token: "user@pve!tokenid=secret"`
       - Separate fields: `api_token_id: "user@pve!tokenid"` + `api_token_secret: "secret"`
-- **Generated outputs:** Values populate `generated/{env}/terraform/{provider}/terraform.tfvars` and Ansible vars automatically.
+- **Generated outputs:** Provider credentials are passed to Terraform as `TF_VAR_*` environment variables (no `.tfvars` files are generated). Ansible vars are populated automatically.
 
 ## Validation and Checks
 
 - Run `infra validate --env <env> --check-api` to confirm structure and credentials.
-- Inspect generated tfvars to verify SSH overrides and provider settings:
+- Inspect generated `.tf` files to verify provider configuration and variables:
   ```bash
-  cat generated/dev/terraform/proxmox/terraform.tfvars
+  cat generated/dev/terraform/proxmox/variables.tf
   ```
+- Credentials are passed as `TF_VAR_*` env vars at runtime (not written to disk).
 - Ensure `settings.yaml` is encrypted and keys are git-ignored.
 
 ## Examples
@@ -222,7 +223,7 @@ Each environment uses a single SOPS-encrypted `settings.yaml` to define metadata
 
 ## Troubleshooting
 
-- **Symptom:** Missing values in generated tfvars. **Fix:** Ensure fields exist in `settings.yaml` and rerun `infra plan`.
+- **Symptom:** Missing credential values at Terraform runtime. **Fix:** Ensure fields exist in `settings.yaml` under `provider_settings` and rerun `infra plan`. Credentials are mapped to `TF_VAR_*` env vars via each provider's `_CREDENTIAL_ENV_MAPPING`.
 - **Symptom:** SSH fails during Proxmox operations. **Fix:** Verify `ssh`/`provider_ssh` entries and key paths; re-validate with `--check-api`.
 - **Symptom:** Secrets exposed in git. **Fix:** Encrypt `settings.yaml` with SOPS/age and confirm ignore rules include keys.
 - **Symptom:** Provider not loading despite having resources defined. **Fix:** Check `providers` list in `settings.yaml`; if specified, only listed providers will be enabled.
@@ -232,7 +233,7 @@ Each environment uses a single SOPS-encrypted `settings.yaml` to define metadata
 
 ---
 
-Last updated: 2025-12-27 15:20 GMT
+Last updated: 2026-03-18
 
 
 ---

--- a/docs/development/event-system.md
+++ b/docs/development/event-system.md
@@ -54,17 +54,21 @@ The `EventContext` includes `provider` and `runner` fields, and the `data` dict 
 
 Event handlers are configured in your environment's `settings.yaml` under the `events:` key. The key is the event type name and the value is a list of handler configurations. Handlers are loaded at the start of each workflow (plan, apply, destroy).
 
+!!! tip "Prefer Resource Lifecycle Events"
+    For post-apply actions, use resource-level `on_create`/`on_update`/`on_destroy`
+    events instead of `RUNNER_COMPLETED`. See [Resource Lifecycle Events](#resource-lifecycle-events).
+
 ```yaml
 # envs/<env>/settings.yaml
 events:
-  RUNNER_COMPLETED:
-    - type: script
-      name: "ontap-setup"
-      script: scripts/ontap-post-terraform.sh
-      timeout: 600
   DRIFT_DETECTED:
     - type: webhook
       url: "https://hooks.slack.com/..."
+  AFTER_APPLY:
+    - type: script
+      name: "post-apply-notify"
+      script: scripts/notify.sh
+      timeout: 60
 ```
 
 **ScriptHandler** exposes the runner name as `INFRAFOUNDRY_RUNNER` environment variable, allowing scripts to filter by runner type:
@@ -81,7 +85,7 @@ events:
 | `INFRAFOUNDRY_DEPLOYMENT_ID` | `context.deployment_id` is set |
 | `INFRAFOUNDRY_TARGET_RESOURCES` | `-r` filter is active (comma-separated list) |
 
-**Example:** Run an Ansible playbook after Terraform finishes for a specific provider:
+**Example (deprecated):** Run a script on `RUNNER_COMPLETED` (use resource lifecycle events instead):
 
 ```yaml
 events:
@@ -91,12 +95,19 @@ events:
     description: "Run post-Terraform Ansible setup"
 ```
 
-```bash
-#!/bin/bash
-# scripts/post-terraform.sh
-if [ "$INFRAFOUNDRY_RUNNER" = "terraform" ] && [ "$INFRAFOUNDRY_PROVIDER" = "proxmox" ] && [ "${INFRAFOUNDRY_PHASE:-}" = "apply" ]; then
-    ansible-playbook -i inventory.yml site.yml
-fi
+**Example (recommended):** Use resource lifecycle events for post-apply actions:
+
+```yaml
+vm:
+  - name: web-server
+    cores: 2
+    memory: 4096
+    events:
+      on_create:
+        - type: script
+          name: post-provision
+          script: scripts/post-provision.sh
+          timeout: 300
 ```
 
 ### Real-Time Output Streaming
@@ -210,6 +221,8 @@ Scripts and playbooks receive resource context via environment variables:
 | `INFRAFOUNDRY_PACKAGE` | Package name |
 | `INFRAFOUNDRY_ENV` | Environment name |
 | `INFRAFOUNDRY_CONFIG_DIR` | Path to environment config directory |
+| `INFRAFOUNDRY_VAR_<key>` | Individual package variable (uppercase key) |
+| `INFRAFOUNDRY_PACKAGE_VARS` | JSON dict of all merged package variables |
 
 ### Deprecation notice
 
@@ -280,7 +293,7 @@ for full details on package structure and configuration.
 
 ---
 
-Last updated: 2026-03-15
+Last updated: 2026-03-18
 
 
 ---

--- a/docs/providers/esxi.md
+++ b/docs/providers/esxi.md
@@ -312,8 +312,7 @@ After `infra plan`, the generated directory contains:
 ```
 generated/prod/terraform/esxi/
 ├── provider.tf          # ESXi provider with per-host aliases
-├── variables.tf         # Per-host credential variables
-├── terraform.tfvars     # Credential values from settings.yaml
+├── variables.tf         # Per-host credential variables (values passed via TF_VAR_* env vars)
 ├── vswitch.tf           # Virtual switch resources
 ├── portgroup.tf         # Port group resources
 ├── vm.tf                # Guest VM resources

--- a/docs/providers/oci.md
+++ b/docs/providers/oci.md
@@ -224,8 +224,7 @@ After `infra plan`, the generated directory contains:
 ```
 generated/prod/terraform/oci/
 ├── provider.tf          # OCI provider configuration
-├── variables.tf         # Input variables
-├── terraform.tfvars     # Values from settings.yaml
+├── variables.tf         # Input variables (values passed via TF_VAR_* env vars)
 ├── vcn.tf              # VCN, subnet, IGW, route table, security list
 ├── instances.tf        # Compute instances with metadata
 └── outputs.tf          # VCN IDs, subnet IDs, instance IPs

--- a/docs/runners/opentofu.md
+++ b/docs/runners/opentofu.md
@@ -44,7 +44,7 @@ The OpenTofu runner is a drop-in alternative to the Terraform runner. OpenTofu i
 - **Default:** `terraform` (backward compatible).
 - **Generated files:** Output goes to `generated/{env}/terraform/{provider}/` regardless of tool selection. The `.tf` file format is shared between Terraform and OpenTofu.
 - **State location:** `generated/{env}/terraform/{provider}/.terraform/terraform.tfstate` (same as Terraform; OpenTofu uses the same state format).
-- **Settings/secrets:** Identical to Terraform; `settings.yaml` maps to `terraform.tfvars`.
+- **Settings/secrets:** Identical to Terraform; provider credentials from `settings.yaml` are passed as `TF_VAR_*` environment variables. No `.tfvars` files are generated.
 
 ## Architecture
 
@@ -86,7 +86,7 @@ BaseRunner
 
 ---
 
-Last updated: 2026-02-08
+Last updated: 2026-03-18
 
 ---
 [Back to Table of Contents](../index.md)

--- a/docs/runners/terraform.md
+++ b/docs/runners/terraform.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Terraform runner provisions infrastructure from YAML by rendering `.tf` files, mapping settings/secrets into `terraform.tfvars`, and executing `terraform init/plan/apply`.
+The Terraform runner provisions infrastructure from YAML by rendering `.tf` files and executing `terraform init/plan/apply`. Provider credentials and settings are passed to Terraform via `TF_VAR_*` environment variables — no `.tfvars` files are written to disk.
 
 ## Audience and Prerequisites
 
@@ -25,7 +25,7 @@ infra apply --env dev
 ## Configuration Details
 
 - **Resource definitions:** YAML resources map to provider Terraform resources; no direct HCL authoring.
-- **Settings/secrets:** `settings.yaml` → `terraform.tfvars` in `generated/{env}/terraform/{provider}/`.
+- **Settings/secrets:** Provider credentials from `settings.yaml` are mapped to `TF_VAR_*` environment variables via each provider's `_CREDENTIAL_ENV_MAPPING`. The `TerraformRunner._prepare_environment()` method calls `provider.get_terraform_env_vars()` to build the full set of `TF_VAR_*` variables. No `.tfvars` files are generated.
 - **State location:** `generated/{env}/terraform/{provider}/.terraform/terraform.tfstate` (remote backends configurable via env vars/provider settings).
 - **Customization:** Provider-specific options (e.g., cloud-init snippets) are surfaced via YAML fields; raw HCL injection is intentionally limited to preserve consistency.
 
@@ -38,7 +38,6 @@ infra apply --env dev
 - Inspect generated files for debugging:
   ```bash
   cat generated/dev/terraform/proxmox/main.tf
-  cat generated/dev/terraform/proxmox/terraform.tfvars
   ```
 
 ## Examples
@@ -71,13 +70,13 @@ infra apply --env dev
 
 ## Troubleshooting
 
-- **Symptom:** Terraform errors on apply. **Fix:** Inspect generated `.tf`/`terraform.tfvars`; rerun `infra validate --check-api --check-refs`.
+- **Symptom:** Terraform errors on apply. **Fix:** Inspect generated `.tf` files; rerun `infra validate --check-api --check-refs`. Check that provider credentials in `settings.yaml` are correct — they are passed as `TF_VAR_*` env vars.
 - **Symptom:** State conflicts. **Fix:** Configure remote backend with locking (e.g., S3 + DynamoDB) and avoid sharing local state dirs.
-- **Symptom:** Missing credentials. **Fix:** Ensure `settings.yaml` contains provider credentials and is decrypted; confirm env vars if using remote backend.
+- **Symptom:** Missing credentials. **Fix:** Ensure `settings.yaml` contains provider credentials and is decrypted. Credentials are mapped to `TF_VAR_*` env vars automatically via each provider's `_CREDENTIAL_ENV_MAPPING`.
 
 ---
 
-Last updated: 2025-12-23 14:27 GMT
+Last updated: 2026-03-18
 
 
 ---


### PR DESCRIPTION
## Description

Updates 11 documentation files that were stale after recent changes (#403-#421).

Addresses #423

## Type of Change

- [x] Documentation update

## Changes Made

### Terraform runner — TF_VAR_* env vars
- `docs/runners/terraform.md` — TF_VAR_* approach, removed tfvars references
- `docs/runners/opentofu.md` — Same
- `docs/providers/esxi.md` — Removed tfvars from generated files
- `docs/providers/oci.md` — Same
- `docs/architecture/orchestrator-architecture.md` — Removed _export_secrets(), updated sequence diagrams
- `docs/configuration/settings-file-structure.md` — Env vars instead of tfvars

### Event system — resource lifecycle events
- `docs/architecture/events.md` — Lifecycle events as primary, RUNNER_* deprecated
- `docs/development/event-system.md` — Same with updated examples

### Secrets — env var transport
- `docs/architecture/secrets-architecture.md` — No-secrets-on-disk, per-package secrets.yaml
- `docs/configuration/per-environment-credentials.md` — _CREDENTIAL_ENV_MAPPING
- `docs/configuration/infrastructure-packages.md` — INFRAFOUNDRY_VAR_* for scripts

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings