### PR TITLE
docs: fix overclaimed features in AGENTS.md and README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ def generate_terraform(self, resources: list[dict[str, Any]]) -> Path:
 - **YAML Unsafe Loading**: Always use `yaml.safe_load()`, never `yaml.load()`
 
 ### State Management Pitfalls
-- **Race Conditions**: Use state locking for concurrent operations
+- **Race Conditions**: Configure Terraform backend locking (e.g., S3+DynamoDB) for concurrent operations
 - **Stale State**: Always refresh state before operations
 - **Lost State**: Never delete generated configs without destroy first
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ infra apply --env dev
 ## Features
 
 - Pluggable providers (Proxmox, OPNsense, Kubernetes; extensible)
-- Pluggable secrets (SOPS/age default; Vault/AWS/custom via SecretProvider)
+- Secrets management via SOPS/age (pluggable backends planned — see #419)
 - YAML-only configuration; generated Terraform/Ansible artifacts
 - Separate config repos; CI/CD-ready with GitHub/GitLab examples
 - State/history tracking (SQLite/PostgreSQL)


### PR DESCRIPTION
## Description

Fix two documentation overclaims identified in the feature audit:

1. **AGENTS.md** — "Use state locking for concurrent operations" implied InfraFoundry has its own state locking. Clarified that this is about configuring Terraform backend locking (S3+DynamoDB).

2. **README.md** — "Pluggable secrets (SOPS/age default; Vault/AWS/custom via SecretProvider)" implied Vault/AWS backends exist. Updated to reflect SOPS-only reality with pluggable backends planned (#419).

Addresses #247

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass