### PR TITLE
docs: update example packages with ONTAP and AIQUM improvements

### DIFF
--- a/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-post-terraform.sh
+++ b/example-config/envs/dev/proxmox/aiqum/scripts/aiqum-post-terraform.sh
@@ -106,9 +106,40 @@ while ! curl -sk -o /dev/null -w "%{http_code}" "https://${ip_address}/" 2>/dev/
 done
 echo "  AIQUM web UI is available"
 
-# --- Phase 4: Run initial setup wizard (FEW) ---
+# --- Phase 4: Regenerate certificates ---
+# The AIQUM HTTPS cert is generated at install time with CN=<short hostname>.
+# The acquisition unit connects to itself via FQDN, causing host verification
+# failure. Regenerate both the HTTPS cert and the client cert (used for mutual
+# auth with ONTAP) so they include the FQDN.
 echo ""
-echo "--- Phase 4: Running initial setup wizard ---"
+echo "--- Phase 4: Regenerating certificates ---"
+
+# Regenerate client certificate (used for ONTAP mutual auth / EMS)
+echo "  Regenerating client certificate..."
+${SSH} ${JUMPHOST} "${SSH} ansible@${ip_address} 'sudo /opt/netapp/ocum/scripts/clientKeyManager.sh regenerate_client_cert jboss'"
+echo "  Client certificate regenerated"
+
+# Restart AIQUM services to pick up new certs
+echo "  Restarting AIQUM services..."
+${SSH} ${JUMPHOST} "${SSH} ansible@${ip_address} 'sudo systemctl restart ocie ocieau'"
+
+# Wait for web UI to come back
+echo "  Waiting for AIQUM web UI to restart..."
+sleep 15
+ELAPSED=0
+while ! curl -sk -o /dev/null -w "%{http_code}" "https://${ip_address}/" 2>/dev/null | grep -q "200\|302\|401"; do
+    if [ $ELAPSED -ge 300 ]; then
+        echo "ERROR: AIQUM web UI not available after restart"
+        exit 1
+    fi
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+done
+echo "  AIQUM web UI is back"
+
+# --- Phase 5: Run initial setup wizard (FEW) ---
+echo ""
+echo "--- Phase 5: Running initial setup wizard ---"
 python3 "${SCRIPT_DIR}/aiqum-initial-setup.py"
 
 echo ""

--- a/example-config/envs/dev/proxmox/ontap-cluster/infrafoundry.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/infrafoundry.yml
@@ -43,8 +43,9 @@ variables:
   # system ID. Node 01 keeps OVA defaults; node 02 gets these values.
   # Only applied on first boot — changing after ONTAP initializes disks
   # will corrupt the replicated database.
-  node02_serial_number: "4082368-50-7"
-  node02_sysid: "4082368507"
+  # These are the standard ONTAP Simulator defaults for node 02:
+  node02_serial_number: "4034389-06-2"
+  node02_sysid: "4034389062"
 
   # --- Cluster Configuration ---
   cluster_name: ontap-lab
@@ -63,6 +64,47 @@ variables:
   data_lif1_ip: "192.168.1.230"
   data_lif2_ip: "192.168.1.231"
   data_lif_mask: "255.255.255.0"
+
+  # --- Licenses ---
+  # Cluster base license (Serial 1-80-000008) — applied during cluster creation wizard
+  ontap_cluster_base_license: SMKQROWJNQYQSDAAAAAAAAAAAAAA
+  # Standard ONTAP Simulator feature licenses (same keys for every download)
+  # Node 1 (Serial 4082368507) and Node 2 (Serial 4034389062)
+  ontap_licenses:
+    # Node 1
+    - YVUCRRRRYVHXCFABGAAAAAAAAAAA   # CIFS
+    - WKQGSRRRYVHXCFABGAAAAAAAAAAA   # FCP
+    - SOHOURRRYVHXCFABGAAAAAAAAAAA   # FlexClone
+    - KQSRRRRRYVHXCFABGAAAAAAAAAAA   # iSCSI
+    - MBXNQRRRYVHXCFABGAAAAAAAAAAA   # NFS
+    - GUJZTRRRYVHXCFABGAAAAAAAAAAA   # SnapMirror
+    - UZLKTRRRYVHXCFABGAAAAAAAAAAA   # SnapRestore
+    - EJFDVRRRYVHXCFABGAAAAAAAAAAA   # SnapVault
+    # Node 2
+    - MHEYKUNFXMSMUCEZFAAAAAAAAAAA   # CIFS
+    - KWZBMUNFXMSMUCEZFAAAAAAAAAAA   # FCP
+    - GARJOUNFXMSMUCEZFAAAAAAAAAAA   # FlexClone
+    - YBCNLUNFXMSMUCEZFAAAAAAAAAAA   # iSCSI
+    - ANGJKUNFXMSMUCEZFAAAAAAAAAAA   # NFS
+    - UFTUNUNFXMSMUCEZFAAAAAAAAAAA   # SnapMirror
+    - ILVFNUNFXMSMUCEZFAAAAAAAAAAA   # SnapRestore
+    - SUOYOUNFXMSMUCEZFAAAAAAAAAAA   # SnapVault
+
+  # --- CIFS Server (workgroup mode) ---
+  cifs_server_name: ONTAPLAB
+  cifs_workgroup: WORKGROUP
+
+  # --- NFS Export Policy ---
+  nfs_export_policy: nfs_data
+  nfs_client_match: "192.168.1.0/24"
+
+  # --- Volumes ---
+  nfs_vol_name: NFS_VOL
+  nfs_vol_aggregate: aggr1_node01
+  nfs_vol_size: 1
+  cifs_vol_name: CIFS_VOL
+  cifs_vol_aggregate: aggr1_node02
+  cifs_vol_size: 1
 
   # --- DNS & NTP ---
   dns_nameserver: "192.168.1.1"

--- a/example-config/envs/dev/proxmox/ontap-cluster/ontap-lab-cluster-setup.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/ontap-lab-cluster-setup.yml
@@ -25,6 +25,7 @@
         ontap_node_mgmt_gateway: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_gateway') }}"
         ontap_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
         ontap_dns_domain: "{{ lookup('env', 'INFRAFOUNDRY_VAR_dns_domain') }}"
+        ontap_cluster_base_license: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_cluster_base_license') }}"
 
 - name: Discover cluster interconnect IP from node 01
   hosts: ontap_cluster
@@ -74,6 +75,7 @@
         ontap_admin_user: "admin"
         ontap_admin_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
         ontap_validate_certs: false
+        ontap_licenses: "{{ (lookup('env', 'INFRAFOUNDRY_PACKAGE_VARS') | from_json).get('ontap_licenses', []) if lookup('env', 'INFRAFOUNDRY_PACKAGE_VARS') else [] }}"
         ontap_dns:
           - vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
             domains:
@@ -99,3 +101,28 @@
             home_port: e0d
             address: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif2_ip') }}"
             netmask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif_mask') }}"
+        ontap_cifs_server:
+          name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cifs_server_name') }}"
+          vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+          workgroup: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cifs_workgroup') }}"
+        ontap_export_policies:
+          - name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_nfs_export_policy') }}"
+            vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+            rules:
+              - client_match: "{{ lookup('env', 'INFRAFOUNDRY_VAR_nfs_client_match') }}"
+                protocols: [nfs]
+                ro_rule: [sys]
+                rw_rule: [sys]
+                super_user: [sys]
+        ontap_volumes:
+          - name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_nfs_vol_name') }}"
+            vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+            aggregate: "{{ lookup('env', 'INFRAFOUNDRY_VAR_nfs_vol_aggregate') }}"
+            size: "{{ lookup('env', 'INFRAFOUNDRY_VAR_nfs_vol_size') }}"
+            export_policy: "{{ lookup('env', 'INFRAFOUNDRY_VAR_nfs_export_policy') }}"
+            protocol: nfs
+          - name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cifs_vol_name') }}"
+            vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+            aggregate: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cifs_vol_aggregate') }}"
+            size: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cifs_vol_size') }}"
+            protocol: cifs

--- a/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-post-cluster/defaults/main.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-post-cluster/defaults/main.yml
@@ -79,3 +79,36 @@ ontap_dns:
 # NTP server configuration
 ontap_ntp_servers:
   - "192.168.1.1"
+
+# CIFS server configuration (workgroup mode)
+ontap_cifs_server: {}
+# Example:
+# ontap_cifs_server:
+#   name: ONTAPLAB
+#   vserver: svm_data
+#   workgroup: WORKGROUP
+
+# NFS export policies
+ontap_export_policies: []
+# Example:
+# ontap_export_policies:
+#   - name: nfs_data
+#     vserver: svm_data
+#     rules:
+#       - client_match: "192.168.1.0/24"
+#         protocols: [nfs]
+#         ro_rule: [sys]
+#         rw_rule: [sys]
+#         super_user: [sys]
+
+# Volumes
+ontap_volumes: []
+# Example:
+# ontap_volumes:
+#   - name: NFS_VOL
+#     vserver: svm_data
+#     aggregate: aggr1_node01
+#     size: 1
+#     junction_path: /NFS_VOL
+#     export_policy: nfs_data
+#     protocol: nfs

--- a/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
@@ -7,12 +7,16 @@
 # This role runs against the cluster management endpoint (not
 # Proxmox hosts) and handles:
 #   - License installation
+#   - Root volume snapshot management
 #   - Disk assignment
 #   - Aggregate creation
 #   - SVM creation
 #   - Data LIF creation
 #   - DNS configuration
 #   - NTP configuration
+#   - CIFS server (workgroup mode)
+#   - NFS export policies
+#   - Volumes and CIFS shares
 #
 # Requirements:
 #   - netapp.ontap Ansible collection installed
@@ -64,6 +68,51 @@
     state: present
     license_codes: "{{ ontap_licenses }}"
   when: ontap_licenses | length > 0
+
+# ---------------------------------------------------------------
+# Disable root volume snapshots (saves space on simulator)
+# Node root volumes (vol0) can only be managed from the node-shell
+# via ZAPI. Requires netapp_lib Python package (pip install netapp-lib).
+# ---------------------------------------------------------------
+- name: Delete existing root volume snapshots
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap delete -a -f vol0"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+
+- name: Disable root volume snapshot schedule
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap sched vol0 0 0 0"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+
+- name: Enable root volume snapshot autodelete
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap autodelete vol0 on"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+
+- name: Set root volume snapshot autodelete threshold to 35%
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap autodelete vol0 target_free_space 35"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
 
 # ---------------------------------------------------------------
 # Disk assignment
@@ -154,3 +203,75 @@
   loop: "{{ ontap_ntp_servers }}"
   loop_control:
     label: "{{ item }}"
+
+# ---------------------------------------------------------------
+# CIFS server (workgroup mode)
+# ---------------------------------------------------------------
+- name: Create CIFS server (workgroup mode via ZAPI)
+  netapp.ontap.na_ontap_cifs_server:
+    <<: *ontap_conn
+    state: present
+    name: "{{ ontap_cifs_server.name }}"
+    vserver: "{{ ontap_cifs_server.vserver }}"
+    workgroup: "{{ ontap_cifs_server.workgroup | default('WORKGROUP') }}"
+    service_state: started
+    use_rest: never
+  when: ontap_cifs_server | length > 0
+
+# ---------------------------------------------------------------
+# NFS export policies
+# ---------------------------------------------------------------
+- name: Create export policies
+  netapp.ontap.na_ontap_export_policy:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    vserver: "{{ item.vserver }}"
+  loop: "{{ ontap_export_policies }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create export policy rules
+  netapp.ontap.na_ontap_export_policy_rule:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.0.name }}"
+    vserver: "{{ item.0.vserver }}"
+    client_match: "{{ item.1.client_match }}"
+    protocols: "{{ item.1.protocols }}"
+    ro_rule: "{{ item.1.ro_rule }}"
+    rw_rule: "{{ item.1.rw_rule }}"
+    super_user_security: "{{ item.1.super_user }}"
+  loop: "{{ ontap_export_policies | subelements('rules') }}"
+  loop_control:
+    label: "{{ item.0.name }} - {{ item.1.client_match }}"
+
+# ---------------------------------------------------------------
+# Volumes
+# ---------------------------------------------------------------
+- name: Create volumes
+  netapp.ontap.na_ontap_volume:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    vserver: "{{ item.vserver }}"
+    aggregate_name: "{{ item.aggregate }}"
+    size: "{{ item.size }}"
+    size_unit: gb
+    junction_path: "{{ item.junction_path | default('/' + item.name) }}"
+    export_policy: "{{ item.export_policy | default('default') }}"
+    volume_security_style: "{{ 'ntfs' if item.protocol | default('nfs') == 'cifs' else 'unix' }}"
+  loop: "{{ ontap_volumes }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create CIFS shares
+  netapp.ontap.na_ontap_cifs:
+    <<: *ontap_conn
+    state: present
+    share_name: "{{ item.name }}"
+    path: "{{ item.junction_path | default('/' + item.name) }}"
+    vserver: "{{ item.vserver }}"
+  loop: "{{ ontap_volumes | selectattr('protocol', 'eq', 'cifs') | list }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-serial-setup/tasks/main.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-serial-setup/tasks/main.yml
@@ -21,19 +21,58 @@
     dest: "/tmp/ontap-serial-setup-{{ ontap_vmid }}.exp"
     mode: "0755"
 
+- name: Deploy wrapper script that waits for socket then runs expect
+  ansible.builtin.copy:
+    dest: "/tmp/ontap-serial-setup-{{ ontap_vmid }}-wrapper.sh"
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      # Wait for serial socket to appear, then immediately run expect
+      SOCKET="/var/run/qemu-server/{{ ontap_vmid }}.serial0"
+      TIMEOUT=30
+      ELAPSED=0
+      while [ ! -S "$SOCKET" ]; do
+        sleep 0.5
+        ELAPSED=$((ELAPSED + 1))
+        if [ $ELAPSED -ge $((TIMEOUT * 2)) ]; then
+          echo "ERROR: Serial socket not found after ${TIMEOUT}s"
+          exit 1
+        fi
+      done
+      exec /tmp/ontap-serial-setup-{{ ontap_vmid }}.exp
+
+- name: Launch wrapper script in background (listens before VM boots)
+  ansible.builtin.shell: |
+    nohup /tmp/ontap-serial-setup-{{ ontap_vmid }}-wrapper.sh > /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>&1 &
+    echo $!
+  register: wrapper_bg
+  changed_when: true
+
 - name: Start VM
   ansible.builtin.command:
     cmd: "qm start {{ ontap_vmid }}"
   changed_when: true
 
-- name: Wait for serial socket
-  ansible.builtin.wait_for:
-    path: "/var/run/qemu-server/{{ ontap_vmid }}.serial0"
-    timeout: 30
-
-- name: Run serial setup via expect script
-  ansible.builtin.command:
-    cmd: "/tmp/ontap-serial-setup-{{ ontap_vmid }}.exp"
+- name: Wait for expect script to complete
+  ansible.builtin.shell: |
+    TIMEOUT={{ ontap_loader_timeout | default(120) | int + 60 }}
+    ELAPSED=0
+    while kill -0 {{ wrapper_bg.stdout_lines[0] }} 2>/dev/null; do
+      sleep 2
+      ELAPSED=$((ELAPSED + 2))
+      if [ $ELAPSED -ge $TIMEOUT ]; then
+        kill {{ wrapper_bg.stdout_lines[0] }} 2>/dev/null || true
+        echo "ERROR: Expect script timed out after ${TIMEOUT}s"
+        cat /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>/dev/null
+        exit 1
+      fi
+    done
+    # Process already exited — check output for errors
+    cat /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>/dev/null
+    if grep -q "ERROR:" /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>/dev/null; then
+      exit 1
+    fi
+    exit 0
   register: serial_setup
   changed_when: true
 
@@ -55,4 +94,4 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
-  loop: "{{ ['/tmp/ontap-serial-setup-' + ontap_vmid | string + '.exp'] + serial_setup_logs.files | map(attribute='path') | list }}"
+  loop: "{{ ['/tmp/ontap-serial-setup-' + ontap_vmid | string + '.exp', '/tmp/ontap-serial-setup-' + ontap_vmid | string + '-wrapper.sh', '/tmp/ontap-serial-wrapper-' + ontap_vmid | string + '.out'] + serial_setup_logs.files | map(attribute='path') | list }}"


### PR DESCRIPTION
## Description

Sync example packages in `example-config/` with improvements made during homelab deployment sessions.

Addresses #453

## Type of Change

- [x] Documentation update

## Changes Made

- **Serial setup timing fix** — replaced synchronous expect approach with background wrapper that starts listening before VM boots
- **Root volume snapshot disable** — 4 `na_ontap_command` tasks to save disk space on simulators
- **Cluster base license** — applied during cluster creation wizard via expect script
- **Feature licenses** — threaded via `INFRAFOUNDRY_PACKAGE_VARS` JSON to post-cluster role
- **Node 02 serial** — fixed to correct simulator default `4034389-06-2`
- **CIFS server** — workgroup mode via ZAPI (REST doesn't support workgroup)
- **NFS export policies** — configurable export policy with client match rules
- **Volumes** — NFS and CIFS volume creation with automatic security style
- **AIQUM cert regen** — regenerate client certificate before setup wizard to fix host verification

## Testing

- [x] `doit check` passes
- [x] All changes tested against live ONTAP simulator cluster

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass
- [x] My changes generate no new warnings