### PR TITLE
feat: add generate_mac Jinja2 filter for deterministic virtual MAC addresses

### DIFF
--- a/src/infrafoundry/core/config/filters.py
+++ b/src/infrafoundry/core/config/filters.py
@@ -1,0 +1,20 @@
+"""Custom Jinja2 filters for InfraFoundry configuration rendering."""
+
+import hashlib
+
+
+def generate_mac(value: str) -> str:
+    """Generate a deterministic locally-administered MAC address from a string.
+
+    Uses SHA-256 to hash the input, then formats the first 5 bytes as a
+    MAC address with a fixed ``02`` first octet (locally administered,
+    unicast).
+
+    Args:
+        value: Input string to derive the MAC address from.
+
+    Returns:
+        MAC address in the format ``02:xx:xx:xx:xx:xx``.
+    """
+    digest = hashlib.sha256(value.encode()).digest()
+    return "02:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}".format(*digest[:5])

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 import jinja2
 import yaml
 
+from infrafoundry.core.config.filters import generate_mac
 from infrafoundry.core.config.inventory_generator import InventoryGenerator
 from infrafoundry.core.config.models import PackageManifest
 from infrafoundry.core.config.sops import load_yaml_with_sops
@@ -241,7 +242,9 @@ class PackageLoader:
 
             events_json = json.dumps(manifest.events)
             try:
-                events_template = jinja2.Template(events_json)
+                events_env = jinja2.Environment(undefined=jinja2.Undefined)  # nosec B701 - rendering JSON, not HTML
+                events_env.filters["generate_mac"] = generate_mac
+                events_template = events_env.from_string(events_json)
                 rendered_events_json = events_template.render(**manifest.variables)
                 manifest.events = json.loads(rendered_events_json)
             except (jinja2.TemplateError, json.JSONDecodeError) as e:
@@ -333,6 +336,7 @@ class PackageLoader:
         # Render Jinja2 template with StrictUndefined
         try:
             env = jinja2.Environment(undefined=jinja2.StrictUndefined)  # nosec B701 - rendering YAML, not HTML
+            env.filters["generate_mac"] = generate_mac
             template = env.from_string(content)
             rendered = template.render(**variables)
         except jinja2.UndefinedError as e:

--- a/src/infrafoundry/core/provider_mixins.py
+++ b/src/infrafoundry/core/provider_mixins.py
@@ -135,6 +135,11 @@ class TemplateRendererMixin:
         # Python repr for code generation
         self.jinja_env.filters["repr"] = repr
 
+        # Generate deterministic MAC addresses from strings
+        from infrafoundry.core.config.filters import generate_mac
+
+        self.jinja_env.filters["generate_mac"] = generate_mac
+
     def get_template(self, template_name: str) -> Template:
         """Load a Jinja2 template by name.
 

--- a/tests/unit/test_generate_mac.py
+++ b/tests/unit/test_generate_mac.py
@@ -1,0 +1,74 @@
+"""Tests for the generate_mac Jinja2 filter."""
+
+from __future__ import annotations
+
+import re
+
+import jinja2
+import pytest
+
+from infrafoundry.core.config.filters import generate_mac
+
+
+class TestGenerateMac:
+    """Tests for the generate_mac filter function."""
+
+    def test_deterministic_same_input(self) -> None:
+        """Same input always produces the same MAC address."""
+        result1 = generate_mac("test-vm-01")
+        result2 = generate_mac("test-vm-01")
+        assert result1 == result2
+
+    def test_different_inputs_produce_different_macs(self) -> None:
+        """Different inputs produce different MAC addresses."""
+        mac1 = generate_mac("vm-alpha")
+        mac2 = generate_mac("vm-beta")
+        assert mac1 != mac2
+
+    def test_first_octet_is_02(self) -> None:
+        """First octet is always 02 (locally administered, unicast)."""
+        for name in ["a", "server-1", "long-name-with-many-chars"]:
+            mac = generate_mac(name)
+            assert mac.startswith("02:"), f"MAC for '{name}' does not start with 02: {mac}"
+
+    def test_format_matches_mac_pattern(self) -> None:
+        """Output matches the expected 02:xx:xx:xx:xx:xx format."""
+        pattern = re.compile(r"^02:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}$")
+        for name in ["foo", "bar", "baz-123", ""]:
+            mac = generate_mac(name)
+            assert pattern.match(mac), f"MAC '{mac}' for input '{name}' doesn't match pattern"
+
+    def test_empty_string_does_not_crash(self) -> None:
+        """Empty string input produces a valid MAC without errors."""
+        mac = generate_mac("")
+        assert mac.startswith("02:")
+        assert len(mac) == 17  # 02:xx:xx:xx:xx:xx = 17 chars
+
+    def test_works_as_jinja2_filter(self) -> None:
+        """Filter integrates correctly in a Jinja2 environment."""
+        env = jinja2.Environment()
+        env.filters["generate_mac"] = generate_mac
+        template = env.from_string("{{ name | generate_mac }}")
+        result = template.render(name="my-server")
+        assert result == generate_mac("my-server")
+
+    @pytest.mark.parametrize(
+        "input_value",
+        [
+            "simple",
+            "with spaces",
+            "with-dashes",
+            "with_underscores",
+            "CamelCase",
+            "123numeric",
+            "special!@#$%",
+        ],
+    )
+    def test_various_inputs(self, input_value: str) -> None:
+        """Various string inputs all produce valid MAC addresses."""
+        mac = generate_mac(input_value)
+        assert mac.startswith("02:")
+        parts = mac.split(":")
+        assert len(parts) == 6
+        for part in parts:
+            assert len(part) == 2


### PR DESCRIPTION
## Description

Add a `generate_mac` Jinja2 filter that produces deterministic locally-administered MAC addresses from string input. Useful for virtual appliance DHCP reservations where the MAC is a placeholder for DNS entries.

Addresses #458

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`filters.py`** (new) — `generate_mac()`: SHA-256 hashes input, formats first 5 bytes as `02:xx:xx:xx:xx:xx`
- **`package_loader.py`** — registered filter in resource template and event rendering environments
- **`provider_mixins.py`** — registered filter in provider template environment
- **`test_generate_mac.py`** (new) — tests for determinism, uniqueness, format, empty string, Jinja2 integration

### Usage

```yaml
cluster_mgmt_mac: "{{ cluster_name | generate_mac }}"
# "ontapcl" → "02:a1:b2:c3:d4:e5" (deterministic)
# "ontapcl-test" → "02:f6:g7:h8:i9:j0" (different)
```

## Testing

- [x] All existing tests pass
- [x] New tests for generate_mac function and Jinja2 integration
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass
- [x] My changes generate no new warnings
