### PR TITLE
fix: blueprint resolver, event rendering, and ontap-cluster blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ envs/
 *.yaml
 !example-config/**/*.yaml
 !src/**/*.yaml
+!blueprints/**/*.yaml
 !.sops.yaml
 !.pre-commit-config.yaml
 .env

--- a/blueprints/ontap-cluster/ansible.cfg
+++ b/blueprints/ontap-cluster/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles

--- a/blueprints/ontap-cluster/blueprint.yaml
+++ b/blueprints/ontap-cluster/blueprint.yaml
@@ -1,0 +1,90 @@
+name: ontap-cluster
+description: "NetApp ONTAP Simulator 2-node cluster on Proxmox"
+version: "1.0.0"
+
+defaults:
+  # --- VM Configuration ---
+  disk_storage: nas01
+  ova_source: "/mnt/pve/infra/appliances/ontap/9.18.1/vsim-netapp-DOT9.18.1-cm_nodar.ova"
+
+  # --- Network ---
+  bridge: vmbr0
+  mgmt_vlan: 10
+
+  # --- MAC Addresses (optional — set for DHCP reservations) ---
+  node01_mgmt_mac: ""
+  node01_data_mac: ""
+  node02_mgmt_mac: ""
+  node02_data_mac: ""
+
+  # --- Node 02 Identity (standard ONTAP simulator defaults) ---
+  node02_serial_number: "4034389-06-2"
+  node02_sysid: "4034389062"
+
+  # --- Netmasks/Gateways ---
+  cluster_mgmt_mask: "255.255.255.0"
+  node_mgmt_mask: "255.255.255.0"
+
+  # --- Licenses (standard ONTAP simulator keys) ---
+  ontap_cluster_base_license: SMKQROWJNQYQSDAAAAAAAAAAAAAA
+  ontap_licenses:
+    # Node 1 (Serial 4082368507)
+    - YVUCRRRRYVHXCFABGAAAAAAAAAAA   # CIFS
+    - WKQGSRRRYVHXCFABGAAAAAAAAAAA   # FCP
+    - SOHOURRRYVHXCFABGAAAAAAAAAAA   # FlexClone
+    - KQSRRRRRYVHXCFABGAAAAAAAAAAA   # iSCSI
+    - MBXNQRRRYVHXCFABGAAAAAAAAAAA   # NFS
+    - GUJZTRRRYVHXCFABGAAAAAAAAAAA   # SnapMirror
+    - UZLKTRRRYVHXCFABGAAAAAAAAAAA   # SnapRestore
+    - EJFDVRRRYVHXCFABGAAAAAAAAAAA   # SnapVault
+    # Node 2 (Serial 4034389062)
+    - MHEYKUNFXMSMUCEZFAAAAAAAAAAA   # CIFS
+    - KWZBMUNFXMSMUCEZFAAAAAAAAAAA   # FCP
+    - GARJOUNFXMSMUCEZFAAAAAAAAAAA   # FlexClone
+    - YBCNLUNFXMSMUCEZFAAAAAAAAAAA   # iSCSI
+    - ANGJKUNFXMSMUCEZFAAAAAAAAAAA   # NFS
+    - UFTUNUNFXMSMUCEZFAAAAAAAAAAA   # SnapMirror
+    - ILVFNUNFXMSMUCEZFAAAAAAAAAAA   # SnapRestore
+    - SUOYOUNFXMSMUCEZFAAAAAAAAAAA   # SnapVault
+
+  # --- Post-Cluster: SVM ---
+  svm_name: svm_data
+  data_lif_mask: "255.255.255.0"
+
+  # --- CIFS Server (workgroup mode) ---
+  cifs_server_name: ""
+  cifs_workgroup: WORKGROUP
+
+  # --- NFS Export Policy ---
+  nfs_export_policy: ""
+  nfs_client_match: ""
+
+  # --- Volumes ---
+  nfs_vol_name: ""
+  nfs_vol_aggregate: ""
+  nfs_vol_size: 1
+  cifs_vol_name: ""
+  cifs_vol_aggregate: ""
+  cifs_vol_size: 1
+
+  # --- DHCP ---
+  dhcp_subnet: opt1-infrastructure
+  data_lif1_mac: ""
+  data_lif2_mac: ""
+  cluster_mgmt_mac: "01:01:01:01:01:01"
+
+resources:
+  - vm.yaml
+  - dhcp.yaml
+
+events:
+  on_create:
+    - type: script
+      name: ontap-cluster-setup
+      script: scripts/ontap-post-terraform.sh
+      description: "Run ONTAP lab Ansible playbook after both VMs are created"
+      timeout: 3600
+      continue_on_error: false
+      requires:
+        - "{{ node01_name }}"
+        - "{{ node02_name }}"

--- a/blueprints/ontap-cluster/dhcp.yaml
+++ b/blueprints/ontap-cluster/dhcp.yaml
@@ -1,0 +1,57 @@
+# ONTAP Lab DHCP Reservations — Jinja2 template rendered by infrafoundry.yml variables
+# Uses resource-centric format for cross-provider resources (opnsense DHCP)
+#
+# NOTE: These reservations serve as DNS entries via Kea integrated DNS.
+# All IPs are statically assigned during ONTAP cluster setup, not via DHCP.
+# Placeholder MACs (e.g., 01:01:01:01:01:01) are used where the actual
+# MAC is not known or not applicable.
+resources:
+  - provider: opnsense
+    type: kea_reservation
+    name: "{{ node01_name }}"
+    config:
+      subnet_ref: "{{ dhcp_subnet }}"
+      hw_address: "{{ node01_mgmt_mac | lower }}"
+      ip_address: "{{ node01_mgmt_ip }}"
+      hostname: "{{ node01_name }}"
+      description: "ONTAP Simulator Node 1 (e0c mgmt)"
+
+  - provider: opnsense
+    type: kea_reservation
+    name: "{{ node02_name }}"
+    config:
+      subnet_ref: "{{ dhcp_subnet }}"
+      hw_address: "{{ node02_mgmt_mac | lower }}"
+      ip_address: "{{ node02_mgmt_ip }}"
+      hostname: "{{ node02_name }}"
+      description: "ONTAP Simulator Node 2 (e0c mgmt)"
+
+  - provider: opnsense
+    type: kea_reservation
+    name: "{{ cluster_name }}"
+    config:
+      subnet_ref: "{{ dhcp_subnet }}"
+      hw_address: "{{ cluster_mgmt_mac }}"
+      ip_address: "{{ cluster_mgmt_ip }}"
+      hostname: "{{ cluster_name }}"
+      description: "ONTAP Lab Cluster Management LIF"
+
+  - provider: opnsense
+    type: kea_reservation
+    name: "{{ cluster_name }}-data1"
+    config:
+      subnet_ref: "{{ dhcp_subnet }}"
+      hw_address: "{{ node01_data_mac | lower }}"
+      ip_address: "{{ data_lif1_ip }}"
+      hostname: "{{ cluster_name }}-data1"
+      description: "ONTAP Cluster Data LIF 1 ({{ svm_name }})"
+
+  - provider: opnsense
+    type: kea_reservation
+    name: "{{ cluster_name }}-data2"
+    config:
+      subnet_ref: "{{ dhcp_subnet }}"
+      hw_address: "{{ node02_data_mac | lower }}"
+      ip_address: "{{ data_lif2_ip }}"
+      hostname: "{{ cluster_name }}-data2"
+      description: "ONTAP Cluster Data LIF 2 ({{ svm_name }})"

--- a/blueprints/ontap-cluster/ontap-lab-cluster-setup.yml
+++ b/blueprints/ontap-cluster/ontap-lab-cluster-setup.yml
@@ -1,0 +1,138 @@
+---
+# ONTAP Simulator Lab — Cluster Setup Playbook
+#
+# Creates cluster on node 01, joins node 02, then configures via REST API.
+# Run AFTER serial setup (ontap-lab-serial-setup.yml).
+#
+# All variables are read from INFRAFOUNDRY_VAR_* environment variables
+# set by the InfraFoundry framework (includes merged secrets from secrets.yaml).
+
+- name: Create ONTAP cluster on node 01
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_target') }}"
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-cluster-setup
+      vars:
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_vmid') }}"
+        ontap_cluster_create: true
+        ontap_cluster_name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_name') }}"
+        ontap_cluster_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}"
+        ontap_cluster_mgmt_mask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_mask') }}"
+        ontap_cluster_mgmt_gateway: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_gateway') }}"
+        ontap_node_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_mgmt_ip') }}"
+        ontap_node_mgmt_mask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_mask') }}"
+        ontap_node_mgmt_gateway: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_gateway') }}"
+        ontap_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
+        ontap_dns_domain: "{{ lookup('env', 'INFRAFOUNDRY_VAR_dns_domain') }}"
+        ontap_cluster_base_license: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_cluster_base_license') }}"
+
+- name: Discover cluster interconnect IP from node 01
+  hosts: ontap_cluster
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Query cluster network interfaces
+      ansible.builtin.uri:
+        url: "https://{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}/api/network/ip/interfaces?ipspace.name=Cluster&fields=ip.address"
+        user: "admin"
+        password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
+        validate_certs: false
+        force_basic_auth: true
+      register: cluster_interfaces
+
+    - name: Set cluster interconnect IP fact
+      ansible.builtin.set_fact:
+        ontap_cluster_interconnect_ip: "{{ cluster_interfaces.json.records[0].ip.address }}"
+
+    - name: Display cluster interconnect IP
+      ansible.builtin.debug:
+        msg: "Cluster interconnect IP for join: {{ ontap_cluster_interconnect_ip }}"
+
+- name: Join ONTAP node 02 to cluster
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_target') }}"
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-cluster-setup
+      vars:
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_vmid') }}"
+        ontap_cluster_create: false
+        ontap_cluster_join_ip: "{{ hostvars['ontap-cluster']['ontap_cluster_interconnect_ip'] }}"
+        ontap_node_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_mgmt_ip') }}"
+        ontap_node_mgmt_mask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_mask') }}"
+        ontap_node_mgmt_gateway: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node_mgmt_gateway') }}"
+        ontap_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
+
+- name: Configure ONTAP cluster (aggregates, SVMs, LIFs)
+  hosts: ontap_cluster
+  gather_facts: false
+  connection: local
+  roles:
+    - role: ontap-post-cluster
+      vars:
+        ontap_cluster_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}"
+        ontap_admin_user: "admin"
+        ontap_admin_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
+        ontap_validate_certs: false
+        ontap_licenses: "{{ (lookup('env', 'INFRAFOUNDRY_PACKAGE_VARS') | from_json).get('ontap_licenses', []) if lookup('env', 'INFRAFOUNDRY_PACKAGE_VARS') else [] }}"
+        ontap_dns:
+          - vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+            domains:
+              - "{{ lookup('env', 'INFRAFOUNDRY_VAR_dns_domain') }}"
+            nameservers:
+              - "{{ lookup('env', 'INFRAFOUNDRY_VAR_dns_nameserver') }}"
+        ontap_ntp_servers:
+          - "{{ lookup('env', 'INFRAFOUNDRY_VAR_ntp_server') }}"
+        ontap_lifs:
+          - name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}_lif1"
+            vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+            role: data
+            protocol: nfs
+            node_index: 0
+            home_port: e0d
+            address: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif1_ip') }}"
+            netmask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif_mask') }}"
+          - name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}_lif2"
+            vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+            role: data
+            protocol: nfs
+            node_index: 1
+            home_port: e0d
+            address: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif2_ip') }}"
+            netmask: "{{ lookup('env', 'INFRAFOUNDRY_VAR_data_lif_mask') }}"
+        ontap_cifs_server:
+          name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cifs_server_name') }}"
+          vserver: "{{ lookup('env', 'INFRAFOUNDRY_VAR_svm_name') }}"
+          workgroup: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cifs_workgroup') }}"
+        ontap_export_policies: >-
+          {{
+            [{"name": lookup('env', 'INFRAFOUNDRY_VAR_nfs_export_policy'),
+              "vserver": lookup('env', 'INFRAFOUNDRY_VAR_svm_name'),
+              "rules": [{"client_match": lookup('env', 'INFRAFOUNDRY_VAR_nfs_client_match'),
+                         "protocols": ["nfs"], "ro_rule": ["sys"], "rw_rule": ["sys"], "super_user": ["sys"]}]
+             }]
+            if lookup('env', 'INFRAFOUNDRY_VAR_nfs_export_policy')
+            else []
+          }}
+        ontap_volumes: >-
+          {{
+            (
+              [{"name": lookup('env', 'INFRAFOUNDRY_VAR_nfs_vol_name'),
+                "vserver": lookup('env', 'INFRAFOUNDRY_VAR_svm_name'),
+                "aggregate": lookup('env', 'INFRAFOUNDRY_VAR_nfs_vol_aggregate'),
+                "size": lookup('env', 'INFRAFOUNDRY_VAR_nfs_vol_size'),
+                "export_policy": lookup('env', 'INFRAFOUNDRY_VAR_nfs_export_policy'),
+                "protocol": "nfs"}]
+              if lookup('env', 'INFRAFOUNDRY_VAR_nfs_vol_name')
+              else []
+            ) + (
+              [{"name": lookup('env', 'INFRAFOUNDRY_VAR_cifs_vol_name'),
+                "vserver": lookup('env', 'INFRAFOUNDRY_VAR_svm_name'),
+                "aggregate": lookup('env', 'INFRAFOUNDRY_VAR_cifs_vol_aggregate'),
+                "size": lookup('env', 'INFRAFOUNDRY_VAR_cifs_vol_size'),
+                "protocol": "cifs"}]
+              if lookup('env', 'INFRAFOUNDRY_VAR_cifs_vol_name')
+              else []
+            )
+          }}

--- a/blueprints/ontap-cluster/ontap-lab-playbook.yml
+++ b/blueprints/ontap-cluster/ontap-lab-playbook.yml
@@ -1,0 +1,20 @@
+---
+# ONTAP Simulator Lab — Full Orchestration Playbook
+#
+# Runs both serial setup and cluster setup in sequence.
+# For selective runs, use the individual playbooks:
+#   - ontap-lab-serial-setup.yml  (first boot only — sets sysid on node 02)
+#   - ontap-lab-cluster-setup.yml (cluster create, join, post-config)
+#
+# Usage (automated — all variables from infrafoundry.yml):
+#   Triggered by ontap-post-terraform.sh event handler
+#
+# Usage (manual):
+#   ansible-playbook -i .generated-inventory.yml ontap-lab-playbook.yml \
+#     -e @.generated-vars.json -v
+
+- name: Serial setup
+  ansible.builtin.import_playbook: ontap-lab-serial-setup.yml
+
+- name: Cluster setup
+  ansible.builtin.import_playbook: ontap-lab-cluster-setup.yml

--- a/blueprints/ontap-cluster/ontap-lab-serial-setup.yml
+++ b/blueprints/ontap-cluster/ontap-lab-serial-setup.yml
@@ -1,0 +1,44 @@
+---
+# ONTAP Simulator Lab — Serial Setup Playbook
+#
+# Sets serial console as primary and optionally assigns unique serial/sysid.
+# Must run on first boot BEFORE ONTAP initializes disks.
+#
+# All variables are read from INFRAFOUNDRY_VAR_* environment variables
+# set by the InfraFoundry framework.
+
+- name: Install dependencies on Proxmox hosts
+  hosts: proxmox_hosts
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Install serial console dependencies
+      ansible.builtin.apt:
+        name:
+          - expect
+          - socat
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+# Node 01: set serial console as primary (keep default serial/sysid)
+- name: Configure serial console on ONTAP node 01
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_target') }}"
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-serial-setup
+      vars:
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_vmid') }}"
+
+# Node 02: set serial console + unique serial/sysid
+- name: Configure serial console and sysid on ONTAP node 02
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_target') }}"
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-serial-setup
+      vars:
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_vmid') }}"
+        ontap_serial_number: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_serial_number') }}"
+        ontap_sysid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_sysid') }}"

--- a/blueprints/ontap-cluster/requirements.yml
+++ b/blueprints/ontap-cluster/requirements.yml
@@ -1,0 +1,7 @@
+---
+# Ansible collection dependencies for ONTAP lab automation
+#
+# Install: ansible-galaxy collection install -r requirements.yml
+collections:
+  - name: netapp.ontap
+    version: ">=22.0.0"

--- a/blueprints/ontap-cluster/roles/ontap-cluster-setup/defaults/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-cluster-setup/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+# ONTAP Cluster Setup — Default Variables
+#
+# These variables control the cluster creation and node join process
+# for a 2-node ONTAP Simulator cluster via `qm terminal`.
+
+# Proxmox VM ID of the ONTAP node on this host
+ontap_vmid: 220
+
+# Cluster name
+ontap_cluster_name: "ontap-lab"
+
+# Cluster management interface configuration
+ontap_cluster_mgmt_ip: "192.168.1.220"
+ontap_cluster_mgmt_mask: "255.255.255.0"
+ontap_cluster_mgmt_gateway: "192.168.1.1"
+
+# Node management IP (for the node running on this host)
+ontap_node_mgmt_ip: "192.168.1.221"
+ontap_node_mgmt_mask: "255.255.255.0"
+ontap_node_mgmt_gateway: "192.168.1.1"
+
+# Admin password for the cluster
+ontap_password: "changeme123"
+
+# Whether this host creates the cluster (true) or joins it (false)
+ontap_cluster_create: true
+
+# Cluster IP to join (only used when ontap_cluster_create is false)
+ontap_cluster_join_ip: "192.168.1.220"
+
+# Timeout (seconds) to wait for the cluster setup wizard
+ontap_setup_timeout: 600
+
+# Timeout (seconds) to wait for cluster join
+ontap_join_timeout: 300

--- a/blueprints/ontap-cluster/roles/ontap-cluster-setup/meta/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-cluster-setup/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: ontap-cluster-setup
+  author: InfraFoundry
+  description: Create or join an ONTAP Simulator cluster via serial console wizard
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []

--- a/blueprints/ontap-cluster/roles/ontap-cluster-setup/tasks/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-cluster-setup/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+# ONTAP Cluster Setup — Tasks
+#
+# Creates a new ONTAP cluster on the first node or joins an existing
+# cluster on subsequent nodes via the Proxmox serial socket.
+
+- name: Start VM if not running
+  ansible.builtin.command:
+    cmd: "qm start {{ ontap_vmid }}"
+  register: vm_start
+  failed_when: vm_start.rc != 0 and 'already running' not in vm_start.stderr
+  changed_when: vm_start.rc == 0
+
+- name: Wait for serial socket
+  ansible.builtin.wait_for:
+    path: "/var/run/qemu-server/{{ ontap_vmid }}.serial0"
+    timeout: 30
+
+- name: Deploy cluster create expect script
+  when: ontap_cluster_create | bool
+  ansible.builtin.template:
+    src: cluster-create.exp.j2
+    dest: "/tmp/ontap-cluster-create-{{ ontap_vmid }}.exp"
+    mode: "0755"
+
+- name: Run cluster create via expect script
+  when: ontap_cluster_create | bool
+  ansible.builtin.command:
+    cmd: "/tmp/ontap-cluster-create-{{ ontap_vmid }}.exp"
+  register: cluster_create
+  changed_when: true
+
+- name: Find cluster create log
+  when: ontap_cluster_create | bool
+  ansible.builtin.find:
+    paths: /tmp
+    patterns: "ontap-cluster-create-{{ ontap_vmid }}-*.log"
+  register: cluster_create_logs
+
+- name: Fetch cluster create log
+  when: ontap_cluster_create | bool
+  ansible.builtin.fetch:
+    src: "{{ item.path }}"
+    dest: "logs/{{ item.path | basename }}"
+    flat: true
+  loop: "{{ cluster_create_logs.files | default([]) }}"
+  ignore_errors: true
+
+- name: Clean up cluster create script and log
+  when: ontap_cluster_create | bool
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ ['/tmp/ontap-cluster-create-' + ontap_vmid | string + '.exp'] + (cluster_create_logs.files | default([]) | map(attribute='path') | list) }}"
+
+- name: Deploy cluster join expect script
+  when: not (ontap_cluster_create | bool)
+  ansible.builtin.template:
+    src: cluster-join.exp.j2
+    dest: "/tmp/ontap-cluster-join-{{ ontap_vmid }}.exp"
+    mode: "0755"
+
+- name: Run cluster join via expect script
+  when: not (ontap_cluster_create | bool)
+  ansible.builtin.command:
+    cmd: "/tmp/ontap-cluster-join-{{ ontap_vmid }}.exp"
+  register: cluster_join
+  changed_when: true
+
+- name: Find cluster join log
+  when: not (ontap_cluster_create | bool)
+  ansible.builtin.find:
+    paths: /tmp
+    patterns: "ontap-cluster-join-{{ ontap_vmid }}-*.log"
+  register: cluster_join_logs
+
+- name: Fetch cluster join log
+  when: not (ontap_cluster_create | bool)
+  ansible.builtin.fetch:
+    src: "{{ item.path }}"
+    dest: "logs/{{ item.path | basename }}"
+    flat: true
+  loop: "{{ cluster_join_logs.files | default([]) }}"
+  ignore_errors: true
+
+- name: Clean up cluster join script and log
+  when: not (ontap_cluster_create | bool)
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ ['/tmp/ontap-cluster-join-' + ontap_vmid | string + '.exp'] + (cluster_join_logs.files | default([]) | map(attribute='path') | list) }}"

--- a/blueprints/ontap-cluster/roles/ontap-cluster-setup/templates/cluster-create.exp.j2
+++ b/blueprints/ontap-cluster/roles/ontap-cluster-setup/templates/cluster-create.exp.j2
@@ -1,0 +1,145 @@
+#!/usr/bin/expect -f
+# ONTAP Cluster Create — Expect Script (fresh boot, serial primary)
+# Handles both:
+#   A. Wizard auto-start: "Type yes to confirm" → node mgmt → create/join
+#   B. Login prompt: login as admin → cluster setup → wizard
+
+set timestamp [clock format [clock seconds] -format "%Y%m%d-%H%M%S"]
+log_file -noappend /tmp/ontap-cluster-create-{{ ontap_vmid }}-${timestamp}.log
+set timeout {{ ontap_setup_timeout }}
+log_user 1
+spawn socat STDIO,rawer UNIX-CONNECT:/var/run/qemu-server/{{ ontap_vmid }}.serial0
+
+# Nudge console
+send "\r"
+sleep 2
+send "\r"
+
+# Detect state: wizard, login prompt, or CLI
+set need_node_mgmt 1
+expect {
+  "Type yes to confirm and continue*" {
+    # Flow A: wizard auto-started
+    send "yes\r"
+  }
+  "login:" {
+    # Flow B: login as admin (no password on fresh install)
+    send "admin\r"
+    expect {
+      "Password:" {
+        send "\r"
+        expect {
+          "Type yes to confirm and continue*" {
+            send "yes\r"
+          }
+          "::>" {
+            send "cluster setup\r"
+            expect "Type yes to confirm and continue*"
+            send "yes\r"
+          }
+        }
+      }
+      "::>" {
+        send "cluster setup\r"
+        expect "Type yes to confirm and continue*"
+        send "yes\r"
+      }
+    }
+  }
+  "::>" {
+    send "cluster setup\r"
+    expect "Type yes to confirm and continue*"
+    send "yes\r"
+  }
+  timeout {
+    puts "ERROR: Timed out waiting for ONTAP prompt"
+    exit 1
+  }
+}
+
+# Node management (comes first in 9.18.1 wizard)
+expect "Enter the node management interface port*"
+send "e0c\r"
+expect "Enter the node management interface*address*"
+send "{{ ontap_node_mgmt_ip }}\r"
+expect "Enter the node management interface netmask*"
+send "{{ ontap_node_mgmt_mask }}\r"
+expect "Enter the node management interface default gateway*"
+send "{{ ontap_node_mgmt_gateway }}\r"
+
+# Intermediate "press Enter for CLI setup" prompt
+expect "*press Enter to complete cluster setup*"
+send "\r"
+
+# Create or join
+expect "*create*join*"
+send "create\r"
+
+# Single node
+expect "*single node cluster*"
+send "no\r"
+
+# Existing cluster interface configuration (may or may not appear)
+expect {
+  "Do you want to use this configuration*" {
+    send "yes\r"
+    expect "*admin*password*"
+    send "{{ ontap_password }}\r"
+  }
+  "*admin*password*" {
+    send "{{ ontap_password }}\r"
+  }
+}
+expect "Retype the password"
+send "{{ ontap_password }}\r"
+
+# Cluster name
+expect "Enter the cluster name*"
+send "{{ ontap_cluster_name }}\r"
+
+# Cluster base license
+expect "*license key*"
+send "{{ ontap_cluster_base_license }}\r"
+
+# Skip additional license keys (feature licenses applied post-cluster via REST)
+expect "*license key*"
+send "\r"
+
+# Cluster management
+expect "Enter the cluster management interface port*"
+send "e0c\r"
+expect "Enter the cluster management interface*address*"
+send "{{ ontap_cluster_mgmt_ip }}\r"
+expect "Enter the cluster management interface netmask*"
+send "{{ ontap_cluster_mgmt_mask }}\r"
+expect "Enter the cluster management interface default gateway*"
+send "{{ ontap_cluster_mgmt_gateway }}\r"
+
+# DNS
+expect "Enter the DNS domain name*"
+send "{{ ontap_dns_domain | default('lab.local') }}\r"
+expect "Enter the name server IP address*"
+send "{{ ontap_cluster_mgmt_gateway }}\r"
+
+# Location (optional)
+expect "Where is the controller located*"
+send "\r"
+
+# Wait for completion
+set timeout {{ ontap_setup_timeout }}
+expect {
+  "Cluster setup is complete" {
+    puts "\nCluster created successfully"
+  }
+  "*::>" {
+    puts "\nCluster setup complete"
+  }
+  "login:" {
+    puts "\nCluster setup complete, at login prompt"
+  }
+  timeout {
+    puts "\nWARNING: Timed out waiting for cluster setup completion"
+  }
+}
+
+exit 0

--- a/blueprints/ontap-cluster/roles/ontap-cluster-setup/templates/cluster-join.exp.j2
+++ b/blueprints/ontap-cluster/roles/ontap-cluster-setup/templates/cluster-join.exp.j2
@@ -1,0 +1,158 @@
+#!/usr/bin/expect -f
+# ONTAP Cluster Join — Expect Script (fresh boot, serial primary)
+# Handles both:
+#   A. Wizard auto-start: "Type yes to confirm" → node mgmt → create/join
+#   B. Login prompt: login as admin → cluster setup → wizard
+
+set timestamp [clock format [clock seconds] -format "%Y%m%d-%H%M%S"]
+log_file -noappend /tmp/ontap-cluster-join-{{ ontap_vmid }}-${timestamp}.log
+set timeout {{ ontap_join_timeout }}
+log_user 1
+spawn socat STDIO,rawer UNIX-CONNECT:/var/run/qemu-server/{{ ontap_vmid }}.serial0
+
+# Nudge console
+send "\r"
+sleep 2
+send "\r"
+
+# Detect state: wizard, login prompt, or CLI
+expect {
+  "Type yes to confirm and continue*" {
+    send "yes\r"
+  }
+  "login:" {
+    send "admin\r"
+    expect {
+      "Password:" {
+        send "\r"
+        expect {
+          "Type yes to confirm and continue*" {
+            send "yes\r"
+          }
+          "::>" {
+            send "cluster setup\r"
+            expect "Type yes to confirm and continue*"
+            send "yes\r"
+          }
+        }
+      }
+      "::>" {
+        send "cluster setup\r"
+        expect "Type yes to confirm and continue*"
+        send "yes\r"
+      }
+    }
+  }
+  "::>" {
+    send "cluster setup\r"
+    expect "Type yes to confirm and continue*"
+    send "yes\r"
+  }
+  timeout {
+    puts "ERROR: Timed out waiting for ONTAP prompt"
+    exit 1
+  }
+}
+
+# Node management (comes first in 9.18.1 wizard)
+expect "Enter the node management interface port*"
+send "e0c\r"
+expect "Enter the node management interface*address*"
+send "{{ ontap_node_mgmt_ip }}\r"
+expect "Enter the node management interface netmask*"
+send "{{ ontap_node_mgmt_mask }}\r"
+expect "Enter the node management interface default gateway*"
+send "{{ ontap_node_mgmt_gateway }}\r"
+
+# Intermediate "press Enter for CLI setup" prompt
+expect "*press Enter to complete cluster setup*"
+send "\r"
+
+# Join existing cluster
+expect "*create*join*"
+send "join\r"
+
+# Handle existing cluster interface configuration (ONTAP 9.18.1)
+# After choosing "join", ONTAP shows the current cluster network config
+# and asks to confirm before requesting the cluster IP to join.
+expect {
+  "Do you want to use this configuration*" {
+    send "yes\r"
+  }
+  "*IP address*" {
+    # No config prompt, go straight to cluster IP
+    send "{{ ontap_cluster_join_ip }}\r"
+    exp_continue
+  }
+}
+
+# Enter the IP address of an interface on the private cluster network
+# This must be a cluster interconnect IP (169.254.x.x), not the mgmt IP
+expect {
+  "*IP address*" {
+    send "{{ ontap_cluster_join_ip }}\r"
+  }
+  "Cluster setup is complete" {
+    puts "\nNode joined cluster successfully (auto-discovered)"
+    exit 0
+  }
+  "This node has been joined*" {
+    puts "\nNode joined cluster successfully (auto-discovered)"
+    exit 0
+  }
+}
+
+# Admin username for the cluster being joined
+expect {
+  "*username*" {
+    send "{{ ontap_admin_user | default('admin') }}\r"
+  }
+  "Cluster setup is complete" {
+    puts "\nNode joined cluster successfully"
+    exit 0
+  }
+}
+
+# Admin password for the cluster being joined
+expect {
+  "*password*" {
+    send "{{ ontap_password }}\r"
+  }
+  "Cluster setup is complete" {
+    puts "\nNode joined cluster successfully"
+    exit 0
+  }
+}
+
+# Location (optional)
+expect {
+  "Where is the controller located*" {
+    send "\r"
+  }
+  "Cluster setup is complete" {
+    puts "\nNode joined cluster successfully"
+    exit 0
+  }
+}
+
+# Wait for completion
+set timeout {{ ontap_join_timeout }}
+expect {
+  "Cluster setup is complete" {
+    puts "\nNode joined cluster successfully"
+  }
+  "This node has been joined*" {
+    puts "\nNode joined cluster successfully"
+  }
+  "*::>" {
+    puts "\nCluster join complete"
+  }
+  "login:" {
+    puts "\nCluster join complete, at login prompt"
+  }
+  timeout {
+    puts "\nWARNING: Timed out waiting for cluster join completion"
+  }
+}
+
+exit 0

--- a/blueprints/ontap-cluster/roles/ontap-post-cluster/defaults/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-post-cluster/defaults/main.yml
@@ -1,0 +1,114 @@
+---
+# ONTAP Post-Cluster Setup — Default Variables
+#
+# These variables configure the ONTAP cluster after it has been
+# created and all nodes have joined. Uses netapp.ontap modules
+# via the ONTAP REST API.
+
+# Cluster management endpoint
+ontap_cluster_mgmt_ip: "192.168.1.220"
+ontap_admin_user: "admin"
+ontap_admin_password: "changeme123"
+
+# Set to true to validate SSL certificates
+ontap_validate_certs: false
+
+# ONTAP feature licenses (comma-separated license keys)
+# Leave empty to skip license installation
+ontap_licenses: []
+# Example:
+# ontap_licenses:
+#   - "AAAAAAAAAAAAAAAA"
+#   - "BBBBBBBBBBBBBBBB"
+
+# Disk assignment — assign all unowned disks
+ontap_assign_disks: true
+
+# Aggregate configuration
+# Use node_index (0-based) instead of hardcoded node names.
+# Actual node names are discovered from the ONTAP REST API at runtime.
+ontap_aggregates:
+  - name: aggr1_node01
+    node_index: 0
+    disk_count: 5
+    raid_type: raid_dp
+  - name: aggr1_node02
+    node_index: 1
+    disk_count: 5
+    raid_type: raid_dp
+
+# Storage Virtual Machine (SVM) configuration
+ontap_svms:
+  - name: svm_data
+    root_volume: svm_data_root
+    root_volume_aggregate: aggr1_node01
+    allowed_protocols:
+      - nfs
+      - cifs
+      - iscsi
+
+# Data LIF configuration
+# Use node_index (0-based) instead of hardcoded node names.
+ontap_lifs:
+  - name: svm_data_lif1
+    vserver: svm_data
+    role: data
+    protocol: nfs
+    node_index: 0
+    home_port: e0d
+    address: "192.168.1.230"
+    netmask: "255.255.255.0"
+
+  - name: svm_data_lif2
+    vserver: svm_data
+    role: data
+    protocol: nfs
+    node_index: 1
+    home_port: e0d
+    address: "192.168.1.231"
+    netmask: "255.255.255.0"
+
+# DNS configuration for the SVM
+ontap_dns:
+  - vserver: svm_data
+    domains:
+      - lab.local
+    nameservers:
+      - "192.168.1.1"
+
+# NTP server configuration
+ontap_ntp_servers:
+  - "192.168.1.1"
+
+# CIFS server configuration (workgroup mode)
+ontap_cifs_server: {}
+# Example:
+# ontap_cifs_server:
+#   name: ONTAPCL
+#   vserver: svm_data
+#   workgroup: WORKGROUP
+
+# NFS export policies
+ontap_export_policies: []
+# Example:
+# ontap_export_policies:
+#   - name: nfs_data
+#     vserver: svm_data
+#     rules:
+#       - client_match: "192.168.10.0/24"
+#         protocols: [nfs]
+#         ro_rule: [sys]
+#         rw_rule: [sys]
+#         super_user: [sys]
+
+# Volumes
+ontap_volumes: []
+# Example:
+# ontap_volumes:
+#   - name: NFS_VOL
+#     vserver: svm_data
+#     aggregate: aggr1_node01
+#     size: 1g
+#     junction_path: /NFS_VOL
+#     export_policy: nfs_data
+#     protocol: nfs

--- a/blueprints/ontap-cluster/roles/ontap-post-cluster/meta/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-post-cluster/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ontap-post-cluster
+  author: InfraFoundry
+  description: Configure ONTAP cluster post-creation via netapp.ontap API modules
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []
+# Collection dependency: netapp.ontap (install via requirements.yml)

--- a/blueprints/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
@@ -1,0 +1,273 @@
+---
+# ONTAP Post-Cluster Setup — Tasks
+#
+# Configures an ONTAP cluster after creation using the netapp.ontap
+# Ansible collection modules via the ONTAP REST API.
+#
+# This role runs against the cluster management endpoint (not
+# Proxmox hosts) and handles:
+#   - License installation
+#   - Disk assignment
+#   - Aggregate creation
+#   - SVM creation
+#   - Data LIF creation
+#   - DNS configuration
+#   - NTP configuration
+#
+# Requirements:
+#   - netapp.ontap Ansible collection installed
+#   - Network connectivity to the ONTAP cluster management IP
+#   - Cluster must be fully formed (all nodes joined)
+
+# ---------------------------------------------------------------
+# Connection defaults for netapp.ontap modules
+# ---------------------------------------------------------------
+- name: Set ONTAP connection facts
+  ansible.builtin.set_fact:
+    ontap_connection: &ontap_conn
+      hostname: "{{ ontap_cluster_mgmt_ip }}"
+      username: "{{ ontap_admin_user }}"
+      password: "{{ ontap_admin_password }}"
+      https: true
+      validate_certs: "{{ ontap_validate_certs }}"
+
+# ---------------------------------------------------------------
+# Node discovery — query actual node names from the cluster
+# ---------------------------------------------------------------
+- name: Discover cluster nodes
+  ansible.builtin.uri:
+    url: "https://{{ ontap_cluster_mgmt_ip }}/api/cluster/nodes"
+    user: "{{ ontap_admin_user }}"
+    password: "{{ ontap_admin_password }}"
+    validate_certs: "{{ ontap_validate_certs }}"
+    force_basic_auth: true
+  register: cluster_nodes_response
+
+- name: Set discovered node names
+  ansible.builtin.set_fact:
+    ontap_discovered_nodes: >-
+      {{ cluster_nodes_response.json.records
+         | sort(attribute='name')
+         | map(attribute='name')
+         | list }}
+
+- name: Display discovered nodes
+  ansible.builtin.debug:
+    msg: "Discovered ONTAP nodes: {{ ontap_discovered_nodes }}"
+
+# ---------------------------------------------------------------
+# License installation
+# ---------------------------------------------------------------
+- name: Install ONTAP licenses
+  netapp.ontap.na_ontap_license:
+    <<: *ontap_conn
+    state: present
+    license_codes: "{{ ontap_licenses }}"
+  when: ontap_licenses | length > 0
+
+# ---------------------------------------------------------------
+# Disable root volume snapshots (saves space on simulator)
+# Node root volumes (vol0) can only be managed from the node-shell
+# via ZAPI. Requires netapp_lib Python package (pip install netapp-lib).
+# ---------------------------------------------------------------
+- name: Delete existing root volume snapshots
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap delete -a -f vol0"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+
+- name: Disable root volume snapshot schedule
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap sched vol0 0 0 0"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+
+- name: Enable root volume snapshot autodelete
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap autodelete vol0 on"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+
+- name: Set root volume snapshot autodelete threshold to 35%
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "run -node {{ item }} snap autodelete vol0 target_free_space 35"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+
+# ---------------------------------------------------------------
+# Disk assignment
+# ---------------------------------------------------------------
+- name: Assign all unowned disks
+  netapp.ontap.na_ontap_disks:
+    <<: *ontap_conn
+    node: "{{ ontap_discovered_nodes[item.node_index] }}"
+  loop: "{{ ontap_aggregates }}"
+  loop_control:
+    label: "{{ ontap_discovered_nodes[item.node_index] }}"
+  when: ontap_assign_disks | bool
+  register: disk_assign
+  failed_when:
+    - disk_assign is failed
+    - "'No disk available' not in (disk_assign.msg | default(''))"
+
+# ---------------------------------------------------------------
+# Aggregate creation
+# ---------------------------------------------------------------
+- name: Create data aggregates
+  netapp.ontap.na_ontap_aggregate:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    nodes:
+      - "{{ ontap_discovered_nodes[item.node_index] }}"
+    disk_count: "{{ item.disk_count }}"
+    raid_type: "{{ item.raid_type }}"
+  loop: "{{ ontap_aggregates }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
+# SVM creation
+# ---------------------------------------------------------------
+- name: Create storage virtual machines
+  netapp.ontap.na_ontap_svm:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    allowed_protocols: "{{ item.allowed_protocols }}"
+  loop: "{{ ontap_svms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
+# Data LIF creation
+# ---------------------------------------------------------------
+- name: Create data LIFs
+  netapp.ontap.na_ontap_interface:
+    <<: *ontap_conn
+    state: present
+    interface_name: "{{ item.name }}"
+    vserver: "{{ item.vserver }}"
+    role: "{{ item.role }}"
+    protocols: "{{ item.protocol }}"
+    home_node: "{{ ontap_discovered_nodes[item.node_index] }}"
+    home_port: "{{ item.home_port }}"
+    address: "{{ item.address }}"
+    netmask: "{{ item.netmask }}"
+  loop: "{{ ontap_lifs }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
+# DNS configuration
+# ---------------------------------------------------------------
+- name: Configure DNS for SVMs
+  netapp.ontap.na_ontap_dns:
+    <<: *ontap_conn
+    state: present
+    vserver: "{{ item.vserver }}"
+    domains: "{{ item.domains }}"
+    nameservers: "{{ item.nameservers }}"
+  loop: "{{ ontap_dns }}"
+  loop_control:
+    label: "{{ item.vserver }}"
+
+# ---------------------------------------------------------------
+# NTP configuration
+# ---------------------------------------------------------------
+- name: Configure NTP servers
+  netapp.ontap.na_ontap_ntp:
+    <<: *ontap_conn
+    state: present
+    server_name: "{{ item }}"
+  loop: "{{ ontap_ntp_servers }}"
+  loop_control:
+    label: "{{ item }}"
+
+# ---------------------------------------------------------------
+# CIFS server (workgroup mode)
+# ---------------------------------------------------------------
+- name: Create CIFS server (workgroup mode via ZAPI)
+  netapp.ontap.na_ontap_cifs_server:
+    <<: *ontap_conn
+    state: present
+    name: "{{ ontap_cifs_server.name }}"
+    vserver: "{{ ontap_cifs_server.vserver }}"
+    workgroup: "{{ ontap_cifs_server.workgroup | default('WORKGROUP') }}"
+    service_state: started
+    use_rest: never
+  when: ontap_cifs_server.name | default('') | length > 0
+
+# ---------------------------------------------------------------
+# NFS export policies
+# ---------------------------------------------------------------
+- name: Create export policies
+  netapp.ontap.na_ontap_export_policy:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    vserver: "{{ item.vserver }}"
+  loop: "{{ ontap_export_policies }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create export policy rules
+  netapp.ontap.na_ontap_export_policy_rule:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.0.name }}"
+    vserver: "{{ item.0.vserver }}"
+    client_match: "{{ item.1.client_match }}"
+    protocols: "{{ item.1.protocols }}"
+    ro_rule: "{{ item.1.ro_rule }}"
+    rw_rule: "{{ item.1.rw_rule }}"
+    super_user_security: "{{ item.1.super_user }}"
+  loop: "{{ ontap_export_policies | subelements('rules') }}"
+  loop_control:
+    label: "{{ item.0.name }} - {{ item.1.client_match }}"
+
+# ---------------------------------------------------------------
+# Volumes
+# ---------------------------------------------------------------
+- name: Create volumes
+  netapp.ontap.na_ontap_volume:
+    <<: *ontap_conn
+    state: present
+    name: "{{ item.name }}"
+    vserver: "{{ item.vserver }}"
+    aggregate_name: "{{ item.aggregate }}"
+    size: "{{ item.size }}"
+    size_unit: gb
+    junction_path: "{{ item.junction_path | default('/' + item.name) }}"
+    export_policy: "{{ item.export_policy | default('default') }}"
+    volume_security_style: "{{ 'ntfs' if item.protocol | default('nfs') == 'cifs' else 'unix' }}"
+  loop: "{{ ontap_volumes }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create CIFS shares
+  netapp.ontap.na_ontap_cifs:
+    <<: *ontap_conn
+    state: present
+    share_name: "{{ item.name }}"
+    path: "{{ item.junction_path | default('/' + item.name) }}"
+    vserver: "{{ item.vserver }}"
+  loop: "{{ ontap_volumes | selectattr('protocol', 'eq', 'cifs') | list }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/blueprints/ontap-cluster/roles/ontap-serial-setup/defaults/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-serial-setup/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# ONTAP Serial Setup — Default Variables
+#
+# Sets serial console as primary and optionally assigns unique
+# serial number and system ID via the VLOADER prompt.
+
+# Proxmox VM ID of the ONTAP node to configure
+ontap_vmid: 220
+
+# Unique serial number to assign to the node (optional).
+# Omit to keep OVA defaults. Only set on first boot — changing
+# after ONTAP initializes disks will corrupt the RDB.
+# ontap_serial_number: "4082368-50-7"
+
+# Unique system ID to assign to the node (optional).
+# Must be set together with ontap_serial_number.
+# ontap_sysid: "4082368507"
+
+# Timeout (seconds) to wait for the LOADER prompt
+ontap_loader_timeout: 120
+
+# Timeout (seconds) to wait for boot completion
+ontap_boot_timeout: 600

--- a/blueprints/ontap-cluster/roles/ontap-serial-setup/meta/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-serial-setup/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: ontap-serial-setup
+  author: InfraFoundry
+  description: Assign unique serial number and system ID to ONTAP Simulator node via LOADER prompt
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []

--- a/blueprints/ontap-cluster/roles/ontap-serial-setup/tasks/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-serial-setup/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+# ONTAP Serial Setup — Tasks
+#
+# Assigns a unique serial number and system ID to an ONTAP Simulator
+# node at the VLOADER prompt via the Proxmox serial socket.
+
+- name: Stop VM if running
+  ansible.builtin.command:
+    cmd: "qm stop {{ ontap_vmid }}"
+  register: vm_stop
+  failed_when: vm_stop.rc != 0 and 'not running' not in vm_stop.stderr
+  changed_when: vm_stop.rc == 0
+
+- name: Wait for VM to fully stop
+  ansible.builtin.pause:
+    seconds: 5
+
+- name: Deploy expect script
+  ansible.builtin.template:
+    src: serial-setup.exp.j2
+    dest: "/tmp/ontap-serial-setup-{{ ontap_vmid }}.exp"
+    mode: "0755"
+
+- name: Deploy wrapper script that waits for socket then runs expect
+  ansible.builtin.copy:
+    dest: "/tmp/ontap-serial-setup-{{ ontap_vmid }}-wrapper.sh"
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      # Wait for serial socket to appear, then immediately run expect
+      SOCKET="/var/run/qemu-server/{{ ontap_vmid }}.serial0"
+      TIMEOUT=30
+      ELAPSED=0
+      while [ ! -S "$SOCKET" ]; do
+        sleep 0.5
+        ELAPSED=$((ELAPSED + 1))
+        if [ $ELAPSED -ge $((TIMEOUT * 2)) ]; then
+          echo "ERROR: Serial socket not found after ${TIMEOUT}s"
+          exit 1
+        fi
+      done
+      exec /tmp/ontap-serial-setup-{{ ontap_vmid }}.exp
+
+- name: Launch wrapper script in background (listens before VM boots)
+  ansible.builtin.shell: |
+    nohup /tmp/ontap-serial-setup-{{ ontap_vmid }}-wrapper.sh > /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>&1 &
+    echo $!
+  register: wrapper_bg
+  changed_when: true
+
+- name: Start VM
+  ansible.builtin.command:
+    cmd: "qm start {{ ontap_vmid }}"
+  changed_when: true
+
+- name: Wait for expect script to complete
+  ansible.builtin.shell: |
+    TIMEOUT={{ ontap_loader_timeout | default(120) | int + 60 }}
+    ELAPSED=0
+    while kill -0 {{ wrapper_bg.stdout_lines[0] }} 2>/dev/null; do
+      sleep 2
+      ELAPSED=$((ELAPSED + 2))
+      if [ $ELAPSED -ge $TIMEOUT ]; then
+        kill {{ wrapper_bg.stdout_lines[0] }} 2>/dev/null || true
+        echo "ERROR: Expect script timed out after ${TIMEOUT}s"
+        cat /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>/dev/null
+        exit 1
+      fi
+    done
+    # Process already exited — check output for errors
+    cat /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>/dev/null
+    if grep -q "ERROR:" /tmp/ontap-serial-wrapper-{{ ontap_vmid }}.out 2>/dev/null; then
+      exit 1
+    fi
+    exit 0
+  register: serial_setup
+  changed_when: true
+
+- name: Find expect log
+  ansible.builtin.find:
+    paths: /tmp
+    patterns: "ontap-serial-setup-{{ ontap_vmid }}-*.log"
+  register: serial_setup_logs
+
+- name: Fetch expect log
+  ansible.builtin.fetch:
+    src: "{{ item.path }}"
+    dest: "logs/{{ item.path | basename }}"
+    flat: true
+  loop: "{{ serial_setup_logs.files }}"
+  ignore_errors: true
+
+- name: Clean up expect script and log
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ ['/tmp/ontap-serial-setup-' + ontap_vmid | string + '.exp', '/tmp/ontap-serial-setup-' + ontap_vmid | string + '-wrapper.sh', '/tmp/ontap-serial-wrapper-' + ontap_vmid | string + '.out'] + serial_setup_logs.files | map(attribute='path') | list }}"

--- a/blueprints/ontap-cluster/roles/ontap-serial-setup/templates/serial-setup.exp.j2
+++ b/blueprints/ontap-cluster/roles/ontap-serial-setup/templates/serial-setup.exp.j2
@@ -1,0 +1,51 @@
+#!/usr/bin/expect -f
+# ONTAP Serial Setup — Expect Script
+# Intercepts the boot prompt, drops to VLOADER, sets serial/sysid, boots.
+
+set timestamp [clock format [clock seconds] -format "%Y%m%d-%H%M%S"]
+log_file -noappend /tmp/ontap-serial-setup-{{ ontap_vmid }}-${timestamp}.log
+set timeout {{ ontap_loader_timeout }}
+spawn socat STDIO,rawer UNIX-CONNECT:/var/run/qemu-server/{{ ontap_vmid }}.serial0
+
+# Wait for the boot intercept prompt (10 second window)
+expect {
+  "Hit*to boot immediately, or any other key for command prompt." {
+    send " "
+  }
+  "VLOADER>" {
+    # Already at VLOADER prompt
+  }
+  timeout {
+    puts "ERROR: Timed out waiting for boot prompt"
+    exit 1
+  }
+}
+
+{% if ontap_serial_number is defined and ontap_sysid is defined %}
+expect "VLOADER>"
+send "setenv SYS_SERIAL_NUM {{ ontap_serial_number }}\r"
+
+expect "VLOADER>"
+send "setenv bootarg.nvram.sysid {{ ontap_sysid }}\r"
+{% endif %}
+
+# Force serial as primary console (ONTAP 9.18.1 defaults to video primary)
+expect "VLOADER>"
+send "set console=comconsole,vidconsole\r"
+
+expect "VLOADER>"
+send "boot_ontap\r"
+
+# Wait just long enough to confirm boot started, then exit.
+# Do NOT consume the wizard prompt — the cluster setup script needs it.
+set timeout 30
+expect {
+  -glob "*BOOT*NetApp*" {
+    puts "\nONTAP boot started"
+  }
+  timeout {
+    puts "\nWARNING: Did not see boot banner, continuing anyway"
+  }
+}
+
+exit 0

--- a/blueprints/ontap-cluster/scripts/ontap-post-terraform.sh
+++ b/blueprints/ontap-cluster/scripts/ontap-post-terraform.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# ONTAP Lab Cluster Setup — Post-Terraform Event Handler
+#
+# Triggered by on_create resource lifecycle event after both ONTAP VMs are created.
+# Runs the full ONTAP lab playbook: serial setup, cluster create, join, post-config.
+#
+# All variables are provided by the framework via INFRAFOUNDRY_VAR_* env vars.
+# Ansible playbooks read variables directly from the environment via lookup('env', ...).
+# The script only generates a dynamic inventory (host mappings).
+#
+# Environment variables (injected by ScriptHandler):
+#   INFRAFOUNDRY_PACKAGE_VARS - JSON string of all package variables (including secrets)
+#   INFRAFOUNDRY_VAR_<key>    - Individual package variables
+#   INFRAFOUNDRY_EVENT        - event type (e.g., "resource_created")
+#   INFRAFOUNDRY_ENV          - environment name (e.g., "prod")
+#   INFRAFOUNDRY_CONFIG_DIR   - path to envs/<env>/
+
+set -euo pipefail
+
+# Script lives in ontap-cluster/scripts/, so package dir is one level up
+PACKAGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLAYBOOK="${PACKAGE_DIR}/ontap-lab-playbook.yml"
+
+# Verify required files exist
+if [ ! -f "$PLAYBOOK" ]; then
+    echo "ERROR: Playbook not found: $PLAYBOOK"
+    exit 1
+fi
+
+# Generate Ansible inventory from package variables
+echo "Generating Ansible inventory from environment variables..."
+INVENTORY="${PACKAGE_DIR}/.generated-inventory.yml"
+
+python3 -c "
+import json, os, sys, yaml
+
+# Read variables from INFRAFOUNDRY_PACKAGE_VARS env var (set by framework)
+vars_json = os.environ.get('INFRAFOUNDRY_PACKAGE_VARS')
+if vars_json:
+    v = json.loads(vars_json)
+else:
+    # Fallback: read from infrafoundry.yml directly (for manual runs)
+    print('Warning: INFRAFOUNDRY_PACKAGE_VARS not set, reading from infrafoundry.yml')
+    with open(sys.argv[1]) as f:
+        data = yaml.safe_load(f)
+    v = data.get('variables', {})
+
+# Build host lookup from target names
+host_lookup = {}
+for key in v:
+    if key.endswith('_host') and key.startswith('pve'):
+        host_lookup[key.replace('_host', '')] = v[key]
+
+# Build proxmox_hosts inventory — handle both nodes on same host
+node01_target = v.get('node01_target', 'pve1')
+node02_target = v.get('node02_target', 'pve2')
+proxmox_hosts = {}
+
+# Node 01
+proxmox_hosts[node01_target] = {
+    'ansible_host': host_lookup.get(node01_target, node01_target),
+    'ansible_user': 'root',
+    'ontap_vmid': v['node01_vmid'],
+}
+
+# Node 02 — if same host, add vmid as node02_vmid
+if node02_target == node01_target:
+    proxmox_hosts[node01_target]['ontap_node02_vmid'] = v['node02_vmid']
+else:
+    proxmox_hosts[node02_target] = {
+        'ansible_host': host_lookup.get(node02_target, node02_target),
+        'ansible_user': 'root',
+        'ontap_vmid': v['node02_vmid'],
+    }
+
+# Generate inventory
+inventory = {
+    'all': {
+        'children': {
+            'proxmox_hosts': {
+                'hosts': proxmox_hosts,
+            },
+            'ontap_cluster': {
+                'hosts': {
+                    'ontap-cluster': {
+                        'ansible_host': v['cluster_mgmt_ip'],
+                        'ansible_connection': 'local',
+                    },
+                },
+            },
+        },
+    },
+}
+
+with open(sys.argv[2], 'w') as f:
+    yaml.dump(inventory, f, default_flow_style=False)
+" "${PACKAGE_DIR}/infrafoundry.yml" "$INVENTORY"
+
+echo "Running ONTAP lab cluster setup playbook..."
+cd "$PACKAGE_DIR"
+ansible-playbook -i "$INVENTORY" "$PLAYBOOK" -v

--- a/blueprints/ontap-cluster/vm.yaml
+++ b/blueprints/ontap-cluster/vm.yaml
@@ -1,0 +1,71 @@
+# ONTAP Simulator VMs — Jinja2 template rendered by infrafoundry.yml variables
+vms:
+  - name: "{{ node01_name }}"
+    target_node: {{ node01_target }}
+    vmid: {{ node01_vmid }}
+    ova_source: "{{ ova_source }}"
+    cores: 2
+    cpu_type: SandyBridge
+    memory: 6144
+    disk_bus: ide
+    disk_storage: {{ disk_storage }}
+    serial: true
+    boot_order: [ide0]
+    onboot: false
+    tags: [ontap, ontap-lab]
+    network:
+      - bridge: {{ bridge }}
+        model: e1000        # e0a — cluster interconnect
+      - bridge: {{ bridge }}
+        model: e1000        # e0b — cluster interconnect
+      - bridge: {{ bridge }}
+        model: e1000        # e0c — management
+{% if mgmt_vlan %}
+        tag: {{ mgmt_vlan }}
+{% endif %}
+{% if node01_mgmt_mac %}
+        macaddr: "{{ node01_mgmt_mac }}"
+{% endif %}
+      - bridge: {{ bridge }}
+        model: e1000        # e0d — data
+{% if mgmt_vlan %}
+        tag: {{ mgmt_vlan }}
+{% endif %}
+{% if node01_data_mac %}
+        macaddr: "{{ node01_data_mac }}"
+{% endif %}
+
+  - name: "{{ node02_name }}"
+    target_node: {{ node02_target }}
+    vmid: {{ node02_vmid }}
+    ova_source: "{{ ova_source }}"
+    cores: 2
+    cpu_type: SandyBridge
+    memory: 6144
+    disk_bus: ide
+    disk_storage: {{ disk_storage }}
+    serial: true
+    boot_order: [ide0]
+    onboot: false
+    tags: [ontap, ontap-lab]
+    network:
+      - bridge: {{ bridge }}
+        model: e1000        # e0a — cluster interconnect
+      - bridge: {{ bridge }}
+        model: e1000        # e0b — cluster interconnect
+      - bridge: {{ bridge }}
+        model: e1000        # e0c — management
+{% if mgmt_vlan %}
+        tag: {{ mgmt_vlan }}
+{% endif %}
+{% if node02_mgmt_mac %}
+        macaddr: "{{ node02_mgmt_mac }}"
+{% endif %}
+      - bridge: {{ bridge }}
+        model: e1000        # e0d — data
+{% if mgmt_vlan %}
+        tag: {{ mgmt_vlan }}
+{% endif %}
+{% if node02_data_mac %}
+        macaddr: "{{ node02_data_mac }}"
+{% endif %}

--- a/src/infrafoundry/core/config/blueprint_resolver.py
+++ b/src/infrafoundry/core/config/blueprint_resolver.py
@@ -36,10 +36,18 @@ class BlueprintResolver:
 
         Args:
             base_dir: The ``envs/`` directory (same as PackageLoader.base_dir).
-                The blueprints directory is resolved as ``base_dir.parent / "blueprints"``.
+                Blueprints are resolved from the framework's ``blueprints/``
+                directory (relative to the infrafoundry package installation).
         """
-        self.base_dir = base_dir
-        self.blueprints_dir = base_dir.parent / "blueprints"
+        self.base_dir = base_dir.resolve()
+        # Blueprints live in the framework repo, not the config repo.
+        # Walk up from this file to find the repo root (contains pyproject.toml).
+        framework_root = Path(__file__).resolve().parent
+        while framework_root != framework_root.parent:
+            if (framework_root / "pyproject.toml").exists():
+                break
+            framework_root = framework_root.parent
+        self.blueprints_dir = framework_root / "blueprints"
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -234,6 +234,19 @@ class PackageLoader:
             resources.extend(parsed)
 
         # ----- Events -----
+        # Render event configs through Jinja2 to resolve variable references
+        # (e.g., requires: ["{{ node01_name }}"] → requires: ["ontapcl-test-01"])
+        if manifest.events:
+            import json
+
+            events_json = json.dumps(manifest.events)
+            try:
+                events_template = jinja2.Template(events_json)
+                rendered_events_json = events_template.render(**manifest.variables)
+                manifest.events = json.loads(rendered_events_json)
+            except (jinja2.TemplateError, json.JSONDecodeError) as e:
+                logger.warning("Failed to render event templates: %s", e)
+
         env_dir = self.base_dir / env_name
         events = self._rewrite_event_scripts(
             manifest.events, package_dir, env_dir, blueprint_dir=blueprint_dir

--- a/tests/unit/test_blueprint_resolver.py
+++ b/tests/unit/test_blueprint_resolver.py
@@ -7,6 +7,13 @@ from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
 from infrafoundry.core.exceptions import InvalidConfigurationError
 
 
+def _make_resolver(base_dir):
+    """Create a BlueprintResolver with blueprints_dir overridden for testing."""
+    resolver = BlueprintResolver(base_dir)
+    resolver.blueprints_dir = base_dir.parent / "blueprints"
+    return resolver
+
+
 def _create_blueprint(base_dir, name, manifest_data, extra_files=None):
     """Helper to create a blueprint directory structure.
 
@@ -45,7 +52,7 @@ class TestBlueprintResolverResolve:
         """All fields are parsed and returned correctly."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         manifest = {
             "name": "ontap-cluster",
@@ -73,7 +80,7 @@ class TestBlueprintResolverResolve:
         """Name-only blueprint works with defaults for optional fields."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         _create_blueprint(envs_dir, "minimal", {"name": "minimal"})
 
@@ -91,7 +98,7 @@ class TestBlueprintResolverResolve:
         """Resolving a missing blueprint raises InvalidConfigurationError."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         with pytest.raises(InvalidConfigurationError, match="not found"):
             resolver.resolve("nonexistent")
@@ -100,7 +107,7 @@ class TestBlueprintResolverResolve:
         """Directory without blueprint.yaml raises InvalidConfigurationError."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         # Create directory without manifest
         bp_dir = envs_dir.parent / "blueprints" / "no-manifest"
@@ -113,7 +120,7 @@ class TestBlueprintResolverResolve:
         """Invalid YAML in manifest raises InvalidConfigurationError."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         bp_dir = envs_dir.parent / "blueprints" / "bad-yaml"
         bp_dir.mkdir(parents=True)
@@ -126,7 +133,7 @@ class TestBlueprintResolverResolve:
         """Manifest without name field raises InvalidConfigurationError."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         _create_blueprint(envs_dir, "no-name", {"description": "missing name"})
 
@@ -137,7 +144,7 @@ class TestBlueprintResolverResolve:
         """Empty manifest file raises InvalidConfigurationError."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         bp_dir = envs_dir.parent / "blueprints" / "empty"
         bp_dir.mkdir(parents=True)
@@ -155,7 +162,7 @@ class TestBlueprintResolverExists:
         """Returns True for valid blueprint."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         _create_blueprint(envs_dir, "test-bp", {"name": "test-bp"})
 
@@ -165,7 +172,7 @@ class TestBlueprintResolverExists:
         """Returns False for non-existent blueprint."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         assert resolver.exists("nonexistent") is False
 
@@ -173,7 +180,7 @@ class TestBlueprintResolverExists:
         """Returns False for directory without blueprint.yaml."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         bp_dir = envs_dir.parent / "blueprints" / "no-manifest"
         bp_dir.mkdir(parents=True)
@@ -189,7 +196,7 @@ class TestBlueprintResolverListBlueprints:
         """Lists all valid blueprints sorted by name."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         _create_blueprint(envs_dir, "zeta-bp", {"name": "zeta"})
         _create_blueprint(envs_dir, "alpha-bp", {"name": "alpha"})
@@ -201,7 +208,7 @@ class TestBlueprintResolverListBlueprints:
         """Returns empty list when no blueprints directory exists."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         assert resolver.list_blueprints() == []
 
@@ -209,7 +216,7 @@ class TestBlueprintResolverListBlueprints:
         """Skips directories without blueprint.yaml."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         _create_blueprint(envs_dir, "valid", {"name": "valid"})
         # Create dir without manifest
@@ -227,7 +234,7 @@ class TestBlueprintResolverResolveFile:
         """File in package dir is preferred over blueprint."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         package_dir = temp_dir / "pkg"
         package_dir.mkdir()
@@ -244,7 +251,7 @@ class TestBlueprintResolverResolveFile:
         """File not in package falls back to blueprint."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         package_dir = temp_dir / "pkg"
         package_dir.mkdir()
@@ -260,7 +267,7 @@ class TestBlueprintResolverResolveFile:
         """Nested paths (scripts/setup.sh) resolve correctly."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         package_dir = temp_dir / "pkg"
         package_dir.mkdir()
@@ -277,7 +284,7 @@ class TestBlueprintResolverResolveFile:
         """File in neither location raises InvalidConfigurationError."""
         envs_dir = temp_dir / "envs"
         envs_dir.mkdir()
-        resolver = BlueprintResolver(envs_dir)
+        resolver = _make_resolver(envs_dir)
 
         package_dir = temp_dir / "pkg"
         package_dir.mkdir()

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -675,6 +675,7 @@ class TestBlueprintIntegration:
     def test_blueprint_defaults_merged(self, temp_dir):
         """Blueprint defaults are merged under package variables."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "test-bp",
@@ -710,6 +711,7 @@ class TestBlueprintIntegration:
     def test_blueprint_resources_inherited(self, temp_dir):
         """Package without resources inherits from blueprint."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "infra-bp",
@@ -741,6 +743,7 @@ class TestBlueprintIntegration:
     def test_blueprint_events_inherited(self, temp_dir):
         """Package without events inherits from blueprint."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         bp_dir = _create_blueprint(
             temp_dir,
             "event-bp",
@@ -772,6 +775,7 @@ class TestBlueprintIntegration:
     def test_package_overrides_blueprint_resources(self, temp_dir):
         """Package's own resources take priority over blueprint."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "override-bp",
@@ -806,6 +810,7 @@ class TestBlueprintIntegration:
     def test_blueprint_file_fallback(self, temp_dir):
         """Resource files fall back to blueprint dir when not in package."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "fallback-bp",
@@ -839,6 +844,7 @@ class TestBlueprintIntegration:
     def test_package_file_preferred_over_blueprint(self, temp_dir):
         """Package's own resource file is used even if blueprint has same name."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "prefer-bp",
@@ -871,6 +877,7 @@ class TestBlueprintIntegration:
     def test_no_blueprint_works_unchanged(self, temp_dir):
         """Packages without blueprint: key work exactly as before."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
 
         pkg_dir = _create_package(
@@ -912,6 +919,7 @@ class TestBlueprintIntegration:
     def test_blueprint_inventory_inherited(self, temp_dir):
         """Inventory from blueprint is inherited and generated."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "inv-bp",
@@ -957,6 +965,7 @@ class TestBlueprintIntegration:
     def test_package_inventory_overrides_blueprint(self, temp_dir):
         """Package's own inventory overrides blueprint inventory."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "inv-override-bp",
@@ -994,6 +1003,7 @@ class TestBlueprintIntegration:
     def test_blueprint_handler_tagged_with_blueprint_dir(self, temp_dir):
         """Event handlers from blueprint packages have _blueprint_dir tag."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         bp_dir = _create_blueprint(
             temp_dir,
             "tagged-bp",
@@ -1025,6 +1035,7 @@ class TestBlueprintIntegration:
     def test_secrets_override_blueprint_defaults(self, temp_dir):
         """Secrets take priority over both blueprint defaults and package vars."""
         resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
         _create_blueprint(
             temp_dir,
             "secret-bp",


### PR DESCRIPTION
## Description

Follow-up fixes discovered during blueprint testing with a live ONTAP cluster deployment.

Addresses #456

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**Framework fixes:**
- **Blueprint resolver** — resolve blueprints from framework repo root (via pyproject.toml discovery) instead of config repo
- **Event Jinja2 rendering** — render event handler configs through Jinja2 so `requires: ["{{ node01_name }}"]` resolves to actual resource names
- **Test fixtures** — override `blueprints_dir` in tests to use temp directories

**First blueprint (ontap-cluster):**
- 20 implementation files (roles, playbooks, scripts, resource templates)
- `blueprint.yaml` with defaults, resources, events
- CIFS server `when` condition fixed to check `name` not dict length
- Conditional volume/export policy list construction in playbook
- `.gitignore` updated to allow `blueprints/**/*.yaml`

**Tested end-to-end:** Deployed a complete ONTAP 2-node cluster (ontapcl-test) from a 2-file package referencing the blueprint — VMs, serial setup, cluster create/join, licenses, snapshots, aggregates, SVM, LIFs, DNS, NTP, CIFS server, NFS export policy, NFS volume, CIFS volume with share.

## Testing

- [x] All existing tests pass
- [x] `doit check` passes
- [x] Manual: full ONTAP cluster deployment from blueprint — zero failures

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass
- [x] My changes generate no new warnings