### PR TITLE
feat: skip OVA extraction when VMDKs already exist

### DIFF
--- a/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/ova_vms.tf.j2
@@ -13,12 +13,16 @@ resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
     ssh_target = "{{ ssh_target }}"
   }
 
-  # Phase 1: Extract OVA to temp directory on Proxmox host
+  # Phase 1: Extract OVA to temp directory on Proxmox host (skip if VMDKs exist)
   provisioner "local-exec" {
     command = <<-EOT
       ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_target }} \
         "mkdir -p /tmp/ova-${self.triggers_replace.name} && \
-         tar -xf ${self.triggers_replace.ova_source} -C /tmp/ova-${self.triggers_replace.name}"
+         if ! ls /tmp/ova-${self.triggers_replace.name}/*.vmdk 1>/dev/null 2>&1; then \
+           tar -xf ${self.triggers_replace.ova_source} -C /tmp/ova-${self.triggers_replace.name}; \
+         else \
+           echo 'VMDKs already exist, skipping extraction'; \
+         fi"
     EOT
   }
 
@@ -66,7 +70,7 @@ resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
     EOT
   }
 
-  # Phase 4: Configure boot order and cleanup temp files
+  # Phase 4: Configure boot order (extracted files persist for future runs)
   provisioner "local-exec" {
     command = <<-EOT
       ${local.ssh_cmd} ${var.proxmox_ssh_user}@{{ ssh_target }} "
@@ -81,7 +85,6 @@ resource "terraform_data" "ova_vm_{{ vm_tf_name }}" {
         {% if vm.config.tags is defined %}
         qm set ${self.triggers_replace.vmid} --tags {{ vm.config.tags | join(',') }}
         {% endif %}
-        rm -rf /tmp/ova-${self.triggers_replace.name}
       "
     EOT
   }

--- a/tests/unit/providers/proxmox/test_ova_vms.py
+++ b/tests/unit/providers/proxmox/test_ova_vms.py
@@ -67,6 +67,19 @@ class TestOVAExtraction:
         content = _render_ova_vms(provider, vms)
         assert "/tmp/ova-${self.triggers_replace.name}" in content
 
+    def test_extraction_checks_for_existing_vmdks(self, provider):
+        """Phase 1 should check if VMDKs exist before extracting."""
+        vms = [_make_ova_vm()]
+        content = _render_ova_vms(provider, vms)
+        assert "ls /tmp/ova-${self.triggers_replace.name}/*.vmdk" in content
+        assert "skipping extraction" in content
+
+    def test_no_cleanup_in_phase_4(self, provider):
+        """Phase 4 should not delete extracted OVA files."""
+        vms = [_make_ova_vm()]
+        content = _render_ova_vms(provider, vms)
+        assert "rm -rf /tmp/ova-" not in content
+
 
 class TestOVADiskImport:
     """Tests for disk bus type rendering in import commands."""


### PR DESCRIPTION
## Description

Skip OVA extraction when VMDKs already exist from a previous run, and stop deleting extracted files after disk import.

Addresses #362

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **Phase 1**: Check if `*.vmdk` files exist in `/tmp/ova-{name}/` before running `tar -xf`. Skip extraction if they do.
- **Phase 4**: Remove `rm -rf /tmp/ova-{name}` cleanup so extracted files persist for reuse on future applies.

## Testing

- [x] All existing tests pass
- [x] Added test: extraction checks for existing VMDKs
- [x] Added test: Phase 4 does not contain `rm -rf`
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] My changes generate no new warnings
