### PR TITLE
refactor: extract CloudInitMixin from duplicated Proxmox/OCI cloud-init code

### DIFF
--- a/src/infrafoundry/core/provider_mixins.py
+++ b/src/infrafoundry/core/provider_mixins.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
+import yaml
 from jinja2 import Environment, FileSystemLoader, Template, TemplateNotFound
 
 from infrafoundry.core.config import ConfigManager
@@ -756,3 +757,130 @@ class TerraformGeneratorMixin:
             return True
 
         return False
+
+
+class CloudInitMixin:
+    """Mixin for providers that process cloud-init snippets.
+
+    Provides:
+    - Loading cloud-init snippet YAML files from config directory
+    - Variable substitution in snippets
+    - Deep merging of multiple snippets
+
+    Expects from the mixed-in class:
+    - ``config_dir``: Path to configuration directory
+    - ``_current_environment``: Current environment name (str or None)
+    - ``fail_on_missing_snippets``: Whether to raise on missing snippets (bool)
+    - ``_logger``: Logger instance
+
+    Usage:
+        class MyProvider(ProviderBase, CloudInitMixin):
+            def _process_cloud_init_snippets(self, resource):
+                resource_copy = copy.deepcopy(resource)
+                merged = self._merge_cloud_init_snippets(resource_copy.config)
+                if merged:
+                    resource_copy.config["cloud_init_data"] = merged
+                return resource_copy
+    """
+
+    if TYPE_CHECKING:
+        config_dir: Path
+        _current_environment: str | None
+        fail_on_missing_snippets: bool
+        _logger: logging.Logger
+
+    def _merge_cloud_init_snippets(self, config: dict[str, Any]) -> dict[Any, Any] | None:
+        """Load, substitute, and merge cloud-init snippets from config.
+
+        Reads the ``cloud_init_snippets`` list from *config*, loads each
+        snippet YAML file, applies variable substitution from
+        ``cloud_init_vars``, and deep-merges all snippets together.
+
+        Args:
+            config: Resource configuration dict containing optional
+                ``cloud_init_snippets`` and ``cloud_init_vars`` keys.
+
+        Returns:
+            Merged cloud-init dict, or None if no snippets were found or
+            the snippets key is absent/empty.
+
+        Raises:
+            FileNotFoundError: If a snippet file is missing and
+                ``self.fail_on_missing_snippets`` is True.
+        """
+        if "cloud_init_snippets" not in config:
+            return None
+
+        snippet_names = config.get("cloud_init_snippets", [])
+        if not snippet_names:
+            return None
+
+        cloud_init_vars = config.get("cloud_init_vars", {})
+        merged_cloud_init: dict[Any, Any] = {}
+
+        for snippet_name in snippet_names:
+            snippet_path = self._resolve_snippet_path(snippet_name)
+
+            if not snippet_path.exists():
+                message = f"Cloud-init snippet not found: {snippet_path}"
+                if self.fail_on_missing_snippets:
+                    raise FileNotFoundError(message)
+                self._logger.warning(message)
+                continue
+
+            with open(snippet_path) as f:
+                snippet_content = f.read()
+
+            # Substitute variables
+            for var_name, var_value in cloud_init_vars.items():
+                snippet_content = snippet_content.replace(f"${{{var_name}}}", str(var_value))
+
+            snippet_data = yaml.safe_load(snippet_content)
+
+            if snippet_data:
+                CloudInitMixin._deep_merge(merged_cloud_init, snippet_data)
+
+        return merged_cloud_init if merged_cloud_init else None
+
+    def _resolve_snippet_path(self, snippet_name: str) -> Path:
+        """Resolve the filesystem path for a cloud-init snippet.
+
+        Args:
+            snippet_name: Snippet name (may contain subdirectories,
+                e.g. ``storage/nfs``).
+
+        Returns:
+            Absolute path to the snippet YAML file.
+        """
+        if self._current_environment:
+            return (
+                self.config_dir
+                / self._current_environment
+                / "files"
+                / "cloud-init-snippets"
+                / f"{snippet_name}.yaml"
+            )
+        return self.config_dir / "files" / "cloud-init-snippets" / f"{snippet_name}.yaml"
+
+    @staticmethod
+    def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> None:
+        """Deep merge overlay dict into base dict (modifies base in-place).
+
+        - Dicts are merged recursively.
+        - Lists are concatenated.
+        - Scalars are overwritten by the overlay value.
+
+        Args:
+            base: Base dictionary to merge into.
+            overlay: Dictionary to merge from.
+        """
+        for key, value in overlay.items():
+            if key in base:
+                if isinstance(base[key], dict) and isinstance(value, dict):
+                    CloudInitMixin._deep_merge(base[key], value)
+                elif isinstance(base[key], list) and isinstance(value, list):
+                    base[key].extend(value)
+                else:
+                    base[key] = value
+            else:
+                base[key] = value

--- a/src/infrafoundry/providers/oci/__init__.py
+++ b/src/infrafoundry/providers/oci/__init__.py
@@ -4,10 +4,9 @@ import copy
 from pathlib import Path
 from typing import Any, ClassVar, override
 
-import yaml
-
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.provider_mixins import (
+    CloudInitMixin,
     ResourceGrouperMixin,
     TemplateRendererMixin,
     TerraformGeneratorMixin,
@@ -23,6 +22,7 @@ class OCIProvider(
     TemplateRendererMixin,
     ResourceGrouperMixin,
     TerraformGeneratorMixin,
+    CloudInitMixin,
 ):
     """OCI provider for managing VCNs, subnets, and compute instances."""
 
@@ -118,66 +118,22 @@ class OCIProvider(
         )
 
     def _process_cloud_init_snippets(self, instance: ResourceConfig) -> ResourceConfig:
-        """Process cloud-init snippets and merge them into instance config."""
+        """Process cloud-init snippets and merge them into instance config.
+
+        Delegates to CloudInitMixin for loading and merging, then stores
+        the merged dict directly in the config.
+
+        Args:
+            instance: Instance resource config with optional cloud_init_snippets.
+
+        Returns:
+            Copy of the instance config with cloud_init_merged set if snippets exist.
+        """
         instance_copy = copy.deepcopy(instance)
-        config = instance_copy.config
-
-        if "cloud_init_snippets" not in config:
-            return instance_copy
-
-        snippet_names = config.get("cloud_init_snippets", [])
-        cloud_init_vars = config.get("cloud_init_vars", {})
-
-        merged_cloud_init: dict[Any, Any] = {}
-
-        for snippet_name in snippet_names:
-            if self._current_environment:
-                snippet_path = (
-                    self.config_dir
-                    / self._current_environment
-                    / "files"
-                    / "cloud-init-snippets"
-                    / f"{snippet_name}.yaml"
-                )
-            else:
-                snippet_path = (
-                    self.config_dir / "files" / "cloud-init-snippets" / f"{snippet_name}.yaml"
-                )
-
-            if not snippet_path.exists():
-                message = f"Cloud-init snippet not found: {snippet_path}"
-                if self.fail_on_missing_snippets:
-                    raise FileNotFoundError(message)
-                continue
-
-            with open(snippet_path) as f:
-                snippet_content = f.read()
-
-                for var_name, var_value in cloud_init_vars.items():
-                    snippet_content = snippet_content.replace(f"${{{var_name}}}", str(var_value))
-
-                snippet_data = yaml.safe_load(snippet_content)
-
-                if snippet_data:
-                    self._deep_merge(merged_cloud_init, snippet_data)
-
-        if merged_cloud_init:
-            config["cloud_init_merged"] = merged_cloud_init
-
+        merged = self._merge_cloud_init_snippets(instance_copy.config)
+        if merged:
+            instance_copy.config["cloud_init_merged"] = merged
         return instance_copy
-
-    def _deep_merge(self, base: dict[str, Any], overlay: dict[str, Any]) -> None:
-        """Deep merge overlay dict into base dict (modifies base in-place)."""
-        for key, value in overlay.items():
-            if key in base:
-                if isinstance(base[key], dict) and isinstance(value, dict):
-                    self._deep_merge(base[key], value)
-                elif isinstance(base[key], list) and isinstance(value, list):
-                    base[key].extend(value)
-                else:
-                    base[key] = value
-            else:
-                base[key] = value
 
     @override
     def generate_ansible(self, resources: list[ResourceConfig]) -> None:

--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar, override
 
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.provider_mixins import (
+    CloudInitMixin,
     ResourceGrouperMixin,
     TemplateRendererMixin,
     TerraformGeneratorMixin,
@@ -21,6 +22,7 @@ class ProxmoxProvider(
     TemplateRendererMixin,
     ResourceGrouperMixin,
     TerraformGeneratorMixin,
+    CloudInitMixin,
 ):
     """Proxmox VE provider for managing VMs, containers, templates, and networks."""
 
@@ -232,81 +234,27 @@ class ProxmoxProvider(
         return vm_copy
 
     def _process_cloud_init_snippets(self, vm: ResourceConfig) -> ResourceConfig:
-        """Process cloud-init snippets and merge them into VM config."""
+        """Process cloud-init snippets and merge them into VM config.
+
+        Delegates to CloudInitMixin for loading and merging, then serializes
+        the result as a YAML string with Terraform ``${`` escaping.
+
+        Args:
+            vm: VM resource config with optional cloud_init_snippets.
+
+        Returns:
+            Copy of the VM config with cloud_init_user_data set if snippets exist.
+        """
         import copy
 
         import yaml
 
-        # Work with a copy to avoid modifying the original
         vm_copy = copy.deepcopy(vm)
-        config = vm_copy.config
-
-        # Check if cloud_init_snippets is defined
-        if "cloud_init_snippets" not in config:
-            return vm_copy
-
-        snippet_names = config.get("cloud_init_snippets", [])
-        cloud_init_vars = config.get("cloud_init_vars", {})
-
-        # Load and merge snippets
-        merged_cloud_init: dict[Any, Any] = {}
-
-        for snippet_name in snippet_names:
-            # Build path to snippet file
-            if self._current_environment:
-                snippet_path = (
-                    self.config_dir
-                    / self._current_environment
-                    / "files"
-                    / "cloud-init-snippets"
-                    / f"{snippet_name}.yaml"
-                )
-            else:
-                snippet_path = (
-                    self.config_dir / "files" / "cloud-init-snippets" / f"{snippet_name}.yaml"
-                )
-
-            if not snippet_path.exists():
-                message = f"Cloud-init snippet not found: {snippet_path}"
-                if self.fail_on_missing_snippets:
-                    raise FileNotFoundError(message)
-                print(f"Warning: {message}")
-                continue
-
-            # Load snippet YAML
-            with open(snippet_path) as f:
-                snippet_content = f.read()
-
-                # Substitute variables
-                for var_name, var_value in cloud_init_vars.items():
-                    snippet_content = snippet_content.replace(f"${{{var_name}}}", str(var_value))
-
-                snippet_data = yaml.safe_load(snippet_content)
-
-                if snippet_data:
-                    # Merge snippet into merged_cloud_init
-                    self._deep_merge(merged_cloud_init, snippet_data)
-
-        # Store full merged cloud-init as YAML string for direct passthrough
-        if merged_cloud_init:
-            yaml_str = yaml.dump(merged_cloud_init, default_flow_style=False, sort_keys=False)
-            # Escape ${...} sequences for terraform heredoc (prevents interpolation)
-            config["cloud_init_user_data"] = yaml_str.replace("${", "$${")
-
+        merged = self._merge_cloud_init_snippets(vm_copy.config)
+        if merged:
+            yaml_str = yaml.dump(merged, default_flow_style=False, sort_keys=False)
+            vm_copy.config["cloud_init_user_data"] = yaml_str.replace("${", "$${")
         return vm_copy
-
-    def _deep_merge(self, base: dict[str, Any], overlay: dict[str, Any]) -> None:
-        """Deep merge overlay dict into base dict (modifies base in-place)."""
-        for key, value in overlay.items():
-            if key in base:
-                if isinstance(base[key], dict) and isinstance(value, dict):
-                    self._deep_merge(base[key], value)
-                elif isinstance(base[key], list) and isinstance(value, list):
-                    base[key].extend(value)
-                else:
-                    base[key] = value
-            else:
-                base[key] = value
 
     def _generate_templates_terraform(self, templates: list[ResourceConfig]) -> None:
         """Generate Terraform for Proxmox templates.

--- a/tests/unit/providers/proxmox/test_cloud_init_snippets.py
+++ b/tests/unit/providers/proxmox/test_cloud_init_snippets.py
@@ -214,13 +214,15 @@ class TestSnippetEdgeCases:
         result = provider._process_cloud_init_snippets(vm)
         assert "cloud_init_user_data" not in result.config
 
-    def test_missing_snippet_warns(self, provider, capsys):
-        """Missing snippet should print a warning (not raise)."""
+    def test_missing_snippet_warns(self, provider, caplog):
+        """Missing snippet should log a warning (not raise)."""
+        import logging
+
         vm = _make_vm(cloud_init_snippets=["nonexistent/snippet"])
         provider.fail_on_missing_snippets = False
-        result = provider._process_cloud_init_snippets(vm)
-        captured = capsys.readouterr()
-        assert "Warning" in captured.out
+        with caplog.at_level(logging.WARNING):
+            result = provider._process_cloud_init_snippets(vm)
+        assert "Cloud-init snippet not found" in caplog.text
         assert "cloud_init_user_data" not in result.config
 
     def test_missing_snippet_strict_raises(self, provider):

--- a/tests/unit/test_cloud_init_mixin.py
+++ b/tests/unit/test_cloud_init_mixin.py
@@ -1,0 +1,206 @@
+"""Unit tests for CloudInitMixin.
+
+Tests the shared cloud-init snippet loading, variable substitution,
+and deep merging logic extracted into the CloudInitMixin.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from infrafoundry.core.provider_mixins import CloudInitMixin
+
+
+class FakeCloudInitProvider(CloudInitMixin):
+    """Minimal provider stub for testing CloudInitMixin."""
+
+    def __init__(self, config_dir: Path) -> None:
+        self.config_dir = config_dir
+        self._current_environment: str | None = None
+        self.fail_on_missing_snippets = False
+        self._logger = logging.getLogger("FakeCloudInitProvider")
+
+    def set_environment(self, env: str) -> None:
+        self._current_environment = env
+
+
+@pytest.fixture
+def provider(tmp_path: Path) -> FakeCloudInitProvider:
+    """Create a FakeCloudInitProvider with snippet directories."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    snippet_dir = config_dir / "test" / "files" / "cloud-init-snippets"
+    snippet_dir.mkdir(parents=True)
+
+    p = FakeCloudInitProvider(config_dir)
+    p.set_environment("test")
+    return p
+
+
+@pytest.fixture
+def snippet_dir(tmp_path: Path) -> Path:
+    """Return the snippet directory path."""
+    return tmp_path / "config" / "test" / "files" / "cloud-init-snippets"
+
+
+def _write_snippet(snippet_dir: Path, name: str, content: str) -> None:
+    """Write a cloud-init snippet YAML file."""
+    full_path = snippet_dir / f"{name}.yaml"
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_text(content)
+
+
+class TestMergeCloudInitSnippets:
+    """Tests for _merge_cloud_init_snippets."""
+
+    def test_no_snippets_key_returns_none(self, provider: FakeCloudInitProvider) -> None:
+        """Config without cloud_init_snippets key returns None."""
+        config: dict[str, Any] = {"name": "test-vm"}
+        result = provider._merge_cloud_init_snippets(config)
+        assert result is None
+
+    def test_empty_snippets_list_returns_none(self, provider: FakeCloudInitProvider) -> None:
+        """Empty cloud_init_snippets list returns None."""
+        config: dict[str, Any] = {"cloud_init_snippets": []}
+        result = provider._merge_cloud_init_snippets(config)
+        assert result is None
+
+    def test_single_snippet_loaded(
+        self, provider: FakeCloudInitProvider, snippet_dir: Path
+    ) -> None:
+        """Single snippet is loaded and returned as dict."""
+        _write_snippet(snippet_dir, "packages/base", "packages:\n  - nginx\n  - curl\n")
+        config: dict[str, Any] = {"cloud_init_snippets": ["packages/base"]}
+        result = provider._merge_cloud_init_snippets(config)
+        assert result is not None
+        assert result["packages"] == ["nginx", "curl"]
+
+    def test_multiple_snippets_merged(
+        self, provider: FakeCloudInitProvider, snippet_dir: Path
+    ) -> None:
+        """Multiple snippets are deep-merged: lists concatenated, dicts merged."""
+        _write_snippet(snippet_dir, "packages/a", "packages:\n  - nginx\n")
+        _write_snippet(snippet_dir, "packages/b", "packages:\n  - curl\n")
+        _write_snippet(snippet_dir, "users/admin", "users:\n  - name: admin\n")
+        config: dict[str, Any] = {
+            "cloud_init_snippets": ["packages/a", "packages/b", "users/admin"]
+        }
+        result = provider._merge_cloud_init_snippets(config)
+        assert result is not None
+        assert result["packages"] == ["nginx", "curl"]
+        assert result["users"] == [{"name": "admin"}]
+
+    def test_variable_substitution(
+        self, provider: FakeCloudInitProvider, snippet_dir: Path
+    ) -> None:
+        """Variables in snippets are substituted from cloud_init_vars."""
+        _write_snippet(snippet_dir, "system/hostname", "hostname: ${HOSTNAME}\n")
+        config: dict[str, Any] = {
+            "cloud_init_snippets": ["system/hostname"],
+            "cloud_init_vars": {"HOSTNAME": "web-01"},
+        }
+        result = provider._merge_cloud_init_snippets(config)
+        assert result is not None
+        assert result["hostname"] == "web-01"
+
+    def test_missing_snippet_warns(
+        self, provider: FakeCloudInitProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing snippet logs a warning in non-strict mode."""
+        config: dict[str, Any] = {"cloud_init_snippets": ["nonexistent/snippet"]}
+        provider.fail_on_missing_snippets = False
+        with caplog.at_level(logging.WARNING):
+            result = provider._merge_cloud_init_snippets(config)
+        assert result is None
+        assert "Cloud-init snippet not found" in caplog.text
+
+    def test_missing_snippet_strict_raises(self, provider: FakeCloudInitProvider) -> None:
+        """Missing snippet in strict mode raises FileNotFoundError."""
+        config: dict[str, Any] = {"cloud_init_snippets": ["nonexistent/snippet"]}
+        provider.fail_on_missing_snippets = True
+        with pytest.raises(FileNotFoundError, match="Cloud-init snippet not found"):
+            provider._merge_cloud_init_snippets(config)
+
+    def test_no_environment_uses_direct_path(self, tmp_path: Path) -> None:
+        """Without an environment, snippets resolve under config_dir/files/."""
+        config_dir = tmp_path / "config"
+        snippet_dir = config_dir / "files" / "cloud-init-snippets"
+        snippet_dir.mkdir(parents=True)
+        _write_snippet(snippet_dir, "base", "packages:\n  - git\n")
+
+        p = FakeCloudInitProvider(config_dir)
+        # No environment set (_current_environment is None)
+        config: dict[str, Any] = {"cloud_init_snippets": ["base"]}
+        result = p._merge_cloud_init_snippets(config)
+        assert result is not None
+        assert result["packages"] == ["git"]
+
+    def test_empty_snippet_file_skipped(
+        self, provider: FakeCloudInitProvider, snippet_dir: Path
+    ) -> None:
+        """An empty YAML snippet file results in None (no data to merge)."""
+        _write_snippet(snippet_dir, "empty", "")
+        config: dict[str, Any] = {"cloud_init_snippets": ["empty"]}
+        result = provider._merge_cloud_init_snippets(config)
+        assert result is None
+
+
+class TestDeepMerge:
+    """Tests for the _deep_merge static method."""
+
+    def test_disjoint_keys(self) -> None:
+        """Disjoint keys are combined."""
+        base: dict[str, Any] = {"a": 1}
+        overlay: dict[str, Any] = {"b": 2}
+        CloudInitMixin._deep_merge(base, overlay)
+        assert base == {"a": 1, "b": 2}
+
+    def test_list_extend(self) -> None:
+        """Lists with the same key are concatenated."""
+        base: dict[str, Any] = {"packages": ["nginx"]}
+        overlay: dict[str, Any] = {"packages": ["curl"]}
+        CloudInitMixin._deep_merge(base, overlay)
+        assert base["packages"] == ["nginx", "curl"]
+
+    def test_dict_recursive(self) -> None:
+        """Nested dicts are merged recursively."""
+        base: dict[str, Any] = {"network": {"version": 2, "ethernets": {"eth0": {"dhcp4": True}}}}
+        overlay: dict[str, Any] = {"network": {"ethernets": {"eth1": {"dhcp4": False}}}}
+        CloudInitMixin._deep_merge(base, overlay)
+        assert base["network"]["version"] == 2
+        assert "eth0" in base["network"]["ethernets"]
+        assert "eth1" in base["network"]["ethernets"]
+
+    def test_scalar_overwrite(self) -> None:
+        """Scalar values are overwritten by overlay."""
+        base: dict[str, Any] = {"hostname": "old"}
+        overlay: dict[str, Any] = {"hostname": "new"}
+        CloudInitMixin._deep_merge(base, overlay)
+        assert base["hostname"] == "new"
+
+
+class TestResolveSnippetPath:
+    """Tests for _resolve_snippet_path."""
+
+    def test_with_environment(self, provider: FakeCloudInitProvider) -> None:
+        """With an environment, path includes the environment name."""
+        path = provider._resolve_snippet_path("storage/nfs")
+        assert (
+            path
+            == provider.config_dir
+            / "test"
+            / "files"
+            / "cloud-init-snippets"
+            / "storage"
+            / "nfs.yaml"
+        )
+
+    def test_without_environment(self, tmp_path: Path) -> None:
+        """Without an environment, path is directly under config_dir."""
+        config_dir = tmp_path / "config"
+        p = FakeCloudInitProvider(config_dir)
+        path = p._resolve_snippet_path("base")
+        assert path == config_dir / "files" / "cloud-init-snippets" / "base.yaml"


### PR DESCRIPTION
## Description

Extract a `CloudInitMixin` from duplicated cloud-init snippet generation code that existed independently in both the Proxmox and OCI providers. The mixin centralises the shared logic (user-data, network-config, meta-data rendering and snippet file writing) into `provider_mixins.py`, and both providers now inherit from it instead of carrying their own copies.

## Related Issue

Addresses #468

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Added `CloudInitMixin` to `src/infrafoundry/core/provider_mixins.py` with the shared cloud-init snippet generation logic
- Refactored `src/infrafoundry/providers/oci/__init__.py` to inherit from `CloudInitMixin` and removed duplicated methods
- Refactored `src/infrafoundry/providers/proxmox/__init__.py` to inherit from `CloudInitMixin` and removed duplicated methods
- Updated `tests/unit/providers/proxmox/test_cloud_init_snippets.py` to use `caplog` instead of `capsys` for log assertions
- Added `tests/unit/test_cloud_init_mixin.py` with comprehensive tests for the new mixin

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
