### PR TITLE
fix: filter package events by --package flag

### DIFF
--- a/src/infrafoundry/cli/commands/infra/apply.py
+++ b/src/infrafoundry/cli/commands/infra/apply.py
@@ -81,5 +81,6 @@ def apply(
             resource_filter=resource_filter,
             parallel=parallel,
             max_workers=max_workers,
+            package_filter=package_name,
         )
     console.success(f"Apply complete! ({timer.elapsed_str})")

--- a/src/infrafoundry/cli/commands/infra/destroy.py
+++ b/src/infrafoundry/cli/commands/infra/destroy.py
@@ -65,5 +65,6 @@ def destroy(
             env,
             auto_approve=auto_approve,
             resource_filter=resource_filter,
+            package_filter=package_name,
         )
     console.success(f"Destroy complete! ({timer.elapsed_str})")

--- a/src/infrafoundry/cli/commands/infra/plan.py
+++ b/src/infrafoundry/cli/commands/infra/plan.py
@@ -55,6 +55,7 @@ def plan(
             dry_run=dry_run,
             resource_filter=resource_filter,
             enforce_policies=enforce_policies,
+            package_filter=package_name,
         )
 
     if dry_run:

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -184,6 +184,11 @@ class PackageLoader:
         env_dir = self.base_dir / env_name
         events = self._rewrite_event_scripts(manifest.events, package_dir, env_dir)
 
+        # Tag each handler config with its originating package name
+        for _event_key, handler_list in events.items():
+            for handler_config in handler_list:
+                handler_config["_package"] = manifest.name
+
         # Rewrite resource-level event script paths
         for resource in resources:
             if resource.events:

--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -141,6 +141,7 @@ class DeploymentExecutor:
         resources_by_provider: dict[str, list[ResourceConfig]],
         resource_filter: list[str] | None,
         auto_approve: bool,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Apply providers sequentially.
 
@@ -150,6 +151,7 @@ class DeploymentExecutor:
             resources_by_provider: Dict mapping provider names to resources
             resource_filter: Optional list of resource names to target
             auto_approve: If True, skip confirmation prompts
+            package_filter: Optional package name to restrict event handlers
 
         Returns:
             Dict with apply results per provider
@@ -196,6 +198,7 @@ class DeploymentExecutor:
                 resources=resources,
                 auto_approve=auto_approve,
                 resource_filter=resource_filter,
+                package_filter=package_filter,
             )
             results[provider_name] = result
 
@@ -231,6 +234,7 @@ class DeploymentExecutor:
                 {"action": "create", "resources": all_created},
                 target_resources=all_created,
                 package_variables=merged_pkg_vars,
+                package_filter=package_filter,
             )
 
         return results
@@ -243,6 +247,7 @@ class DeploymentExecutor:
         resource_filter: list[str] | None,
         auto_approve: bool,
         max_workers: int,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Apply providers in parallel, respecting provider execution order.
 
@@ -257,6 +262,7 @@ class DeploymentExecutor:
             resource_filter: Optional list of resource names to target
             auto_approve: If True, skip confirmation prompts
             max_workers: Maximum number of parallel workers
+            package_filter: Optional package name to restrict event handlers
 
         Returns:
             Dict with apply results per provider
@@ -324,6 +330,7 @@ class DeploymentExecutor:
                         resources=resources,
                         auto_approve=auto_approve,
                         resource_filter=resource_filter,
+                        package_filter=package_filter,
                     )
                     future_to_provider[future] = provider_name
 
@@ -365,6 +372,7 @@ class DeploymentExecutor:
         resources: list[ResourceConfig],
         auto_approve: bool,
         resource_filter: list[str] | None = None,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Apply a single provider's resources.
 
@@ -385,6 +393,7 @@ class DeploymentExecutor:
             resources: List of resources to apply
             auto_approve: If True, skip confirmation prompts
             resource_filter: Optional list of resource names to target with -target
+            package_filter: Optional package name to restrict event handlers
 
         Returns:
             Dict with apply results including terraform outcomes
@@ -412,6 +421,7 @@ class DeploymentExecutor:
                 env_name,
                 creating_event,
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
 
         runner_results: dict[str, Any] = {}
@@ -447,6 +457,7 @@ class DeploymentExecutor:
                 provider=provider_name,
                 runner=tool_name,
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
 
             try:
@@ -481,6 +492,7 @@ class DeploymentExecutor:
                     provider=provider_name,
                     runner=tool_name,
                     target_resources=resource_filter,
+                    package_filter=package_filter,
                 )
             except Exception as exc:
                 failed_event: RunnerEventData = {
@@ -496,6 +508,7 @@ class DeploymentExecutor:
                     provider=provider_name,
                     runner=tool_name,
                     target_resources=resource_filter,
+                    package_filter=package_filter,
                 )
                 raise
 
@@ -529,11 +542,18 @@ class DeploymentExecutor:
                     env_name,
                     created_event,
                     target_resources=[resource.name],
+                    package_filter=package_filter,
                 )
 
         # Fire resource lifecycle events based on IaC outcomes
         self._fire_resource_lifecycle_events(
-            env_name, provider_name, provider, resources, all_outcomes, resource_filter
+            env_name,
+            provider_name,
+            provider,
+            resources,
+            all_outcomes,
+            resource_filter,
+            package_filter,
         )
 
         # Replace ResourceOutcome objects with JSON-safe dicts for audit logging
@@ -553,6 +573,7 @@ class DeploymentExecutor:
         resources: list[ResourceConfig],
         outcomes: list[ResourceOutcome],
         resource_filter: list[str] | None,
+        package_filter: str | None = None,
     ) -> None:
         """Fire resource lifecycle events based on terraform outcomes.
 
@@ -569,6 +590,7 @@ class DeploymentExecutor:
             resources: List of resource configurations
             outcomes: List of terraform resource outcomes
             resource_filter: Optional resource name filter
+            package_filter: Optional package name to restrict event handlers
         """
         if not outcomes:
             return
@@ -661,6 +683,7 @@ class DeploymentExecutor:
                 resource=outcome.resource_name,
                 target_resources=[outcome.resource_name],
                 package_variables=resource.package_variables or {},
+                package_filter=package_filter,
             )
 
         # NOTE: Aggregate events for group handlers (requires: [...]) are NOT

--- a/src/infrafoundry/core/events/bus.py
+++ b/src/infrafoundry/core/events/bus.py
@@ -239,6 +239,12 @@ class UnifiedEventBus(BaseManager):
 
         # Execute registered handlers
         for handler in self._handlers[event_type]:
+            if not handler.matches_package(context.package_filter):
+                self._log_debug(
+                    f"Skipping handler {handler.name}: "
+                    f"no package match for {context.package_filter}"
+                )
+                continue
             if not handler.matches_resources(context.target_resources):
                 self._log_debug(
                     f"Skipping handler {handler.name}: "

--- a/src/infrafoundry/core/events/context.py
+++ b/src/infrafoundry/core/events/context.py
@@ -42,6 +42,7 @@ class EventContext:
     target_resources: list[str] | None = None
     previous_results: list["EventResult"] = field(default_factory=list)
     package_variables: dict[str, Any] = field(default_factory=dict)
+    package_filter: str | None = None
 
     def __repr__(self) -> str:
         parts = [f"EventContext({self.event_type.value}, env={self.environment}"]

--- a/src/infrafoundry/core/events/handlers/base.py
+++ b/src/infrafoundry/core/events/handlers/base.py
@@ -20,6 +20,7 @@ class BaseHandler(ABC):
         """
         self.config = config
         self._name = config.get("name", self.__class__.__name__)
+        self._package: str | None = config.get("_package")
 
     @property
     def name(self) -> str:
@@ -46,6 +47,26 @@ class BaseHandler(ABC):
             List of validation error messages (empty if valid)
         """
         ...
+
+    def matches_package(self, package_filter: str | None) -> bool:
+        """Check whether this handler should fire for the given package filter.
+
+        A handler fires if:
+        - No package filter is set (all packages targeted).
+        - The handler has no ``_package`` (resource-level or env-level events).
+        - The handler's package matches the filter.
+
+        Args:
+            package_filter: Package name from the --package CLI flag, or None.
+
+        Returns:
+            True if this handler should execute, False to skip.
+        """
+        if package_filter is None:
+            return True
+        if self._package is None:
+            return True
+        return self._package == package_filter
 
     def matches_resources(self, target_resources: list[str] | None) -> bool:
         """Check whether this handler should fire for the given target resources.

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -509,6 +509,7 @@ class Orchestrator:
         dry_run: bool = False,
         resource_filter: list[str] | None = None,
         enforce_policies: bool = False,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Plan infrastructure changes.
 
@@ -517,11 +518,14 @@ class Orchestrator:
             dry_run: If True, only show what would be done
             resource_filter: Optional list of resource names to target
             enforce_policies: If True, block on policy violations
+            package_filter: Optional package name to restrict event handlers
 
         Returns:
             Dict with plan results per provider
         """
-        return self.plan_orchestrator.plan(env_name, dry_run, resource_filter, enforce_policies)
+        return self.plan_orchestrator.plan(
+            env_name, dry_run, resource_filter, enforce_policies, package_filter
+        )
 
     def apply(
         self,
@@ -530,6 +534,7 @@ class Orchestrator:
         resource_filter: list[str] | None = None,
         parallel: bool = False,
         max_workers: int = 4,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Apply infrastructure changes.
 
@@ -539,18 +544,22 @@ class Orchestrator:
             resource_filter: Optional list of resource names to target
             parallel: If True, apply resources in parallel where possible
             max_workers: Maximum number of parallel workers (default: 4)
+            package_filter: Optional package name to restrict event handlers
 
         Returns:
             Dict with apply results per provider
         """
         # First, generate the plans
-        self.plan(env_name, dry_run=False, resource_filter=resource_filter)
+        self.plan(
+            env_name, dry_run=False, resource_filter=resource_filter, package_filter=package_filter
+        )
         return self.apply_orchestrator.apply(
             env_name=env_name,
             resource_filter=resource_filter,
             auto_approve=auto_approve,
             parallel=parallel,
             max_workers=max_workers,
+            package_filter=package_filter,
         )
 
     def _apply_providers_serial(
@@ -560,6 +569,7 @@ class Orchestrator:
         resources_by_provider: dict[str, list[ResourceConfig]],
         resource_filter: list[str] | None,
         auto_approve: bool,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Apply providers sequentially."""
         # Load runner priorities, IaC tool, and provider order from environment config
@@ -574,7 +584,12 @@ class Orchestrator:
             )
 
         return self.deployment_executor.apply_serial(
-            env_name, deployment_id, resources_by_provider, resource_filter, auto_approve
+            env_name,
+            deployment_id,
+            resources_by_provider,
+            resource_filter,
+            auto_approve,
+            package_filter=package_filter,
         )
 
     def _apply_providers_parallel(
@@ -585,6 +600,7 @@ class Orchestrator:
         resource_filter: list[str] | None,
         auto_approve: bool,
         max_workers: int,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Apply providers in parallel."""
         # Load runner priorities, IaC tool, and provider order from environment config
@@ -605,6 +621,7 @@ class Orchestrator:
             resource_filter,
             auto_approve,
             max_workers,
+            package_filter=package_filter,
         )
 
     def _apply_single_provider(
@@ -628,6 +645,7 @@ class Orchestrator:
         auto_approve: bool = False,
         resource_filter: list[str] | None = None,
         confirm_callback: Callable[[], bool] | None = None,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Destroy infrastructure.
 
@@ -636,12 +654,13 @@ class Orchestrator:
             auto_approve: If True, skip confirmation prompts
             resource_filter: Optional list of resource names to target
             confirm_callback: Optional callback for user confirmation
+            package_filter: Optional package name to restrict event handlers
 
         Returns:
             Dict with destroy results per provider
         """
         return self.destroy_orchestrator.destroy(
-            env_name, resource_filter, auto_approve, confirm_callback
+            env_name, resource_filter, auto_approve, confirm_callback, package_filter
         )
 
     def rollback(

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -351,6 +351,7 @@ class PlanOrchestrator(HookExecutionMixin):
         dry_run: bool,
         resource_filter: list[str] | None,
         enforce_policies: bool,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Execute the plan workflow for the requested environment."""
         plan_metadata: PlanDeploymentMetadata = {"resource_filter": resource_filter}
@@ -366,6 +367,7 @@ class PlanOrchestrator(HookExecutionMixin):
             env_name,
             {"deployment_id": deployment_id, "dry_run": dry_run},
             target_resources=resource_filter,
+            package_filter=package_filter,
         )
 
         results: dict[str, Any] = {}
@@ -466,6 +468,7 @@ class PlanOrchestrator(HookExecutionMixin):
                                 provider=provider_name,
                                 runner=tool_name,
                                 target_resources=resource_filter,
+                                package_filter=package_filter,
                             )
 
                             try:
@@ -495,6 +498,7 @@ class PlanOrchestrator(HookExecutionMixin):
                                     provider=provider_name,
                                     runner=tool_name,
                                     target_resources=resource_filter,
+                                    package_filter=package_filter,
                                 )
                             except Exception as exc:
                                 failed_event: RunnerEventData = {
@@ -510,6 +514,7 @@ class PlanOrchestrator(HookExecutionMixin):
                                     provider=provider_name,
                                     runner=tool_name,
                                     target_resources=resource_filter,
+                                    package_filter=package_filter,
                                 )
                                 raise
                         else:
@@ -533,6 +538,7 @@ class PlanOrchestrator(HookExecutionMixin):
                 env_name,
                 {"deployment_id": deployment_id, "results": results},
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
         except Exception as exc:
             self.state_manager.update_deployment_status(
@@ -543,6 +549,7 @@ class PlanOrchestrator(HookExecutionMixin):
                 env_name,
                 {"deployment_id": deployment_id, "error": str(exc)},
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
             raise
@@ -720,13 +727,8 @@ class ApplyOrchestrator(HookExecutionMixin):
         load_resources: Callable[
             [str], tuple[list[ResourceConfig], dict[str, list[ResourceConfig]]]
         ],
-        apply_serial: Callable[
-            [str, int, dict[str, list[ResourceConfig]], list[str] | None, bool], dict[str, Any]
-        ],
-        apply_parallel: Callable[
-            [str, int, dict[str, list[ResourceConfig]], list[str] | None, bool, int],
-            dict[str, Any],
-        ],
+        apply_serial: Callable[..., dict[str, Any]],
+        apply_parallel: Callable[..., dict[str, Any]],
         get_current_user: Callable[[], str],
         hook_manager: HookManager | None = None,
         load_environment: Callable[[str], EnvironmentConfig | None] | None = None,
@@ -748,6 +750,7 @@ class ApplyOrchestrator(HookExecutionMixin):
         auto_approve: bool,
         parallel: bool,
         max_workers: int,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Apply infrastructure across providers."""
         apply_metadata: ApplyDeploymentMetadata = {
@@ -766,6 +769,7 @@ class ApplyOrchestrator(HookExecutionMixin):
             env_name,
             {"deployment_id": deployment_id, "auto_approve": auto_approve},
             target_resources=resource_filter,
+            package_filter=package_filter,
         )
 
         results: dict[str, Any] = {}
@@ -801,6 +805,7 @@ class ApplyOrchestrator(HookExecutionMixin):
                     resource_filter,
                     auto_approve,
                     max_workers,
+                    package_filter=package_filter,
                 )
             else:
                 results = self._apply_serial(
@@ -809,6 +814,7 @@ class ApplyOrchestrator(HookExecutionMixin):
                     resources_by_provider,
                     resource_filter,
                     auto_approve,
+                    package_filter=package_filter,
                 )
 
             # Execute resource-level after_apply hooks
@@ -828,6 +834,7 @@ class ApplyOrchestrator(HookExecutionMixin):
                 env_name,
                 {"deployment_id": deployment_id, "results": results},
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
         except Exception as exc:
             self.state_manager.update_deployment_status(
@@ -838,6 +845,7 @@ class ApplyOrchestrator(HookExecutionMixin):
                 env_name,
                 {"deployment_id": deployment_id, "error": str(exc)},
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
             raise
@@ -919,6 +927,7 @@ class DestroyOrchestrator(HookExecutionMixin):
         resource_filter: list[str] | None,
         auto_approve: bool,
         confirm_callback: Callable[[], bool] | None = None,
+        package_filter: str | None = None,
     ) -> dict[str, Any]:
         """Destroy all requested resources."""
         destroy_metadata: DestroyDeploymentMetadata = {
@@ -937,6 +946,7 @@ class DestroyOrchestrator(HookExecutionMixin):
             env_name,
             {"deployment_id": deployment_id, "auto_approve": auto_approve},
             target_resources=resource_filter,
+            package_filter=package_filter,
         )
 
         results: dict[str, Any] = {}
@@ -1037,6 +1047,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                         provider=provider_name,
                         runner=tool_name,
                         target_resources=resource_filter,
+                        package_filter=package_filter,
                     )
 
                     try:
@@ -1071,6 +1082,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                             provider=provider_name,
                             runner=tool_name,
                             target_resources=resource_filter,
+                            package_filter=package_filter,
                         )
                     except Exception as exc:
                         failed_event: RunnerEventData = {
@@ -1086,12 +1098,18 @@ class DestroyOrchestrator(HookExecutionMixin):
                             provider=provider_name,
                             runner=tool_name,
                             target_resources=resource_filter,
+                            package_filter=package_filter,
                         )
                         raise
 
                 # Fire resource lifecycle events for on_destroy handlers
                 self._fire_destroy_lifecycle_events(
-                    env_name, provider_name, resources, all_outcomes, resource_filter
+                    env_name,
+                    provider_name,
+                    resources,
+                    all_outcomes,
+                    resource_filter,
+                    package_filter,
                 )
 
                 self._finalize_destroyed_resources(env_name, provider_name, resource_ids)
@@ -1118,6 +1136,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                 env_name,
                 {"deployment_id": deployment_id, "results": results},
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
         except Exception as exc:
             self.state_manager.update_deployment_status(
@@ -1128,6 +1147,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                 env_name,
                 {"deployment_id": deployment_id, "error": str(exc)},
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
             raise
@@ -1189,6 +1209,7 @@ class DestroyOrchestrator(HookExecutionMixin):
         resources: list[ResourceConfig],
         outcomes: list[ResourceOutcome],
         resource_filter: list[str] | None,
+        package_filter: str | None = None,
     ) -> None:
         """Fire on_destroy resource lifecycle events based on terraform outcomes.
 
@@ -1198,6 +1219,7 @@ class DestroyOrchestrator(HookExecutionMixin):
             resources: List of resource configurations
             outcomes: List of terraform resource outcomes
             resource_filter: Optional resource name filter
+            package_filter: Optional package name to restrict event handlers
         """
         if not outcomes:
             return
@@ -1247,6 +1269,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                 provider=provider_name,
                 resource=outcome.resource_name,
                 target_resources=resource_filter,
+                package_filter=package_filter,
             )
 
     def _print_header(

--- a/tests/unit/test_cli_apply.py
+++ b/tests/unit/test_cli_apply.py
@@ -37,6 +37,7 @@ def test_apply_with_confirmation(cli_runner, mock_orchestrator):
             resource_filter=None,
             parallel=False,
             max_workers=4,
+            package_filter=None,
         )
 
 
@@ -64,6 +65,7 @@ def test_apply_with_auto_approve(cli_runner, mock_orchestrator):
             resource_filter=None,
             parallel=False,
             max_workers=4,
+            package_filter=None,
         )
 
 
@@ -82,6 +84,7 @@ def test_apply_with_resource_filter(cli_runner, mock_orchestrator):
             resource_filter=["vm-01", "vm-02"],
             parallel=False,
             max_workers=4,
+            package_filter=None,
         )
 
 
@@ -109,6 +112,7 @@ def test_apply_with_parallel(cli_runner, mock_orchestrator):
             resource_filter=None,
             parallel=True,
             max_workers=8,
+            package_filter=None,
         )
 
 

--- a/tests/unit/test_cli_plan.py
+++ b/tests/unit/test_cli_plan.py
@@ -35,6 +35,7 @@ def test_plan_basic(cli_runner, mock_orchestrator):
             dry_run=False,
             resource_filter=None,
             enforce_policies=False,
+            package_filter=None,
         )
 
 
@@ -50,6 +51,7 @@ def test_plan_with_dry_run(cli_runner, mock_orchestrator):
             dry_run=True,
             resource_filter=None,
             enforce_policies=False,
+            package_filter=None,
         )
 
 
@@ -67,6 +69,7 @@ def test_plan_with_resource_filter(cli_runner, mock_orchestrator):
             dry_run=False,
             resource_filter=["vm-01", "vm-02"],
             enforce_policies=False,
+            package_filter=None,
         )
 
 
@@ -84,6 +87,7 @@ def test_plan_with_enforce_policies(cli_runner, mock_orchestrator):
             dry_run=False,
             resource_filter=None,
             enforce_policies=True,
+            package_filter=None,
         )
 
 

--- a/tests/unit/test_deployment_executor.py
+++ b/tests/unit/test_deployment_executor.py
@@ -88,6 +88,7 @@ def test_apply_serial_orders_providers_and_tracks_states():
             "terraform_id": None,
         },
         target_resources=None,
+        package_filter=None,
     )
     assert any(
         call_args[0][0] == EventType.RESOURCE_CREATED
@@ -659,6 +660,7 @@ def test_apply_emits_runner_starting_and_completed():
         "provider": "proxmox",
         "runner": "terraform",
         "target_resources": None,
+        "package_filter": None,
     }
 
     assert completed_calls[0][0][2] == {
@@ -671,6 +673,7 @@ def test_apply_emits_runner_starting_and_completed():
         "provider": "proxmox",
         "runner": "terraform",
         "target_resources": None,
+        "package_filter": None,
     }
 
     # Verify ordering: STARTING before apply, COMPLETED after
@@ -744,6 +747,7 @@ def test_apply_emits_runner_failed_on_exception():
         "provider": "proxmox",
         "runner": "terraform",
         "target_resources": None,
+        "package_filter": None,
     }
 
     # RUNNER_COMPLETED should NOT have been emitted

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -81,12 +81,14 @@ def test_plan_orchestrator_dry_run_skips_generation(console):
         "dev",
         {"deployment_id": 1, "dry_run": True},
         target_resources=None,
+        package_filter=None,
     )
     event_manager.emit_event.assert_any_call(
         EventType.AFTER_PLAN,
         "dev",
         {"deployment_id": 1, "results": result},
         target_resources=None,
+        package_filter=None,
     )
 
 
@@ -336,6 +338,7 @@ def test_plan_emits_runner_starting_and_completed(console):
         "provider": "proxmox",
         "runner": "terraform",
         "target_resources": None,
+        "package_filter": None,
     }
     assert completed_calls[0][0][2] == {
         "provider": "proxmox",
@@ -412,6 +415,7 @@ def test_destroy_emits_runner_starting_and_completed(console):
         "provider": "proxmox",
         "runner": "terraform",
         "target_resources": None,
+        "package_filter": None,
     }
     assert completed_calls[0][0][2] == {
         "provider": "proxmox",

--- a/tests/unit/test_package_event_filtering.py
+++ b/tests/unit/test_package_event_filtering.py
@@ -1,0 +1,213 @@
+"""Tests for package-level event filtering (#427).
+
+When --package is specified, only event handlers from that package should fire.
+Handlers from other packages should be skipped.
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from infrafoundry.core.config.package_loader import PackageLoader
+from infrafoundry.core.events import EventContext, EventType, UnifiedEventBus
+from infrafoundry.core.events.handlers.base import BaseHandler
+
+# --- BaseHandler.matches_package() ---
+
+
+class TestMatchesPackage:
+    """Tests for BaseHandler.matches_package()."""
+
+    def test_no_filter_returns_true(self) -> None:
+        """No package_filter means all handlers fire."""
+        handler = _make_handler(package="minio")
+        assert handler.matches_package(None) is True
+
+    def test_no_package_on_handler_returns_true(self) -> None:
+        """Handler without _package fires regardless of filter."""
+        handler = _make_handler(package=None)
+        assert handler.matches_package("k3s-cluster") is True
+
+    def test_matching_package_returns_true(self) -> None:
+        """Handler fires when its package matches the filter."""
+        handler = _make_handler(package="k3s-cluster")
+        assert handler.matches_package("k3s-cluster") is True
+
+    def test_different_package_returns_false(self) -> None:
+        """Handler is skipped when its package differs from the filter."""
+        handler = _make_handler(package="minio")
+        assert handler.matches_package("k3s-cluster") is False
+
+
+# --- Package tagging in PackageLoader ---
+
+
+class TestPackageTagging:
+    """Tests for _package tagging in PackageLoader.load_package()."""
+
+    def test_load_package_tags_handlers(self, tmp_path: Path) -> None:
+        """load_package() adds _package field to each handler config."""
+        env_dir = tmp_path / "test-env"
+        provider_dir = env_dir / "kubernetes"
+        pkg_dir = provider_dir / "k3s-cluster"
+        pkg_dir.mkdir(parents=True)
+
+        # Create manifest with events
+        (pkg_dir / "infrafoundry.yml").write_text(
+            "name: k3s-cluster\n"
+            "resources:\n  - vm.yaml\n"
+            "events:\n"
+            "  after_apply:\n"
+            "    - type: script\n"
+            "      name: setup-k3s\n"
+            "      script: scripts/setup.sh\n"
+            "    - type: script\n"
+            "      name: deploy-apps\n"
+            "      script: scripts/deploy.sh\n"
+        )
+        (pkg_dir / "vm.yaml").write_text("vm:\n  - name: k3s-node\n    cores: 4\n")
+
+        loader = PackageLoader(base_dir=tmp_path)
+        _resources, events, _variables = loader.load_package(pkg_dir, "kubernetes", "test-env")
+
+        # All handlers should have _package set
+        assert "after_apply" in events
+        for handler in events["after_apply"]:
+            assert handler["_package"] == "k3s-cluster"
+
+    def test_load_package_tags_multiple_event_types(self, tmp_path: Path) -> None:
+        """_package is set across all event types."""
+        env_dir = tmp_path / "test-env"
+        provider_dir = env_dir / "proxmox"
+        pkg_dir = provider_dir / "minio"
+        pkg_dir.mkdir(parents=True)
+
+        (pkg_dir / "infrafoundry.yml").write_text(
+            "name: minio\n"
+            "resources:\n  - vm.yaml\n"
+            "events:\n"
+            "  before_plan:\n"
+            "    - type: script\n"
+            "      name: pre-check\n"
+            "      script: scripts/check.sh\n"
+            "  after_apply:\n"
+            "    - type: script\n"
+            "      name: configure-minio\n"
+            "      script: scripts/configure.sh\n"
+        )
+        (pkg_dir / "vm.yaml").write_text("vm:\n  - name: minio-srv\n    cores: 2\n")
+
+        loader = PackageLoader(base_dir=tmp_path)
+        _resources, events, _variables = loader.load_package(pkg_dir, "proxmox", "test-env")
+
+        for event_key, handlers in events.items():
+            for handler in handlers:
+                assert handler["_package"] == "minio", f"Handler in {event_key} missing _package"
+
+
+# --- Event bus integration ---
+
+
+class TestEventBusPackageFiltering:
+    """Integration tests for package filtering in UnifiedEventBus.emit()."""
+
+    def test_filter_skips_other_package_handlers(self) -> None:
+        """emit() with package_filter skips handlers from other packages."""
+        bus = UnifiedEventBus()
+        bus.register_handler(
+            EventType.AFTER_APPLY,
+            {"type": "python", "module": "dummy", "function": "handler", "_package": "k3s-cluster"},
+        )
+        bus.register_handler(
+            EventType.AFTER_APPLY,
+            {"type": "python", "module": "dummy", "function": "handler", "_package": "minio"},
+        )
+
+        ctx = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="prod",
+            package_filter="k3s-cluster",
+        )
+        # Both handlers will fail to execute (dummy module), but we can check
+        # how many were attempted by examining the results count
+        results = bus.emit(ctx, abort_on_failure=False)
+        # Only the k3s-cluster handler should have been attempted
+        assert len(results) == 1
+
+    def test_no_filter_fires_all_handlers(self) -> None:
+        """emit() without package_filter fires all handlers."""
+        bus = UnifiedEventBus()
+        bus.register_handler(
+            EventType.AFTER_APPLY,
+            {"type": "python", "module": "dummy", "function": "handler", "_package": "k3s-cluster"},
+        )
+        bus.register_handler(
+            EventType.AFTER_APPLY,
+            {"type": "python", "module": "dummy", "function": "handler", "_package": "minio"},
+        )
+
+        ctx = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="prod",
+            # No package_filter
+        )
+        results = bus.emit(ctx, abort_on_failure=False)
+        assert len(results) == 2
+
+    def test_handler_without_package_always_fires(self) -> None:
+        """Handlers without _package fire regardless of filter."""
+        bus = UnifiedEventBus()
+        bus.register_handler(
+            EventType.AFTER_APPLY,
+            {"type": "python", "module": "dummy", "function": "handler"},
+        )
+        bus.register_handler(
+            EventType.AFTER_APPLY,
+            {"type": "python", "module": "dummy", "function": "handler", "_package": "minio"},
+        )
+
+        ctx = EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="prod",
+            package_filter="k3s-cluster",
+        )
+        results = bus.emit(ctx, abort_on_failure=False)
+        # The handler without _package fires; the minio handler does not
+        assert len(results) == 1
+
+    def test_emit_event_passes_package_filter(self) -> None:
+        """emit_event() convenience method passes package_filter to context."""
+        bus = UnifiedEventBus()
+        bus.register_handler(
+            EventType.BEFORE_PLAN,
+            {"type": "python", "module": "dummy", "function": "handler", "_package": "minio"},
+        )
+
+        results = bus.emit_event(
+            EventType.BEFORE_PLAN,
+            "prod",
+            package_filter="k3s-cluster",
+        )
+        # minio handler should be skipped
+        assert len(results) == 0
+
+
+# --- Helpers ---
+
+
+class _StubHandler(BaseHandler):
+    """Minimal concrete handler for unit testing matches_package()."""
+
+    def execute(self, context: EventContext) -> Any:
+        return MagicMock(success=True)
+
+    def validate_config(self) -> list[str]:
+        return []
+
+
+def _make_handler(package: str | None) -> _StubHandler:
+    """Create a handler with the given _package value."""
+    config: dict[str, Any] = {"name": "test-handler"}
+    if package is not None:
+        config["_package"] = package
+    return _StubHandler(config)

--- a/tests/unit/test_package_filter.py
+++ b/tests/unit/test_package_filter.py
@@ -191,6 +191,7 @@ class TestPlanWithPackage:
                 dry_run=False,
                 resource_filter=["vm-01", "vm-02"],
                 enforce_policies=False,
+                package_filter="my-cluster",
             )
 
     def test_plan_with_unknown_package_fails(self, cli_runner, mock_orchestrator):
@@ -239,6 +240,7 @@ class TestApplyWithPackage:
                 resource_filter=["vm-01"],
                 parallel=False,
                 max_workers=4,
+                package_filter="my-cluster",
             )
 
     def test_apply_with_package_shows_package_in_prompt(self, cli_runner, mock_orchestrator):
@@ -288,6 +290,7 @@ class TestDestroyWithPackage:
             )
             call_args = mock_orchestrator.destroy.call_args
             assert call_args[1]["resource_filter"] == ["vm-01", "vm-02"]
+            assert call_args[1]["package_filter"] == "my-cluster"
 
     def test_destroy_with_package_shows_package_in_prompt(self, cli_runner, mock_orchestrator):
         """Destroy --package shows package name in confirmation prompt."""


### PR DESCRIPTION
## Description

When running `infra apply --env prod --package k3s-cluster`, event handlers from unrelated packages (e.g., MinIO) also fire because package-level events are loaded globally without respecting the `--package` filter. This causes failures when handler scripts reference variables only available in the targeted package.

Addresses #427

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Tag each handler config with its originating package name (`_package` field) during `PackageLoader.load_package()`
- Add `matches_package()` method to `BaseHandler` that checks whether a handler should fire for the given package filter
- Add `package_filter` field to `EventContext` so the filter propagates through the event system
- Thread `package_filter` parameter from CLI commands (`plan`, `apply`, `destroy`) through orchestrator workflows, deployment executor, and into the event bus
- Skip handlers in `UnifiedEventBus.fire()` when their package does not match the active filter
- Handlers with no package tag (resource-level or env-level events) always fire regardless of filter

## Testing

- [x] All existing tests pass
- [x] Added new test file `tests/unit/test_package_event_filtering.py` with dedicated tests for the package filtering logic
- [x] Updated existing test files to accommodate the new `package_filter` parameter
- [x] `doit check` passes (tests, lint, type-check, security, spelling)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
