### PR TITLE
fix: replace broken OPNsense ansible filter reload with credential validation and single apply task

### DIFF
--- a/src/infrafoundry/providers/opnsense/templates/opnsense/inventory.yml.j2
+++ b/src/infrafoundry/providers/opnsense/templates/opnsense/inventory.yml.j2
@@ -9,6 +9,6 @@ all:
           ansible_host: "{% raw %}{{ lookup('env', 'OPNSENSE_HOST') | default('opnsense.local') }}{% endraw %}"
           ansible_connection: local
       vars:
-        opnsense_api_url: "{% raw %}{{ lookup('env', 'OPNSENSE_API_URL') }}{% endraw %}"
+        opnsense_api_url: "{% raw %}{{ lookup('env', 'OPNSENSE_API_URL') | default('', true) }}{% endraw %}"
         opnsense_api_key: "{% raw %}{{ lookup('env', 'OPNSENSE_API_KEY') }}{% endraw %}"
         opnsense_api_secret: "{% raw %}{{ lookup('env', 'OPNSENSE_API_SECRET') }}{% endraw %}"

--- a/src/infrafoundry/providers/opnsense/templates/opnsense/playbook.yml.j2
+++ b/src/infrafoundry/providers/opnsense/templates/opnsense/playbook.yml.j2
@@ -6,18 +6,20 @@
   gather_facts: false
 
   tasks:
-    - name: Reload firewall rules
+    - name: Validate OPNsense API credentials
+      ansible.builtin.assert:
+        that:
+          - {% raw %}opnsense_api_url | default('') | length > 0{% endraw %}
+          - {% raw %}opnsense_api_key | default('') | length > 0{% endraw %}
+          - {% raw %}opnsense_api_secret | default('') | length > 0{% endraw %}
+        fail_msg: >-
+          OPNsense API credentials are not configured.
+          Set OPNSENSE_API_URL, OPNSENSE_API_KEY, and OPNSENSE_API_SECRET
+          environment variables or configure them in your secrets file.
+
+    - name: Apply firewall filter changes
       uri:
         url: "{% raw %}{{ opnsense_api_url }}{% endraw %}/api/firewall/filter/apply"
-        method: POST
-        headers:
-          Authorization: "Basic {% raw %}{{ (opnsense_api_key + ':' + opnsense_api_secret) | b64encode }}{% endraw %}"
-        validate_certs: false
-      when: firewall_rules_changed | default(false)
-
-    - name: Reload filter
-      uri:
-        url: "{% raw %}{{ opnsense_api_url }}{% endraw %}/api/firewall/filter/reload"
         method: POST
         headers:
           Authorization: "Basic {% raw %}{{ (opnsense_api_key + ':' + opnsense_api_secret) | b64encode }}{% endraw %}"

--- a/tests/unit/test_provider_templates.py
+++ b/tests/unit/test_provider_templates.py
@@ -568,7 +568,9 @@ class TestOPNsenseTemplates:
             content = playbook.read_text()
             assert "Configure OPNsense" in content
             assert "api/firewall/filter/apply" in content
-            assert "api/firewall/filter/reload" in content
+            assert "api/firewall/filter/reload" not in content
+            assert "Validate OPNsense API credentials" in content
+            assert "ansible.builtin.assert" in content
 
     def test_generate_outputs_tf(
         self, provider: OPNsenseProvider, firewall_rule: ResourceConfig


### PR DESCRIPTION
## Description

Fix the OPNsense Ansible playbook that fails with `unknown url type` when `OPNSENSE_API_URL` is unset. The playbook previously had two separate reload tasks (`filter/apply` and `filter/reload`) that would both fail if API credentials were missing. This replaces them with a credential validation assertion followed by a single `filter/apply` task, which is the correct OPNsense API endpoint for applying firewall changes.

## Related Issue

Addresses #391

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **playbook.yml.j2**: Replaced two broken reload tasks (`filter/apply` conditional on a variable + `filter/reload` which doesn't exist in OPNsense API) with a credential validation assertion and a single `filter/apply` task
- **inventory.yml.j2**: Added `| default('', true)` to `OPNSENSE_API_URL` env lookup so missing values produce an empty string instead of an Ansible error
- **test_provider_templates.py**: Updated assertions to verify the new playbook structure (no `filter/reload`, has credential validation)

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type check, security, spelling, tests)
