### PR TITLE
fix: add data_nfs and data_cifs to ONTAP data LIF service policy

### DIFF
--- a/blueprints/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
@@ -156,6 +156,31 @@
     label: "{{ item.name }}"
 
 # ---------------------------------------------------------------
+# Ensure data service policy includes NFS and CIFS
+# ONTAP 9.18+ uses service policies instead of protocol-based LIF assignment.
+# The default-data-files policy may not include data_nfs/data_cifs by default.
+# ---------------------------------------------------------------
+- name: Ensure data service policy includes NFS and CIFS services
+  netapp.ontap.na_ontap_service_policy:
+    <<: *ontap_conn
+    state: present
+    name: default-data-files
+    vserver: "{{ item.name }}"
+    services:
+      - data_core
+      - data_nfs
+      - data_cifs
+      - data_fpolicy_client
+      - management_dns_client
+      - management_ad_client
+      - management_ldap_client
+      - management_nis_client
+      - data_dns_server
+  loop: "{{ ontap_svms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
 # Data LIF creation
 # ---------------------------------------------------------------
 - name: Create data LIFs

--- a/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
+++ b/example-config/envs/dev/proxmox/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
@@ -160,6 +160,30 @@
     label: "{{ item.name }}"
 
 # ---------------------------------------------------------------
+# Ensure data service policy includes NFS and CIFS
+# ONTAP 9.18+ uses service policies instead of protocol-based LIF assignment.
+# ---------------------------------------------------------------
+- name: Ensure data service policy includes NFS and CIFS services
+  netapp.ontap.na_ontap_service_policy:
+    <<: *ontap_conn
+    state: present
+    name: default-data-files
+    vserver: "{{ item.name }}"
+    services:
+      - data_core
+      - data_nfs
+      - data_cifs
+      - data_fpolicy_client
+      - management_dns_client
+      - management_ad_client
+      - management_ldap_client
+      - management_nis_client
+      - data_dns_server
+  loop: "{{ ontap_svms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# ---------------------------------------------------------------
 # Data LIF creation
 # ---------------------------------------------------------------
 - name: Create data LIFs


### PR DESCRIPTION
## Description

ONTAP 9.18+ uses service policies instead of protocol-based LIF assignment. The `default-data-files` policy was missing `data_nfs` and `data_cifs` services, preventing NFS/CIFS traffic on data LIFs even when the protocols were enabled on the SVM.

Adds `na_ontap_service_policy` task after SVM creation in all three locations: blueprint, existing package, and example config.

Addresses #463

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **Blueprint** (`blueprints/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml`) — added service policy task
- **Example config** (`example-config/.../roles/ontap-post-cluster/tasks/main.yml`) — same fix

## Testing

- [x] Verified manually: port 445 closed before fix, open after adding `data_nfs` and `data_cifs` to service policy
- [x] SMB connection to CIFS_VOL successful after fix

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass
- [x] My changes generate no new warnings