### PR TITLE
chore: harden secrets handling file permissions

### DIFF
--- a/docs/development/security/secrets-handling.md
+++ b/docs/development/security/secrets-handling.md
@@ -1,0 +1,84 @@
+# Secrets Handling Security
+
+## Overview
+
+InfraFoundry decrypts SOPS-encrypted secrets and delivers them to Terraform and Ansible
+runners. This document describes the security controls applied to plaintext secret files
+during that process.
+
+## Where Plaintext Secrets Appear
+
+| Location | Purpose | Lifetime |
+|---|---|---|
+| `generated/{env}/terraform/{provider}/terraform.tfvars` | Provider credentials for Terraform | Duration of apply |
+| `generated/{env}/ansible/{provider}/vars/*.yml` | Ansible variable files | Duration of playbook run |
+| SOPS `.tmp` files | Intermediate plaintext before encryption | Momentary (during `save_secret`) |
+| `TF_VAR_*` environment variables | Preferred credential delivery | Process lifetime only |
+
+## File Permissions Policy
+
+All plaintext secret files are written with **0o600** (owner read/write only) permissions
+using the `secure_write` and `secure_write_yaml` utilities in
+`infrafoundry.core.security.file_utils`.
+
+These functions use `os.open()` with explicit mode bits to atomically create files with
+the correct permissions, avoiding the TOCTOU race condition that occurs when calling
+`open()` followed by `chmod()`.
+
+```python
+from infrafoundry.core.security.file_utils import secure_write, secure_write_yaml
+
+# Write plaintext content with 0o600 permissions
+secure_write(path, content)
+
+# Write YAML data with 0o600 permissions
+secure_write_yaml(path, data)
+```
+
+## Secret Delivery Architecture
+
+### Preferred: Environment Variables
+
+The preferred method for delivering secrets to Terraform is via `TF_VAR_*` environment
+variables through the `build_terraform_env_vars()` method on provider mixins. This
+approach:
+
+- Never writes secrets to disk
+- Limits secret exposure to the subprocess lifetime
+- Cannot be accidentally committed to version control
+
+### Legacy: File-Based Export
+
+The `export_for_terraform()` and `export_for_ansible()` methods write plaintext files.
+These are hardened with:
+
+1. **Restrictive permissions** (0o600) via `secure_write`
+2. **Cleanup support** via the `temporary_export()` context manager
+
+```python
+# Automatic cleanup after use
+with secret_manager.temporary_export("secrets.yaml", output_path, fmt="terraform") as path:
+    # Use the exported file
+    runner.apply(tfvars=path)
+# File is automatically deleted here, even if an exception occurred
+```
+
+## Cleanup Behavior
+
+The `temporary_export()` context manager ensures exported secret files are deleted after
+use, even when exceptions occur. For manual cleanup, use `cleanup_secret_files()`:
+
+```python
+SecretManager.cleanup_secret_files(path1, path2)
+```
+
+## Production Recommendations
+
+1. **Use environment variables** (`build_terraform_env_vars()`) instead of tfvars files
+   whenever possible.
+2. **Use remote state backends** (S3, GCS, Azure Blob) with encryption at rest to avoid
+   plaintext state files on disk.
+3. **Restrict access** to the `generated/` directory tree, which is gitignored but may
+   contain plaintext secrets during apply operations.
+4. **Rotate secrets regularly** using `SecretManager.rotate_secrets()`.
+5. **Audit file permissions** periodically -- all secret files should be 0o600.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
     - CI/CD Testing: development/ci-cd-testing.md
     - Release & Automation: development/release-and-automation.md
     - Implementing Secret Providers: development/implementing-secret-providers.md
+    - Secrets Handling: development/security/secrets-handling.md
 
   - Runners:
     - Overview: runners/overview.md

--- a/src/infrafoundry/core/provider_mixins.py
+++ b/src/infrafoundry/core/provider_mixins.py
@@ -16,6 +16,7 @@ from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.exceptions import TemplateError
 from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.security.file_utils import secure_write
 
 if TYPE_CHECKING:
     # Type stubs for mixin expectations - not used at runtime
@@ -455,7 +456,7 @@ class TerraformGeneratorMixin:
             return
 
         tfvars_path = Path(self.terraform_dir) / "terraform.tfvars"
-        tfvars_path.write_text("".join(lines))
+        secure_write(tfvars_path, "".join(lines))
 
     def generate_provider_tfvars(
         self,

--- a/src/infrafoundry/core/secrets/providers/sops.py
+++ b/src/infrafoundry/core/secrets/providers/sops.py
@@ -12,6 +12,7 @@ from infrafoundry.core.exceptions import (
     SecretNotFoundError,
 )
 from infrafoundry.core.secrets.provider import SecretProvider
+from infrafoundry.core.security.file_utils import secure_write_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +91,7 @@ class SopsSecretProvider(SecretProvider):
         temp_file = file_path.with_suffix(".tmp")
 
         try:
-            with open(temp_file, "w") as f:
-                yaml.dump(data, f)
+            secure_write_yaml(temp_file, data)
 
             # Encrypt in place
             subprocess.run(  # nosec B603

--- a/src/infrafoundry/core/secrets/secret_manager.py
+++ b/src/infrafoundry/core/secrets/secret_manager.py
@@ -1,16 +1,17 @@
 """Secret management using SOPS with age encryption."""
 
 import json
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
-
-import yaml
 
 from infrafoundry.core.base_manager import PathBasedManager
 from infrafoundry.core.secrets.age_key_manager import check_age_key, create_sops_config
 from infrafoundry.core.secrets.provider import SecretProvider
 from infrafoundry.core.secrets.providers.sops import SopsSecretProvider
 from infrafoundry.core.secrets.rotation import SecretsRotator
+from infrafoundry.core.security.file_utils import secure_write, secure_write_yaml
 
 
 class SecretManager(PathBasedManager):
@@ -139,12 +140,13 @@ class SecretManager(PathBasedManager):
             output_file: Path to write tfvars file
         """
         data = self.decrypt_file(filename)
-        with open(output_file, "w") as f:
-            for key, value in data.items():
-                if isinstance(value, str):
-                    f.write(f'{key} = "{value}"\n')
-                else:
-                    f.write(f"{key} = {json.dumps(value)}\n")
+        lines: list[str] = []
+        for key, value in data.items():
+            if isinstance(value, str):
+                lines.append(f'{key} = "{value}"\n')
+            else:
+                lines.append(f"{key} = {json.dumps(value)}\n")
+        secure_write(output_file, "".join(lines))
 
     def export_for_ansible(self, filename: str, output_file: Path) -> None:
         """Export secrets as Ansible vars file.
@@ -154,8 +156,46 @@ class SecretManager(PathBasedManager):
             output_file: Path to write vars file
         """
         data = self.decrypt_file(filename)
-        with open(output_file, "w") as f:
-            yaml.dump(data, f)
+        secure_write_yaml(output_file, data)
+
+    @contextmanager
+    def temporary_export(
+        self, filename: str, output_file: Path, fmt: str = "terraform"
+    ) -> Generator[Path, None, None]:
+        """Export secrets to a temporary file and clean up after use.
+
+        Args:
+            filename: Name of encrypted secrets file
+            output_file: Path to write the exported file
+            fmt: Export format - "terraform" for tfvars or "ansible" for YAML vars
+
+        Yields:
+            Path to the exported file
+
+        Raises:
+            ValueError: If fmt is not "terraform" or "ansible"
+        """
+        if fmt == "terraform":
+            self.export_for_terraform(filename, output_file)
+        elif fmt == "ansible":
+            self.export_for_ansible(filename, output_file)
+        else:
+            raise ValueError(f"Unsupported export format: {fmt}")
+
+        try:
+            yield output_file
+        finally:
+            self.cleanup_secret_files(output_file)
+
+    @staticmethod
+    def cleanup_secret_files(*paths: Path) -> None:
+        """Remove exported secret files from disk.
+
+        Args:
+            paths: Paths to secret files to remove
+        """
+        for path in paths:
+            path.unlink(missing_ok=True)
 
     def cleanup(self) -> None:
         """Cleanup resources (required by BaseManager).

--- a/src/infrafoundry/core/security/__init__.py
+++ b/src/infrafoundry/core/security/__init__.py
@@ -4,6 +4,7 @@ This module provides security scanning capabilities for generated
 Terraform and Ansible configurations using tools like Checkov.
 """
 
+from infrafoundry.core.security.file_utils import secure_write, secure_write_yaml
 from infrafoundry.core.security.scanner import (
     ScanResult,
     ScanSeverity,
@@ -16,4 +17,6 @@ __all__ = [
     "ScanSeverity",
     "SecurityScanner",
     "SecurityViolation",
+    "secure_write",
+    "secure_write_yaml",
 ]

--- a/src/infrafoundry/core/security/file_utils.py
+++ b/src/infrafoundry/core/security/file_utils.py
@@ -1,0 +1,55 @@
+"""Secure file writing utilities for secrets handling."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def secure_write(path: Path, content: str, permissions: int = 0o600) -> None:
+    """Write content to a file with restrictive permissions.
+
+    Removes any existing file first, then uses os.open() with explicit
+    mode bits to atomically create the file with the correct permissions,
+    avoiding the race condition of open() followed by chmod().
+
+    Args:
+        path: Path to write to
+        content: String content to write
+        permissions: File permission bits (default: 0o600 - owner read/write only)
+    """
+    # Remove existing file so os.open() applies the mode bits on creation
+    path.unlink(missing_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, permissions)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+    except BaseException:
+        # fd is already closed by os.fdopen, but file may exist
+        path.unlink(missing_ok=True)
+        raise
+    logger.debug("Wrote secure file: %s (mode %s)", path, oct(permissions))
+
+
+def secure_write_yaml(path: Path, data: dict[str, Any], permissions: int = 0o600) -> None:
+    """Write YAML data to a file with restrictive permissions.
+
+    Args:
+        path: Path to write to
+        data: Dictionary to serialize as YAML
+        permissions: File permission bits (default: 0o600 - owner read/write only)
+    """
+    # Remove existing file so os.open() applies the mode bits on creation
+    path.unlink(missing_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, permissions)
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(data, f)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+    logger.debug("Wrote secure YAML file: %s (mode %s)", path, oct(permissions))

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,5 +1,7 @@
 """Unit tests for SecretManager."""
 
+import os
+import stat
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -268,3 +270,106 @@ class TestSecretManager:
         assert output_file.exists()
         exported_data = yaml.safe_load(output_file.read_text())
         assert exported_data == decrypted_data
+
+    def test_export_for_terraform_sets_restrictive_permissions(
+        self, temp_secrets_dir, mock_provider
+    ):
+        """Test that export_for_terraform creates files with 0o600 permissions."""
+        manager = SecretManager(
+            env_name="dev", secrets_dir=temp_secrets_dir, provider=mock_provider
+        )
+        mock_provider.load_secret.return_value = {"api_token": "secret123"}
+
+        output_file = temp_secrets_dir / "secrets.tfvars"
+        manager.export_for_terraform("secrets.yaml", output_file)
+
+        assert stat.S_IMODE(os.stat(output_file).st_mode) == 0o600
+
+    def test_export_for_ansible_sets_restrictive_permissions(self, temp_secrets_dir, mock_provider):
+        """Test that export_for_ansible creates files with 0o600 permissions."""
+        manager = SecretManager(
+            env_name="dev", secrets_dir=temp_secrets_dir, provider=mock_provider
+        )
+        mock_provider.load_secret.return_value = {"api_token": "secret123"}
+
+        output_file = temp_secrets_dir / "secrets_vars.yml"
+        manager.export_for_ansible("secrets.yaml", output_file)
+
+        assert stat.S_IMODE(os.stat(output_file).st_mode) == 0o600
+
+    def test_temporary_export_cleans_up_file(self, temp_secrets_dir, mock_provider):
+        """Test that temporary_export removes the file after context manager exits."""
+        manager = SecretManager(
+            env_name="dev", secrets_dir=temp_secrets_dir, provider=mock_provider
+        )
+        mock_provider.load_secret.return_value = {"api_token": "secret123"}
+
+        output_file = temp_secrets_dir / "temp_secrets.tfvars"
+        with manager.temporary_export("secrets.yaml", output_file, fmt="terraform") as path:
+            assert path.exists()
+            assert path == output_file
+
+        assert not output_file.exists()
+
+    def test_temporary_export_cleans_up_on_exception(self, temp_secrets_dir, mock_provider):
+        """Test that temporary_export cleans up even when an exception occurs."""
+        manager = SecretManager(
+            env_name="dev", secrets_dir=temp_secrets_dir, provider=mock_provider
+        )
+        mock_provider.load_secret.return_value = {"api_token": "secret123"}
+
+        output_file = temp_secrets_dir / "temp_secrets.tfvars"
+        with (
+            pytest.raises(RuntimeError, match="test error"),
+            manager.temporary_export("secrets.yaml", output_file, fmt="terraform") as path,
+        ):
+            assert path.exists()
+            raise RuntimeError("test error")
+
+        assert not output_file.exists()
+
+    def test_temporary_export_ansible_format(self, temp_secrets_dir, mock_provider):
+        """Test that temporary_export works with ansible format."""
+        manager = SecretManager(
+            env_name="dev", secrets_dir=temp_secrets_dir, provider=mock_provider
+        )
+        mock_provider.load_secret.return_value = {"api_token": "secret123"}
+
+        output_file = temp_secrets_dir / "temp_vars.yml"
+        with manager.temporary_export("secrets.yaml", output_file, fmt="ansible") as path:
+            assert path.exists()
+            data = yaml.safe_load(path.read_text())
+            assert data == {"api_token": "secret123"}
+
+        assert not output_file.exists()
+
+    def test_temporary_export_invalid_format(self, temp_secrets_dir, mock_provider):
+        """Test that temporary_export raises ValueError for unsupported format."""
+        manager = SecretManager(
+            env_name="dev", secrets_dir=temp_secrets_dir, provider=mock_provider
+        )
+
+        output_file = temp_secrets_dir / "temp.txt"
+        with (
+            pytest.raises(ValueError, match="Unsupported export format"),
+            manager.temporary_export("secrets.yaml", output_file, fmt="invalid"),
+        ):
+            pass  # pragma: no cover
+
+    def test_cleanup_secret_files(self, temp_secrets_dir):
+        """Test that cleanup_secret_files removes specified files."""
+        file1 = temp_secrets_dir / "secret1.tfvars"
+        file2 = temp_secrets_dir / "secret2.yml"
+        file1.write_text("secret")
+        file2.write_text("secret")
+
+        SecretManager.cleanup_secret_files(file1, file2)
+
+        assert not file1.exists()
+        assert not file2.exists()
+
+    def test_cleanup_secret_files_missing_file(self, temp_secrets_dir):
+        """Test that cleanup_secret_files handles already-deleted files gracefully."""
+        missing_file = temp_secrets_dir / "nonexistent.tfvars"
+        # Should not raise
+        SecretManager.cleanup_secret_files(missing_file)

--- a/tests/unit/test_security_file_utils.py
+++ b/tests/unit/test_security_file_utils.py
@@ -1,0 +1,91 @@
+"""Tests for secure file writing utilities."""
+
+import os
+import stat
+
+import yaml
+
+from infrafoundry.core.security.file_utils import secure_write, secure_write_yaml
+
+
+class TestSecureWrite:
+    """Tests for secure_write function."""
+
+    def test_creates_file_with_600_permissions(self, tmp_path):
+        """Test that secure_write creates files with 0o600 permissions."""
+        path = tmp_path / "secret.txt"
+        secure_write(path, "secret content")
+        assert path.exists()
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+    def test_writes_correct_content(self, tmp_path):
+        """Test that secure_write writes the expected content."""
+        path = tmp_path / "secret.txt"
+        secure_write(path, "secret content")
+        assert path.read_text() == "secret content"
+
+    def test_custom_permissions(self, tmp_path):
+        """Test that custom permissions are applied."""
+        path = tmp_path / "secret.txt"
+        secure_write(path, "content", permissions=0o640)
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o640
+
+    def test_overwrites_existing_file(self, tmp_path):
+        """Test that existing files are overwritten with correct permissions."""
+        path = tmp_path / "secret.txt"
+        path.write_text("old content")
+        os.chmod(path, 0o644)
+        secure_write(path, "new content")
+        assert path.read_text() == "new content"
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+    def test_empty_content(self, tmp_path):
+        """Test that empty content is handled correctly."""
+        path = tmp_path / "empty.txt"
+        secure_write(path, "")
+        assert path.exists()
+        assert path.read_text() == ""
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+
+class TestSecureWriteYaml:
+    """Tests for secure_write_yaml function."""
+
+    def test_creates_file_with_600_permissions(self, tmp_path):
+        """Test that secure_write_yaml creates files with 0o600 permissions."""
+        path = tmp_path / "secret.yaml"
+        secure_write_yaml(path, {"key": "value"})
+        assert path.exists()
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+    def test_writes_valid_yaml(self, tmp_path):
+        """Test that secure_write_yaml writes valid YAML content."""
+        path = tmp_path / "secret.yaml"
+        data = {"api_key": "secret123", "api_url": "https://example.com"}
+        secure_write_yaml(path, data)
+        loaded = yaml.safe_load(path.read_text())
+        assert loaded == data
+
+    def test_custom_permissions(self, tmp_path):
+        """Test that custom permissions are applied to YAML files."""
+        path = tmp_path / "secret.yaml"
+        secure_write_yaml(path, {"key": "value"}, permissions=0o640)
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o640
+
+    def test_overwrites_existing_yaml_file(self, tmp_path):
+        """Test that existing YAML files are overwritten with correct permissions."""
+        path = tmp_path / "secret.yaml"
+        path.write_text("old: data\n")
+        os.chmod(path, 0o644)
+        secure_write_yaml(path, {"new": "data"})
+        loaded = yaml.safe_load(path.read_text())
+        assert loaded == {"new": "data"}
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+    def test_nested_data(self, tmp_path):
+        """Test that nested dictionaries are serialized correctly."""
+        path = tmp_path / "nested.yaml"
+        data = {"level1": {"level2": {"key": "value"}}, "list": [1, 2, 3]}
+        secure_write_yaml(path, data)
+        loaded = yaml.safe_load(path.read_text())
+        assert loaded == data


### PR DESCRIPTION
## Description

Audit and harden secrets handling to prevent plaintext exposure risks. This adds restrictive file permissions (0o600) to all paths where secrets are written to disk, introduces secure write utilities, and adds a cleanup context manager for temporary decrypted files.

## Related Issue

Addresses #359

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Add `secure_write` and `secure_write_yaml` utilities in `core/security/file_utils.py` for writing files with restrictive permissions (0o600)
- Fix exported secret file permissions in `SecretManager` to use 0o600 instead of default umask
- Add `secrets_cleanup` context manager in `SecretManager` for automatic cleanup of temporary decrypted files
- Fix SOPS provider temp file permissions to use 0o600
- Fix tfvars file permissions in `provider_mixins.py` to use 0o600
- Update `core/security/__init__.py` exports to include new utilities
- Add comprehensive tests for secure write utilities and permission enforcement
- Add `docs/development/security/secrets-handling.md` documenting secrets handling best practices
- Add secrets handling doc to mkdocs navigation

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No user-facing behavior changes. All modifications are internal permission hardening. No CHANGELOG.md exists in the project root, so that checklist item is not applicable.
