### PR TITLE
feat: add trigger resource type to Proxmox provider

### DIFF
--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -107,6 +107,9 @@ class ProxmoxProvider(
         if "template" in resources_by_type:
             self._generate_templates_terraform(resources_by_type["template"])
 
+        if "trigger" in resources_by_type:
+            self._generate_triggers_terraform(resources_by_type["trigger"])
+
         if "network" in resources_by_type:
             self._generate_networks_terraform(resources_by_type["network"])
 
@@ -415,10 +418,26 @@ class ProxmoxProvider(
         content = self.render_template("proxmox/deploy.py.j2", {"resources": resources})
         self._write_pyinfra_file("deploy.py", content)
 
+    def _generate_triggers_terraform(self, triggers: list[ResourceConfig]) -> None:
+        """Generate Terraform for trigger resources.
+
+        Renders lightweight ``terraform_data`` resources that serve as state
+        markers for packages without real infrastructure. Useful for triggering
+        ``on_create`` lifecycle events in script-only packages.
+
+        Args:
+            triggers: List of trigger resource configs.
+        """
+        self.render_and_write_terraform(
+            "proxmox/triggers.tf.j2",
+            context={"triggers": triggers},
+            output_name="triggers.tf",
+        )
+
     @override
     def get_resource_types(self) -> list[str]:
         """Get supported resource types."""
-        return ["vm", "container", "template", "network", "storage"]
+        return ["vm", "container", "template", "network", "storage", "trigger"]
 
     @override
     def get_terraform_resource_types(self) -> dict[str, list[str]]:
@@ -432,6 +451,7 @@ class ProxmoxProvider(
                 "proxmox_virtual_environment_storage_cifs",
                 "proxmox_virtual_environment_storage_dir",
             ],
+            "trigger": ["terraform_data"],
         }
 
     @override
@@ -443,4 +463,5 @@ class ProxmoxProvider(
             "template": [],
             "network": [],
             "storage": [],
+            "trigger": [],
         }

--- a/src/infrafoundry/providers/proxmox/templates/proxmox/triggers.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/triggers.tf.j2
@@ -1,0 +1,12 @@
+{% for trigger in triggers %}
+resource "terraform_data" "{{ trigger.name | replace('-', '_') }}" {
+  {% if trigger.config.inputs is defined %}
+  input = {
+    {% for key, value in trigger.config.inputs.items() %}
+    {{ key }} = "{{ value }}"
+    {% endfor %}
+  }
+  {% endif %}
+}
+
+{% endfor %}

--- a/tests/unit/providers/proxmox/test_trigger_support.py
+++ b/tests/unit/providers/proxmox/test_trigger_support.py
@@ -1,0 +1,96 @@
+"""Unit tests for Proxmox trigger resource type.
+
+Tests template rendering for terraform_data trigger resources used
+to fire lifecycle events in packages without real infrastructure.
+"""
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.proxmox import ProxmoxProvider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    """Create a ProxmoxProvider for template testing."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    p = ProxmoxProvider(config_dir, output_dir)
+    p.set_environment("test")
+    return p
+
+
+def _make_trigger(name: str = "test-trigger", **config_overrides) -> ResourceConfig:
+    """Helper to create a trigger ResourceConfig."""
+    config: dict = {**config_overrides}
+    return ResourceConfig(name=name, type="trigger", provider="proxmox", config=config)
+
+
+def _render_triggers(provider: ProxmoxProvider, triggers: list[ResourceConfig]) -> str:
+    """Render trigger resources through the template."""
+    return provider.render_template("proxmox/triggers.tf.j2", {"triggers": triggers})
+
+
+class TestTriggerRendering:
+    """Tests for trigger resource template rendering."""
+
+    def test_trigger_basic(self, provider):
+        """Basic trigger should render a terraform_data resource."""
+        triggers = [_make_trigger()]
+        content = _render_triggers(provider, triggers)
+        assert 'resource "terraform_data" "test_trigger"' in content
+
+    def test_trigger_with_inputs(self, provider):
+        """Trigger with inputs should render input block."""
+        triggers = [_make_trigger(inputs={"deployment": "minio", "version": "1.0"})]
+        content = _render_triggers(provider, triggers)
+        assert 'resource "terraform_data" "test_trigger"' in content
+        assert "input = {" in content
+        assert 'deployment = "minio"' in content
+        assert 'version = "1.0"' in content
+
+    def test_trigger_without_inputs(self, provider):
+        """Trigger without inputs should not render input block."""
+        triggers = [_make_trigger()]
+        content = _render_triggers(provider, triggers)
+        assert "input" not in content
+
+    def test_trigger_name_with_hyphens(self, provider):
+        """Hyphens in trigger name should be converted to underscores."""
+        triggers = [_make_trigger(name="minio-deploy-trigger")]
+        content = _render_triggers(provider, triggers)
+        assert 'resource "terraform_data" "minio_deploy_trigger"' in content
+
+    def test_multiple_triggers(self, provider):
+        """Multiple triggers should render multiple terraform_data resources."""
+        triggers = [
+            _make_trigger(name="trigger-1", inputs={"app": "minio"}),
+            _make_trigger(name="trigger-2", inputs={"app": "redis"}),
+        ]
+        content = _render_triggers(provider, triggers)
+        assert 'resource "terraform_data" "trigger_1"' in content
+        assert 'resource "terraform_data" "trigger_2"' in content
+        assert 'app = "minio"' in content
+        assert 'app = "redis"' in content
+
+
+class TestTriggerProviderIntegration:
+    """Tests for trigger type registration in the Proxmox provider."""
+
+    def test_trigger_in_resource_types(self, provider):
+        """Trigger should be a supported resource type."""
+        assert "trigger" in provider.get_resource_types()
+
+    def test_trigger_terraform_type(self, provider):
+        """Trigger should map to terraform_data."""
+        tf_types = provider.get_terraform_resource_types()
+        assert "trigger" in tf_types
+        assert "terraform_data" in tf_types["trigger"]
+
+    def test_trigger_has_no_dependencies(self, provider):
+        """Trigger should have no dependencies."""
+        deps = provider.get_dependencies()
+        assert "trigger" in deps
+        assert deps["trigger"] == []


### PR DESCRIPTION
## Description

Add a `trigger` resource type to the Proxmox provider that generates lightweight `terraform_data` resources. This enables packages without real infrastructure (e.g., Helm deployments on existing clusters) to fire `on_create` lifecycle events via a `requires` filter.

Addresses #428

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`triggers.tf.j2`** — New template that renders `terraform_data` resources with optional `input` variables
- **`__init__.py`** — Register `trigger` as a supported resource type, add `_generate_triggers_terraform()` method, map to `terraform_data` Terraform type
- **`test_trigger_support.py`** — 8 tests covering rendering (basic, inputs, hyphens, multiple) and provider integration (types, dependencies)

### YAML format

```yaml
resources:
  - provider: proxmox
    type: trigger
    name: minio-deploy-trigger
    config:
      inputs:
        package: minio
        version: "1.0"
```

### Use case

```yaml
# Package with no real infrastructure but needs lifecycle events
resources:
  - resources.yaml  # contains the trigger resource

events:
  on_create:
    - type: script
      name: deploy
      script: scripts/deploy.sh
      requires:
        - minio-deploy-trigger  # only fires when THIS resource is created
```

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings