### PR TITLE
feat: add package blueprints with shared templates and inventory generation

### DIFF
--- a/src/infrafoundry/core/config/__init__.py
+++ b/src/infrafoundry/core/config/__init__.py
@@ -10,7 +10,9 @@ from infrafoundry.core.config.backend_config import (
     S3BackendConfig,
     TerraformCloudBackendConfig,
 )
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
 from infrafoundry.core.config.config_manager import ConfigManager
+from infrafoundry.core.config.inventory_generator import InventoryGenerator
 from infrafoundry.core.config.models import EnvironmentConfig, IaCTool, PackageManifest, SSHConfig
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
@@ -21,10 +23,12 @@ __all__ = [
     "AzureBackendConfig",
     "BackendConfig",
     "BackendType",
+    "BlueprintResolver",
     "ConfigManager",
     "EnvironmentConfig",
     "GCSBackendConfig",
     "IaCTool",
+    "InventoryGenerator",
     "LocalBackendConfig",
     "PackageLoader",
     "PackageManifest",

--- a/src/infrafoundry/core/config/blueprint_resolver.py
+++ b/src/infrafoundry/core/config/blueprint_resolver.py
@@ -1,0 +1,204 @@
+"""Blueprint resolver for infrastructure packages.
+
+Discovers and loads blueprints from ``config_repo/blueprints/``, allowing
+packages to reference shared implementation files (roles, playbooks, scripts,
+resource templates) via a ``blueprint: <name>`` declaration in their manifest.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+logger = logging.getLogger(__name__)
+
+BLUEPRINT_MANIFEST = "blueprint.yaml"
+
+
+class BlueprintResolver:
+    """Resolves blueprint references for infrastructure packages.
+
+    Blueprints live at ``config_repo_root/blueprints/<name>/`` where
+    *config_repo_root* is the parent of the ``envs/`` directory (i.e.
+    ``base_dir.parent``).
+
+    A blueprint directory must contain a ``blueprint.yaml`` manifest with
+    at minimum a ``name`` field.  Optional fields: ``description``,
+    ``version``, ``defaults`` (dict), ``resources`` (list), ``events``
+    (dict), ``inventory`` (dict).
+    """
+
+    def __init__(self, base_dir: Path) -> None:
+        """Initialize the blueprint resolver.
+
+        Args:
+            base_dir: The ``envs/`` directory (same as PackageLoader.base_dir).
+                The blueprints directory is resolved as ``base_dir.parent / "blueprints"``.
+        """
+        self.base_dir = base_dir
+        self.blueprints_dir = base_dir.parent / "blueprints"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def resolve(self, blueprint_name: str) -> dict[str, Any]:
+        """Load and return a blueprint manifest by name.
+
+        Args:
+            blueprint_name: Name of the blueprint (directory name under
+                ``blueprints/``).
+
+        Returns:
+            Parsed blueprint manifest as a dictionary with keys:
+            ``name``, ``description``, ``version``, ``defaults``,
+            ``resources``, ``events``, ``inventory``, ``blueprint_dir``.
+
+        Raises:
+            InvalidConfigurationError: If the blueprint directory or
+                manifest is missing/invalid.
+        """
+        blueprint_dir = self.blueprints_dir / blueprint_name
+        if not blueprint_dir.is_dir():
+            raise InvalidConfigurationError(
+                f"Blueprint '{blueprint_name}' not found at {blueprint_dir}"
+            )
+
+        manifest_path = blueprint_dir / BLUEPRINT_MANIFEST
+        if not manifest_path.exists():
+            raise InvalidConfigurationError(f"Blueprint manifest not found: {manifest_path}")
+
+        data = self._load_manifest(manifest_path)
+        self._validate_manifest(data, manifest_path)
+
+        # Normalise optional fields
+        result: dict[str, Any] = {
+            "name": data["name"],
+            "description": data.get("description"),
+            "version": data.get("version"),
+            "defaults": data.get("defaults", {}),
+            "resources": data.get("resources", []),
+            "events": data.get("events", {}),
+            "inventory": data.get("inventory"),
+            "blueprint_dir": blueprint_dir,
+        }
+
+        logger.debug(
+            "Resolved blueprint '%s' from %s",
+            blueprint_name,
+            blueprint_dir,
+        )
+        return result
+
+    def exists(self, blueprint_name: str) -> bool:
+        """Check whether a named blueprint exists.
+
+        Args:
+            blueprint_name: Blueprint directory name.
+
+        Returns:
+            ``True`` if the blueprint directory and manifest exist.
+        """
+        blueprint_dir = self.blueprints_dir / blueprint_name
+        return (blueprint_dir / BLUEPRINT_MANIFEST).is_file()
+
+    def list_blueprints(self) -> list[str]:
+        """List all available blueprint names.
+
+        Returns:
+            Sorted list of blueprint directory names that contain a valid
+            ``blueprint.yaml``.
+        """
+        if not self.blueprints_dir.is_dir():
+            return []
+
+        return sorted(
+            d.name
+            for d in self.blueprints_dir.iterdir()
+            if d.is_dir() and (d / BLUEPRINT_MANIFEST).is_file()
+        )
+
+    def resolve_file(
+        self,
+        filename: str,
+        package_dir: Path,
+        blueprint_dir: Path,
+    ) -> Path:
+        """Resolve a file path with package-first, blueprint fallback.
+
+        Args:
+            filename: Relative filename to look up (e.g. ``vm.yaml`` or
+                ``scripts/setup.sh``).
+            package_dir: The package directory to check first.
+            blueprint_dir: The blueprint directory to check as fallback.
+
+        Returns:
+            Resolved absolute path to the file.
+
+        Raises:
+            InvalidConfigurationError: If the file is not found in either
+                location.
+        """
+        package_path = package_dir / filename
+        if package_path.exists():
+            return package_path
+
+        blueprint_path = blueprint_dir / filename
+        if blueprint_path.exists():
+            return blueprint_path
+
+        raise InvalidConfigurationError(
+            f"File '{filename}' not found in package ({package_dir}) or blueprint ({blueprint_dir})"
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+        """Load a blueprint.yaml file.
+
+        Args:
+            manifest_path: Path to the blueprint.yaml file.
+
+        Returns:
+            Parsed YAML data.
+
+        Raises:
+            InvalidConfigurationError: On YAML errors.
+        """
+        try:
+            with open(manifest_path) as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise InvalidConfigurationError(
+                f"Invalid YAML in blueprint manifest {manifest_path}: {e}"
+            ) from e
+
+        if not data or not isinstance(data, dict):
+            raise InvalidConfigurationError(
+                f"Blueprint manifest must be a YAML mapping: {manifest_path}"
+            )
+
+        result: dict[str, Any] = data
+        return result
+
+    @staticmethod
+    def _validate_manifest(data: dict[str, Any], manifest_path: Path) -> None:
+        """Validate required fields in a blueprint manifest.
+
+        Args:
+            data: Parsed manifest data.
+            manifest_path: Path for error messages.
+
+        Raises:
+            InvalidConfigurationError: If required fields are missing.
+        """
+        if "name" not in data:
+            raise InvalidConfigurationError(
+                f"Blueprint manifest missing required 'name' field: {manifest_path}"
+            )

--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -8,6 +8,7 @@ from typing import Any
 import yaml
 
 from infrafoundry.core.base_manager import PathBasedManager
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
 from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
@@ -52,10 +53,11 @@ class ConfigManager(PathBasedManager):
         self.base_dir: Path = base_dir  # Type assertion - base_dir is always Path here
         self._log_debug(f"Initialized ConfigManager with base_dir: {self.base_dir}")
 
-        # Initialize loaders
-        self.provider_centric = ProviderCentricLoader(base_dir)
+        # Initialize blueprint resolver and loaders
+        self._blueprint_resolver = BlueprintResolver(base_dir)
+        self.provider_centric = ProviderCentricLoader(base_dir, self._blueprint_resolver)
         self.resource_centric = ResourceCentricLoader(base_dir)
-        self._package_loader = PackageLoader(base_dir)
+        self._package_loader = PackageLoader(base_dir, self._blueprint_resolver)
 
     def load_environment(self, env_name: str) -> EnvironmentConfig:
         """Load environment configuration.

--- a/src/infrafoundry/core/config/inventory_generator.py
+++ b/src/infrafoundry/core/config/inventory_generator.py
@@ -1,0 +1,136 @@
+"""Ansible inventory generator for infrastructure packages.
+
+Renders inventory declarations from package manifests into
+``.generated-inventory.yml`` files that Ansible can consume directly.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import jinja2
+import yaml
+
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+logger = logging.getLogger(__name__)
+
+GENERATED_INVENTORY_FILENAME = ".generated-inventory.yml"
+
+
+class InventoryGenerator:
+    """Generates Ansible inventory files from manifest declarations.
+
+    The ``inventory`` section of a package manifest (or blueprint) declares
+    host groups with optional Jinja2 templating.  This class renders those
+    declarations with the merged variable set and writes the result to
+    the package directory.
+    """
+
+    def generate(
+        self,
+        inventory_schema: dict[str, Any],
+        variables: dict[str, Any],
+        output_dir: Path,
+    ) -> Path:
+        """Render an inventory declaration and write it to disk.
+
+        Args:
+            inventory_schema: The ``inventory`` dict from the manifest.
+                Expected structure::
+
+                    groups:
+                      group_name:
+                        hosts:
+                          host_name:
+                            ansible_host: "{{ some_var }}"
+                        vars:
+                          key: value
+
+            variables: Merged variables for Jinja2 rendering.
+            output_dir: Directory to write the generated inventory file.
+
+        Returns:
+            Path to the generated inventory file.
+
+        Raises:
+            InvalidConfigurationError: If rendering or writing fails.
+        """
+        rendered = self._render_inventory(inventory_schema, variables)
+        output_path = output_dir / GENERATED_INVENTORY_FILENAME
+        self._write_inventory(rendered, output_path)
+
+        logger.info("Generated inventory at %s", output_path)
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _render_inventory(
+        self,
+        inventory_schema: dict[str, Any],
+        variables: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Render Jinja2 templates in an inventory schema.
+
+        Serialises the inventory dict to YAML, renders Jinja2, then
+        parses back to a dict.  This allows templates anywhere in the
+        structure (host names, vars, etc.).
+
+        Args:
+            inventory_schema: Raw inventory declaration.
+            variables: Template variables.
+
+        Returns:
+            Rendered inventory as a dict.
+
+        Raises:
+            InvalidConfigurationError: On template or YAML errors.
+        """
+        raw_yaml = yaml.dump(inventory_schema, default_flow_style=False)
+
+        try:
+            env = jinja2.Environment(
+                undefined=jinja2.StrictUndefined,
+            )  # nosec B701 - rendering YAML, not HTML
+            template = env.from_string(raw_yaml)
+            rendered_yaml = template.render(**variables)
+        except jinja2.UndefinedError as e:
+            raise InvalidConfigurationError(
+                f"Undefined variable in inventory declaration: {e}"
+            ) from e
+        except jinja2.TemplateSyntaxError as e:
+            raise InvalidConfigurationError(
+                f"Template syntax error in inventory declaration: {e}"
+            ) from e
+
+        try:
+            data = yaml.safe_load(rendered_yaml)
+        except yaml.YAMLError as e:
+            raise InvalidConfigurationError(f"Invalid YAML after rendering inventory: {e}") from e
+
+        if not isinstance(data, dict):
+            raise InvalidConfigurationError("Inventory declaration must render to a YAML mapping")
+
+        return data
+
+    @staticmethod
+    def _write_inventory(inventory: dict[str, Any], output_path: Path) -> None:
+        """Write inventory dict to a YAML file.
+
+        Args:
+            inventory: Rendered inventory data.
+            output_path: Destination file path.
+
+        Raises:
+            InvalidConfigurationError: If writing fails.
+        """
+        try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_path, "w") as f:
+                yaml.dump(inventory, f, default_flow_style=False, sort_keys=False)
+        except OSError as e:
+            raise InvalidConfigurationError(
+                f"Failed to write inventory file {output_path}: {e}"
+            ) from e

--- a/src/infrafoundry/core/config/models.py
+++ b/src/infrafoundry/core/config/models.py
@@ -130,6 +130,8 @@ class PackageManifest(BaseModel):
     name: str
     description: str | None = None
     provider: str | None = None
+    blueprint: str | None = None
     variables: dict[str, Any] = Field(default_factory=dict)
     resources: list[str] = Field(default_factory=list)
     events: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
+    inventory: dict[str, Any] | None = None

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -3,20 +3,32 @@
 Discovers and loads infrastructure packages from provider subdirectories.
 Each package is a directory containing an infrafoundry.yml manifest that
 declares variables, resource templates, and event handlers.
+
+Packages may reference a shared blueprint via ``blueprint: <name>`` in
+their manifest.  When a blueprint is referenced the loader merges
+blueprint defaults, inherits resources/events/inventory if the package
+does not declare its own, and resolves file paths with a
+package-first / blueprint-fallback strategy.
 """
+
+from __future__ import annotations
 
 import copy
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jinja2
 import yaml
 
+from infrafoundry.core.config.inventory_generator import InventoryGenerator
 from infrafoundry.core.config.models import PackageManifest
 from infrafoundry.core.config.sops import load_yaml_with_sops
 from infrafoundry.core.exceptions import InvalidConfigurationError
 from infrafoundry.core.provider import ResourceConfig
+
+if TYPE_CHECKING:
+    from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +69,22 @@ class PackageLoader:
         }
     )
 
-    def __init__(self, base_dir: Path) -> None:
+    def __init__(
+        self,
+        base_dir: Path,
+        blueprint_resolver: BlueprintResolver | None = None,
+    ) -> None:
         """Initialize package loader.
 
         Args:
             base_dir: Base directory for environment configs (e.g., ./envs)
+            blueprint_resolver: Optional resolver for blueprint references.
+                When ``None``, packages that declare ``blueprint:`` will
+                raise an error.
         """
         self.base_dir = base_dir
+        self._blueprint_resolver = blueprint_resolver
+        self._inventory_generator = InventoryGenerator()
 
     def discover_packages(self, env_name: str, provider: str) -> list[Path]:
         """Find subdirectories of a provider directory that contain a manifest.
@@ -129,8 +150,10 @@ class PackageLoader:
     ) -> tuple[list[ResourceConfig], dict[str, list[dict[str, Any]]], dict[str, Any]]:
         """Load an infrastructure package.
 
-        Parses the manifest, renders resource templates with variables,
-        and rewrites event handler script paths.
+        Parses the manifest, optionally resolves a blueprint reference,
+        merges variables (blueprint defaults < package < secrets),
+        renders resource templates, rewrites event handler script paths,
+        and generates inventory if declared.
 
         Args:
             package_dir: Path to the package directory
@@ -148,7 +171,36 @@ class PackageLoader:
         manifest_path = package_dir / self.MANIFEST_FILENAME
         manifest = self._parse_manifest(manifest_path)
 
-        # Load and merge secrets if secrets.yaml exists
+        # ----- Blueprint resolution -----
+        blueprint: dict[str, Any] | None = None
+        blueprint_dir: Path | None = None
+
+        if manifest.blueprint:
+            if self._blueprint_resolver is None:
+                raise InvalidConfigurationError(
+                    f"Package '{manifest.name}' references blueprint "
+                    f"'{manifest.blueprint}' but no blueprint resolver is configured"
+                )
+            blueprint = self._blueprint_resolver.resolve(manifest.blueprint)
+            blueprint_dir = blueprint["blueprint_dir"]
+
+            # Merge defaults: blueprint defaults < package variables
+            merged_vars: dict[str, Any] = {**blueprint["defaults"], **manifest.variables}
+            manifest.variables = merged_vars
+
+            # Inherit resources from blueprint if package doesn't declare its own
+            if not manifest.resources and blueprint["resources"]:
+                manifest.resources = list(blueprint["resources"])
+
+            # Inherit events from blueprint if package doesn't declare its own
+            if not manifest.events and blueprint["events"]:
+                manifest.events = dict(blueprint["events"])
+
+            # Inherit inventory from blueprint if package doesn't declare its own
+            if manifest.inventory is None and blueprint.get("inventory"):
+                manifest.inventory = dict(blueprint["inventory"])
+
+        # ----- Secrets -----
         secrets_path = package_dir / "secrets.yaml"
         if secrets_path.exists():
             secrets_data = load_yaml_with_sops(secrets_path)
@@ -165,34 +217,48 @@ class PackageLoader:
         effective_provider = manifest.provider or provider
 
         logger.debug(
-            "Loading package '%s' from %s (provider=%s, env=%s)",
+            "Loading package '%s' from %s (provider=%s, env=%s, blueprint=%s)",
             manifest.name,
             package_dir,
             effective_provider,
             env_name,
+            manifest.blueprint or "none",
         )
 
-        # Render and parse resource files
+        # ----- Resources -----
         resources: list[ResourceConfig] = []
         for resource_file in manifest.resources:
-            resource_path = package_dir / resource_file
+            resource_path = self._resolve_package_file(resource_file, package_dir, blueprint_dir)
             data = self._render_resource_file(resource_path, manifest.variables)
             parsed = self._parse_resources_from_data(data, resource_file, effective_provider)
             resources.extend(parsed)
 
-        # Rewrite event script paths (package-level)
+        # ----- Events -----
         env_dir = self.base_dir / env_name
-        events = self._rewrite_event_scripts(manifest.events, package_dir, env_dir)
+        events = self._rewrite_event_scripts(
+            manifest.events, package_dir, env_dir, blueprint_dir=blueprint_dir
+        )
 
         # Tag each handler config with its originating package name
         for _event_key, handler_list in events.items():
             for handler_config in handler_list:
                 handler_config["_package"] = manifest.name
+                if blueprint_dir:
+                    handler_config["_blueprint_dir"] = str(blueprint_dir)
 
         # Rewrite resource-level event script paths
         for resource in resources:
             if resource.events:
-                resource.events = self._rewrite_event_scripts(resource.events, package_dir, env_dir)
+                resource.events = self._rewrite_event_scripts(
+                    resource.events, package_dir, env_dir, blueprint_dir=blueprint_dir
+                )
+
+        # ----- Inventory generation -----
+        if manifest.inventory:
+            inventory_path = self._inventory_generator.generate(
+                manifest.inventory, manifest.variables, package_dir
+            )
+            logger.info("Generated inventory for package '%s': %s", manifest.name, inventory_path)
 
         return resources, events, dict(manifest.variables)
 
@@ -368,21 +434,55 @@ class PackageLoader:
             )
         return result
 
+    def _resolve_package_file(
+        self,
+        filename: str,
+        package_dir: Path,
+        blueprint_dir: Path | None,
+    ) -> Path:
+        """Resolve a file with package-first, blueprint fallback.
+
+        Args:
+            filename: Relative filename to locate.
+            package_dir: Package directory (checked first).
+            blueprint_dir: Blueprint directory (fallback).  ``None``
+                means no fallback.
+
+        Returns:
+            Absolute path to the resolved file.
+
+        Raises:
+            InvalidConfigurationError: If the file is not found.
+        """
+        if self._blueprint_resolver and blueprint_dir:
+            return self._blueprint_resolver.resolve_file(filename, package_dir, blueprint_dir)
+
+        package_path = package_dir / filename
+        if not package_path.exists():
+            raise InvalidConfigurationError(f"Resource file not found: {package_path}")
+        return package_path
+
     def _rewrite_event_scripts(
         self,
         events: dict[str, list[dict[str, Any]]],
         package_dir: Path,
         env_dir: Path,
+        *,
+        blueprint_dir: Path | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
-        """Rewrite script paths in event handlers to be relative to env dir.
+        """Rewrite script paths in event handlers.
 
-        For each handler with type=script, the script path is prepended
-        with the relative path from the env directory to the package directory.
+        For each handler with type=script, the script path is resolved
+        using the package-first / blueprint-fallback strategy.  If the
+        script lives in the package dir the path is rewritten relative
+        to *env_dir*.  If it lives in the blueprint dir an absolute path
+        is stored instead (because the blueprint is outside the env tree).
 
         Args:
             events: Event handler configurations from the manifest
             package_dir: Path to the package directory
             env_dir: Path to the environment directory
+            blueprint_dir: Optional blueprint directory for fallback
 
         Returns:
             Deep copy of events with rewritten script paths
@@ -390,12 +490,50 @@ class PackageLoader:
         if not events:
             return {}
 
-        rel_path = package_dir.relative_to(env_dir)
         rewritten = copy.deepcopy(events)
 
         for _, handlers in rewritten.items():
             for handler in handlers:
                 if handler.get("type") == "script" and "script" in handler:
-                    handler["script"] = str(rel_path / handler["script"])
+                    script_name = handler["script"]
+
+                    # Resolve script file location
+                    resolved = self._resolve_script_path(
+                        script_name, package_dir, env_dir, blueprint_dir
+                    )
+                    handler["script"] = resolved
 
         return rewritten
+
+    def _resolve_script_path(
+        self,
+        script_name: str,
+        package_dir: Path,
+        env_dir: Path,
+        blueprint_dir: Path | None,
+    ) -> str:
+        """Resolve a single script path.
+
+        Args:
+            script_name: Script filename from the manifest.
+            package_dir: Package directory.
+            env_dir: Environment directory.
+            blueprint_dir: Optional blueprint directory.
+
+        Returns:
+            Rewritten path string (relative to env_dir or absolute for
+            blueprint scripts).
+        """
+        package_script = package_dir / script_name
+        if package_script.exists():
+            rel_path = package_dir.relative_to(env_dir)
+            return str(rel_path / script_name)
+
+        if blueprint_dir:
+            blueprint_script = blueprint_dir / script_name
+            if blueprint_script.exists():
+                return str(blueprint_script)
+
+        # Fall back to package-relative (original behaviour)
+        rel_path = package_dir.relative_to(env_dir)
+        return str(rel_path / script_name)

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -3,26 +3,36 @@
 Loads resources from envs/{env}/{provider}/*.yaml files.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.provider import ResourceConfig
 
+if TYPE_CHECKING:
+    from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+
 
 class ProviderCentricLoader:
     """Loads resources from provider-centric directory structure."""
 
-    def __init__(self, base_dir: Path) -> None:
+    def __init__(
+        self,
+        base_dir: Path,
+        blueprint_resolver: BlueprintResolver | None = None,
+    ) -> None:
         """Initialize loader.
 
         Args:
             base_dir: Base directory for environment configs (e.g., ./envs)
+            blueprint_resolver: Optional resolver for blueprint references.
         """
         self.base_dir = base_dir
-        self._package_loader = PackageLoader(base_dir)
+        self._package_loader = PackageLoader(base_dir, blueprint_resolver)
         self._pending_package_events: dict[str, list[dict[str, Any]]] = {}
 
     def load_resources(

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -95,8 +95,17 @@ class ScriptHandler(BaseHandler):
             EventResult with script output
         """
         env_dir = self.config_base_dir / "envs" / context.environment
-        script_path = env_dir / self.config["script"]
+        raw_script = self.config["script"]
         timeout = self.config.get("timeout", 300)
+
+        # Resolve script path: absolute paths (from blueprint resolution)
+        # are used directly; relative paths are resolved against env_dir
+        script_candidate = Path(raw_script)
+        script_path = script_candidate if script_candidate.is_absolute() else env_dir / raw_script
+
+        # Determine working directory: blueprint dir if set, else env_dir
+        blueprint_dir_str = self.config.get("_blueprint_dir")
+        working_dir = Path(blueprint_dir_str) if blueprint_dir_str else env_dir
 
         # Validate script exists
         if not script_path.exists():
@@ -117,12 +126,23 @@ class ScriptHandler(BaseHandler):
         # Prepare environment
         env = self._prepare_environment(context, env_dir)
 
+        # Inject blueprint-specific env vars
+        if blueprint_dir_str:
+            env["INFRAFOUNDRY_BLUEPRINT_DIR"] = blueprint_dir_str
+
+        # Inject inventory path if a generated inventory exists
+        package_dir = self.config.get("_package_dir")
+        if package_dir:
+            inventory_path = Path(package_dir) / ".generated-inventory.yml"
+            if inventory_path.exists():
+                env["INFRAFOUNDRY_INVENTORY"] = str(inventory_path)
+
         # Execute script with real-time streaming
         start_time = time.monotonic()
         try:
             process = subprocess.Popen(  # nosec B603 - user-controlled scripts
                 [str(script_path)],
-                cwd=env_dir,
+                cwd=working_dir,
                 env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/tests/unit/test_blueprint_resolver.py
+++ b/tests/unit/test_blueprint_resolver.py
@@ -1,0 +1,289 @@
+"""Unit tests for BlueprintResolver."""
+
+import pytest
+import yaml
+
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+
+def _create_blueprint(base_dir, name, manifest_data, extra_files=None):
+    """Helper to create a blueprint directory structure.
+
+    Args:
+        base_dir: The envs/ directory (blueprints dir is base_dir.parent / "blueprints")
+        name: Blueprint name (directory name)
+        manifest_data: Dict for blueprint.yaml content
+        extra_files: Optional dict of relative_path -> content
+    """
+    blueprints_dir = base_dir.parent / "blueprints"
+    blueprint_dir = blueprints_dir / name
+    blueprint_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = blueprint_dir / "blueprint.yaml"
+    with open(manifest_path, "w") as f:
+        yaml.dump(manifest_data, f)
+
+    if extra_files:
+        for rel_path, content in extra_files.items():
+            file_path = blueprint_dir / rel_path
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, str):
+                file_path.write_text(content)
+            else:
+                with open(file_path, "w") as f:
+                    yaml.dump(content, f)
+
+    return blueprint_dir
+
+
+@pytest.mark.unit
+class TestBlueprintResolverResolve:
+    """Tests for BlueprintResolver.resolve."""
+
+    def test_resolve_full_blueprint(self, temp_dir):
+        """All fields are parsed and returned correctly."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        manifest = {
+            "name": "ontap-cluster",
+            "description": "ONTAP cluster blueprint",
+            "version": "1.0.0",
+            "defaults": {"cluster_name": "default-cluster", "node_count": 2},
+            "resources": ["vm.yaml", "network.yaml"],
+            "events": {"AFTER_APPLY": [{"type": "script", "script": "scripts/setup.sh"}]},
+            "inventory": {"groups": {"hosts": {"host1": {}}}},
+        }
+        _create_blueprint(envs_dir, "ontap-cluster", manifest)
+
+        result = resolver.resolve("ontap-cluster")
+
+        assert result["name"] == "ontap-cluster"
+        assert result["description"] == "ONTAP cluster blueprint"
+        assert result["version"] == "1.0.0"
+        assert result["defaults"]["cluster_name"] == "default-cluster"
+        assert result["resources"] == ["vm.yaml", "network.yaml"]
+        assert len(result["events"]["AFTER_APPLY"]) == 1
+        assert result["inventory"]["groups"]["hosts"]["host1"] == {}
+        assert result["blueprint_dir"].name == "ontap-cluster"
+
+    def test_resolve_minimal_blueprint(self, temp_dir):
+        """Name-only blueprint works with defaults for optional fields."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        _create_blueprint(envs_dir, "minimal", {"name": "minimal"})
+
+        result = resolver.resolve("minimal")
+
+        assert result["name"] == "minimal"
+        assert result["description"] is None
+        assert result["version"] is None
+        assert result["defaults"] == {}
+        assert result["resources"] == []
+        assert result["events"] == {}
+        assert result["inventory"] is None
+
+    def test_resolve_nonexistent_blueprint(self, temp_dir):
+        """Resolving a missing blueprint raises InvalidConfigurationError."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        with pytest.raises(InvalidConfigurationError, match="not found"):
+            resolver.resolve("nonexistent")
+
+    def test_resolve_missing_manifest(self, temp_dir):
+        """Directory without blueprint.yaml raises InvalidConfigurationError."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        # Create directory without manifest
+        bp_dir = envs_dir.parent / "blueprints" / "no-manifest"
+        bp_dir.mkdir(parents=True)
+
+        with pytest.raises(InvalidConfigurationError, match="manifest not found"):
+            resolver.resolve("no-manifest")
+
+    def test_resolve_invalid_yaml(self, temp_dir):
+        """Invalid YAML in manifest raises InvalidConfigurationError."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        bp_dir = envs_dir.parent / "blueprints" / "bad-yaml"
+        bp_dir.mkdir(parents=True)
+        (bp_dir / "blueprint.yaml").write_text("invalid: yaml: content::\n")
+
+        with pytest.raises(InvalidConfigurationError, match="Invalid YAML"):
+            resolver.resolve("bad-yaml")
+
+    def test_resolve_missing_name_field(self, temp_dir):
+        """Manifest without name field raises InvalidConfigurationError."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        _create_blueprint(envs_dir, "no-name", {"description": "missing name"})
+
+        with pytest.raises(InvalidConfigurationError, match="missing required 'name'"):
+            resolver.resolve("no-name")
+
+    def test_resolve_empty_manifest(self, temp_dir):
+        """Empty manifest file raises InvalidConfigurationError."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        bp_dir = envs_dir.parent / "blueprints" / "empty"
+        bp_dir.mkdir(parents=True)
+        (bp_dir / "blueprint.yaml").write_text("")
+
+        with pytest.raises(InvalidConfigurationError, match="must be a YAML mapping"):
+            resolver.resolve("empty")
+
+
+@pytest.mark.unit
+class TestBlueprintResolverExists:
+    """Tests for BlueprintResolver.exists."""
+
+    def test_exists_returns_true(self, temp_dir):
+        """Returns True for valid blueprint."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        _create_blueprint(envs_dir, "test-bp", {"name": "test-bp"})
+
+        assert resolver.exists("test-bp") is True
+
+    def test_exists_returns_false_missing(self, temp_dir):
+        """Returns False for non-existent blueprint."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        assert resolver.exists("nonexistent") is False
+
+    def test_exists_returns_false_no_manifest(self, temp_dir):
+        """Returns False for directory without blueprint.yaml."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        bp_dir = envs_dir.parent / "blueprints" / "no-manifest"
+        bp_dir.mkdir(parents=True)
+
+        assert resolver.exists("no-manifest") is False
+
+
+@pytest.mark.unit
+class TestBlueprintResolverListBlueprints:
+    """Tests for BlueprintResolver.list_blueprints."""
+
+    def test_list_blueprints(self, temp_dir):
+        """Lists all valid blueprints sorted by name."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        _create_blueprint(envs_dir, "zeta-bp", {"name": "zeta"})
+        _create_blueprint(envs_dir, "alpha-bp", {"name": "alpha"})
+
+        result = resolver.list_blueprints()
+        assert result == ["alpha-bp", "zeta-bp"]
+
+    def test_list_blueprints_empty(self, temp_dir):
+        """Returns empty list when no blueprints directory exists."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        assert resolver.list_blueprints() == []
+
+    def test_list_blueprints_skips_invalid(self, temp_dir):
+        """Skips directories without blueprint.yaml."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        _create_blueprint(envs_dir, "valid", {"name": "valid"})
+        # Create dir without manifest
+        (envs_dir.parent / "blueprints" / "invalid").mkdir(parents=True)
+
+        result = resolver.list_blueprints()
+        assert result == ["valid"]
+
+
+@pytest.mark.unit
+class TestBlueprintResolverResolveFile:
+    """Tests for BlueprintResolver.resolve_file."""
+
+    def test_resolve_file_from_package(self, temp_dir):
+        """File in package dir is preferred over blueprint."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        package_dir = temp_dir / "pkg"
+        package_dir.mkdir()
+        (package_dir / "vm.yaml").write_text("vm: []\n")
+
+        blueprint_dir = temp_dir / "bp"
+        blueprint_dir.mkdir()
+        (blueprint_dir / "vm.yaml").write_text("bp_vm: []\n")
+
+        result = resolver.resolve_file("vm.yaml", package_dir, blueprint_dir)
+        assert result == package_dir / "vm.yaml"
+
+    def test_resolve_file_fallback_to_blueprint(self, temp_dir):
+        """File not in package falls back to blueprint."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        package_dir = temp_dir / "pkg"
+        package_dir.mkdir()
+
+        blueprint_dir = temp_dir / "bp"
+        blueprint_dir.mkdir()
+        (blueprint_dir / "vm.yaml").write_text("bp_vm: []\n")
+
+        result = resolver.resolve_file("vm.yaml", package_dir, blueprint_dir)
+        assert result == blueprint_dir / "vm.yaml"
+
+    def test_resolve_file_nested_path(self, temp_dir):
+        """Nested paths (scripts/setup.sh) resolve correctly."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        package_dir = temp_dir / "pkg"
+        package_dir.mkdir()
+
+        blueprint_dir = temp_dir / "bp"
+        scripts_dir = blueprint_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "setup.sh").write_text("#!/bin/bash\n")
+
+        result = resolver.resolve_file("scripts/setup.sh", package_dir, blueprint_dir)
+        assert result == blueprint_dir / "scripts" / "setup.sh"
+
+    def test_resolve_file_not_found(self, temp_dir):
+        """File in neither location raises InvalidConfigurationError."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = BlueprintResolver(envs_dir)
+
+        package_dir = temp_dir / "pkg"
+        package_dir.mkdir()
+
+        blueprint_dir = temp_dir / "bp"
+        blueprint_dir.mkdir()
+
+        with pytest.raises(InvalidConfigurationError, match="not found"):
+            resolver.resolve_file("missing.yaml", package_dir, blueprint_dir)

--- a/tests/unit/test_inventory_generator.py
+++ b/tests/unit/test_inventory_generator.py
@@ -1,0 +1,170 @@
+"""Unit tests for InventoryGenerator."""
+
+import pytest
+import yaml
+
+from infrafoundry.core.config.inventory_generator import (
+    GENERATED_INVENTORY_FILENAME,
+    InventoryGenerator,
+)
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+
+@pytest.mark.unit
+class TestInventoryGeneratorGenerate:
+    """Tests for InventoryGenerator.generate."""
+
+    def test_generate_simple_inventory(self, temp_dir):
+        """Generates a valid inventory file from a simple schema."""
+        generator = InventoryGenerator()
+        schema = {
+            "groups": {
+                "webservers": {
+                    "hosts": {
+                        "web-01": {
+                            "ansible_host": "192.168.1.10",
+                        }
+                    },
+                    "vars": {
+                        "ansible_user": "root",
+                    },
+                }
+            }
+        }
+
+        output_path = generator.generate(schema, {}, temp_dir)
+
+        assert output_path == temp_dir / GENERATED_INVENTORY_FILENAME
+        assert output_path.exists()
+
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["groups"]["webservers"]["hosts"]["web-01"]["ansible_host"] == "192.168.1.10"
+        assert data["groups"]["webservers"]["vars"]["ansible_user"] == "root"
+
+    def test_generate_with_jinja2_variables(self, temp_dir):
+        """Jinja2 templates in schema are rendered with variables."""
+        generator = InventoryGenerator()
+        schema = {
+            "groups": {
+                "cluster": {
+                    "hosts": {
+                        "node-01": {
+                            "ansible_host": "{{ node01_ip }}",
+                        }
+                    }
+                }
+            }
+        }
+        variables = {"node01_ip": "10.0.0.1"}
+
+        output_path = generator.generate(schema, variables, temp_dir)
+
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["groups"]["cluster"]["hosts"]["node-01"]["ansible_host"] == "10.0.0.1"
+
+    def test_generate_undefined_variable_raises(self, temp_dir):
+        """Undefined variables in schema raise InvalidConfigurationError."""
+        generator = InventoryGenerator()
+        schema = {
+            "groups": {
+                "cluster": {
+                    "hosts": {
+                        "node-01": {
+                            "ansible_host": "{{ missing_var }}",
+                        }
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(InvalidConfigurationError, match="Undefined variable"):
+            generator.generate(schema, {}, temp_dir)
+
+    def test_generate_overwrites_existing(self, temp_dir):
+        """Generating inventory overwrites an existing file."""
+        generator = InventoryGenerator()
+        existing = temp_dir / GENERATED_INVENTORY_FILENAME
+        existing.write_text("old: content\n")
+
+        schema = {"groups": {"new": {"hosts": {"h1": {}}}}}
+        generator.generate(schema, {}, temp_dir)
+
+        with open(existing) as f:
+            data = yaml.safe_load(f)
+
+        assert "new" in data["groups"]
+        assert "old" not in data
+
+    def test_generate_creates_parent_dirs(self, temp_dir):
+        """Parent directories are created if they don't exist."""
+        generator = InventoryGenerator()
+        output_dir = temp_dir / "deep" / "nested" / "dir"
+
+        schema = {"groups": {"test": {"hosts": {}}}}
+        output_path = generator.generate(schema, {}, output_dir)
+
+        assert output_path.exists()
+
+    def test_generate_multiple_groups(self, temp_dir):
+        """Multiple groups are rendered correctly."""
+        generator = InventoryGenerator()
+        schema = {
+            "groups": {
+                "proxmox_hosts": {
+                    "hosts": {
+                        "pve1": {"ansible_host": "{{ pve1_ip }}"},
+                        "pve2": {"ansible_host": "{{ pve2_ip }}"},
+                    },
+                    "vars": {"ansible_user": "root"},
+                },
+                "ontap_cluster": {
+                    "hosts": {
+                        "ontap-mgmt": {
+                            "ansible_host": "{{ cluster_mgmt_ip }}",
+                            "ansible_connection": "local",
+                        }
+                    },
+                },
+            }
+        }
+        variables = {
+            "pve1_ip": "192.168.10.1",
+            "pve2_ip": "192.168.10.2",
+            "cluster_mgmt_ip": "192.168.10.203",
+        }
+
+        output_path = generator.generate(schema, variables, temp_dir)
+
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["groups"]["proxmox_hosts"]["hosts"]["pve1"]["ansible_host"] == "192.168.10.1"
+        assert data["groups"]["ontap_cluster"]["hosts"]["ontap-mgmt"]["ansible_connection"] == (
+            "local"
+        )
+
+
+@pytest.mark.unit
+class TestInventoryGeneratorRenderInventory:
+    """Tests for InventoryGenerator._render_inventory."""
+
+    def test_render_template_syntax_error(self, temp_dir):
+        """Template syntax error raises InvalidConfigurationError."""
+        generator = InventoryGenerator()
+        schema = {"groups": {"test": {"hosts": {"h1": {"ip": "{{ broken }"}}}}}
+
+        with pytest.raises(InvalidConfigurationError, match="Template syntax error"):
+            generator._render_inventory(schema, {})
+
+    def test_render_non_dict_result(self, temp_dir):
+        """Non-dict rendering result raises InvalidConfigurationError."""
+        generator = InventoryGenerator()
+        # A schema that renders to a list
+        schema = ["item1", "item2"]
+
+        with pytest.raises(InvalidConfigurationError, match="must render to a YAML mapping"):
+            generator._render_inventory(schema, {})

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -3,6 +3,8 @@
 import pytest
 import yaml
 
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+from infrafoundry.core.config.inventory_generator import GENERATED_INVENTORY_FILENAME
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.exceptions import InvalidConfigurationError
 
@@ -635,3 +637,423 @@ resources:
         assert len(resources) == 1
         assert resources[0].name == "ontap-01"
         assert resources[0].config["vmid"] == 220
+
+
+def _create_blueprint(base_dir, name, manifest_data, extra_files=None):
+    """Helper to create a blueprint directory under config_repo/blueprints/.
+
+    Args:
+        base_dir: The envs/ directory (base_dir.parent / "blueprints" is used)
+        name: Blueprint name
+        manifest_data: Dict for blueprint.yaml
+        extra_files: Optional dict of relative_path -> content
+    """
+    blueprint_dir = base_dir.parent / "blueprints" / name
+    blueprint_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = blueprint_dir / "blueprint.yaml"
+    with open(manifest_path, "w") as f:
+        yaml.dump(manifest_data, f)
+
+    if extra_files:
+        for rel_path, content in extra_files.items():
+            file_path = blueprint_dir / rel_path
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, str):
+                file_path.write_text(content)
+            else:
+                with open(file_path, "w") as f:
+                    yaml.dump(content, f)
+
+    return blueprint_dir
+
+
+@pytest.mark.unit
+class TestBlueprintIntegration:
+    """Tests for blueprint resolution in PackageLoader."""
+
+    def test_blueprint_defaults_merged(self, temp_dir):
+        """Blueprint defaults are merged under package variables."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "test-bp",
+            {
+                "name": "test-bp",
+                "defaults": {"cluster_name": "default-cluster", "node_count": 2},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ cluster_name }}-node\n    count: {{ node_count }}\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        # Package overrides cluster_name but inherits node_count
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "my-cluster",
+            {
+                "name": "my-cluster",
+                "blueprint": "test-bp",
+                "variables": {"cluster_name": "prod-cluster"},
+            },
+        )
+
+        resources, _, variables = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "prod-cluster-node"
+        assert variables["cluster_name"] == "prod-cluster"
+        assert variables["node_count"] == 2
+
+    def test_blueprint_resources_inherited(self, temp_dir):
+        """Package without resources inherits from blueprint."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "infra-bp",
+            {
+                "name": "infra-bp",
+                "defaults": {"vm_name": "web"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ vm_name }}-01\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "web-pkg",
+            {
+                "name": "web-pkg",
+                "blueprint": "infra-bp",
+            },
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "web-01"
+
+    def test_blueprint_events_inherited(self, temp_dir):
+        """Package without events inherits from blueprint."""
+        resolver = BlueprintResolver(temp_dir)
+        bp_dir = _create_blueprint(
+            temp_dir,
+            "event-bp",
+            {
+                "name": "event-bp",
+                "events": {"AFTER_APPLY": [{"type": "script", "script": "scripts/setup.sh"}]},
+            },
+            {"scripts/setup.sh": "#!/bin/bash\necho setup\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "event-pkg",
+            {
+                "name": "event-pkg",
+                "blueprint": "event-bp",
+            },
+        )
+
+        _, events, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert "AFTER_APPLY" in events
+        # Script resolves to blueprint (absolute path) since not in package
+        assert str(bp_dir) in events["AFTER_APPLY"][0]["script"]
+
+    def test_package_overrides_blueprint_resources(self, temp_dir):
+        """Package's own resources take priority over blueprint."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "override-bp",
+            {
+                "name": "override-bp",
+                "defaults": {"name_prefix": "bp"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ name_prefix }}-node\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "custom-pkg",
+            {
+                "name": "custom-pkg",
+                "blueprint": "override-bp",
+                "variables": {"name_prefix": "custom"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ name_prefix }}-custom\n"},
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "custom-custom"
+
+    def test_blueprint_file_fallback(self, temp_dir):
+        """Resource files fall back to blueprint dir when not in package."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "fallback-bp",
+            {
+                "name": "fallback-bp",
+                "defaults": {"host": "web"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ host }}-server\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        # Package references vm.yaml from blueprint resources,
+        # but does NOT have vm.yaml locally
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "fallback-pkg",
+            {
+                "name": "fallback-pkg",
+                "blueprint": "fallback-bp",
+            },
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "web-server"
+
+    def test_package_file_preferred_over_blueprint(self, temp_dir):
+        """Package's own resource file is used even if blueprint has same name."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "prefer-bp",
+            {
+                "name": "prefer-bp",
+                "defaults": {"x": "bp-value"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: blueprint-vm\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "prefer-pkg",
+            {
+                "name": "prefer-pkg",
+                "blueprint": "prefer-bp",
+            },
+            {"vm.yaml": "vm:\n  - name: package-vm\n"},
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "package-vm"
+
+    def test_no_blueprint_works_unchanged(self, temp_dir):
+        """Packages without blueprint: key work exactly as before."""
+        resolver = BlueprintResolver(temp_dir)
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "normal-pkg",
+            {
+                "name": "normal-pkg",
+                "variables": {"prefix": "app"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ prefix }}-01\n"},
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "app-01"
+
+    def test_blueprint_without_resolver_raises(self, temp_dir):
+        """Package referencing blueprint without resolver raises error."""
+        loader = PackageLoader(temp_dir)  # No resolver
+
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "bad-pkg",
+            {
+                "name": "bad-pkg",
+                "blueprint": "nonexistent",
+            },
+        )
+
+        with pytest.raises(InvalidConfigurationError, match="no blueprint resolver"):
+            loader.load_package(pkg_dir, "proxmox", "dev")
+
+    def test_blueprint_inventory_inherited(self, temp_dir):
+        """Inventory from blueprint is inherited and generated."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "inv-bp",
+            {
+                "name": "inv-bp",
+                "defaults": {"host_ip": "10.0.0.1"},
+                "inventory": {
+                    "groups": {
+                        "servers": {
+                            "hosts": {
+                                "server-01": {
+                                    "ansible_host": "{{ host_ip }}",
+                                }
+                            }
+                        }
+                    }
+                },
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "inv-pkg",
+            {
+                "name": "inv-pkg",
+                "blueprint": "inv-bp",
+            },
+        )
+
+        loader.load_package(pkg_dir, "proxmox", "dev")
+
+        inventory_path = pkg_dir / GENERATED_INVENTORY_FILENAME
+        assert inventory_path.exists()
+
+        with open(inventory_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["groups"]["servers"]["hosts"]["server-01"]["ansible_host"] == "10.0.0.1"
+
+    def test_package_inventory_overrides_blueprint(self, temp_dir):
+        """Package's own inventory overrides blueprint inventory."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "inv-override-bp",
+            {
+                "name": "inv-override-bp",
+                "defaults": {"host_ip": "10.0.0.1"},
+                "inventory": {"groups": {"blueprint_group": {"hosts": {"bp-host": {}}}}},
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "inv-override-pkg",
+            {
+                "name": "inv-override-pkg",
+                "blueprint": "inv-override-bp",
+                "inventory": {"groups": {"package_group": {"hosts": {"pkg-host": {}}}}},
+            },
+        )
+
+        loader.load_package(pkg_dir, "proxmox", "dev")
+
+        inventory_path = pkg_dir / GENERATED_INVENTORY_FILENAME
+        assert inventory_path.exists()
+
+        with open(inventory_path) as f:
+            data = yaml.safe_load(f)
+
+        assert "package_group" in data["groups"]
+        assert "blueprint_group" not in data["groups"]
+
+    def test_blueprint_handler_tagged_with_blueprint_dir(self, temp_dir):
+        """Event handlers from blueprint packages have _blueprint_dir tag."""
+        resolver = BlueprintResolver(temp_dir)
+        bp_dir = _create_blueprint(
+            temp_dir,
+            "tagged-bp",
+            {
+                "name": "tagged-bp",
+                "events": {"AFTER_APPLY": [{"type": "script", "script": "scripts/run.sh"}]},
+            },
+            {"scripts/run.sh": "#!/bin/bash\necho run\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "tagged-pkg",
+            {
+                "name": "tagged-pkg",
+                "blueprint": "tagged-bp",
+            },
+        )
+
+        _, events, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        handler = events["AFTER_APPLY"][0]
+        assert handler["_blueprint_dir"] == str(bp_dir)
+        assert handler["_package"] == "tagged-pkg"
+
+    def test_secrets_override_blueprint_defaults(self, temp_dir):
+        """Secrets take priority over both blueprint defaults and package vars."""
+        resolver = BlueprintResolver(temp_dir)
+        _create_blueprint(
+            temp_dir,
+            "secret-bp",
+            {
+                "name": "secret-bp",
+                "defaults": {"password": "bp-default", "host": "bp-host"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ host }}\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "secret-pkg",
+            {
+                "name": "secret-pkg",
+                "blueprint": "secret-bp",
+                "variables": {"host": "pkg-host"},
+            },
+            # secrets.yaml with variable overrides
+            {"secrets.yaml": "variables:\n  password: secret-password\n  host: secret-host\n"},
+        )
+
+        resources, _, variables = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        # Secrets override everything
+        assert variables["password"] == "secret-password"
+        assert variables["host"] == "secret-host"
+        assert resources[0].name == "secret-host"


### PR DESCRIPTION
## Description

Add a package blueprint system that separates reusable implementation (roles, playbooks, scripts, resource templates) from per-instance configuration. Packages can now reference a shared blueprint via `blueprint: <name>` in their manifest, inheriting defaults, resources, events, and inventory declarations while providing only instance-specific variables and secrets.

Also adds framework-level Ansible inventory generation: packages (or blueprints) declare an `inventory:` section in their manifest and the framework renders it with Jinja2 variables and writes `.generated-inventory.yml` before event handlers run.

Addresses #456
Also addresses #348

## Related Issue

Addresses #456
Also addresses #348

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

### Blueprint resolver (`blueprint_resolver.py` -- new)
- `BlueprintResolver` discovers blueprints from `config_repo/blueprints/<name>/`
- Loads and validates `blueprint.yaml` manifests (requires `name` field; optional `defaults`, `resources`, `events`, `inventory`)
- `resolve_file()` implements package-first / blueprint-fallback file resolution
- `list_blueprints()` and `exists()` for discovery

### Inventory generator (`inventory_generator.py` -- new)
- `InventoryGenerator` renders `inventory:` declarations with Jinja2 variables
- Writes `.generated-inventory.yml` to the package directory
- Supports templates anywhere in the inventory structure (host names, vars, etc.)

### Package loader changes
- Accepts optional `BlueprintResolver` via constructor injection
- Blueprint resolution: merges defaults (blueprint < package < secrets), inherits resources/events/inventory when package doesn't declare its own
- File resolution uses package-first / blueprint-fallback strategy
- Inventory generation runs after variable merge, before returning

### Event handler changes
- `ScriptHandler` resolves absolute paths from blueprint directories directly
- Injects `INFRAFOUNDRY_BLUEPRINT_DIR` and `INFRAFOUNDRY_INVENTORY` env vars
- Working directory set to blueprint dir when script originates from a blueprint

### Model changes
- `PackageManifest` gains `blueprint: str | None` and `inventory: dict | None` fields

### Wiring
- `ConfigManager` creates `BlueprintResolver` and passes it to loaders
- `ProviderCentricLoader` forwards resolver to `PackageLoader`
- `__init__.py` exports `BlueprintResolver` and `InventoryGenerator`

## Testing

- [x] All existing tests pass (`doit check` passes)
- [x] Added `tests/unit/test_blueprint_resolver.py` (289 lines) -- covers resolution, validation, file fallback, listing, error cases
- [x] Added `tests/unit/test_inventory_generator.py` (170 lines) -- covers rendering, Jinja2 templating, error handling
- [x] Extended `tests/unit/test_package_loader.py` (+420 lines) -- covers blueprint integration, variable merging, inheritance, inventory generation

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Documentation Note

The existing `docs/configuration/blueprints.md` documents the `infra new` scaffolding feature (a different concept). The new package blueprint system should be documented in `docs/configuration/infrastructure-packages.md` as an extension of the packages feature. This documentation update should be done as a follow-up or added to this PR before merge.

## Additional Notes

- Fully backward compatible -- packages without `blueprint:` work exactly as before
- Blueprint discovery is config-repo-scoped (`config_repo/blueprints/`)
- No `needs-adr` label on the issue, but this is an architectural addition worth considering for a future ADR
