### PR TITLE
refactor: make PackageLoader use pluggable SecretProvider instead of hardcoded SOPS

### DIFF
--- a/src/infrafoundry/core/config/config_manager.py
+++ b/src/infrafoundry/core/config/config_manager.py
@@ -16,6 +16,7 @@ from infrafoundry.core.config.resource_centric_loader import ResourceCentricLoad
 from infrafoundry.core.config.sops import load_yaml_with_sops
 from infrafoundry.core.exceptions import InvalidConfigurationError, PackageNotFoundError
 from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.secrets.provider import SecretProvider
 
 
 class ConfigManager(PathBasedManager):
@@ -25,12 +26,18 @@ class ConfigManager(PathBasedManager):
     to support both configuration formats.
     """
 
-    def __init__(self, base_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        base_dir: Path | None = None,
+        secret_provider: SecretProvider | None = None,
+    ) -> None:
         """Initialize configuration manager.
 
         Args:
             base_dir: Base directory for configs
                 (defaults to INFRAFOUNDRY_CONFIG_REPO/envs)
+            secret_provider: Provider used to load package secrets.
+                Forwarded to ``ProviderCentricLoader`` and ``PackageLoader``.
 
         Raises:
             ValueError: If base_dir is None and INFRAFOUNDRY_CONFIG_REPO is not set
@@ -55,9 +62,11 @@ class ConfigManager(PathBasedManager):
 
         # Initialize blueprint resolver and loaders
         self._blueprint_resolver = BlueprintResolver(base_dir)
-        self.provider_centric = ProviderCentricLoader(base_dir, self._blueprint_resolver)
+        self.provider_centric = ProviderCentricLoader(
+            base_dir, self._blueprint_resolver, secret_provider
+        )
         self.resource_centric = ResourceCentricLoader(base_dir)
-        self._package_loader = PackageLoader(base_dir, self._blueprint_resolver)
+        self._package_loader = PackageLoader(base_dir, self._blueprint_resolver, secret_provider)
 
     def load_environment(self, env_name: str) -> EnvironmentConfig:
         """Load environment configuration.

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -24,9 +24,10 @@ import yaml
 from infrafoundry.core.config.filters import generate_mac
 from infrafoundry.core.config.inventory_generator import InventoryGenerator
 from infrafoundry.core.config.models import PackageManifest
-from infrafoundry.core.config.sops import load_yaml_with_sops
 from infrafoundry.core.exceptions import InvalidConfigurationError
 from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.secrets.provider import SecretProvider
+from infrafoundry.core.secrets.providers.sops import SopsSecretProvider
 
 if TYPE_CHECKING:
     from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
@@ -74,6 +75,7 @@ class PackageLoader:
         self,
         base_dir: Path,
         blueprint_resolver: BlueprintResolver | None = None,
+        secret_provider: SecretProvider | None = None,
     ) -> None:
         """Initialize package loader.
 
@@ -82,9 +84,12 @@ class PackageLoader:
             blueprint_resolver: Optional resolver for blueprint references.
                 When ``None``, packages that declare ``blueprint:`` will
                 raise an error.
+            secret_provider: Provider used to load package secrets.yaml files.
+                Defaults to ``SopsSecretProvider`` when ``None``.
         """
         self.base_dir = base_dir
         self._blueprint_resolver = blueprint_resolver
+        self._secret_provider = secret_provider or SopsSecretProvider()
         self._inventory_generator = InventoryGenerator()
 
     def discover_packages(self, env_name: str, provider: str) -> list[Path]:
@@ -204,7 +209,7 @@ class PackageLoader:
         # ----- Secrets -----
         secrets_path = package_dir / "secrets.yaml"
         if secrets_path.exists():
-            secrets_data = load_yaml_with_sops(secrets_path)
+            secrets_data = self._secret_provider.load_secret(secrets_path)
             secret_vars = secrets_data.get("variables", {})
             if secret_vars:
                 manifest.variables.update(secret_vars)

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -12,6 +12,7 @@ import yaml
 
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.secrets.provider import SecretProvider
 
 if TYPE_CHECKING:
     from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
@@ -24,15 +25,18 @@ class ProviderCentricLoader:
         self,
         base_dir: Path,
         blueprint_resolver: BlueprintResolver | None = None,
+        secret_provider: SecretProvider | None = None,
     ) -> None:
         """Initialize loader.
 
         Args:
             base_dir: Base directory for environment configs (e.g., ./envs)
             blueprint_resolver: Optional resolver for blueprint references.
+            secret_provider: Provider used to load package secrets.
+                Forwarded to ``PackageLoader``.
         """
         self.base_dir = base_dir
-        self._package_loader = PackageLoader(base_dir, blueprint_resolver)
+        self._package_loader = PackageLoader(base_dir, blueprint_resolver, secret_provider)
         self._pending_package_events: dict[str, list[dict[str, Any]]] = {}
 
     def load_resources(

--- a/src/infrafoundry/core/secrets/providers/sops.py
+++ b/src/infrafoundry/core/secrets/providers/sops.py
@@ -38,21 +38,52 @@ class SopsSecretProvider(SecretProvider):
         """Check if sops is installed."""
         _ = self._sops_path  # Will raise SecretError if not found
 
-    def load_secret(self, location: str | Path) -> dict[str, Any]:
-        """
-        Loads a secret from a file using SOPS.
+    @staticmethod
+    def _is_sops_encrypted(file_content: str) -> bool:
+        """Check whether file content contains SOPS encryption markers.
+
+        Both the ``sops:`` metadata key and ``ENC[AES256_GCM,`` value markers
+        must be present for the file to be considered SOPS-encrypted.
 
         Args:
-            location: Path to the encrypted file.
+            file_content: Raw file content to inspect.
 
         Returns:
-            The decrypted data as a dictionary.
+            True if the content appears to be SOPS-encrypted.
         """
-        self._ensure_sops_installed()
+        return "sops:" in file_content and "ENC[AES256_GCM," in file_content
+
+    def load_secret(self, location: str | Path) -> dict[str, Any]:
+        """Load a secret from a file, decrypting with SOPS only if encrypted.
+
+        Reads the file content and checks for SOPS encryption markers.
+        Plaintext YAML files are loaded directly without requiring sops
+        to be installed.  Encrypted files are decrypted via ``sops --decrypt``.
+
+        Args:
+            location: Path to the secret file.
+
+        Returns:
+            The secret data as a dictionary.
+        """
         file_path = Path(location)
         if not file_path.exists():
-            raise SecretNotFoundError(f"Encrypted file not found: {file_path}")
+            raise SecretNotFoundError(f"Secret file not found: {file_path}")
 
+        try:
+            raw = file_path.read_text()
+        except Exception as e:
+            raise SecretError(f"Failed to read secret file {file_path}: {e}") from e
+
+        # Plaintext YAML — return directly without requiring sops
+        if not self._is_sops_encrypted(raw):
+            try:
+                return cast(dict[str, Any], yaml.safe_load(raw)) or {}
+            except yaml.YAMLError as e:
+                raise SecretDecryptionError(f"Failed to parse YAML from {file_path}: {e}") from e
+
+        # Encrypted — sops must be available
+        self._ensure_sops_installed()
         try:
             result = subprocess.run(  # nosec B603
                 [self._sops_path, "--decrypt", str(file_path)],

--- a/tests/test_package_loader.py
+++ b/tests/test_package_loader.py
@@ -2,13 +2,15 @@
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
 
 from infrafoundry.core.config.package_loader import PackageLoader
 from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.secrets.provider import SecretProvider
+from infrafoundry.core.secrets.providers.sops import SopsSecretProvider
 
 
 @pytest.fixture
@@ -303,7 +305,7 @@ class TestPackageSecrets:
         assert resources[0].config["host"] == "localhost"
 
     def test_sops_encrypted_secrets_are_decrypted(self, tmp_path: Path) -> None:
-        """SOPS-encrypted secrets.yaml triggers sops --decrypt subprocess."""
+        """Encrypted secrets.yaml is loaded via the injected secret provider."""
         manifest = {
             "name": "test-pkg",
             "variables": {"host": "localhost"},
@@ -313,25 +315,20 @@ class TestPackageSecrets:
 
         package_dir = _create_package(tmp_path, manifest, resource, secrets_data=None)
 
-        # Write a fake SOPS-encrypted file
+        # Write a fake SOPS-encrypted file (content doesn't matter — provider is mocked)
         sops_content = (
             "variables:\n    password: ENC[AES256_GCM,data:abc123]\nsops:\n    version: 3.7.3\n"
         )
         (package_dir / "secrets.yaml").write_text(sops_content)
 
-        # Mock subprocess.run to simulate sops --decrypt
-        decrypted_yaml = "variables:\n  password: decrypted-secret\n"
-        mock_result = type("Result", (), {"stdout": decrypted_yaml, "returncode": 0})()
+        # Use a mock secret provider that returns decrypted data
+        mock_provider = MagicMock(spec=SecretProvider)
+        mock_provider.load_secret.return_value = {"variables": {"password": "decrypted-secret"}}
 
-        with patch(
-            "infrafoundry.core.config.sops.subprocess.run", return_value=mock_result
-        ) as mock_run:
-            loader = PackageLoader(tmp_path)
-            _resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
+        loader = PackageLoader(tmp_path, secret_provider=mock_provider)
+        _resources, _, _pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
 
-        mock_run.assert_called_once()
-        call_args = mock_run.call_args
-        assert call_args[0][0] == ["sops", "--decrypt", str(package_dir / "secrets.yaml")]
+        mock_provider.load_secret.assert_called_once_with(package_dir / "secrets.yaml")
 
     def test_secret_variables_available_in_rendered_templates(self, tmp_path: Path) -> None:
         """Variables from secrets are used when rendering resource templates."""
@@ -356,3 +353,33 @@ class TestPackageSecrets:
         assert len(resources) == 1
         assert resources[0].config["password"] == "super-secret"
         assert resources[0].config["host"] == "db.local"
+
+
+class TestSecretProviderInjection:
+    """Tests for pluggable SecretProvider injection into PackageLoader."""
+
+    def test_default_secret_provider_is_sops(self, tmp_path: Path) -> None:
+        """PackageLoader uses SopsSecretProvider by default."""
+        loader = PackageLoader(tmp_path)
+        assert isinstance(loader._secret_provider, SopsSecretProvider)
+
+    def test_custom_secret_provider_is_used(self, tmp_path: Path) -> None:
+        """PackageLoader uses the injected custom secret provider."""
+        manifest = {
+            "name": "test-pkg",
+            "variables": {"host": "localhost"},
+            "resources": ["vm.yaml"],
+        }
+        resource = {"vm": [{"name": "test-vm", "host": "{{ host }}"}]}
+        secrets = {"variables": {"api_key": "custom-provider-secret"}}
+
+        package_dir = _create_package(tmp_path, manifest, resource, secrets)
+
+        mock_provider = MagicMock(spec=SecretProvider)
+        mock_provider.load_secret.return_value = secrets
+
+        loader = PackageLoader(tmp_path, secret_provider=mock_provider)
+        _resources, _, pkg_vars = loader.load_package(package_dir, "proxmox", "test-env")
+
+        mock_provider.load_secret.assert_called_once_with(package_dir / "secrets.yaml")
+        assert pkg_vars["api_key"] == "custom-provider-secret"

--- a/tests/test_sops.py
+++ b/tests/test_sops.py
@@ -1,9 +1,10 @@
-"""Tests for the shared SOPS decryption utility."""
+"""Tests for the shared SOPS decryption utility and SopsSecretProvider."""
 
 from pathlib import Path
 from unittest.mock import patch
 
 from infrafoundry.core.config.sops import load_yaml_with_sops
+from infrafoundry.core.secrets.providers.sops import SopsSecretProvider
 
 
 class TestLoadYamlWithSops:
@@ -82,3 +83,78 @@ class TestLoadYamlWithSops:
             result = load_yaml_with_sops(yaml_file)
 
         assert result == {}
+
+
+class TestSopsSecretProvider:
+    """Tests for SopsSecretProvider plaintext detection and load_secret."""
+
+    def test_is_sops_encrypted_both_markers(self) -> None:
+        """Content with both sops: and ENC markers is detected as encrypted."""
+        content = "key: ENC[AES256_GCM,data:abc]\nsops:\n  version: 3.7.3\n"
+        assert SopsSecretProvider._is_sops_encrypted(content) is True
+
+    def test_is_sops_encrypted_only_sops_marker(self) -> None:
+        """Content with only sops: marker is not encrypted."""
+        content = "sops:\n  note: not encrypted\n"
+        assert SopsSecretProvider._is_sops_encrypted(content) is False
+
+    def test_is_sops_encrypted_only_enc_marker(self) -> None:
+        """Content with only ENC marker is not encrypted."""
+        content = "key: 'ENC[AES256_GCM,data:abc]'\n"
+        assert SopsSecretProvider._is_sops_encrypted(content) is False
+
+    def test_is_sops_encrypted_plaintext(self) -> None:
+        """Plain YAML content is not encrypted."""
+        content = "key: value\nnested:\n  foo: bar\n"
+        assert SopsSecretProvider._is_sops_encrypted(content) is False
+
+    def test_load_secret_plaintext_yaml(self, tmp_path: Path) -> None:
+        """Plaintext YAML file is loaded directly without subprocess call."""
+        yaml_file = tmp_path / "plain.yaml"
+        yaml_file.write_text("variables:\n  host: localhost\n")
+
+        provider = SopsSecretProvider()
+
+        with patch("infrafoundry.core.secrets.providers.sops.subprocess.run") as mock_run:
+            result = provider.load_secret(yaml_file)
+
+        mock_run.assert_not_called()
+        assert result == {"variables": {"host": "localhost"}}
+
+    def test_load_secret_encrypted_yaml(self, tmp_path: Path) -> None:
+        """Encrypted YAML file calls sops --decrypt."""
+        yaml_file = tmp_path / "encrypted.yaml"
+        sops_content = "key: ENC[AES256_GCM,data:abc]\nsops:\n  version: 3.7.3\n"
+        yaml_file.write_text(sops_content)
+
+        decrypted_yaml = "key: decrypted-value\n"
+        mock_result = type("Result", (), {"stdout": decrypted_yaml, "returncode": 0})()
+
+        provider = SopsSecretProvider()
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/sops"),
+            patch(
+                "infrafoundry.core.secrets.providers.sops.subprocess.run",
+                return_value=mock_result,
+            ) as mock_run,
+        ):
+            result = provider.load_secret(yaml_file)
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert call_args[0][0] == ["/usr/bin/sops", "--decrypt", str(yaml_file)]
+        assert result == {"key": "decrypted-value"}
+
+    def test_plaintext_works_without_sops_installed(self, tmp_path: Path) -> None:
+        """Plaintext detection skips sops check, so missing sops doesn't matter."""
+        yaml_file = tmp_path / "plain.yaml"
+        yaml_file.write_text("database:\n  host: db.local\n  port: 5432\n")
+
+        provider = SopsSecretProvider()
+
+        # sops is not installed (shutil.which returns None)
+        with patch("shutil.which", return_value=None):
+            result = provider.load_secret(yaml_file)
+
+        assert result == {"database": {"host": "db.local", "port": 5432}}


### PR DESCRIPTION
## Description

Refactor `PackageLoader` to accept a pluggable `SecretProvider` instead of calling the hardcoded `load_yaml_with_sops` utility directly. This decouples package secret loading from SOPS, enabling alternative secret backends (e.g., Vault, AWS Secrets Manager) without modifying loader internals. `SopsSecretProvider` remains the default.

Additionally, `SopsSecretProvider.load_secret` now detects plaintext YAML files and loads them directly without requiring `sops` to be installed, making development and testing easier when secrets are not encrypted.

Addresses #419

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring

## Breaking Change

`ConfigManager`, `ProviderCentricLoader`, and `PackageLoader` constructors now accept an optional `secret_provider` parameter. Internal attribute initialization for `ConfigManager.provider_centric` changed to forward the provider. Existing callers are unaffected as the parameter defaults to `None` (uses `SopsSecretProvider`).

## Changes Made

- Add optional `secret_provider` parameter to `PackageLoader`, `ProviderCentricLoader`, and `ConfigManager`
- Default to `SopsSecretProvider` when no provider is injected
- Replace direct `load_yaml_with_sops` call in `PackageLoader._load_package_data` with `self._secret_provider.load_secret`
- Add `_is_sops_encrypted` static method to `SopsSecretProvider` for plaintext detection
- Update `SopsSecretProvider.load_secret` to skip sops subprocess for plaintext YAML files
- Update `test_package_loader.py` to use mock `SecretProvider` instead of patching subprocess
- Add `TestSecretProviderInjection` and `TestSopsSecretProvider` test classes

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type-check, security, spell, tests)
