### PR TITLE
fix: use provider-qualified resource owner to prevent cross-provider event firing

### DIFF
--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -641,10 +641,12 @@ class DeploymentExecutor:
             )
 
             # Register and fire handlers for this resource event.
-            # Tag each handler with _resource_owner so it only fires for
-            # this specific resource, not for any resource with the same name.
+            # Tag each handler with a provider-qualified _resource_owner so it
+            # only fires for this specific resource, not for any resource with
+            # the same name from a different provider.
+            qualified_owner = f"{provider_name}:{outcome.resource_name}"
             for handler_config in handlers:
-                tagged_config = {**handler_config, "_resource_owner": outcome.resource_name}
+                tagged_config = {**handler_config, "_resource_owner": qualified_owner}
                 try:
                     self.event_manager.register_handler(
                         EventType.RESOURCE_CREATED
@@ -664,8 +666,9 @@ class DeploymentExecutor:
                     continue
 
             # Emit per-resource event for resource-level handlers.
-            # Pass only the single resource name as target so that group
-            # handlers with ``requires`` don't match individual emissions.
+            # Include both qualified (provider:name) and unqualified name in
+            # target_resources so _resource_owner matching uses the qualified
+            # form while requires/resources filters still work with plain names.
             event_type = (
                 EventType.RESOURCE_CREATED
                 if outcome.action == "create"
@@ -684,7 +687,7 @@ class DeploymentExecutor:
                 },
                 provider=provider_name,
                 resource=outcome.resource_name,
-                target_resources=[outcome.resource_name],
+                target_resources=[qualified_owner, outcome.resource_name],
                 package_variables=resource.package_variables or {},
                 package_filter=package_filter,
             )


### PR DESCRIPTION
## Description

Follow-up to PR #443. The original `_resource_owner` fix used unqualified resource names, which didn't prevent cross-provider firing when resources from different providers share the same name (e.g., `proxmox:aiqum` VM and `opnsense:aiqum` DHCP reservation).

This PR qualifies `_resource_owner` with the provider name (`provider:name`) and includes both qualified and unqualified names in `target_resources` so existing `requires`/`resources` filters still work.

Addresses #442

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Qualify `_resource_owner` as `f"{provider_name}:{resource_name}"` in `_fire_resource_lifecycle_events()`
- Include both `qualified_owner` and `resource_name` in `target_resources` for backward compatibility

## Testing

- [x] All existing tests pass (20 event filtering tests)
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass
- [x] My changes generate no new warnings