### PR TITLE
refactor: implement Kubernetes validators for kubeconfig, namespace, CRD, and Helm validation

### DIFF
--- a/src/infrafoundry/core/types.py
+++ b/src/infrafoundry/core/types.py
@@ -60,6 +60,7 @@ class KubernetesProviderSettings(TypedDict, total=False):
     """Provider settings expected by the Kubernetes provider."""
 
     kubeconfig_path: str
+    context: str
 
 
 class OPNsenseEnvironmentConfig(TypedDict, total=False):

--- a/src/infrafoundry/providers/kubernetes/validator.py
+++ b/src/infrafoundry/providers/kubernetes/validator.py
@@ -2,21 +2,26 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import cast
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.types import EnvironmentData, KubernetesProviderSettings
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.kubernetes.validators import (
+    CRDValidator,
+    HelmValidator,
+    KubeconfigValidator,
+    NamespaceValidator,
+)
 
 
 class KubernetesValidator:
     """Validates Kubernetes configurations.
 
-    Performs pre-flight validation including:
-    - Kubeconfig file existence and accessibility
-    - Cross-resource reference validation (namespaces, secrets, configmaps)
+    Composes specialized validators for kubeconfig, namespaces,
+    CRDs, and Helm releases. Local cross-reference checks always
+    run; API-based checks only run when connectivity is established.
     """
 
     def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
@@ -33,53 +38,105 @@ class KubernetesValidator:
             KubernetesProviderSettings, self.api_validator.provider_settings
         )
 
+        # Initialize specialized validators
+        self.kubeconfig_validator = KubeconfigValidator(self.api_validator, report)
+        self.namespace_validator = NamespaceValidator(self.api_validator, report)
+        self.crd_validator = CRDValidator(self.api_validator, report)
+        self.helm_validator = HelmValidator(report)
+
     def validate_connectivity(self) -> None:
         """Validate Kubernetes connectivity prerequisites.
 
-        Checks:
-        - Kubeconfig file exists and is readable
+        Delegates to KubeconfigValidator which parses the kubeconfig,
+        extracts credentials, and tests API connectivity.
         """
         kubeconfig_path = self.provider_settings.get("kubeconfig_path")
-
-        if not kubeconfig_path:
-            # Check default location
-            default_path = Path.home() / ".kube" / "config"
-            if default_path.exists():
-                self.report.add_check(
-                    check_name="kubernetes_kubeconfig",
-                    passed=True,
-                    message=f"Using default kubeconfig at {default_path}",
-                    level=ValidationLevel.INFO,
-                )
-            else:
-                self.report.add_check(
-                    check_name="kubernetes_kubeconfig",
-                    passed=False,
-                    message=("No kubeconfig_path specified and default ~/.kube/config not found"),
-                    level=ValidationLevel.WARNING,
-                )
-            return
-
-        kubeconfig = Path(kubeconfig_path).expanduser()
-        if kubeconfig.exists():
-            self.report.add_check(
-                check_name="kubernetes_kubeconfig",
-                passed=True,
-                message=f"Kubeconfig found at {kubeconfig}",
-            )
-        else:
-            self.report.add_check(
-                check_name="kubernetes_kubeconfig",
-                passed=False,
-                message=f"Kubeconfig not found at {kubeconfig}",
-                level=ValidationLevel.ERROR,
-            )
+        context_override = self.provider_settings.get("context")
+        self.kubeconfig_validator.validate(kubeconfig_path, context_override)
 
     def validate_references(self, resources: list[ResourceConfig]) -> None:
         """Validate Kubernetes resource references.
 
+        Always runs:
+        - Local cross-reference checks (configmaps, secrets, service accounts, selectors)
+        - Helm release validation
+
+        When connected:
+        - Namespace existence checks via API
+        - CRD existence checks via API
+
+        Args:
+            resources: List of resources to validate
+        """
+        # Local cross-reference checks always run
+        self._validate_local_references(resources)
+
+        # Helm validation always runs (no API needed)
+        helm_releases = [r for r in resources if r.type == "helm_releases"]
+        self.helm_validator.validate(helm_releases)
+
+        # API-based checks only when connected
+        if self.kubeconfig_validator.is_connected:
+            conn = self.kubeconfig_validator.connection_info
+            self._validate_api_references(resources, conn)
+
+        # Report success if we have resources
+        if resources:
+            self.report.add_check(
+                check_name="kubernetes_references",
+                passed=True,
+                message=f"Validated references for {len(resources)} Kubernetes resources",
+            )
+
+    def _validate_api_references(
+        self,
+        resources: list[ResourceConfig],
+        conn: object,
+    ) -> None:
+        """Run API-based validation checks.
+
+        Args:
+            resources: All resources to validate
+            conn: KubeConnectionInfo with server_url, headers, verify_ssl
+        """
+        from infrafoundry.providers.kubernetes.validators.kubeconfig_validator import (
+            KubeConnectionInfo,
+        )
+
+        info = cast(KubeConnectionInfo, conn)
+
+        # Collect namespace references and config-defined namespaces
+        config_namespaces = {r.name for r in resources if r.type == "namespaces"}
+        referenced_namespaces: set[str] = set()
+        for resource in resources:
+            if resource.type == "namespaces":
+                continue
+            ns = resource.config.get("namespace")
+            if ns:
+                referenced_namespaces.add(ns)
+
+        self.namespace_validator.validate(
+            server_url=info.server_url,
+            headers=info.headers,
+            verify_ssl=info.verify_ssl,
+            referenced_namespaces=referenced_namespaces,
+            config_namespaces=config_namespaces,
+        )
+
+        # CRD validation for manifest resources
+        manifests = [r for r in resources if r.type == "manifests"]
+        self.crd_validator.validate(
+            server_url=info.server_url,
+            headers=info.headers,
+            verify_ssl=info.verify_ssl,
+            manifests=manifests,
+        )
+
+    def _validate_local_references(self, resources: list[ResourceConfig]) -> None:
+        """Validate cross-resource references locally (no API calls).
+
         Checks:
-        - Resources reference valid namespaces
+        - Resources reference valid namespaces (within config)
         - ConfigMap/Secret references exist in config
         - Service selectors match deployments
 
@@ -96,11 +153,10 @@ class KubernetesValidator:
         # Validate namespace references
         for resource in resources:
             if resource.type in ("namespaces",):
-                continue  # Namespaces don't reference other namespaces
+                continue
 
             namespace = resource.config.get("namespace")
             if namespace and namespace not in namespaces:
-                # It might be an existing namespace not in config - just warn
                 self.report.add_check(
                     check_name=f"kubernetes_ref_{resource.name}_namespace",
                     passed=True,
@@ -118,7 +174,6 @@ class KubernetesValidator:
 
             config = resource.config or {}
 
-            # Check configmap references in env_from
             env_from = config.get("env_from", [])
             for ref in env_from:
                 cm_ref = ref.get("configmap")
@@ -144,7 +199,6 @@ class KubernetesValidator:
                         level=ValidationLevel.ERROR,
                     )
 
-            # Check service account references
             sa_ref = config.get("service_account")
             if sa_ref and sa_ref not in serviceaccounts:
                 self.report.add_check(
@@ -165,9 +219,7 @@ class KubernetesValidator:
             config = resource.config or {}
             selector = config.get("selector", {})
 
-            # Check if selector matches any deployment
             if selector:
-                # Simple check - see if app label matches a deployment name
                 app_label = selector.get("app") or selector.get("app.kubernetes.io/name")
                 if app_label and app_label not in deployments:
                     self.report.add_check(
@@ -179,11 +231,3 @@ class KubernetesValidator:
                         ),
                         level=ValidationLevel.INFO,
                     )
-
-        # Report success if we have resources
-        if resources:
-            self.report.add_check(
-                check_name="kubernetes_references",
-                passed=True,
-                message=f"Validated references for {len(resources)} Kubernetes resources",
-            )

--- a/src/infrafoundry/providers/kubernetes/validators/__init__.py
+++ b/src/infrafoundry/providers/kubernetes/validators/__init__.py
@@ -1,0 +1,17 @@
+"""Specialized validators for Kubernetes resources."""
+
+from infrafoundry.providers.kubernetes.validators.crd_validator import CRDValidator
+from infrafoundry.providers.kubernetes.validators.helm_validator import HelmValidator
+from infrafoundry.providers.kubernetes.validators.kubeconfig_validator import (
+    KubeconfigValidator,
+)
+from infrafoundry.providers.kubernetes.validators.namespace_validator import (
+    NamespaceValidator,
+)
+
+__all__ = [
+    "CRDValidator",
+    "HelmValidator",
+    "KubeconfigValidator",
+    "NamespaceValidator",
+]

--- a/src/infrafoundry/providers/kubernetes/validators/crd_validator.py
+++ b/src/infrafoundry/providers/kubernetes/validators/crd_validator.py
@@ -1,0 +1,157 @@
+"""CRD validation for Kubernetes provider."""
+
+from __future__ import annotations
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
+
+# Standard Kubernetes API groups that don't require CRDs
+_STANDARD_API_GROUPS: frozenset[str] = frozenset(
+    {
+        "",
+        "apps",
+        "batch",
+        "networking.k8s.io",
+        "rbac.authorization.k8s.io",
+        "policy",
+        "autoscaling",
+        "storage.k8s.io",
+        "admissionregistration.k8s.io",
+        "apiextensions.k8s.io",
+        "certificates.k8s.io",
+        "coordination.k8s.io",
+        "discovery.k8s.io",
+        "events.k8s.io",
+        "flowcontrol.apiserver.k8s.io",
+        "node.k8s.io",
+        "scheduling.k8s.io",
+    }
+)
+
+
+class CRDValidator:
+    """Validates that CRDs required by manifest resources exist.
+
+    Queries the Kubernetes API for installed CRDs and checks that
+    any custom resource references in manifest resources have their
+    corresponding CRD installed.
+    """
+
+    def __init__(self, api_validator: BaseAPIValidator, report: ValidationReport) -> None:
+        """Initialize CRD validator.
+
+        Args:
+            api_validator: Shared API validator helper
+            report: ValidationReport to add results to
+        """
+        self.api_validator = api_validator
+        self.report = report
+
+    def validate(
+        self,
+        server_url: str,
+        headers: dict[str, str],
+        verify_ssl: bool,
+        manifests: list[ResourceConfig],
+    ) -> None:
+        """Validate that CRDs required by manifests are installed.
+
+        Args:
+            server_url: Kubernetes API server URL
+            headers: HTTP headers with authorization
+            verify_ssl: Whether to verify SSL certificates
+            manifests: Manifest resources to check for CRD requirements
+        """
+        if not manifests:
+            return
+
+        # Extract required CRD groups from manifests
+        required_groups = self._extract_custom_api_groups(manifests)
+        if not required_groups:
+            return
+
+        # Fetch installed CRDs
+        installed_groups = self._fetch_crd_groups(server_url, headers, verify_ssl)
+        if installed_groups is None:
+            return  # API error already reported
+
+        for group, resource_names in sorted(required_groups.items()):
+            if group in installed_groups:
+                self.report.add_check(
+                    check_name=f"kubernetes_crd_{group}",
+                    passed=True,
+                    message=(
+                        f"CRD group '{group}' is installed "
+                        f"(used by: {', '.join(sorted(resource_names))})"
+                    ),
+                )
+            else:
+                self.report.add_check(
+                    check_name=f"kubernetes_crd_{group}",
+                    passed=False,
+                    message=(
+                        f"CRD group '{group}' not found in cluster "
+                        f"(required by: {', '.join(sorted(resource_names))})"
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+
+    def _extract_custom_api_groups(self, manifests: list[ResourceConfig]) -> dict[str, list[str]]:
+        """Extract non-standard API groups from manifest resources.
+
+        Returns:
+            Mapping of API group to list of resource names using it.
+        """
+        groups: dict[str, list[str]] = {}
+        for manifest in manifests:
+            config = manifest.config or {}
+            api_version = config.get("apiVersion", "")
+            group = self._parse_api_group(api_version)
+            if group and group not in _STANDARD_API_GROUPS:
+                groups.setdefault(group, []).append(manifest.name)
+        return groups
+
+    def _parse_api_group(self, api_version: str) -> str:
+        """Parse the API group from an apiVersion string.
+
+        Args:
+            api_version: Kubernetes apiVersion (e.g., "apps/v1", "cert-manager.io/v1")
+
+        Returns:
+            The API group portion, or empty string for core API.
+        """
+        if "/" in api_version:
+            return api_version.rsplit("/", 1)[0]
+        return ""
+
+    def _fetch_crd_groups(
+        self,
+        server_url: str,
+        headers: dict[str, str],
+        verify_ssl: bool,
+    ) -> set[str] | None:
+        """Fetch the set of API groups that have CRDs installed.
+
+        Returns:
+            Set of API group names, or None if the API call failed.
+        """
+        data = self.api_validator.fetch_json(
+            url=f"{server_url}/apis/apiextensions.k8s.io/v1/customresourcedefinitions",
+            headers=headers,
+            verify_ssl=verify_ssl,
+            timeout=10,
+            check_name="kubernetes_crds_list",
+            error_message="Failed to list CRDs (status {status})",
+            error_level=ValidationLevel.WARNING,
+        )
+        if data is None:
+            return None
+
+        items = data.get("items", [])
+        groups: set[str] = set()
+        for item in items:
+            group = item.get("spec", {}).get("group", "")
+            if group:
+                groups.add(group)
+        return groups

--- a/src/infrafoundry/providers/kubernetes/validators/helm_validator.py
+++ b/src/infrafoundry/providers/kubernetes/validators/helm_validator.py
@@ -1,0 +1,64 @@
+"""Helm release validation for Kubernetes provider."""
+
+from __future__ import annotations
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+
+
+class HelmValidator:
+    """Validates Helm release resource configurations.
+
+    Performs local (report-only) validation that helm_release resources
+    have the required fields (chart, repository). No API calls are made.
+    """
+
+    def __init__(self, report: ValidationReport) -> None:
+        """Initialize Helm validator.
+
+        Args:
+            report: ValidationReport to add results to
+        """
+        self.report = report
+
+    def validate(self, helm_releases: list[ResourceConfig]) -> None:
+        """Validate helm release resources have required fields.
+
+        Args:
+            helm_releases: Helm release resources to validate
+        """
+        if not helm_releases:
+            return
+
+        for release in helm_releases:
+            config = release.config or {}
+            name = release.name
+
+            has_chart = bool(config.get("chart"))
+            has_repository = bool(config.get("repository"))
+
+            if not has_chart:
+                self.report.add_check(
+                    check_name=f"kubernetes_helm_{name}_chart",
+                    passed=False,
+                    message=f"Helm release '{name}' is missing required 'chart' field",
+                    level=ValidationLevel.ERROR,
+                )
+
+            if not has_repository:
+                self.report.add_check(
+                    check_name=f"kubernetes_helm_{name}_repository",
+                    passed=False,
+                    message=f"Helm release '{name}' is missing required 'repository' field",
+                    level=ValidationLevel.ERROR,
+                )
+
+            if has_chart and has_repository:
+                self.report.add_check(
+                    check_name=f"kubernetes_helm_{name}",
+                    passed=True,
+                    message=(
+                        f"Helm release '{name}' has valid chart "
+                        f"'{config['chart']}' from '{config['repository']}'"
+                    ),
+                )

--- a/src/infrafoundry/providers/kubernetes/validators/kubeconfig_validator.py
+++ b/src/infrafoundry/providers/kubernetes/validators/kubeconfig_validator.py
@@ -1,0 +1,382 @@
+"""Kubeconfig validation for Kubernetes provider."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
+
+
+@dataclass
+class KubeConnectionInfo:
+    """Connection information extracted from kubeconfig."""
+
+    server_url: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+    verify_ssl: bool = True
+    connected: bool = False
+
+
+class KubeconfigValidator:
+    """Validates kubeconfig file and establishes connection info.
+
+    Parses the kubeconfig to extract server URL, bearer token,
+    and CA certificate info. Tests API connectivity and stores
+    connection state for other validators.
+    """
+
+    def __init__(self, api_validator: BaseAPIValidator, report: ValidationReport) -> None:
+        """Initialize kubeconfig validator.
+
+        Args:
+            api_validator: Shared API validator helper
+            report: ValidationReport to add results to
+        """
+        self.api_validator = api_validator
+        self.report = report
+        self._connection_info = KubeConnectionInfo()
+        self._ca_temp_file: Any = None
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether API connectivity was successfully established."""
+        return self._connection_info.connected
+
+    @property
+    def connection_info(self) -> KubeConnectionInfo:
+        """Connection info extracted from kubeconfig."""
+        return self._connection_info
+
+    def validate(
+        self,
+        kubeconfig_path: str | None,
+        context_override: str | None = None,
+    ) -> None:
+        """Validate kubeconfig and test API connectivity.
+
+        Args:
+            kubeconfig_path: Path to kubeconfig file, or None for default
+            context_override: Optional context name to use instead of current-context
+        """
+        resolved_path = self._resolve_kubeconfig_path(kubeconfig_path)
+        if resolved_path is None:
+            return
+
+        kubeconfig_data = self._load_kubeconfig(resolved_path)
+        if kubeconfig_data is None:
+            return
+
+        context_name = self._resolve_context(kubeconfig_data, context_override)
+        if context_name is None:
+            return
+
+        context_entry = self._get_context_entry(kubeconfig_data, context_name)
+        if context_entry is None:
+            return
+
+        cluster_name = context_entry.get("context", {}).get("cluster")
+        user_name = context_entry.get("context", {}).get("user")
+
+        cluster_info = self._get_cluster_info(kubeconfig_data, cluster_name)
+        if cluster_info is None:
+            return
+
+        server_url = cluster_info.get("server", "")
+        if not server_url:
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig",
+                passed=False,
+                message=f"Cluster '{cluster_name}' has no server URL",
+                level=ValidationLevel.ERROR,
+            )
+            return
+
+        # Extract auth info
+        headers = self._extract_auth_headers(kubeconfig_data, user_name)
+        verify_ssl = self._resolve_ca_cert(cluster_info)
+
+        self._connection_info = KubeConnectionInfo(
+            server_url=server_url.rstrip("/"),
+            headers=headers,
+            verify_ssl=verify_ssl,
+        )
+
+        # Test connectivity
+        self._test_connectivity()
+
+    def _resolve_kubeconfig_path(self, kubeconfig_path: str | None) -> Path | None:
+        """Resolve and validate the kubeconfig file path."""
+        if not kubeconfig_path:
+            default_path = Path.home() / ".kube" / "config"
+            if default_path.exists():
+                self.report.add_check(
+                    check_name="kubernetes_kubeconfig",
+                    passed=True,
+                    message=f"Using default kubeconfig at {default_path}",
+                    level=ValidationLevel.INFO,
+                )
+                return default_path
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig",
+                passed=False,
+                message="No kubeconfig_path specified and default ~/.kube/config not found",
+                level=ValidationLevel.WARNING,
+            )
+            return None
+
+        path = Path(kubeconfig_path).expanduser()
+        if not path.exists():
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig",
+                passed=False,
+                message=f"Kubeconfig not found at {path}",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+
+        self.report.add_check(
+            check_name="kubernetes_kubeconfig",
+            passed=True,
+            message=f"Kubeconfig found at {path}",
+        )
+        return path
+
+    def _load_kubeconfig(self, path: Path) -> dict[str, Any] | None:
+        """Load and parse the kubeconfig YAML file."""
+        try:
+            content = path.read_text()
+            data = yaml.safe_load(content)
+            if not isinstance(data, dict):
+                self.report.add_check(
+                    check_name="kubernetes_kubeconfig_parse",
+                    passed=False,
+                    message=f"Kubeconfig at {path} is not valid YAML mapping",
+                    level=ValidationLevel.ERROR,
+                )
+                return None
+            return data
+        except yaml.YAMLError as exc:
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig_parse",
+                passed=False,
+                message=f"Failed to parse kubeconfig at {path}: {exc}",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+        except OSError as exc:
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig_parse",
+                passed=False,
+                message=f"Failed to read kubeconfig at {path}: {exc}",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+
+    def _resolve_context(
+        self, kubeconfig: dict[str, Any], context_override: str | None
+    ) -> str | None:
+        """Resolve which context to use."""
+        if context_override:
+            return context_override
+
+        current_context = kubeconfig.get("current-context")
+        if not current_context:
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig_context",
+                passed=False,
+                message="Kubeconfig has no current-context set",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+        return str(current_context)
+
+    def _get_context_entry(
+        self, kubeconfig: dict[str, Any], context_name: str
+    ) -> dict[str, Any] | None:
+        """Find a context entry by name in kubeconfig."""
+        contexts = kubeconfig.get("contexts", [])
+        for ctx in contexts:
+            if ctx.get("name") == context_name:
+                return dict(ctx)
+
+        self.report.add_check(
+            check_name="kubernetes_kubeconfig_context",
+            passed=False,
+            message=f"Context '{context_name}' not found in kubeconfig",
+            level=ValidationLevel.ERROR,
+        )
+        return None
+
+    def _get_cluster_info(
+        self, kubeconfig: dict[str, Any], cluster_name: str | None
+    ) -> dict[str, Any] | None:
+        """Find cluster info by name in kubeconfig."""
+        if not cluster_name:
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig_cluster",
+                passed=False,
+                message="Context has no cluster reference",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+
+        clusters = kubeconfig.get("clusters", [])
+        for cluster in clusters:
+            if cluster.get("name") == cluster_name:
+                cluster_data = cluster.get("cluster", {})
+                return dict(cluster_data) if isinstance(cluster_data, dict) else {}
+
+        self.report.add_check(
+            check_name="kubernetes_kubeconfig_cluster",
+            passed=False,
+            message=f"Cluster '{cluster_name}' not found in kubeconfig",
+            level=ValidationLevel.ERROR,
+        )
+        return None
+
+    def _extract_auth_headers(
+        self, kubeconfig: dict[str, Any], user_name: str | None
+    ) -> dict[str, str]:
+        """Extract authentication headers from kubeconfig user entry."""
+        headers: dict[str, str] = {}
+        if not user_name:
+            return headers
+
+        users = kubeconfig.get("users", [])
+        for user_entry in users:
+            if user_entry.get("name") != user_name:
+                continue
+            user_info = user_entry.get("user", {})
+
+            # Check for exec-based auth (unsupported)
+            if user_info.get("exec"):
+                self.report.add_check(
+                    check_name="kubernetes_kubeconfig_auth",
+                    passed=True,
+                    message=(
+                        f"User '{user_name}' uses exec-based auth "
+                        "(not supported for API validation)"
+                    ),
+                    level=ValidationLevel.WARNING,
+                )
+                return headers
+
+            # Try bearer token
+            token = user_info.get("token")
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+                return headers
+
+            # Try token file
+            token_file = user_info.get("tokenFile")
+            if token_file:
+                try:
+                    token = Path(token_file).read_text().strip()
+                    headers["Authorization"] = f"Bearer {token}"
+                except OSError:
+                    self.report.add_check(
+                        check_name="kubernetes_kubeconfig_auth",
+                        passed=False,
+                        message=f"Cannot read token file: {token_file}",
+                        level=ValidationLevel.WARNING,
+                    )
+                return headers
+
+            # No supported auth found
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig_auth",
+                passed=True,
+                message=(
+                    f"User '{user_name}' has no supported auth method (token or tokenFile expected)"
+                ),
+                level=ValidationLevel.WARNING,
+            )
+            return headers
+
+        return headers
+
+    def _resolve_ca_cert(self, cluster_info: dict[str, Any]) -> bool:
+        """Resolve CA certificate configuration.
+
+        Returns:
+            True to verify SSL, False to skip verification.
+        """
+        if cluster_info.get("insecure-skip-tls-verify"):
+            return False
+
+        # Check for CA file path
+        ca_path = cluster_info.get("certificate-authority")
+        if ca_path and Path(ca_path).exists():
+            return True
+
+        # Check for inline CA data
+        ca_data = cluster_info.get("certificate-authority-data")
+        if ca_data:
+            # Inline CA data present but we can't easily use it with requests
+            # without writing to a temp file. Use verify=False with warning.
+            self.report.add_check(
+                check_name="kubernetes_kubeconfig_ca",
+                passed=True,
+                message=(
+                    "Using inline certificate-authority-data; "
+                    "SSL verification disabled for API checks"
+                ),
+                level=ValidationLevel.WARNING,
+            )
+            return False
+
+        # No CA configured - skip verification
+        return False
+
+    def _test_connectivity(self) -> None:
+        """Test API connectivity using the extracted connection info."""
+        info = self._connection_info
+        if not info.server_url:
+            return
+
+        if not info.headers.get("Authorization"):
+            self.report.add_check(
+                check_name="kubernetes_connectivity",
+                passed=True,
+                message="No auth credentials available; skipping API connectivity test",
+                level=ValidationLevel.INFO,
+            )
+            return
+
+        url = f"{info.server_url}/api"
+        connected = self.api_validator.check_api_connectivity(
+            url=url,
+            headers=info.headers,
+            verify_ssl=info.verify_ssl,
+        )
+
+        if connected:
+            self._connection_info.connected = True
+            # Try to get version info
+            version_data = self.api_validator.fetch_json(
+                url=f"{info.server_url}/version",
+                headers=info.headers,
+                verify_ssl=info.verify_ssl,
+                timeout=10,
+                check_name="kubernetes_version",
+                error_level=ValidationLevel.INFO,
+                optional=True,
+            )
+            if version_data:
+                version = version_data.get("gitVersion", "unknown")
+                self.api_validator.add_success(
+                    check_name="kubernetes_version",
+                    message=f"Kubernetes version: {version}",
+                )
+        else:
+            self.report.add_check(
+                check_name="kubernetes_connectivity",
+                passed=True,
+                message="Could not connect to Kubernetes API; API checks will be skipped",
+                level=ValidationLevel.WARNING,
+            )

--- a/src/infrafoundry/providers/kubernetes/validators/namespace_validator.py
+++ b/src/infrafoundry/providers/kubernetes/validators/namespace_validator.py
@@ -1,0 +1,102 @@
+"""Namespace validation for Kubernetes provider."""
+
+from __future__ import annotations
+
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
+
+
+class NamespaceValidator:
+    """Validates that referenced namespaces exist in the cluster.
+
+    Queries the Kubernetes API for existing namespaces and checks
+    that all namespace references in resources are either present
+    in the cluster or being created by the configuration.
+    """
+
+    def __init__(self, api_validator: BaseAPIValidator, report: ValidationReport) -> None:
+        """Initialize namespace validator.
+
+        Args:
+            api_validator: Shared API validator helper
+            report: ValidationReport to add results to
+        """
+        self.api_validator = api_validator
+        self.report = report
+
+    def validate(
+        self,
+        server_url: str,
+        headers: dict[str, str],
+        verify_ssl: bool,
+        referenced_namespaces: set[str],
+        config_namespaces: set[str],
+    ) -> None:
+        """Validate that referenced namespaces exist or will be created.
+
+        Args:
+            server_url: Kubernetes API server URL
+            headers: HTTP headers with authorization
+            verify_ssl: Whether to verify SSL certificates
+            referenced_namespaces: Namespaces referenced by resources
+            config_namespaces: Namespaces defined in the configuration
+        """
+        if not referenced_namespaces:
+            return
+
+        # Fetch existing namespaces from API
+        existing = self._fetch_namespaces(server_url, headers, verify_ssl)
+        if existing is None:
+            return  # API error already reported
+
+        for ns in sorted(referenced_namespaces):
+            if ns in existing:
+                self.report.add_check(
+                    check_name=f"kubernetes_namespace_{ns}",
+                    passed=True,
+                    message=f"Namespace '{ns}' exists in cluster",
+                    level=ValidationLevel.INFO,
+                )
+            elif ns in config_namespaces:
+                self.report.add_check(
+                    check_name=f"kubernetes_namespace_{ns}",
+                    passed=True,
+                    message=f"Namespace '{ns}' will be created by configuration",
+                    level=ValidationLevel.INFO,
+                )
+            else:
+                self.report.add_check(
+                    check_name=f"kubernetes_namespace_{ns}",
+                    passed=True,
+                    message=(
+                        f"Namespace '{ns}' not found in cluster or configuration "
+                        "(assuming it exists)"
+                    ),
+                    level=ValidationLevel.WARNING,
+                )
+
+    def _fetch_namespaces(
+        self,
+        server_url: str,
+        headers: dict[str, str],
+        verify_ssl: bool,
+    ) -> set[str] | None:
+        """Fetch the list of existing namespaces from the cluster.
+
+        Returns:
+            Set of namespace names, or None if the API call failed.
+        """
+        data = self.api_validator.fetch_json(
+            url=f"{server_url}/api/v1/namespaces",
+            headers=headers,
+            verify_ssl=verify_ssl,
+            timeout=10,
+            check_name="kubernetes_namespaces_list",
+            error_message="Failed to list namespaces (status {status})",
+            error_level=ValidationLevel.WARNING,
+        )
+        if data is None:
+            return None
+
+        items = data.get("items", [])
+        return {item.get("metadata", {}).get("name", "") for item in items} - {""}

--- a/tests/unit/providers/kubernetes/test_crd_validator.py
+++ b/tests/unit/providers/kubernetes/test_crd_validator.py
@@ -1,0 +1,143 @@
+"""Unit tests for CRDValidator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.kubernetes.validators.crd_validator import CRDValidator
+
+
+@pytest.fixture
+def validation_report():
+    """Create a ValidationReport instance."""
+    return ValidationReport()
+
+
+@pytest.fixture
+def api_validator(validation_report):
+    """Create a BaseAPIValidator instance."""
+    env_config = {
+        "name": "test-env",
+        "provider_settings": {"kubernetes": {}},
+    }
+    return BaseAPIValidator("kubernetes", env_config, validation_report)
+
+
+@pytest.fixture
+def validator(api_validator, validation_report):
+    """Create a CRDValidator instance."""
+    return CRDValidator(api_validator, validation_report)
+
+
+def _crd_api_response(groups: list[str]) -> dict:
+    """Build a mock CRD list response."""
+    return {
+        "items": [{"spec": {"group": g}} for g in groups],
+    }
+
+
+@pytest.mark.unit
+class TestCRDValidator:
+    """Tests for CRDValidator."""
+
+    def test_existing_crd(self, validator, validation_report, api_validator):
+        """Test that existing CRDs produce success."""
+        api_validator.fetch_json = MagicMock(
+            return_value=_crd_api_response(["cert-manager.io", "traefik.io"])
+        )
+        manifests = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="manifests",
+                name="my-cert",
+                config={"apiVersion": "cert-manager.io/v1", "kind": "Certificate"},
+            ),
+        ]
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            manifests=manifests,
+        )
+        assert any(r.passed and "cert-manager.io" in r.message for r in validation_report.results)
+
+    def test_missing_crd_error(self, validator, validation_report, api_validator):
+        """Test that missing CRDs produce ERROR."""
+        api_validator.fetch_json = MagicMock(return_value=_crd_api_response(["some-other.io"]))
+        manifests = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="manifests",
+                name="my-cert",
+                config={"apiVersion": "cert-manager.io/v1", "kind": "Certificate"},
+            ),
+        ]
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            manifests=manifests,
+        )
+        assert any(
+            not r.passed and r.level == ValidationLevel.ERROR and "cert-manager.io" in r.message
+            for r in validation_report.results
+        )
+
+    def test_standard_api_groups_skipped(self, validator, validation_report, api_validator):
+        """Test that standard K8s API groups are not checked."""
+        api_validator.fetch_json = MagicMock(return_value=_crd_api_response([]))
+        manifests = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="manifests",
+                name="my-deploy",
+                config={"apiVersion": "apps/v1", "kind": "Deployment"},
+            ),
+        ]
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            manifests=manifests,
+        )
+        # No CRD checks should be emitted for standard groups
+        api_validator.fetch_json.assert_not_called()
+
+    def test_no_manifests_skips(self, validator, validation_report, api_validator):
+        """Test that empty manifests list makes no API calls."""
+        api_validator.fetch_json = MagicMock()
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            manifests=[],
+        )
+        api_validator.fetch_json.assert_not_called()
+
+    def test_api_failure_graceful(self, validator, validation_report, api_validator):
+        """Test graceful handling when CRD API call fails."""
+        api_validator.fetch_json = MagicMock(return_value=None)
+        manifests = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="manifests",
+                name="my-cert",
+                config={"apiVersion": "cert-manager.io/v1", "kind": "Certificate"},
+            ),
+        ]
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            manifests=manifests,
+        )
+        # No CRD-specific error/success checks since API failed
+        crd_checks = [
+            r for r in validation_report.results if "kubernetes_crd_cert-manager" in r.check_name
+        ]
+        assert len(crd_checks) == 0

--- a/tests/unit/providers/kubernetes/test_helm_validator.py
+++ b/tests/unit/providers/kubernetes/test_helm_validator.py
@@ -1,0 +1,94 @@
+"""Unit tests for HelmValidator."""
+
+from __future__ import annotations
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.kubernetes.validators.helm_validator import HelmValidator
+
+
+@pytest.fixture
+def validation_report():
+    """Create a ValidationReport instance."""
+    return ValidationReport()
+
+
+@pytest.fixture
+def validator(validation_report):
+    """Create a HelmValidator instance."""
+    return HelmValidator(validation_report)
+
+
+@pytest.mark.unit
+class TestHelmValidator:
+    """Tests for HelmValidator."""
+
+    def test_valid_release(self, validator, validation_report):
+        """Test that a valid helm release with chart and repository succeeds."""
+        releases = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="helm_releases",
+                name="nginx",
+                config={
+                    "chart": "nginx",
+                    "repository": "https://charts.bitnami.com/bitnami",
+                },
+            ),
+        ]
+        validator.validate(releases)
+        assert any(r.passed and "nginx" in r.message for r in validation_report.results)
+        assert not validation_report.has_errors()
+
+    def test_missing_chart(self, validator, validation_report):
+        """Test that missing chart field produces ERROR."""
+        releases = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="helm_releases",
+                name="bad-release",
+                config={"repository": "https://charts.example.com"},
+            ),
+        ]
+        validator.validate(releases)
+        assert any(
+            not r.passed and r.level == ValidationLevel.ERROR and "chart" in r.message
+            for r in validation_report.results
+        )
+
+    def test_missing_repository(self, validator, validation_report):
+        """Test that missing repository field produces ERROR."""
+        releases = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="helm_releases",
+                name="bad-release",
+                config={"chart": "my-chart"},
+            ),
+        ]
+        validator.validate(releases)
+        assert any(
+            not r.passed and r.level == ValidationLevel.ERROR and "repository" in r.message
+            for r in validation_report.results
+        )
+
+    def test_missing_both(self, validator, validation_report):
+        """Test that missing both chart and repository produce two ERRORs."""
+        releases = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="helm_releases",
+                name="empty-release",
+                config={},
+            ),
+        ]
+        validator.validate(releases)
+        errors = [r for r in validation_report.results if not r.passed]
+        assert len(errors) == 2
+
+    def test_empty_releases(self, validator, validation_report):
+        """Test that empty releases list produces no checks."""
+        validator.validate([])
+        assert len(validation_report.results) == 0

--- a/tests/unit/providers/kubernetes/test_kubeconfig_validator.py
+++ b/tests/unit/providers/kubernetes/test_kubeconfig_validator.py
@@ -1,0 +1,246 @@
+"""Unit tests for KubeconfigValidator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.kubernetes.validators.kubeconfig_validator import (
+    KubeconfigValidator,
+)
+
+
+@pytest.fixture
+def validation_report():
+    """Create a ValidationReport instance."""
+    return ValidationReport()
+
+
+@pytest.fixture
+def api_validator(validation_report):
+    """Create a BaseAPIValidator instance."""
+    env_config = {
+        "name": "test-env",
+        "provider_settings": {"kubernetes": {"kubeconfig_path": "/path/to/kubeconfig"}},
+    }
+    return BaseAPIValidator("kubernetes", env_config, validation_report)
+
+
+@pytest.fixture
+def validator(api_validator, validation_report):
+    """Create a KubeconfigValidator instance."""
+    return KubeconfigValidator(api_validator, validation_report)
+
+
+def _make_kubeconfig(
+    *,
+    server: str = "https://k8s.example.com:6443",
+    context_name: str = "test-context",
+    cluster_name: str = "test-cluster",
+    user_name: str = "test-user",
+    token: str | None = "test-token",
+    token_file: str | None = None,
+    exec_auth: bool = False,
+    ca_data: str | None = None,
+    insecure: bool = False,
+) -> dict:
+    """Build a minimal kubeconfig dict for testing."""
+    cluster_info: dict = {"server": server}
+    if ca_data:
+        cluster_info["certificate-authority-data"] = ca_data
+    if insecure:
+        cluster_info["insecure-skip-tls-verify"] = True
+
+    user_info: dict = {}
+    if token:
+        user_info["token"] = token
+    if token_file:
+        user_info["tokenFile"] = token_file
+    if exec_auth:
+        user_info["exec"] = {"command": "aws", "args": ["eks", "get-token"]}
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": context_name,
+        "contexts": [
+            {
+                "name": context_name,
+                "context": {"cluster": cluster_name, "user": user_name},
+            }
+        ],
+        "clusters": [{"name": cluster_name, "cluster": cluster_info}],
+        "users": [{"name": user_name, "user": user_info}],
+    }
+
+
+@pytest.mark.unit
+class TestKubeconfigValidatorResolve:
+    """Tests for kubeconfig path resolution."""
+
+    def test_existing_kubeconfig(self, validator, validation_report, tmp_path):
+        """Test with an existing kubeconfig file."""
+        kubeconfig = tmp_path / "config"
+        kubeconfig.write_text("apiVersion: v1\nkind: Config\ncurrent-context: x\n")
+        # Will fail on context parsing but path check should pass
+        validator.validate(str(kubeconfig))
+        assert any(r.passed and "Kubeconfig found" in r.message for r in validation_report.results)
+
+    def test_missing_kubeconfig(self, validator, validation_report):
+        """Test with a missing kubeconfig file."""
+        validator.validate("/nonexistent/kubeconfig")
+        assert any(not r.passed and "not found" in r.message for r in validation_report.results)
+
+    def test_no_path_default_exists(self, validator, validation_report):
+        """Test fallback to default kubeconfig when it exists."""
+        with patch.object(Path, "exists", return_value=True):
+            validator.validate(None)
+        assert any("default kubeconfig" in r.message for r in validation_report.results)
+
+    def test_no_path_no_default(self, validator, validation_report):
+        """Test warning when no kubeconfig path and no default."""
+        with patch.object(Path, "exists", return_value=False):
+            validator.validate(None)
+        assert any(
+            r.level == ValidationLevel.WARNING and not r.passed for r in validation_report.results
+        )
+
+
+@pytest.mark.unit
+class TestKubeconfigValidatorParsing:
+    """Tests for kubeconfig parsing."""
+
+    def test_invalid_yaml(self, validator, validation_report, tmp_path):
+        """Test error on invalid YAML."""
+        kubeconfig = tmp_path / "config"
+        kubeconfig.write_text("{{invalid yaml")
+        validator.validate(str(kubeconfig))
+        assert any(not r.passed and "parse" in r.message.lower() for r in validation_report.results)
+
+    def test_missing_current_context(self, validator, validation_report, tmp_path):
+        """Test error when current-context is missing."""
+        kubeconfig = tmp_path / "config"
+        kubeconfig.write_text("apiVersion: v1\nkind: Config\n")
+        validator.validate(str(kubeconfig))
+        assert any(
+            not r.passed and "current-context" in r.message for r in validation_report.results
+        )
+
+    def test_context_not_found(self, validator, validation_report, tmp_path):
+        """Test error when named context doesn't exist."""
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(context_name="real-context")
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+        validator.validate(str(kubeconfig), context_override="nonexistent")
+        assert any(not r.passed and "nonexistent" in r.message for r in validation_report.results)
+
+    def test_explicit_context_override(self, validator, validation_report, tmp_path):
+        """Test that context override takes precedence."""
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(context_name="override-ctx")
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+        # Mock connectivity to avoid real API calls
+        validator.api_validator.check_api_connectivity = MagicMock(return_value=False)
+        validator.validate(str(kubeconfig), context_override="override-ctx")
+        # Should not fail on context lookup
+        context_errors = [
+            r for r in validation_report.results if not r.passed and "context" in r.check_name
+        ]
+        assert len(context_errors) == 0
+
+
+@pytest.mark.unit
+class TestKubeconfigValidatorAuth:
+    """Tests for authentication extraction."""
+
+    def test_bearer_token(self, validator, validation_report, tmp_path):
+        """Test bearer token extraction."""
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(token="my-secret-token")
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+        validator.api_validator.check_api_connectivity = MagicMock(return_value=False)
+        validator.validate(str(kubeconfig))
+        assert validator.connection_info.headers.get("Authorization") == "Bearer my-secret-token"
+
+    def test_token_file(self, validator, validation_report, tmp_path):
+        """Test tokenFile extraction."""
+        token_file = tmp_path / "token"
+        token_file.write_text("file-based-token\n")
+
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(token=None, token_file=str(token_file))
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+        validator.api_validator.check_api_connectivity = MagicMock(return_value=False)
+        validator.validate(str(kubeconfig))
+        assert validator.connection_info.headers.get("Authorization") == "Bearer file-based-token"
+
+    def test_exec_auth_warning(self, validator, validation_report, tmp_path):
+        """Test that exec-based auth produces a warning."""
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(token=None, exec_auth=True)
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+        validator.api_validator.check_api_connectivity = MagicMock(return_value=False)
+        validator.validate(str(kubeconfig))
+        assert any(
+            "exec-based auth" in r.message and r.level == ValidationLevel.WARNING
+            for r in validation_report.results
+        )
+
+
+@pytest.mark.unit
+class TestKubeconfigValidatorConnectivity:
+    """Tests for API connectivity."""
+
+    def test_connectivity_success(self, validator, validation_report, tmp_path):
+        """Test successful connectivity."""
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(insecure=True)
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+
+        validator.api_validator.check_api_connectivity = MagicMock(return_value=True)
+        validator.api_validator.fetch_json = MagicMock(return_value={"gitVersion": "v1.28.0"})
+        validator.validate(str(kubeconfig))
+        assert validator.is_connected
+
+    def test_connectivity_failure(self, validator, validation_report, tmp_path):
+        """Test connectivity failure produces warning."""
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(insecure=True)
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+
+        validator.api_validator.check_api_connectivity = MagicMock(return_value=False)
+        validator.validate(str(kubeconfig))
+        assert not validator.is_connected
+        assert any(
+            "skipped" in r.message.lower() and r.level == ValidationLevel.WARNING
+            for r in validation_report.results
+        )
+
+    def test_no_auth_skips_connectivity(self, validator, validation_report, tmp_path):
+        """Test that missing auth skips connectivity test."""
+        kubeconfig = tmp_path / "config"
+        data = _make_kubeconfig(token=None, insecure=True)
+        import yaml
+
+        kubeconfig.write_text(yaml.dump(data))
+        validator.validate(str(kubeconfig))
+        assert not validator.is_connected
+        assert any("No auth" in r.message for r in validation_report.results)

--- a/tests/unit/providers/kubernetes/test_namespace_validator.py
+++ b/tests/unit/providers/kubernetes/test_namespace_validator.py
@@ -1,0 +1,119 @@
+"""Unit tests for NamespaceValidator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.kubernetes.validators.namespace_validator import (
+    NamespaceValidator,
+)
+
+
+@pytest.fixture
+def validation_report():
+    """Create a ValidationReport instance."""
+    return ValidationReport()
+
+
+@pytest.fixture
+def api_validator(validation_report):
+    """Create a BaseAPIValidator instance."""
+    env_config = {
+        "name": "test-env",
+        "provider_settings": {"kubernetes": {}},
+    }
+    return BaseAPIValidator("kubernetes", env_config, validation_report)
+
+
+@pytest.fixture
+def validator(api_validator, validation_report):
+    """Create a NamespaceValidator instance."""
+    return NamespaceValidator(api_validator, validation_report)
+
+
+def _namespace_api_response(names: list[str]) -> dict:
+    """Build a mock Kubernetes namespace list response."""
+    return {
+        "items": [{"metadata": {"name": n}} for n in names],
+    }
+
+
+@pytest.mark.unit
+class TestNamespaceValidator:
+    """Tests for NamespaceValidator."""
+
+    def test_existing_namespace(self, validator, validation_report, api_validator):
+        """Test that existing namespaces produce INFO."""
+        api_validator.fetch_json = MagicMock(
+            return_value=_namespace_api_response(["default", "kube-system", "my-ns"])
+        )
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            referenced_namespaces={"my-ns"},
+            config_namespaces=set(),
+        )
+        assert any(
+            "exists in cluster" in r.message and r.check_name == "kubernetes_namespace_my-ns"
+            for r in validation_report.results
+        )
+
+    def test_namespace_in_config(self, validator, validation_report, api_validator):
+        """Test that namespaces in config produce 'will be created' INFO."""
+        api_validator.fetch_json = MagicMock(return_value=_namespace_api_response(["default"]))
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            referenced_namespaces={"new-ns"},
+            config_namespaces={"new-ns"},
+        )
+        assert any("will be created" in r.message for r in validation_report.results)
+
+    def test_namespace_missing_warning(self, validator, validation_report, api_validator):
+        """Test that missing namespaces produce WARNING."""
+        api_validator.fetch_json = MagicMock(return_value=_namespace_api_response(["default"]))
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            referenced_namespaces={"unknown-ns"},
+            config_namespaces=set(),
+        )
+        assert any(
+            r.level == ValidationLevel.WARNING and "not found" in r.message
+            for r in validation_report.results
+        )
+
+    def test_api_failure_graceful(self, validator, validation_report, api_validator):
+        """Test graceful handling of API failure."""
+        api_validator.fetch_json = MagicMock(return_value=None)
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            referenced_namespaces={"my-ns"},
+            config_namespaces=set(),
+        )
+        # Should not have namespace-specific checks since API failed
+        ns_checks = [
+            r for r in validation_report.results if r.check_name == "kubernetes_namespace_my-ns"
+        ]
+        assert len(ns_checks) == 0
+
+    def test_empty_namespaces_skips(self, validator, validation_report, api_validator):
+        """Test that empty namespaces set makes no API calls."""
+        api_validator.fetch_json = MagicMock()
+        validator.validate(
+            server_url="https://k8s:6443",
+            headers={"Authorization": "Bearer tok"},
+            verify_ssl=False,
+            referenced_namespaces=set(),
+            config_namespaces=set(),
+        )
+        api_validator.fetch_json.assert_not_called()

--- a/tests/unit/test_kubernetes_validator.py
+++ b/tests/unit/test_kubernetes_validator.py
@@ -1,7 +1,7 @@
-"""Unit tests for KubernetesValidator."""
+"""Unit tests for KubernetesValidator (composition orchestrator)."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,6 +12,12 @@ from infrafoundry.core.validation import (
     ValidationReport,
 )
 from infrafoundry.providers.kubernetes.validator import KubernetesValidator
+from infrafoundry.providers.kubernetes.validators import (
+    CRDValidator,
+    HelmValidator,
+    KubeconfigValidator,
+    NamespaceValidator,
+)
 
 
 @pytest.fixture
@@ -50,6 +56,27 @@ class TestKubernetesValidatorProtocol:
         assert hasattr(validator, "report")
         assert hasattr(validator, "validate_connectivity")
         assert hasattr(validator, "validate_references")
+
+
+@pytest.mark.unit
+class TestKubernetesValidatorComposition:
+    """Tests verifying composition of specialized validators."""
+
+    def test_has_kubeconfig_validator(self, validator):
+        """Test that KubernetesValidator composes KubeconfigValidator."""
+        assert isinstance(validator.kubeconfig_validator, KubeconfigValidator)
+
+    def test_has_namespace_validator(self, validator):
+        """Test that KubernetesValidator composes NamespaceValidator."""
+        assert isinstance(validator.namespace_validator, NamespaceValidator)
+
+    def test_has_crd_validator(self, validator):
+        """Test that KubernetesValidator composes CRDValidator."""
+        assert isinstance(validator.crd_validator, CRDValidator)
+
+    def test_has_helm_validator(self, validator):
+        """Test that KubernetesValidator composes HelmValidator."""
+        assert isinstance(validator.helm_validator, HelmValidator)
 
 
 @pytest.mark.unit
@@ -108,6 +135,33 @@ class TestKubernetesValidatorConnectivity:
         # Should have warning result
         assert any(
             r.level == ValidationLevel.WARNING and not r.passed for r in validation_report.results
+        )
+
+    def test_validate_connectivity_delegates_to_kubeconfig_validator(
+        self, mock_env_config, validation_report
+    ):
+        """Test that connectivity delegates to KubeconfigValidator."""
+        validator = KubernetesValidator(mock_env_config, validation_report)
+        validator.kubeconfig_validator.validate = MagicMock()
+        validator.validate_connectivity()
+        validator.kubeconfig_validator.validate.assert_called_once_with("/path/to/kubeconfig", None)
+
+    def test_validate_connectivity_passes_context_override(self, validation_report):
+        """Test that context override from settings is passed through."""
+        env_config = {
+            "name": "test-env",
+            "provider_settings": {
+                "kubernetes": {
+                    "kubeconfig_path": "/path/to/kubeconfig",
+                    "context": "my-context",
+                }
+            },
+        }
+        validator = KubernetesValidator(env_config, validation_report)
+        validator.kubeconfig_validator.validate = MagicMock()
+        validator.validate_connectivity()
+        validator.kubeconfig_validator.validate.assert_called_once_with(
+            "/path/to/kubeconfig", "my-context"
         )
 
 
@@ -204,3 +258,34 @@ class TestKubernetesValidatorReferences:
 
         # Should report successful validation
         assert any("Validated references" in r.message for r in validation_report.results)
+
+    def test_validate_references_runs_helm_always(self, validator, validation_report):
+        """Test that Helm validation runs regardless of connectivity."""
+        validator.helm_validator.validate = MagicMock()
+        resources = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="helm_releases",
+                name="nginx",
+                config={"chart": "nginx", "repository": "https://charts.bitnami.com"},
+            ),
+        ]
+        validator.validate_references(resources)
+        validator.helm_validator.validate.assert_called_once()
+
+    def test_validate_references_skips_api_when_disconnected(self, validator, validation_report):
+        """Test that API-based checks are skipped when not connected."""
+        validator.namespace_validator.validate = MagicMock()
+        validator.crd_validator.validate = MagicMock()
+        resources = [
+            ResourceConfig(
+                provider="kubernetes",
+                type="deployments",
+                name="my-app",
+                config={"namespace": "default"},
+            ),
+        ]
+        # kubeconfig_validator.is_connected defaults to False
+        validator.validate_references(resources)
+        validator.namespace_validator.validate.assert_not_called()
+        validator.crd_validator.validate.assert_not_called()


### PR DESCRIPTION
## Description

Phase 2 of the nested-model refactor (ADR-0011). Regenerates all 296 models and 293 mappings with nested structure so that model attribute paths mirror the ONTAP REST API response shape (e.g., `volume.svm.name` instead of `volume.svm_name`).

Addresses #444

## Related Issue

Addresses #444

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

### Models (267 files)
- Regenerated all 296 Pydantic models with nested inner classes matching the API structure
- Sub-model class names now include the full parent path (e.g., `OntapVolumeAntiRansomwareAttackReport` instead of `OntapVolumeAttackReport`)
- Default values use nested model constructors (e.g., `svm: Svm = Svm()`)

### Mappings (533 files)
- Regenerated all 293 TypeMapping definitions with dotted `cache_attr` paths matching nested model structure
- Updated `parent_id_field` to use dotted paths where models are nested (e.g., `svm.uuid` instead of `svm_uuid`)
- Restored `cache_strategy="realtime"` annotations on all applicable fields
- Sub-model transforms now use `get_nested_value()` for correct dotted-path extraction from API records

### Framework (2 files)
- Updated `collector.py` to handle nested model paths in diff tracking
- Updated `diff.py` to support dotted attribute paths

### CLI consumers (4 files)
- Updated `html.py`, `space_usage.py`, `savings.py`, `locks.py` to use nested attribute access (e.g., `vol.svm.name`)
- Updated `job.py` for nested model access patterns

### Tests (10 files)
- Updated all affected test fixtures and assertions for nested model structure
- Updated mapping tests for dotted `cache_attr` paths
- Updated CLI command tests for nested attribute access

## Testing

- [x] All existing tests pass (`doit check` passes: format, lint, type-check, security, spell-check, tests)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- This is phase 2 of a multi-PR refactor. Phase 1 (PR #449) prepared the codegen and framework. This phase regenerates all models/mappings and updates consumers.
- ADR-0011 was included in the phase 1 PR and does not need changes.
- The field-mapping dev guide (`docs/development/field-mapping.md`) may warrant a brief note about nested `cache_attr` paths in a follow-up doc PR, but the canonical example (volume mapping) is self-documenting.
- 817 files changed, ~28.9k insertions, ~14.5k deletions.

BREAKING CHANGE: All model attribute access paths changed from flat (e.g., `volume.svm_name`) to nested (e.g., `volume.svm.name`). Any external code accessing model attributes must be updated.
