### PR TITLE
fix: generate depends_on in kubernetes templates from dependency graph

### DIFF
--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -142,4 +142,20 @@ namespaces → configmaps/secrets/serviceaccounts → deployments → services �
                                                helm_releases → manifests
 ```
 
+The provider automatically generates Terraform `depends_on` blocks for all resource types based on this dependency graph. For example, a `secrets` resource will include `depends_on` referencing the namespace resources it depends on, ensuring Terraform creates namespaces before secrets.
+
 Manifests depend on both namespaces and helm_releases to ensure CRDs are available.
+
+Resources can also declare explicit `depends_on` in their configuration, which are merged with the auto-generated dependencies:
+
+```yaml
+resources:
+  - provider: kubernetes
+    type: deployments
+    name: my-app
+    config:
+      name: my-app
+      namespace: default
+      depends_on:
+        - kubernetes_config_map.extra_config
+```

--- a/src/infrafoundry/providers/kubernetes/__init__.py
+++ b/src/infrafoundry/providers/kubernetes/__init__.py
@@ -58,10 +58,50 @@ class KubernetesProvider(
                 result[f"TF_VAR_{tf_var_name}"] = value
         return result
 
+    def _build_dependency_refs(
+        self,
+        resources_by_type: dict[str, list[ResourceConfig]],
+    ) -> dict[str, list[str]]:
+        """Build Terraform resource references from the dependency graph.
+
+        Uses ``get_dependencies()`` and ``get_terraform_resource_types()`` to map
+        each resource type to the concrete Terraform resource references it depends on,
+        based on which dependency types are actually present in ``resources_by_type``.
+
+        Args:
+            resources_by_type: Resources grouped by InfraFoundry type.
+
+        Returns:
+            Mapping of resource type to list of Terraform resource references,
+            e.g. ``{"secrets": ["kubernetes_namespace.my_ns"]}``.
+        """
+        deps = self.get_dependencies()
+        tf_types = self.get_terraform_resource_types()
+        result: dict[str, list[str]] = {}
+
+        for resource_type, dep_types in deps.items():
+            refs: list[str] = []
+            for dep_type in dep_types:
+                # Only add refs for dependency types that actually have resources
+                dep_resources = resources_by_type.get(dep_type, [])
+                if not dep_resources:
+                    continue
+                tf_resource_types = tf_types.get(dep_type, [])
+                for tf_type in tf_resource_types:
+                    for resource in dep_resources:
+                        ref = f"{tf_type}.{resource.name.replace('-', '_')}"
+                        refs.append(ref)
+            result[resource_type] = refs
+
+        return result
+
     @override
     def generate_terraform(self, resources: list[ResourceConfig]) -> None:
         """Generate Terraform configuration for Kubernetes resources."""
         resources_by_type = self.prepare_terraform_generation(resources)
+
+        # Build dependency refs once for all templates
+        dep_refs = self._build_dependency_refs(resources_by_type)
 
         # Generate backend configuration if remote backend is configured
         self.render_backend()
@@ -84,42 +124,69 @@ class KubernetesProvider(
             self._generate_namespaces_terraform(resources_by_type["namespaces"])
 
         if "configmaps" in resources_by_type:
-            self._generate_configmaps_terraform(resources_by_type["configmaps"])
+            self._generate_configmaps_terraform(
+                resources_by_type["configmaps"],
+                dep_refs.get("configmaps", []),
+            )
 
         if "secrets" in resources_by_type:
-            self._generate_secrets_terraform(resources_by_type["secrets"])
+            self._generate_secrets_terraform(
+                resources_by_type["secrets"],
+                dep_refs.get("secrets", []),
+            )
 
         if "persistentvolumeclaims" in resources_by_type:
-            self._generate_pvcs_terraform(resources_by_type["persistentvolumeclaims"])
+            self._generate_pvcs_terraform(
+                resources_by_type["persistentvolumeclaims"],
+                dep_refs.get("persistentvolumeclaims", []),
+            )
 
         # RBAC resources
-        self._generate_rbac_terraform(resources_by_type)
+        self._generate_rbac_terraform(resources_by_type, dep_refs)
 
         # Workload resources
         if "deployments" in resources_by_type:
-            self._generate_deployments_terraform(resources_by_type["deployments"])
+            self._generate_deployments_terraform(
+                resources_by_type["deployments"],
+                dep_refs.get("deployments", []),
+            )
 
         if "services" in resources_by_type:
-            self._generate_services_terraform(resources_by_type["services"])
+            self._generate_services_terraform(
+                resources_by_type["services"],
+                dep_refs.get("services", []),
+            )
 
         if "ingresses" in resources_by_type:
-            self._generate_ingresses_terraform(resources_by_type["ingresses"])
+            self._generate_ingresses_terraform(
+                resources_by_type["ingresses"],
+                dep_refs.get("ingresses", []),
+            )
 
         if "jobs" in resources_by_type:
-            self._generate_jobs_terraform(resources_by_type["jobs"])
+            self._generate_jobs_terraform(
+                resources_by_type["jobs"],
+                dep_refs.get("jobs", []),
+            )
 
         if "cronjobs" in resources_by_type:
-            self._generate_cronjobs_terraform(resources_by_type["cronjobs"])
+            self._generate_cronjobs_terraform(
+                resources_by_type["cronjobs"],
+                dep_refs.get("cronjobs", []),
+            )
 
         # Helm releases
         if "helm_releases" in resources_by_type:
-            self._generate_helm_releases_terraform(resources_by_type["helm_releases"])
+            self._generate_helm_releases_terraform(
+                resources_by_type["helm_releases"],
+                dep_refs.get("helm_releases", []),
+            )
 
-        # Custom manifests (CRDs, etc.) - pass helm_releases for depends_on
+        # Custom manifests (CRDs, etc.)
         if "manifests" in resources_by_type:
             self._generate_manifests_terraform(
                 resources_by_type["manifests"],
-                resources_by_type.get("helm_releases", []),
+                dep_refs.get("manifests", []),
             )
 
         # Generate outputs
@@ -141,31 +208,47 @@ class KubernetesProvider(
             output_name="namespaces.tf",
         )
 
-    def _generate_configmaps_terraform(self, configmaps: list[ResourceConfig]) -> None:
+    def _generate_configmaps_terraform(
+        self,
+        configmaps: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes configmaps."""
         self.render_and_write_terraform(
             "kubernetes/configmaps.tf.j2",
-            context={"configmaps": configmaps},
+            context={"configmaps": configmaps, "dependency_refs": dependency_refs},
             output_name="configmaps.tf",
         )
 
-    def _generate_secrets_terraform(self, secrets: list[ResourceConfig]) -> None:
+    def _generate_secrets_terraform(
+        self,
+        secrets: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes secrets."""
         self.render_and_write_terraform(
             "kubernetes/secrets.tf.j2",
-            context={"secrets": secrets},
+            context={"secrets": secrets, "dependency_refs": dependency_refs},
             output_name="secrets.tf",
         )
 
-    def _generate_pvcs_terraform(self, pvcs: list[ResourceConfig]) -> None:
+    def _generate_pvcs_terraform(
+        self,
+        pvcs: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes persistent volume claims."""
         self.render_and_write_terraform(
             "kubernetes/pvc.tf.j2",
-            context={"pvcs": pvcs},
+            context={"pvcs": pvcs, "dependency_refs": dependency_refs},
             output_name="pvc.tf",
         )
 
-    def _generate_rbac_terraform(self, resources_by_type: dict[str, list[ResourceConfig]]) -> None:
+    def _generate_rbac_terraform(
+        self,
+        resources_by_type: dict[str, list[ResourceConfig]],
+        dep_refs: dict[str, list[str]],
+    ) -> None:
         """Generate Terraform for RBAC resources."""
         # Collect all RBAC resource types
         serviceaccounts = resources_by_type.get("serviceaccounts", [])
@@ -184,72 +267,101 @@ class KubernetesProvider(
                     "rolebindings": rolebindings,
                     "clusterroles": clusterroles,
                     "clusterrolebindings": clusterrolebindings,
+                    "sa_dependency_refs": dep_refs.get("serviceaccounts", []),
+                    "role_dependency_refs": dep_refs.get("roles", []),
+                    "rolebinding_dependency_refs": dep_refs.get("rolebindings", []),
+                    "clusterrole_dependency_refs": dep_refs.get("clusterroles", []),
+                    "clusterrolebinding_dependency_refs": dep_refs.get("clusterrolebindings", []),
                 },
                 output_name="rbac.tf",
             )
 
-    def _generate_deployments_terraform(self, deployments: list[ResourceConfig]) -> None:
+    def _generate_deployments_terraform(
+        self,
+        deployments: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes deployments."""
         self.render_and_write_terraform(
             "kubernetes/deployments.tf.j2",
-            context={"deployments": deployments},
+            context={"deployments": deployments, "dependency_refs": dependency_refs},
             output_name="deployments.tf",
         )
 
-    def _generate_services_terraform(self, services: list[ResourceConfig]) -> None:
+    def _generate_services_terraform(
+        self,
+        services: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes services."""
         self.render_and_write_terraform(
             "kubernetes/services.tf.j2",
-            context={"services": services},
+            context={"services": services, "dependency_refs": dependency_refs},
             output_name="services.tf",
         )
 
-    def _generate_ingresses_terraform(self, ingresses: list[ResourceConfig]) -> None:
+    def _generate_ingresses_terraform(
+        self,
+        ingresses: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes ingresses."""
         self.render_and_write_terraform(
             "kubernetes/ingress.tf.j2",
-            context={"ingresses": ingresses},
+            context={"ingresses": ingresses, "dependency_refs": dependency_refs},
             output_name="ingress.tf",
         )
 
-    def _generate_jobs_terraform(self, jobs: list[ResourceConfig]) -> None:
+    def _generate_jobs_terraform(
+        self,
+        jobs: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes jobs."""
         self.render_and_write_terraform(
             "kubernetes/jobs.tf.j2",
-            context={"jobs": jobs},
+            context={"jobs": jobs, "dependency_refs": dependency_refs},
             output_name="jobs.tf",
         )
 
-    def _generate_cronjobs_terraform(self, cronjobs: list[ResourceConfig]) -> None:
+    def _generate_cronjobs_terraform(
+        self,
+        cronjobs: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Kubernetes cron jobs."""
         self.render_and_write_terraform(
             "kubernetes/cronjobs.tf.j2",
-            context={"cronjobs": cronjobs},
+            context={"cronjobs": cronjobs, "dependency_refs": dependency_refs},
             output_name="cronjobs.tf",
         )
 
-    def _generate_helm_releases_terraform(self, helm_releases: list[ResourceConfig]) -> None:
+    def _generate_helm_releases_terraform(
+        self,
+        helm_releases: list[ResourceConfig],
+        dependency_refs: list[str],
+    ) -> None:
         """Generate Terraform for Helm releases."""
         self.render_and_write_terraform(
             "kubernetes/helm_releases.tf.j2",
-            context={"helm_releases": helm_releases},
+            context={"helm_releases": helm_releases, "dependency_refs": dependency_refs},
             output_name="helm_releases.tf",
         )
 
     def _generate_manifests_terraform(
         self,
         manifests: list[ResourceConfig],
-        helm_releases: list[ResourceConfig],
+        dependency_refs: list[str],
     ) -> None:
         """Generate Terraform for custom Kubernetes manifests (CRDs, etc.).
 
         Args:
-            manifests: List of manifest resources to generate
-            helm_releases: List of helm releases to add as dependencies (for CRDs)
+            manifests: List of manifest resources to generate.
+            dependency_refs: Terraform resource references for automatic depends_on.
         """
         self.render_and_write_terraform(
             "kubernetes/manifests.tf.j2",
-            context={"manifests": manifests, "helm_releases": helm_releases},
+            context={"manifests": manifests, "dependency_refs": dependency_refs},
             output_name="manifests.tf",
         )
 

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/configmaps.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/configmaps.tf.j2
@@ -12,6 +12,19 @@ resource "kubernetes_config_map" "{{ configmap.config.name | replace('-', '_') }
     EOT
     {% endfor %}
   }
+
+  {% if dependency_refs or configmap.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if configmap.config.depends_on is defined %}
+    {% for dep in configmap.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/cronjobs.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/cronjobs.tf.j2
@@ -198,6 +198,19 @@ resource "kubernetes_cron_job_v1" "{{ cronjob.name | replace('-', '_') }}" {
       }
     }
   }
+
+  {% if dependency_refs or cronjob.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if cronjob.config.depends_on is defined %}
+    {% for dep in cronjob.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/deployments.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/deployments.tf.j2
@@ -86,6 +86,19 @@ resource "kubernetes_deployment" "{{ deployment.config.name | replace('-', '_') 
       }
     }
   }
+
+  {% if dependency_refs or deployment.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if deployment.config.depends_on is defined %}
+    {% for dep in deployment.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/helm_releases.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/helm_releases.tf.j2
@@ -98,11 +98,16 @@ EOT
   {% endfor %}
   {% endif %}
 
-  {% if release.config.depends_on is defined %}
+  {% if dependency_refs or release.config.depends_on is defined %}
   depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if release.config.depends_on is defined %}
     {% for dep in release.config.depends_on %}
     {{ dep }},
     {% endfor %}
+    {% endif %}
   ]
   {% endif %}
 }

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/ingress.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/ingress.tf.j2
@@ -90,6 +90,19 @@ resource "kubernetes_ingress_v1" "{{ ingress.name | replace('-', '_') }}" {
     {% endfor %}
     {% endif %}
   }
+
+  {% if dependency_refs or ingress.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if ingress.config.depends_on is defined %}
+    {% for dep in ingress.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/jobs.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/jobs.tf.j2
@@ -181,6 +181,19 @@ resource "kubernetes_job" "{{ job.name | replace('-', '_') }}" {
   {% if job.config.wait_for_completion is defined %}
   wait_for_completion = {{ job.config.wait_for_completion | lower }}
   {% endif %}
+
+  {% if dependency_refs or job.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if job.config.depends_on is defined %}
+    {% for dep in job.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/manifests.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/manifests.tf.j2
@@ -31,10 +31,10 @@ resource "kubernetes_manifest" "{{ manifest.name | replace('-', '_') }}" {
     {% endif %}
   }
 
-  {% if helm_releases or manifest.config.depends_on is defined %}
+  {% if dependency_refs or manifest.config.depends_on is defined %}
   depends_on = [
-    {% for release in helm_releases %}
-    helm_release.{{ release.name | replace('-', '_') }},
+    {% for ref in dependency_refs %}
+    {{ ref }},
     {% endfor %}
     {% if manifest.config.depends_on is defined %}
     {% for dep in manifest.config.depends_on %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/pvc.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/pvc.tf.j2
@@ -75,6 +75,19 @@ resource "kubernetes_persistent_volume_claim" "{{ pvc.name | replace('-', '_') }
   {% if pvc.config.wait_until_bound is defined %}
   wait_until_bound = {{ pvc.config.wait_until_bound | lower }}
   {% endif %}
+
+  {% if dependency_refs or pvc.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if pvc.config.depends_on is defined %}
+    {% for dep in pvc.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/rbac.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/rbac.tf.j2
@@ -33,6 +33,19 @@ resource "kubernetes_service_account" "{{ sa.name | replace('-', '_') }}" {
   {% if sa.config.automount_service_account_token is defined %}
   automount_service_account_token = {{ sa.config.automount_service_account_token | lower }}
   {% endif %}
+
+  {% if sa_dependency_refs or sa.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in sa_dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if sa.config.depends_on is defined %}
+    {% for dep in sa.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}
@@ -71,6 +84,19 @@ resource "kubernetes_role" "{{ role.name | replace('-', '_') }}" {
     {% endif %}
   }
   {% endfor %}
+
+  {% if role_dependency_refs or role.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in role_dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if role.config.depends_on is defined %}
+    {% for dep in role.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}
@@ -117,6 +143,19 @@ resource "kubernetes_role_binding" "{{ rb.name | replace('-', '_') }}" {
     {% endif %}
   }
   {% endfor %}
+
+  {% if rolebinding_dependency_refs or rb.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in rolebinding_dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if rb.config.depends_on is defined %}
+    {% for dep in rb.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}
@@ -171,6 +210,19 @@ resource "kubernetes_cluster_role" "{{ cr.name | replace('-', '_') }}" {
     {% endfor %}
   }
   {% endif %}
+
+  {% if clusterrole_dependency_refs or cr.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in clusterrole_dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if cr.config.depends_on is defined %}
+    {% for dep in cr.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}
@@ -216,6 +268,19 @@ resource "kubernetes_cluster_role_binding" "{{ crb.name | replace('-', '_') }}" 
     {% endif %}
   }
   {% endfor %}
+
+  {% if clusterrolebinding_dependency_refs or crb.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in clusterrolebinding_dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if crb.config.depends_on is defined %}
+    {% for dep in crb.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/secrets.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/secrets.tf.j2
@@ -38,6 +38,19 @@ resource "kubernetes_secret" "{{ secret.name | replace('-', '_') }}" {
     {% endfor %}
   }
   {% endif %}
+
+  {% if dependency_refs or secret.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if secret.config.depends_on is defined %}
+    {% for dep in secret.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/src/infrafoundry/providers/kubernetes/templates/kubernetes/services.tf.j2
+++ b/src/infrafoundry/providers/kubernetes/templates/kubernetes/services.tf.j2
@@ -36,6 +36,19 @@ resource "kubernetes_service" "{{ service.config.name | replace('-', '_') }}" {
     }
     {% endfor %}
   }
+
+  {% if dependency_refs or service.config.depends_on is defined %}
+  depends_on = [
+    {% for ref in dependency_refs %}
+    {{ ref }},
+    {% endfor %}
+    {% if service.config.depends_on is defined %}
+    {% for dep in service.config.depends_on %}
+    {{ dep }},
+    {% endfor %}
+    {% endif %}
+  ]
+  {% endif %}
 }
 
 {% endfor %}

--- a/tests/unit/providers/kubernetes/test_provider.py
+++ b/tests/unit/providers/kubernetes/test_provider.py
@@ -457,3 +457,282 @@ def test_generate_terraform_manifest(provider, tmp_dirs):
     assert "oci_subnet_router" in content
     assert "tailscale.com/v1alpha1" in content
     assert "Connector" in content
+
+
+class TestBuildDependencyRefs:
+    """Tests for _build_dependency_refs() method."""
+
+    def test_builds_refs_for_present_dependencies(self, provider):
+        """Test that refs are built only for dependency types that have resources."""
+        resources_by_type = {
+            "namespaces": [
+                ResourceConfig(name="my-ns", type="namespaces", provider="kubernetes", config={})
+            ],
+            "secrets": [
+                ResourceConfig(
+                    name="my-secret",
+                    type="secrets",
+                    provider="kubernetes",
+                    config={"namespace": "my-ns", "data": {"k": "v"}},
+                )
+            ],
+        }
+        refs = provider._build_dependency_refs(resources_by_type)
+
+        # secrets depends on namespaces, and namespaces are present
+        assert "kubernetes_namespace.my_ns" in refs["secrets"]
+        # namespaces have no dependencies
+        assert refs["namespaces"] == []
+
+    def test_empty_refs_for_missing_dependencies(self, provider):
+        """Test that refs are empty when dependency types have no resources."""
+        resources_by_type = {
+            "secrets": [
+                ResourceConfig(
+                    name="my-secret",
+                    type="secrets",
+                    provider="kubernetes",
+                    config={"namespace": "default", "data": {"k": "v"}},
+                )
+            ],
+        }
+        refs = provider._build_dependency_refs(resources_by_type)
+
+        # secrets depends on namespaces, but no namespaces in resources_by_type
+        assert refs["secrets"] == []
+
+    def test_builds_multiple_refs(self, provider):
+        """Test that multiple resources of a dependency type produce multiple refs."""
+        resources_by_type = {
+            "namespaces": [
+                ResourceConfig(name="ns-a", type="namespaces", provider="kubernetes", config={}),
+                ResourceConfig(name="ns-b", type="namespaces", provider="kubernetes", config={}),
+            ],
+            "configmaps": [
+                ResourceConfig(
+                    name="cm-1",
+                    type="configmaps",
+                    provider="kubernetes",
+                    config={"name": "cm-1", "data": {"k": "v"}},
+                )
+            ],
+        }
+        refs = provider._build_dependency_refs(resources_by_type)
+
+        assert "kubernetes_namespace.ns_a" in refs["configmaps"]
+        assert "kubernetes_namespace.ns_b" in refs["configmaps"]
+        assert len(refs["configmaps"]) == 2
+
+    def test_complex_dependency_chain(self, provider):
+        """Test refs for types with multiple dependency types (e.g. deployments)."""
+        resources_by_type = {
+            "namespaces": [
+                ResourceConfig(name="my-ns", type="namespaces", provider="kubernetes", config={})
+            ],
+            "secrets": [
+                ResourceConfig(
+                    name="db-creds",
+                    type="secrets",
+                    provider="kubernetes",
+                    config={"data": {"pw": "x"}},
+                )
+            ],
+            "configmaps": [
+                ResourceConfig(
+                    name="app-config",
+                    type="configmaps",
+                    provider="kubernetes",
+                    config={"name": "app-config", "data": {"k": "v"}},
+                )
+            ],
+            "deployments": [
+                ResourceConfig(
+                    name="my-app",
+                    type="deployments",
+                    provider="kubernetes",
+                    config={
+                        "name": "my-app",
+                        "containers": [{"name": "app", "image": "nginx"}],
+                    },
+                )
+            ],
+        }
+        refs = provider._build_dependency_refs(resources_by_type)
+
+        deployment_refs = refs["deployments"]
+        assert "kubernetes_namespace.my_ns" in deployment_refs
+        assert "kubernetes_secret.db_creds" in deployment_refs
+        assert "kubernetes_config_map.app_config" in deployment_refs
+
+    def test_manifests_get_helm_refs(self, provider):
+        """Test that manifests get dependency refs for helm_releases."""
+        resources_by_type = {
+            "namespaces": [
+                ResourceConfig(name="my-ns", type="namespaces", provider="kubernetes", config={})
+            ],
+            "helm_releases": [
+                ResourceConfig(
+                    name="cert-manager",
+                    type="helm_releases",
+                    provider="kubernetes",
+                    config={"chart": "cert-manager"},
+                )
+            ],
+            "manifests": [
+                ResourceConfig(
+                    name="issuer",
+                    type="manifests",
+                    provider="kubernetes",
+                    config={
+                        "manifest": {
+                            "apiVersion": "cert-manager.io/v1",
+                            "kind": "Issuer",
+                            "metadata": {"name": "issuer"},
+                        }
+                    },
+                )
+            ],
+        }
+        refs = provider._build_dependency_refs(resources_by_type)
+
+        manifest_refs = refs["manifests"]
+        assert "kubernetes_namespace.my_ns" in manifest_refs
+        assert "helm_release.cert_manager" in manifest_refs
+
+    def test_all_types_have_entries(self, provider):
+        """Test that all resource types from get_dependencies() appear in result."""
+        resources_by_type = {}
+        refs = provider._build_dependency_refs(resources_by_type)
+        deps = provider.get_dependencies()
+        for resource_type in deps:
+            assert resource_type in refs
+
+
+class TestGenerateTerraformDependsOn:
+    """Integration tests for depends_on in generated Terraform files."""
+
+    def test_secrets_have_depends_on_with_namespaces(self, provider, tmp_dirs):
+        """Test that generated secrets.tf has depends_on for namespaces."""
+        _config_dir, output_dir = tmp_dirs
+        provider.set_environment("test")
+
+        resources = [
+            ResourceConfig(
+                name="my-ns",
+                type="namespaces",
+                provider="kubernetes",
+                config={},
+            ),
+            ResourceConfig(
+                name="my-secret",
+                type="secrets",
+                provider="kubernetes",
+                config={
+                    "namespace": "my-ns",
+                    "type": "Opaque",
+                    "data": {"key": "val"},
+                },
+            ),
+        ]
+
+        provider.generate_terraform(resources)
+
+        terraform_dir = output_dir / "test" / "terraform" / "kubernetes"
+        content = (terraform_dir / "secrets.tf").read_text()
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_no_depends_on_when_no_dependencies_present(self, provider, tmp_dirs):
+        """Test that secrets.tf has no depends_on when no namespaces exist."""
+        _config_dir, output_dir = tmp_dirs
+        provider.set_environment("test")
+
+        resources = [
+            ResourceConfig(
+                name="my-secret",
+                type="secrets",
+                provider="kubernetes",
+                config={
+                    "namespace": "default",
+                    "type": "Opaque",
+                    "data": {"key": "val"},
+                },
+            ),
+        ]
+
+        provider.generate_terraform(resources)
+
+        terraform_dir = output_dir / "test" / "terraform" / "kubernetes"
+        content = (terraform_dir / "secrets.tf").read_text()
+        assert "depends_on" not in content
+
+    def test_helm_releases_have_depends_on_with_namespaces(self, provider, tmp_dirs):
+        """Test that generated helm_releases.tf has depends_on for namespaces."""
+        _config_dir, output_dir = tmp_dirs
+        provider.set_environment("test")
+
+        resources = [
+            ResourceConfig(
+                name="my-ns",
+                type="namespaces",
+                provider="kubernetes",
+                config={},
+            ),
+            ResourceConfig(
+                name="nginx",
+                type="helm_releases",
+                provider="kubernetes",
+                config={
+                    "chart": "ingress-nginx",
+                    "namespace": "my-ns",
+                },
+            ),
+        ]
+
+        provider.generate_terraform(resources)
+
+        terraform_dir = output_dir / "test" / "terraform" / "kubernetes"
+        content = (terraform_dir / "helm_releases.tf").read_text()
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_manifests_have_depends_on_with_namespaces_and_helm(self, provider, tmp_dirs):
+        """Test that manifests.tf has depends_on for namespaces and helm releases."""
+        _config_dir, output_dir = tmp_dirs
+        provider.set_environment("test")
+
+        resources = [
+            ResourceConfig(
+                name="my-ns",
+                type="namespaces",
+                provider="kubernetes",
+                config={},
+            ),
+            ResourceConfig(
+                name="my-operator",
+                type="helm_releases",
+                provider="kubernetes",
+                config={"chart": "my-operator"},
+            ),
+            ResourceConfig(
+                name="my-crd",
+                type="manifests",
+                provider="kubernetes",
+                config={
+                    "manifest": {
+                        "apiVersion": "example.com/v1",
+                        "kind": "Custom",
+                        "metadata": {"name": "my-crd"},
+                        "spec": {},
+                    },
+                },
+            ),
+        ]
+
+        provider.generate_terraform(resources)
+
+        terraform_dir = output_dir / "test" / "terraform" / "kubernetes"
+        content = (terraform_dir / "manifests.tf").read_text()
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+        assert "helm_release.my_operator" in content

--- a/tests/unit/providers/kubernetes/test_templates.py
+++ b/tests/unit/providers/kubernetes/test_templates.py
@@ -65,7 +65,9 @@ class TestSecretsTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/secrets.tf.j2", {"secrets": secrets})
+        content = provider.render_template(
+            "kubernetes/secrets.tf.j2", {"secrets": secrets, "dependency_refs": []}
+        )
         assert 'resource "kubernetes_secret" "my_secret"' in content
         assert 'type = "Opaque"' in content
         assert '"key" = "dmFsdWU="' in content
@@ -84,7 +86,9 @@ class TestSecretsTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/secrets.tf.j2", {"secrets": secrets})
+        content = provider.render_template(
+            "kubernetes/secrets.tf.j2", {"secrets": secrets, "dependency_refs": []}
+        )
         assert 'type = "kubernetes.io/tls"' in content
 
     def test_renders_secret_with_labels(self, provider):
@@ -101,7 +105,9 @@ class TestSecretsTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/secrets.tf.j2", {"secrets": secrets})
+        content = provider.render_template(
+            "kubernetes/secrets.tf.j2", {"secrets": secrets, "dependency_refs": []}
+        )
         assert '"app" = "myapp"' in content
         assert '"managed-by" = "infrafoundry"' in content
 
@@ -138,7 +144,9 @@ class TestIngressTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/ingress.tf.j2", {"ingresses": ingresses})
+        content = provider.render_template(
+            "kubernetes/ingress.tf.j2", {"ingresses": ingresses, "dependency_refs": []}
+        )
         assert 'resource "kubernetes_ingress_v1" "web_ingress"' in content
         assert 'ingress_class_name = "nginx"' in content
         assert 'host = "example.com"' in content
@@ -168,7 +176,9 @@ class TestIngressTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/ingress.tf.j2", {"ingresses": ingresses})
+        content = provider.render_template(
+            "kubernetes/ingress.tf.j2", {"ingresses": ingresses, "dependency_refs": []}
+        )
         assert "tls {" in content
         assert 'secret_name = "tls-secret"' in content
 
@@ -189,7 +199,9 @@ class TestPVCTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/pvc.tf.j2", {"pvcs": pvcs})
+        content = provider.render_template(
+            "kubernetes/pvc.tf.j2", {"pvcs": pvcs, "dependency_refs": []}
+        )
         assert 'resource "kubernetes_persistent_volume_claim" "data_pvc"' in content
         assert 'storage = "5Gi"' in content
         assert '"ReadWriteOnce"' in content
@@ -207,7 +219,9 @@ class TestPVCTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/pvc.tf.j2", {"pvcs": pvcs})
+        content = provider.render_template(
+            "kubernetes/pvc.tf.j2", {"pvcs": pvcs, "dependency_refs": []}
+        )
         assert 'storage_class_name = "fast-ssd"' in content
 
 
@@ -228,7 +242,9 @@ class TestJobTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/jobs.tf.j2", {"jobs": jobs})
+        content = provider.render_template(
+            "kubernetes/jobs.tf.j2", {"jobs": jobs, "dependency_refs": []}
+        )
         assert 'resource "kubernetes_job" "init_job"' in content
         assert 'restart_policy = "Never"' in content
         assert 'image = "busybox"' in content
@@ -246,7 +262,9 @@ class TestJobTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/jobs.tf.j2", {"jobs": jobs})
+        content = provider.render_template(
+            "kubernetes/jobs.tf.j2", {"jobs": jobs, "dependency_refs": []}
+        )
         assert "backoff_limit = 5" in content
 
 
@@ -266,7 +284,9 @@ class TestCronJobTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/cronjobs.tf.j2", {"cronjobs": cronjobs})
+        content = provider.render_template(
+            "kubernetes/cronjobs.tf.j2", {"cronjobs": cronjobs, "dependency_refs": []}
+        )
         assert 'resource "kubernetes_cron_job_v1" "hourly_task"' in content
         assert 'schedule = "0 * * * *"' in content
 
@@ -284,7 +304,9 @@ class TestCronJobTemplate:
                 },
             )
         ]
-        content = provider.render_template("kubernetes/cronjobs.tf.j2", {"cronjobs": cronjobs})
+        content = provider.render_template(
+            "kubernetes/cronjobs.tf.j2", {"cronjobs": cronjobs, "dependency_refs": []}
+        )
         assert 'concurrency_policy = "Forbid"' in content
 
 
@@ -308,6 +330,11 @@ class TestRBACTemplate:
                 "rolebindings": [],
                 "clusterroles": [],
                 "clusterrolebindings": [],
+                "sa_dependency_refs": [],
+                "role_dependency_refs": [],
+                "rolebinding_dependency_refs": [],
+                "clusterrole_dependency_refs": [],
+                "clusterrolebinding_dependency_refs": [],
             },
         )
         assert 'resource "kubernetes_service_account" "app_sa"' in content
@@ -338,6 +365,11 @@ class TestRBACTemplate:
                 "rolebindings": [],
                 "clusterroles": [],
                 "clusterrolebindings": [],
+                "sa_dependency_refs": [],
+                "role_dependency_refs": [],
+                "rolebinding_dependency_refs": [],
+                "clusterrole_dependency_refs": [],
+                "clusterrolebinding_dependency_refs": [],
             },
         )
         assert 'resource "kubernetes_role" "pod_reader"' in content
@@ -366,6 +398,11 @@ class TestRBACTemplate:
                 ],
                 "clusterroles": [],
                 "clusterrolebindings": [],
+                "sa_dependency_refs": [],
+                "role_dependency_refs": [],
+                "rolebinding_dependency_refs": [],
+                "clusterrole_dependency_refs": [],
+                "clusterrolebinding_dependency_refs": [],
             },
         )
         assert 'resource "kubernetes_role_binding" "read_pods_binding"' in content
@@ -399,6 +436,11 @@ class TestRBACTemplate:
                     )
                 ],
                 "clusterrolebindings": [],
+                "sa_dependency_refs": [],
+                "role_dependency_refs": [],
+                "rolebinding_dependency_refs": [],
+                "clusterrole_dependency_refs": [],
+                "clusterrolebinding_dependency_refs": [],
             },
         )
         assert 'resource "kubernetes_cluster_role" "node_reader"' in content
@@ -423,7 +465,7 @@ class TestHelmReleaseTemplate:
             )
         ]
         content = provider.render_template(
-            "kubernetes/helm_releases.tf.j2", {"helm_releases": releases}
+            "kubernetes/helm_releases.tf.j2", {"helm_releases": releases, "dependency_refs": []}
         )
         assert 'resource "helm_release" "nginx_ingress"' in content
         assert 'chart      = "ingress-nginx"' in content
@@ -447,7 +489,7 @@ class TestHelmReleaseTemplate:
             )
         ]
         content = provider.render_template(
-            "kubernetes/helm_releases.tf.j2", {"helm_releases": releases}
+            "kubernetes/helm_releases.tf.j2", {"helm_releases": releases, "dependency_refs": []}
         )
         assert "create_namespace = true" in content
         assert "values = [<<-EOT" in content
@@ -471,7 +513,7 @@ class TestHelmReleaseTemplate:
             )
         ]
         content = provider.render_template(
-            "kubernetes/helm_releases.tf.j2", {"helm_releases": releases}
+            "kubernetes/helm_releases.tf.j2", {"helm_releases": releases, "dependency_refs": []}
         )
         assert "set {" in content
         assert 'name  = "server.replicaCount"' in content
@@ -504,7 +546,7 @@ class TestManifestsTemplate:
             )
         ]
         content = provider.render_template(
-            "kubernetes/manifests.tf.j2", {"manifests": manifests, "helm_releases": []}
+            "kubernetes/manifests.tf.j2", {"manifests": manifests, "dependency_refs": []}
         )
         assert 'resource "kubernetes_manifest" "my_custom_resource"' in content
         assert '"apiVersion" = "example.com/v1"' in content
@@ -539,7 +581,7 @@ class TestManifestsTemplate:
             )
         ]
         content = provider.render_template(
-            "kubernetes/manifests.tf.j2", {"manifests": manifests, "helm_releases": []}
+            "kubernetes/manifests.tf.j2", {"manifests": manifests, "dependency_refs": []}
         )
         assert 'resource "kubernetes_manifest" "oci_subnet_router"' in content
         assert '"apiVersion" = "tailscale.com/v1alpha1"' in content
@@ -570,7 +612,7 @@ class TestManifestsTemplate:
             )
         ]
         content = provider.render_template(
-            "kubernetes/manifests.tf.j2", {"manifests": manifests, "helm_releases": []}
+            "kubernetes/manifests.tf.j2", {"manifests": manifests, "dependency_refs": []}
         )
         assert '"app" = "myapp"' in content
         assert '"env" = "prod"' in content
@@ -596,14 +638,14 @@ class TestManifestsTemplate:
             )
         ]
         content = provider.render_template(
-            "kubernetes/manifests.tf.j2", {"manifests": manifests, "helm_releases": []}
+            "kubernetes/manifests.tf.j2", {"manifests": manifests, "dependency_refs": []}
         )
         assert '"name"      = "global-config"' in content
         # Should not have namespace line
         assert '"namespace"' not in content
 
     def test_renders_manifest_with_helm_depends_on(self, provider):
-        """Test manifest with automatic depends_on for Helm releases."""
+        """Test manifest with automatic depends_on for Helm releases via dependency_refs."""
         manifests = [
             ResourceConfig(
                 name="my-crd",
@@ -619,20 +661,350 @@ class TestManifestsTemplate:
                 },
             )
         ]
-        helm_releases = [
+        dependency_refs = [
+            "kubernetes_namespace.default",
+            "helm_release.my_operator",
+        ]
+        content = provider.render_template(
+            "kubernetes/manifests.tf.j2",
+            {"manifests": manifests, "dependency_refs": dependency_refs},
+        )
+        assert "depends_on" in content
+        assert "helm_release.my_operator" in content
+        assert "kubernetes_namespace.default" in content
+
+
+class TestDependencyRefs:
+    """Tests for dependency_refs (depends_on) rendering across all templates."""
+
+    def test_secrets_renders_depends_on_with_refs(self, provider):
+        """Test secrets template renders depends_on when dependency_refs present."""
+        secrets = [
             ResourceConfig(
-                name="my-operator",
+                name="my-secret",
+                type="secrets",
+                provider="kubernetes",
+                config={"namespace": "default", "type": "Opaque", "data": {"k": "v"}},
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/secrets.tf.j2",
+            {"secrets": secrets, "dependency_refs": ["kubernetes_namespace.my_ns"]},
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_secrets_no_depends_on_when_empty(self, provider):
+        """Test secrets template omits depends_on when no refs and no config.depends_on."""
+        secrets = [
+            ResourceConfig(
+                name="my-secret",
+                type="secrets",
+                provider="kubernetes",
+                config={"namespace": "default", "type": "Opaque", "data": {"k": "v"}},
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/secrets.tf.j2",
+            {"secrets": secrets, "dependency_refs": []},
+        )
+        assert "depends_on" not in content
+
+    def test_configmaps_renders_depends_on(self, provider):
+        """Test configmaps template renders depends_on when dependency_refs present."""
+        configmaps = [
+            ResourceConfig(
+                name="my-config",
+                type="configmaps",
+                provider="kubernetes",
+                config={"name": "my-config", "namespace": "default", "data": {"k": "v"}},
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/configmaps.tf.j2",
+            {
+                "configmaps": configmaps,
+                "dependency_refs": ["kubernetes_namespace.my_ns"],
+            },
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_pvc_renders_depends_on(self, provider):
+        """Test PVC template renders depends_on when dependency_refs present."""
+        pvcs = [
+            ResourceConfig(
+                name="data-pvc",
+                type="persistentvolumeclaims",
+                provider="kubernetes",
+                config={"storage": "5Gi", "access_modes": ["ReadWriteOnce"]},
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/pvc.tf.j2",
+            {"pvcs": pvcs, "dependency_refs": ["kubernetes_namespace.my_ns"]},
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_deployments_renders_depends_on(self, provider):
+        """Test deployments template renders depends_on when dependency_refs present."""
+        deployments = [
+            ResourceConfig(
+                name="my-app",
+                type="deployments",
+                provider="kubernetes",
+                config={
+                    "name": "my-app",
+                    "containers": [{"name": "app", "image": "nginx:latest"}],
+                },
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/deployments.tf.j2",
+            {
+                "deployments": deployments,
+                "dependency_refs": [
+                    "kubernetes_namespace.my_ns",
+                    "kubernetes_secret.my_secret",
+                ],
+            },
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+        assert "kubernetes_secret.my_secret" in content
+
+    def test_services_renders_depends_on(self, provider):
+        """Test services template renders depends_on when dependency_refs present."""
+        services = [
+            ResourceConfig(
+                name="my-svc",
+                type="services",
+                provider="kubernetes",
+                config={
+                    "name": "my-svc",
+                    "ports": [{"port": 80, "targetPort": 80}],
+                },
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/services.tf.j2",
+            {
+                "services": services,
+                "dependency_refs": ["kubernetes_deployment.my_app"],
+            },
+        )
+        assert "depends_on" in content
+        assert "kubernetes_deployment.my_app" in content
+
+    def test_ingress_renders_depends_on(self, provider):
+        """Test ingress template renders depends_on when dependency_refs present."""
+        ingresses = [
+            ResourceConfig(
+                name="my-ingress",
+                type="ingresses",
+                provider="kubernetes",
+                config={
+                    "rules": [
+                        {
+                            "host": "example.com",
+                            "paths": [
+                                {
+                                    "path": "/",
+                                    "backend": {
+                                        "service": {
+                                            "name": "svc",
+                                            "port": {"number": 80},
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                },
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/ingress.tf.j2",
+            {
+                "ingresses": ingresses,
+                "dependency_refs": ["kubernetes_service.my_svc"],
+            },
+        )
+        assert "depends_on" in content
+        assert "kubernetes_service.my_svc" in content
+
+    def test_jobs_renders_depends_on(self, provider):
+        """Test jobs template renders depends_on when dependency_refs present."""
+        jobs = [
+            ResourceConfig(
+                name="init-job",
+                type="jobs",
+                provider="kubernetes",
+                config={
+                    "containers": [{"name": "init", "image": "busybox"}],
+                },
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/jobs.tf.j2",
+            {"jobs": jobs, "dependency_refs": ["kubernetes_namespace.my_ns"]},
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_cronjobs_renders_depends_on(self, provider):
+        """Test cronjobs template renders depends_on when dependency_refs present."""
+        cronjobs = [
+            ResourceConfig(
+                name="hourly-task",
+                type="cronjobs",
+                provider="kubernetes",
+                config={
+                    "schedule": "0 * * * *",
+                    "containers": [{"name": "task", "image": "task:latest"}],
+                },
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/cronjobs.tf.j2",
+            {"cronjobs": cronjobs, "dependency_refs": ["kubernetes_namespace.my_ns"]},
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_helm_releases_renders_automatic_and_manual_depends_on(self, provider):
+        """Test helm_releases merges automatic dependency_refs with config.depends_on."""
+        releases = [
+            ResourceConfig(
+                name="my-chart",
                 type="helm_releases",
                 provider="kubernetes",
                 config={
-                    "chart": "my-operator",
-                    "repository": "https://example.com/charts",
+                    "chart": "my-chart",
+                    "depends_on": ["kubernetes_secret.extra"],
+                },
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/helm_releases.tf.j2",
+            {
+                "helm_releases": releases,
+                "dependency_refs": ["kubernetes_namespace.my_ns"],
+            },
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+        assert "kubernetes_secret.extra" in content
+
+    def test_rbac_sa_renders_depends_on(self, provider):
+        """Test RBAC service account renders depends_on with refs."""
+        content = provider.render_template(
+            "kubernetes/rbac.tf.j2",
+            {
+                "serviceaccounts": [
+                    ResourceConfig(
+                        name="app-sa",
+                        type="serviceaccounts",
+                        provider="kubernetes",
+                        config={"namespace": "default"},
+                    )
+                ],
+                "roles": [],
+                "rolebindings": [],
+                "clusterroles": [],
+                "clusterrolebindings": [],
+                "sa_dependency_refs": ["kubernetes_namespace.my_ns"],
+                "role_dependency_refs": [],
+                "rolebinding_dependency_refs": [],
+                "clusterrole_dependency_refs": [],
+                "clusterrolebinding_dependency_refs": [],
+            },
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+
+    def test_rbac_rolebinding_renders_depends_on(self, provider):
+        """Test RBAC role binding renders depends_on with refs."""
+        content = provider.render_template(
+            "kubernetes/rbac.tf.j2",
+            {
+                "serviceaccounts": [],
+                "roles": [],
+                "rolebindings": [
+                    ResourceConfig(
+                        name="binding",
+                        type="rolebindings",
+                        provider="kubernetes",
+                        config={
+                            "namespace": "default",
+                            "role_ref": {"kind": "Role", "name": "my-role"},
+                            "subjects": [{"kind": "ServiceAccount", "name": "my-sa"}],
+                        },
+                    )
+                ],
+                "clusterroles": [],
+                "clusterrolebindings": [],
+                "sa_dependency_refs": [],
+                "role_dependency_refs": [],
+                "rolebinding_dependency_refs": [
+                    "kubernetes_namespace.my_ns",
+                    "kubernetes_role.my_role",
+                    "kubernetes_service_account.my_sa",
+                ],
+                "clusterrole_dependency_refs": [],
+                "clusterrolebinding_dependency_refs": [],
+            },
+        )
+        assert "depends_on" in content
+        assert "kubernetes_namespace.my_ns" in content
+        assert "kubernetes_role.my_role" in content
+        assert "kubernetes_service_account.my_sa" in content
+
+    def test_manifest_merges_automatic_and_manual_depends_on(self, provider):
+        """Test manifests template merges dependency_refs with config.depends_on."""
+        manifests = [
+            ResourceConfig(
+                name="my-crd",
+                type="manifests",
+                provider="kubernetes",
+                config={
+                    "manifest": {
+                        "apiVersion": "example.com/v1",
+                        "kind": "Custom",
+                        "metadata": {"name": "my-crd"},
+                        "spec": {},
+                    },
+                    "depends_on": ["kubernetes_secret.extra"],
                 },
             )
         ]
         content = provider.render_template(
             "kubernetes/manifests.tf.j2",
-            {"manifests": manifests, "helm_releases": helm_releases},
+            {
+                "manifests": manifests,
+                "dependency_refs": ["helm_release.my_operator"],
+            },
         )
         assert "depends_on" in content
         assert "helm_release.my_operator" in content
+        assert "kubernetes_secret.extra" in content
+
+    def test_no_depends_on_when_all_empty(self, provider):
+        """Test that no depends_on block is rendered when refs and config are empty."""
+        deployments = [
+            ResourceConfig(
+                name="simple-app",
+                type="deployments",
+                provider="kubernetes",
+                config={
+                    "name": "simple-app",
+                    "containers": [{"name": "app", "image": "nginx"}],
+                },
+            )
+        ]
+        content = provider.render_template(
+            "kubernetes/deployments.tf.j2",
+            {"deployments": deployments, "dependency_refs": []},
+        )
+        assert "depends_on" not in content


### PR DESCRIPTION
## Description

The Kubernetes provider declares resource type dependencies via `get_dependencies()`, but these were not translated into Terraform `depends_on` blocks in the generated `.tf` files. Only the `manifests.tf.j2` template had hardcoded `depends_on` for helm releases. This caused Terraform to create resources in parallel, leading to failures when dependent resources (e.g., secrets, helm releases) were created before their namespace existed.

This fix adds a `_build_dependency_refs()` method that resolves the provider's dependency graph into concrete Terraform resource references, then passes those references to every template. All 11 resource templates now emit `depends_on` blocks based on the dependency graph, and also support explicit user-defined `depends_on` entries from resource config.

## Related Issue

Addresses #430

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `_build_dependency_refs()` to `KubernetesProvider` that maps InfraFoundry dependency types to Terraform resource references using `get_dependencies()` and `get_terraform_resource_types()`
- Updated all 11 Kubernetes Jinja2 templates to include `depends_on` blocks combining auto-generated dependency refs with optional user-defined `depends_on`
- Updated `generate_terraform()` and all `_generate_*_terraform()` methods to pass dependency refs to templates
- Refactored `_generate_manifests_terraform()` to use the generic dependency system instead of hardcoded helm release references
- Updated Kubernetes provider documentation to describe the auto-generated `depends_on` behavior
- Added comprehensive tests for `_build_dependency_refs()` and `depends_on` rendering in templates

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type-check, security, spell, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
