### PR TITLE
refactor: extract dedicated API clients for Proxmox and OCI providers

### DIFF
--- a/src/infrafoundry/providers/oci/api_client.py
+++ b/src/infrafoundry/providers/oci/api_client.py
@@ -1,0 +1,232 @@
+"""OCI API client with RSA-SHA256 HTTP Signature authentication."""
+
+from __future__ import annotations
+
+import base64
+import email.utils
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+from infrafoundry.core.exceptions import APIError, ConfigurationError
+from infrafoundry.core.types import OCIProviderSettings
+
+logger = logging.getLogger(__name__)
+
+
+class OCIClient:
+    """OCI API client with RSA-SHA256 HTTP Signature authentication.
+
+    Loads the RSA private key once at construction time and generates
+    per-request signatures. Follows the same pattern as OPNsenseClient
+    for error handling (raises APIError/ConfigurationError).
+    """
+
+    IDENTITY_API_BASE = "https://identity.{region}.oraclecloud.com"
+    OCI_API_BASE = "https://iaas.{region}.oraclecloud.com"
+
+    def __init__(
+        self,
+        tenancy_ocid: str,
+        user_ocid: str,
+        private_key_path: str,
+        fingerprint: str,
+        region: str,
+        timeout: int = 10,
+    ) -> None:
+        """Initialize OCI API client.
+
+        Loads the RSA private key eagerly so signing never fails after construction.
+
+        Args:
+            tenancy_ocid: OCI tenancy OCID
+            user_ocid: OCI user OCID
+            private_key_path: Path to RSA private key PEM file
+            fingerprint: RSA key fingerprint
+            region: OCI region (e.g. us-ashburn-1)
+            timeout: Request timeout in seconds
+
+        Raises:
+            ConfigurationError: If key file is missing, cryptography package
+                unavailable, or key is not a valid RSA key
+        """
+        self.tenancy_ocid = tenancy_ocid
+        self.user_ocid = user_ocid
+        self.fingerprint = fingerprint
+        self.region = region
+        self.timeout = timeout
+
+        # Load private key eagerly
+        key_path = Path(private_key_path).expanduser()
+        if not key_path.exists():
+            raise ConfigurationError(f"OCI private key not found: {key_path}")
+
+        try:
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+        except ImportError as exc:
+            raise ConfigurationError("'cryptography' package required for OCI API signing") from exc
+
+        try:
+            with open(key_path, "rb") as f:
+                loaded_key = serialization.load_pem_private_key(f.read(), password=None)
+            if not isinstance(loaded_key, RSAPrivateKey):
+                raise ConfigurationError("OCI API requires an RSA private key")
+            self._private_key = loaded_key
+        except ConfigurationError:
+            raise
+        except Exception as exc:
+            raise ConfigurationError(f"Failed to load OCI private key: {exc}") from exc
+
+    @classmethod
+    def from_provider_settings(cls, settings: OCIProviderSettings) -> OCIClient:
+        """Create a client from provider settings.
+
+        Args:
+            settings: OCI provider settings dictionary
+
+        Returns:
+            OCIClient instance
+
+        Raises:
+            ConfigurationError: If required settings are missing or key loading fails
+        """
+        return cls(
+            tenancy_ocid=settings.get("tenancy_ocid", ""),
+            user_ocid=settings.get("user_ocid", ""),
+            private_key_path=settings.get("private_key_path", ""),
+            fingerprint=settings.get("fingerprint", ""),
+            region=settings.get("region", ""),
+        )
+
+    def identity_url(self) -> str:
+        """Return the Identity API base URL for the configured region."""
+        return self.IDENTITY_API_BASE.format(region=self.region)
+
+    def iaas_url(self) -> str:
+        """Return the IAAS API base URL for the configured region."""
+        return self.OCI_API_BASE.format(region=self.region)
+
+    def list_resources(self, base_url: str, path: str) -> list[dict[str, Any]]:
+        """Fetch a list resource from the OCI API.
+
+        OCI list endpoints return JSON arrays directly.
+
+        Args:
+            base_url: API base URL (e.g. identity or iaas endpoint)
+            path: API path including query parameters
+
+        Returns:
+            List of resource dicts
+
+        Raises:
+            APIError: On HTTP errors, connection errors, or unexpected response format
+        """
+        url = f"{base_url}{path}"
+        headers = self._build_signed_headers("get", url)
+
+        try:
+            response = requests.get(url, headers=headers, timeout=self.timeout)
+        except requests.exceptions.RequestException as e:
+            raise APIError(
+                f"OCI API request failed: {e}",
+                provider="oci",
+            ) from e
+
+        if not response.ok:
+            raise APIError(
+                f"OCI API request failed: {response.status_code}",
+                status_code=response.status_code,
+                response=response.text,
+                provider="oci",
+            )
+
+        try:
+            data = response.json()
+        except (json.JSONDecodeError, ValueError) as e:
+            raise APIError(
+                "Invalid JSON response from OCI",
+                response=str(e),
+                provider="oci",
+            ) from e
+
+        if not isinstance(data, list):
+            raise APIError(
+                "OCI API returned unexpected format (expected JSON array)",
+                provider="oci",
+            )
+
+        return data
+
+    def _build_signed_headers(self, method: str, url: str, body: str = "") -> dict[str, str]:
+        """Build OCI API signed request headers.
+
+        Uses HTTP Signatures (RFC 7235) with RSA-SHA256 signing.
+
+        Args:
+            method: HTTP method (lowercase)
+            url: Full request URL
+            body: Request body (empty for GET)
+
+        Returns:
+            Headers dict with Authorization signature
+        """
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        # Parse URL for host and path
+        parsed = urlparse(url)
+        host = parsed.netloc
+        path = parsed.path
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+
+        # Build signing headers
+        date = email.utils.formatdate(usegmt=True)
+        headers: dict[str, str] = {
+            "date": date,
+            "host": host,
+            "(request-target)": f"{method} {path}",
+        }
+
+        signing_headers = ["date", "(request-target)", "host"]
+
+        if body:
+            body_hash = hashlib.sha256(body.encode()).digest()
+            content_sha256 = base64.b64encode(body_hash).decode()
+            headers["content-type"] = "application/json"
+            headers["x-content-sha256"] = content_sha256
+            headers["content-length"] = str(len(body))
+            signing_headers.extend(["content-type", "x-content-sha256", "content-length"])
+
+        # Build signing string
+        signing_string = "\n".join(f"{h}: {headers[h]}" for h in signing_headers)
+
+        # Sign with RSA-SHA256
+        signature = self._private_key.sign(
+            signing_string.encode(),
+            padding.PKCS1v15(),
+            hashes.SHA256(),
+        )
+        b64_signature = base64.b64encode(signature).decode()
+
+        # Build Authorization header
+        key_id = f"{self.tenancy_ocid}/{self.user_ocid}/{self.fingerprint}"
+        auth_header = (
+            f'Signature version="1",'
+            f'keyId="{key_id}",'
+            f'algorithm="rsa-sha256",'
+            f'headers="{" ".join(signing_headers)}",'
+            f'signature="{b64_signature}"'
+        )
+
+        return {
+            "date": date,
+            "host": host,
+            "Authorization": auth_header,
+        }

--- a/src/infrafoundry/providers/oci/validator.py
+++ b/src/infrafoundry/providers/oci/validator.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-import base64
-import email.utils
-import hashlib
+import logging
 from typing import Any, cast
 
+from infrafoundry.core.exceptions import APIError, ConfigurationError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.types import EnvironmentData, OCIProviderSettings
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.oci.api_client import OCIClient
 
 from .validators import CompartmentValidator, ImageValidator, NetworkValidator
+
+logger = logging.getLogger(__name__)
 
 
 class OCIValidator:
@@ -25,9 +27,6 @@ class OCIValidator:
     - VCN/subnet name collision detection via OCI API
     - Image OCID validation via OCI API
     """
-
-    OCI_API_BASE = "https://iaas.{region}.oraclecloud.com"
-    IDENTITY_API_BASE = "https://identity.{region}.oraclecloud.com"
 
     def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
         """Initialize OCI validator.
@@ -45,6 +44,22 @@ class OCIValidator:
         self.compartment_validator = CompartmentValidator(report)
         self.network_validator = NetworkValidator(report)
         self.image_validator = ImageValidator(report)
+
+    def _create_client(self) -> OCIClient | None:
+        """Create an OCIClient from provider settings.
+
+        Returns:
+            OCIClient instance, or None if client creation fails
+        """
+        try:
+            return OCIClient.from_provider_settings(self.provider_settings)
+        except ConfigurationError as exc:
+            self.api_validator.add_error(
+                check_name="oci_client",
+                message=str(exc),
+                level=ValidationLevel.WARNING,
+            )
+            return None
 
     def validate_connectivity(self) -> None:
         """Validate connectivity to OCI API.
@@ -65,35 +80,33 @@ class OCIValidator:
         if not credentials:
             return
 
-        region = self.provider_settings.get("region", "")
-        tenancy_ocid = self.provider_settings.get("tenancy_ocid", "")
-
-        # Build the identity API URL for availability domains
-        api_base = self.IDENTITY_API_BASE.format(region=region)
-        url = f"{api_base}/20160918/availabilityDomains?compartmentId={tenancy_ocid}"
-
-        # Build OCI API signature headers
-        headers = self._build_signed_headers("get", url)
-        if not headers:
+        client = self._create_client()
+        if not client:
             return
 
-        # Test API connectivity
-        response_ok = self.api_validator.check_api_connectivity(
-            url=url,
-            headers=headers,
-        )
+        tenancy_ocid = self.provider_settings.get("tenancy_ocid", "")
 
-        if response_ok:
+        # Test API connectivity using availability domains endpoint
+        try:
+            client.list_resources(
+                base_url=client.identity_url(),
+                path=f"/20160918/availabilityDomains?compartmentId={tenancy_ocid}",
+            )
             self.api_validator.add_success(
                 check_name="oci_connectivity",
                 message="OCI API connectivity validated successfully",
+            )
+        except APIError as exc:
+            self.api_validator.add_error(
+                check_name="oci_connectivity",
+                message=f"OCI API connectivity failed: {exc.message}",
             )
 
     def validate_references(self, resources: list[ResourceConfig]) -> None:
         """Validate that referenced OCI resources exist within config and live API.
 
         Performs local cross-reference checks (always) and API-based validation
-        (when signing succeeds and compartment_ocid is configured).
+        (when client creation succeeds and compartment_ocid is configured).
 
         Args:
             resources: List of resources to validate
@@ -166,206 +179,78 @@ class OCIValidator:
     def _validate_api_references(self, resources: list[ResourceConfig]) -> None:
         """Validate resources against live OCI API state.
 
-        Attempts to sign requests independently. If signing fails or
+        Attempts to create an OCIClient. If client creation fails or
         compartment_ocid is not configured, API checks are skipped gracefully.
 
         Args:
             resources: List of resources to validate
         """
-        region = self.provider_settings.get("region", "")
         compartment_ocid = self.provider_settings.get("compartment_ocid", "")
         tenancy_ocid = self.provider_settings.get("tenancy_ocid", "")
 
-        if not compartment_ocid or not region:
+        if not compartment_ocid or not self.provider_settings.get("region", ""):
             return
 
-        # Fetch compartments (uses tenancy_ocid as parent)
-        if tenancy_ocid:
-            compartments = self._fetch_oci_list(
-                base_url=self.IDENTITY_API_BASE.format(region=region),
-                path=f"/20160918/compartments?compartmentId={tenancy_ocid}",
-                check_name="oci_list_compartments",
+        client = self._create_client()
+        if not client:
+            return
+
+        try:
+            # Fetch compartments (uses tenancy_ocid as parent)
+            compartments = None
+            if tenancy_ocid:
+                compartments = self._safe_list(
+                    client,
+                    client.identity_url(),
+                    f"/20160918/compartments?compartmentId={tenancy_ocid}",
+                )
+                self.compartment_validator.validate(compartment_ocid, compartments)
+
+            # Fetch VCNs and subnets
+            vcns = self._safe_list(
+                client,
+                client.iaas_url(),
+                f"/20160918/vcns?compartmentId={compartment_ocid}",
             )
-            self.compartment_validator.validate(compartment_ocid, compartments)
+            subnets = self._safe_list(
+                client,
+                client.iaas_url(),
+                f"/20160918/subnets?compartmentId={compartment_ocid}",
+            )
+            self.network_validator.validate(resources, vcns, subnets)
 
-        # Fetch VCNs
-        vcns = self._fetch_oci_list(
-            base_url=self.OCI_API_BASE.format(region=region),
-            path=f"/20160918/vcns?compartmentId={compartment_ocid}",
-            check_name="oci_list_vcns",
-        )
+            # Fetch images
+            images = self._safe_list(
+                client,
+                client.iaas_url(),
+                f"/20160918/images?compartmentId={compartment_ocid}",
+            )
+            self.image_validator.validate(resources, images)
 
-        # Fetch subnets
-        subnets = self._fetch_oci_list(
-            base_url=self.OCI_API_BASE.format(region=region),
-            path=f"/20160918/subnets?compartmentId={compartment_ocid}",
-            check_name="oci_list_subnets",
-        )
+        except Exception as exc:
+            self.api_validator.handle_validation_exception(
+                check_name="oci_api_validation",
+                error=exc,
+                warning_level=ValidationLevel.WARNING,
+            )
 
-        self.network_validator.validate(resources, vcns, subnets)
-
-        # Fetch images
-        images = self._fetch_oci_list(
-            base_url=self.OCI_API_BASE.format(region=region),
-            path=f"/20160918/images?compartmentId={compartment_ocid}",
-            check_name="oci_list_images",
-        )
-
-        self.image_validator.validate(resources, images)
-
-    def _fetch_oci_list(
+    def _safe_list(
         self,
+        client: OCIClient,
         base_url: str,
         path: str,
-        check_name: str,
     ) -> list[dict[str, Any]] | None:
-        """Fetch a list resource from the OCI API with signed authentication.
-
-        OCI list endpoints return JSON arrays directly, so we use api_request()
-        instead of fetch_json() which expects a dict response.
+        """Safely fetch a list resource, returning None on failure.
 
         Args:
-            base_url: API base URL (e.g. iaas or identity endpoint)
+            client: OCI API client
+            base_url: API base URL
             path: API path including query parameters
-            check_name: Validation check name for error reporting
 
         Returns:
-            List of resource dicts, or None if signing or request fails
+            List of resource dicts, or None if the request fails
         """
-        url = f"{base_url}{path}"
-
-        headers = self._build_signed_headers("get", url)
-        if not headers:
-            return None
-
-        response = self.api_validator.api_request(
-            url=url,
-            check_name=check_name,
-            headers=headers,
-            error_level=ValidationLevel.WARNING,
-            optional=True,
-        )
-
-        if not response:
-            return None
-
         try:
-            data = response.json()
-            if isinstance(data, list):
-                return cast(list[dict[str, Any]], data)
-            # Some endpoints may wrap in a dict — handle gracefully
+            return client.list_resources(base_url, path)
+        except APIError:
             return None
-        except ValueError:
-            return None
-
-    def _build_signed_headers(self, method: str, url: str, body: str = "") -> dict[str, str] | None:
-        """Build OCI API signed request headers.
-
-        Uses HTTP Signatures (RFC 7235) with RSA-SHA256 signing.
-
-        Args:
-            method: HTTP method (lowercase)
-            url: Full request URL
-            body: Request body (empty for GET)
-
-        Returns:
-            Headers dict with Authorization signature, or None on error
-        """
-        from pathlib import Path
-        from urllib.parse import urlparse
-
-        tenancy_ocid = self.provider_settings.get("tenancy_ocid", "")
-        user_ocid = self.provider_settings.get("user_ocid", "")
-        fingerprint = self.provider_settings.get("fingerprint", "")
-        private_key_path = self.provider_settings.get("private_key_path", "")
-
-        # Expand ~ in key path
-        key_path = Path(private_key_path).expanduser()
-        if not key_path.exists():
-            self.api_validator.add_error(
-                check_name="oci_private_key",
-                message=f"OCI private key not found: {key_path}",
-            )
-            return None
-
-        try:
-            from cryptography.hazmat.primitives import hashes, serialization
-            from cryptography.hazmat.primitives.asymmetric import padding
-            from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
-        except ImportError:
-            self.api_validator.add_error(
-                check_name="oci_dependencies",
-                message="'cryptography' package required for OCI API signing",
-                level=ValidationLevel.WARNING,
-            )
-            return None
-
-        # Load private key (OCI requires RSA keys)
-        try:
-            with open(key_path, "rb") as f:
-                loaded_key = serialization.load_pem_private_key(f.read(), password=None)
-            if not isinstance(loaded_key, RSAPrivateKey):
-                self.api_validator.add_error(
-                    check_name="oci_private_key",
-                    message="OCI API requires an RSA private key",
-                )
-                return None
-            private_key = loaded_key
-        except Exception as exc:
-            self.api_validator.add_error(
-                check_name="oci_private_key",
-                message=f"Failed to load OCI private key: {exc}",
-            )
-            return None
-
-        # Parse URL for host and path
-        parsed = urlparse(url)
-        host = parsed.netloc
-        path = parsed.path
-        if parsed.query:
-            path = f"{path}?{parsed.query}"
-
-        # Build signing headers
-        date = email.utils.formatdate(usegmt=True)
-        headers: dict[str, str] = {
-            "date": date,
-            "host": host,
-            "(request-target)": f"{method} {path}",
-        }
-
-        signing_headers = ["date", "(request-target)", "host"]
-
-        if body:
-            body_hash = hashlib.sha256(body.encode()).digest()
-            content_sha256 = base64.b64encode(body_hash).decode()
-            headers["content-type"] = "application/json"
-            headers["x-content-sha256"] = content_sha256
-            headers["content-length"] = str(len(body))
-            signing_headers.extend(["content-type", "x-content-sha256", "content-length"])
-
-        # Build signing string
-        signing_string = "\n".join(f"{h}: {headers[h]}" for h in signing_headers)
-
-        # Sign with RSA-SHA256
-        signature = private_key.sign(
-            signing_string.encode(),
-            padding.PKCS1v15(),
-            hashes.SHA256(),
-        )
-        b64_signature = base64.b64encode(signature).decode()
-
-        # Build Authorization header
-        key_id = f"{tenancy_ocid}/{user_ocid}/{fingerprint}"
-        auth_header = (
-            f'Signature version="1",'
-            f'keyId="{key_id}",'
-            f'algorithm="rsa-sha256",'
-            f'headers="{" ".join(signing_headers)}",'
-            f'signature="{b64_signature}"'
-        )
-
-        return {
-            "date": date,
-            "host": host,
-            "Authorization": auth_header,
-        }

--- a/src/infrafoundry/providers/proxmox/api_client.py
+++ b/src/infrafoundry/providers/proxmox/api_client.py
@@ -1,0 +1,144 @@
+"""Proxmox VE API client with PVE token authentication."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import requests
+import urllib3
+
+from infrafoundry.core.exceptions import APIError, AuthenticationError
+from infrafoundry.core.types import ProxmoxProviderSettings
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+logger = logging.getLogger(__name__)
+
+
+class ProxmoxClient:
+    """Thin wrapper around requests with Proxmox PVE token authentication.
+
+    Handles URL construction, authentication headers, and error conversion
+    following the same pattern as OPNsenseClient.
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        api_token: str,
+        verify_ssl: bool = False,
+        timeout: int = 10,
+    ) -> None:
+        """Initialize Proxmox API client.
+
+        Args:
+            api_url: Proxmox API base URL (e.g. https://pve.example.com:8006/api2/json)
+            api_token: Full PVE API token (USER@REALM!TOKENID=SECRET)
+            verify_ssl: Whether to verify SSL certificates
+            timeout: Request timeout in seconds
+        """
+        self.api_url = api_url
+        self.headers = {"Authorization": f"PVEAPIToken={api_token}"}
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+
+    @classmethod
+    def from_provider_settings(cls, settings: ProxmoxProviderSettings) -> ProxmoxClient | None:
+        """Create a client from provider settings.
+
+        Supports two token formats:
+        - api_token: Full token string
+        - api_token_id + api_token_secret: Terraform provider format
+
+        Args:
+            settings: Proxmox provider settings dictionary
+
+        Returns:
+            ProxmoxClient instance, or None if credentials are insufficient
+        """
+        api_url = settings.get("api_url")
+        if not api_url:
+            return None
+
+        api_token = settings.get("api_token")
+        if not api_token:
+            token_id = settings.get("api_token_id")
+            token_secret = settings.get("api_token_secret")
+            if token_id and token_secret:
+                api_token = f"{token_id}={token_secret}"
+
+        if not api_token:
+            return None
+
+        return cls(api_url=api_url, api_token=api_token)
+
+    def get_json(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        """Make an authenticated GET request and return parsed JSON.
+
+        Args:
+            endpoint: API endpoint path (appended to base URL)
+            **kwargs: Additional arguments passed to requests.get
+
+        Returns:
+            Parsed JSON response as a dictionary
+
+        Raises:
+            AuthenticationError: On 401/403 responses
+            APIError: On other HTTP errors, connection errors, or JSON parse failures
+        """
+        url = f"{self.api_url}/{endpoint}"
+        try:
+            response = requests.get(
+                url,
+                headers=self.headers,
+                verify=self.verify_ssl,
+                timeout=self.timeout,
+                **kwargs,
+            )
+        except requests.exceptions.ConnectionError as e:
+            raise APIError(
+                f"Proxmox API connection failed: {e}",
+                provider="proxmox",
+            ) from e
+        except requests.exceptions.Timeout as e:
+            raise APIError(
+                f"Proxmox API request timed out: {e}",
+                provider="proxmox",
+            ) from e
+        except requests.exceptions.RequestException as e:
+            raise APIError(
+                f"Proxmox API request failed: {e}",
+                provider="proxmox",
+            ) from e
+
+        if response.status_code in (401, 403):
+            raise AuthenticationError(
+                "Proxmox authentication failed",
+                status_code=response.status_code,
+                response=response.text,
+                provider="proxmox",
+            )
+
+        if not response.ok:
+            raise APIError(
+                f"Proxmox API request failed: {response.status_code}",
+                status_code=response.status_code,
+                response=response.text,
+                provider="proxmox",
+            )
+
+        try:
+            return dict(response.json())
+        except (json.JSONDecodeError, ValueError) as e:
+            raise APIError(
+                "Invalid JSON response from Proxmox",
+                response=str(e),
+                provider="proxmox",
+            ) from e
+
+    @property
+    def base_url(self) -> str:
+        """Return the API base URL."""
+        return self.api_url

--- a/src/infrafoundry/providers/proxmox/validator.py
+++ b/src/infrafoundry/providers/proxmox/validator.py
@@ -7,10 +7,12 @@ from typing import Any, TypedDict, cast
 
 import urllib3
 
+from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.types import EnvironmentData, ProxmoxProviderSettings
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.proxmox.api_client import ProxmoxClient
 from infrafoundry.providers.proxmox.validators import (
     NetworkValidator,
     NodeValidator,
@@ -48,10 +50,10 @@ class ProxmoxValidator:
 
     Performs comprehensive pre-flight validation including:
     - API connectivity and authentication
-    - Node availability and status
-    - Storage pool existence and state
-    - Network bridge configuration
-    - Template availability (by VMID or name)
+    - Node availability
+    - Storage pool existence and status
+    - Network bridge availability
+    - VM template existence
     - VMID conflicts and availability
     - MAC address conflicts
     """
@@ -71,9 +73,9 @@ class ProxmoxValidator:
         self._cluster_vm_cache_populated = False
 
         # Initialize specialized validators
-        self.node_validator = NodeValidator(self.api_validator, report)
-        self.storage_validator = StorageValidator(self.api_validator, report)
-        self.network_validator = NetworkValidator(self.api_validator, report)
+        self.node_validator = NodeValidator(report)
+        self.storage_validator = StorageValidator(report)
+        self.network_validator = NetworkValidator(report)
         self.template_validator = TemplateValidator(report)
         self.vmid_validator = VMIDValidator(report)
 
@@ -90,11 +92,9 @@ class ProxmoxValidator:
         if not credentials:
             return
 
-        # Build API token from either format:
-        # Format 1: api_token (full token string)
-        # Format 2: api_token_id + api_token_secret (Terraform provider format)
-        api_token = self._get_api_token()
-        if not api_token:
+        # Create API client from provider settings
+        client = ProxmoxClient.from_provider_settings(self.provider_settings)
+        if not client:
             self.api_validator.add_error(
                 check_name="proxmox_credentials",
                 message=(
@@ -104,35 +104,19 @@ class ProxmoxValidator:
             )
             return
 
-        # Build auth header for Proxmox API
-        # Format: "PVEAPIToken=USER@REALM!TOKENID=SECRET"
-        auth_header = f"PVEAPIToken={api_token}"
-
         # Test API connectivity
-        version_url = f"{credentials['api_url']}/version"
-        response_ok = self.api_validator.check_api_connectivity(
-            url=version_url,
-            headers={"Authorization": auth_header},
-            verify_ssl=False,
-        )
-
-        # If connection succeeded, get version info (best-effort)
-        if response_ok:
-            version_data = self.api_validator.fetch_json(
-                url=version_url,
-                headers={"Authorization": auth_header},
-                verify_ssl=False,
-                timeout=10,
-                check_name="proxmox_version",
-                error_level=ValidationLevel.INFO,
-                optional=True,
+        try:
+            version_data = client.get_json("version")
+            version = version_data.get("data", {}).get("version", "unknown")
+            self.api_validator.add_success(
+                check_name="proxmox_connectivity",
+                message=f"Proxmox API connected successfully (version: {version})",
             )
-            if version_data:
-                version = version_data.get("data", {}).get("version", "unknown")
-                self.api_validator.add_success(
-                    check_name="proxmox_version",
-                    message=f"Proxmox VE version: {version}",
-                )
+        except APIError as exc:
+            self.api_validator.add_error(
+                check_name="proxmox_connectivity",
+                message=f"Proxmox API connectivity failed: {exc.message}",
+            )
 
     def validate_references(self, resources: list[ResourceConfig]) -> None:
         """Validate that referenced Proxmox resources exist.
@@ -148,31 +132,24 @@ class ProxmoxValidator:
         Args:
             resources: List of resources to validate
         """
-        api_url = self.provider_settings.get("api_url")
         default_node = self.provider_settings.get("node")
 
-        # Build API token
-        api_token = self._get_api_token()
-        if api_url is None or api_token is None:
+        # Create API client
+        client = ProxmoxClient.from_provider_settings(self.provider_settings)
+        if not client:
             return  # Already reported in validate_connectivity
 
         try:
-            # Build auth header
-            auth_header = f"PVEAPIToken={api_token}"
-            headers = {"Authorization": auth_header}
-
             # Collect all references from resources
             resource_refs = self._collect_resource_references(resources, default_node)
 
             # Get cluster VMs once for template and VMID validation
-            cluster_vms = self._get_cluster_vms(
-                api_url, headers, check_name="proxmox_cluster_resources"
-            )
+            cluster_vms = self._get_cluster_vms(client)
 
             # Validate each type of reference using specialized validators
-            self.node_validator.validate(api_url, headers, resource_refs.nodes)
-            self.storage_validator.validate(api_url, headers, resource_refs.storage_pools)
-            self.network_validator.validate(api_url, headers, resource_refs.bridges)
+            self.node_validator.validate(client, resource_refs.nodes)
+            self.storage_validator.validate(client, resource_refs.storage_pools)
+            self.network_validator.validate(client, resource_refs.bridges)
             self.template_validator.validate(cluster_vms, resource_refs.template_refs)
             self.vmid_validator.validate(cluster_vms, resource_refs.vmids)
 
@@ -182,24 +159,6 @@ class ProxmoxValidator:
                 error=exc,
                 warning_level=ValidationLevel.WARNING,
             )
-
-    def _get_api_token(self) -> str | None:
-        """Get API token from provider settings.
-
-        Supports both formats:
-        - api_token: Full token string
-        - api_token_id + api_token_secret: Terraform provider format
-
-        Returns:
-            API token string or None if not configured
-        """
-        api_token = self.provider_settings.get("api_token")
-        if not api_token:
-            token_id = self.provider_settings.get("api_token_id")
-            token_secret = self.provider_settings.get("api_token_secret")
-            if token_id and token_secret:
-                api_token = f"{token_id}={token_secret}"
-        return api_token
 
     def _collect_resource_references(
         self, resources: list[ResourceConfig], default_node: str | None
@@ -301,30 +260,23 @@ class ProxmoxValidator:
             mac_addresses=mac_addresses,
         )
 
-    def _get_cluster_vms(
-        self,
-        api_url: str,
-        headers: dict[str, str],
-        *,
-        check_name: str,
-    ) -> list[ClusterVM] | None:
+    def _get_cluster_vms(self, client: ProxmoxClient) -> list[ClusterVM] | None:
         """Fetch and cache cluster VM data for template/vmid checks."""
         if self._cluster_vm_cache_populated:
             return self._cluster_vm_cache
 
-        data = self.api_validator.fetch_json(
-            url=f"{api_url}/cluster/resources",
-            headers=headers,
-            verify_ssl=False,
-            timeout=10,
-            params={"type": "vm"},
-            check_name=check_name,
-            error_message="Failed to query cluster resources (status {status})",
-            error_level=ValidationLevel.WARNING,
-        )
         self._cluster_vm_cache_populated = True
-        if not data:
+        try:
+            data = client.get_json("cluster/resources", params={"type": "vm"})
+        except APIError as exc:
+            self.report.add_check(
+                check_name="proxmox_cluster_resources",
+                passed=False,
+                message=f"Failed to query cluster resources: {exc.message}",
+                level=ValidationLevel.WARNING,
+            )
             self._cluster_vm_cache = None
             return None
+
         self._cluster_vm_cache = data.get("data", [])
         return self._cluster_vm_cache

--- a/src/infrafoundry/providers/proxmox/validators/network_validator.py
+++ b/src/infrafoundry/providers/proxmox/validators/network_validator.py
@@ -1,50 +1,49 @@
 """Network bridge validation for Proxmox."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
-from infrafoundry.core.validation_helpers import BaseAPIValidator
+
+if TYPE_CHECKING:
+    from infrafoundry.providers.proxmox.api_client import ProxmoxClient
 
 
 class NetworkValidator:
     """Validates Proxmox network bridge availability."""
 
-    def __init__(self, api_validator: BaseAPIValidator, report: ValidationReport) -> None:
+    def __init__(self, report: ValidationReport) -> None:
         """Initialize network validator.
 
         Args:
-            api_validator: Shared API validator helper
             report: ValidationReport to add results to
         """
-        self.api_validator = api_validator
         self.report = report
 
-    def validate(
-        self, api_url: str, headers: dict[str, str], bridges: set[tuple[str, str]]
-    ) -> None:
+    def validate(self, client: ProxmoxClient, bridges: set[tuple[str, str]]) -> None:
         """Validate that network bridges exist.
 
         Args:
-            api_url: Proxmox API base URL
-            headers: HTTP headers with authorization
+            client: Proxmox API client
             bridges: Set of (node, bridge) tuples to validate
         """
-        checked_bridges = set()
+        checked_bridges: set[tuple[str, str]] = set()
         for node, bridge in bridges:
             if (node, bridge) in checked_bridges:
                 continue
             checked_bridges.add((node, bridge))
 
-            network_data = self.api_validator.fetch_json(
-                url=f"{api_url}/nodes/{node}/network",
-                headers=headers,
-                verify_ssl=False,
-                timeout=10,
-                check_name=f"proxmox_bridge_{node}_{bridge}",
-                error_message=(
-                    f"Bridge '{bridge}' on node '{node}' not accessible (status {{status}})"
-                ),
-                error_level=ValidationLevel.WARNING,
-            )
-            if not network_data:
+            try:
+                network_data = client.get_json(f"nodes/{node}/network")
+            except APIError:
+                self.report.add_check(
+                    check_name=f"proxmox_bridge_{node}_{bridge}",
+                    passed=False,
+                    message=(f"Bridge '{bridge}' on node '{node}' not accessible"),
+                    level=ValidationLevel.WARNING,
+                )
                 continue
 
             networks = network_data.get("data", [])

--- a/src/infrafoundry/providers/proxmox/validators/node_validator.py
+++ b/src/infrafoundry/providers/proxmox/validators/node_validator.py
@@ -1,40 +1,44 @@
 """Node validation for Proxmox."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
-from infrafoundry.core.validation_helpers import BaseAPIValidator
+
+if TYPE_CHECKING:
+    from infrafoundry.providers.proxmox.api_client import ProxmoxClient
 
 
 class NodeValidator:
     """Validates Proxmox node availability and status."""
 
-    def __init__(self, api_validator: BaseAPIValidator, report: ValidationReport) -> None:
+    def __init__(self, report: ValidationReport) -> None:
         """Initialize node validator.
 
         Args:
-            api_validator: Shared API validator helper
             report: ValidationReport to add results to
         """
-        self.api_validator = api_validator
         self.report = report
 
-    def validate(self, api_url: str, headers: dict[str, str], nodes: set[str]) -> None:
+    def validate(self, client: ProxmoxClient, nodes: set[str]) -> None:
         """Validate that nodes exist and are online.
 
         Args:
-            api_url: Proxmox API base URL
-            headers: HTTP headers with authorization
+            client: Proxmox API client
             nodes: Set of node names to validate
         """
         for node in nodes:
-            status_data = self.api_validator.fetch_json(
-                url=f"{api_url}/nodes/{node}/status",
-                headers=headers,
-                verify_ssl=False,
-                timeout=10,
-                check_name=f"proxmox_node_{node}",
-                error_message=f"Node '{node}' not accessible (status {{status}})",
-            )
-            if not status_data:
+            try:
+                status_data = client.get_json(f"nodes/{node}/status")
+            except APIError:
+                self.report.add_check(
+                    check_name=f"proxmox_node_{node}",
+                    passed=False,
+                    message=f"Node '{node}' not accessible",
+                    level=ValidationLevel.WARNING,
+                )
                 continue
 
             status = status_data.get("data", {})

--- a/src/infrafoundry/providers/proxmox/validators/storage_validator.py
+++ b/src/infrafoundry/providers/proxmox/validators/storage_validator.py
@@ -1,50 +1,49 @@
 """Storage validation for Proxmox."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
-from infrafoundry.core.validation_helpers import BaseAPIValidator
+
+if TYPE_CHECKING:
+    from infrafoundry.providers.proxmox.api_client import ProxmoxClient
 
 
 class StorageValidator:
     """Validates Proxmox storage pool availability and status."""
 
-    def __init__(self, api_validator: BaseAPIValidator, report: ValidationReport) -> None:
+    def __init__(self, report: ValidationReport) -> None:
         """Initialize storage validator.
 
         Args:
-            api_validator: Shared API validator helper
             report: ValidationReport to add results to
         """
-        self.api_validator = api_validator
         self.report = report
 
-    def validate(
-        self, api_url: str, headers: dict[str, str], storage_pools: set[tuple[str, str]]
-    ) -> None:
+    def validate(self, client: ProxmoxClient, storage_pools: set[tuple[str, str]]) -> None:
         """Validate that storage pools exist and are active.
 
         Args:
-            api_url: Proxmox API base URL
-            headers: HTTP headers with authorization
+            client: Proxmox API client
             storage_pools: Set of (node, storage) tuples to validate
         """
-        checked_storage = set()
+        checked_storage: set[tuple[str, str]] = set()
         for node, storage in storage_pools:
             if (node, storage) in checked_storage:
                 continue
             checked_storage.add((node, storage))
 
-            storage_data = self.api_validator.fetch_json(
-                url=f"{api_url}/nodes/{node}/storage",
-                headers=headers,
-                verify_ssl=False,
-                timeout=10,
-                check_name=f"proxmox_storage_{node}_{storage}",
-                error_message=(
-                    f"Storage '{storage}' on node '{node}' not accessible (status {{status}})"
-                ),
-                error_level=ValidationLevel.WARNING,
-            )
-            if not storage_data:
+            try:
+                storage_data = client.get_json(f"nodes/{node}/storage")
+            except APIError:
+                self.report.add_check(
+                    check_name=f"proxmox_storage_{node}_{storage}",
+                    passed=False,
+                    message=(f"Storage '{storage}' on node '{node}' not accessible"),
+                    level=ValidationLevel.WARNING,
+                )
                 continue
 
             storages = storage_data.get("data", [])

--- a/tests/unit/providers/oci/test_api_client.py
+++ b/tests/unit/providers/oci/test_api_client.py
@@ -1,0 +1,257 @@
+"""Unit tests for OCI API client."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from infrafoundry.core.exceptions import APIError, ConfigurationError
+from infrafoundry.providers.oci.api_client import OCIClient
+
+
+@pytest.fixture
+def rsa_key_path(tmp_path):
+    """Create a temporary RSA private key file."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    key_path = tmp_path / "test_key.pem"
+    key_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return str(key_path)
+
+
+@pytest.fixture
+def client(rsa_key_path):
+    """Create an OCIClient instance with a valid test key."""
+    return OCIClient(
+        tenancy_ocid="ocid1.tenancy.oc1..example",
+        user_ocid="ocid1.user.oc1..example",
+        private_key_path=rsa_key_path,
+        fingerprint="aa:bb:cc:dd:ee:ff:00:11",
+        region="us-ashburn-1",
+    )
+
+
+class TestInit:
+    """Tests for OCIClient initialization."""
+
+    def test_loads_rsa_key(self, rsa_key_path):
+        """Successfully loads a valid RSA key."""
+        client = OCIClient(
+            tenancy_ocid="t",
+            user_ocid="u",
+            private_key_path=rsa_key_path,
+            fingerprint="f",
+            region="us-ashburn-1",
+        )
+        assert client._private_key is not None
+
+    def test_missing_key_file_raises(self):
+        """Raises ConfigurationError when key file doesn't exist."""
+        with pytest.raises(ConfigurationError, match="not found"):
+            OCIClient(
+                tenancy_ocid="t",
+                user_ocid="u",
+                private_key_path="/nonexistent/key.pem",
+                fingerprint="f",
+                region="us-ashburn-1",
+            )
+
+    def test_non_rsa_key_raises(self, tmp_path):
+        """Raises ConfigurationError for non-RSA key."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        # Generate an EC key (not RSA)
+        ec_key = ec.generate_private_key(ec.SECP256R1())
+        key_path = tmp_path / "ec_key.pem"
+        key_path.write_bytes(
+            ec_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+        with pytest.raises(ConfigurationError, match="RSA"):
+            OCIClient(
+                tenancy_ocid="t",
+                user_ocid="u",
+                private_key_path=str(key_path),
+                fingerprint="f",
+                region="us-ashburn-1",
+            )
+
+    def test_invalid_key_data_raises(self, tmp_path):
+        """Raises ConfigurationError for invalid key data."""
+        key_path = tmp_path / "bad_key.pem"
+        key_path.write_text("not a real key")
+
+        with pytest.raises(ConfigurationError, match="Failed to load"):
+            OCIClient(
+                tenancy_ocid="t",
+                user_ocid="u",
+                private_key_path=str(key_path),
+                fingerprint="f",
+                region="us-ashburn-1",
+            )
+
+
+class TestBuildSignedHeaders:
+    """Tests for _build_signed_headers."""
+
+    def test_produces_valid_authorization_header(self, client):
+        """Signed headers contain valid Authorization format."""
+        headers = client._build_signed_headers(
+            "get",
+            "https://identity.us-ashburn-1.oraclecloud.com/20160918/availabilityDomains",
+        )
+
+        assert "Authorization" in headers
+        assert "date" in headers
+        assert "host" in headers
+        assert 'Signature version="1"' in headers["Authorization"]
+        assert 'algorithm="rsa-sha256"' in headers["Authorization"]
+        assert "ocid1.tenancy.oc1..example" in headers["Authorization"]
+
+    def test_includes_body_headers_for_post(self, client):
+        """POST requests include content headers in signature."""
+        headers = client._build_signed_headers(
+            "post",
+            "https://iaas.us-ashburn-1.oraclecloud.com/20160918/vcns",
+            body='{"displayName": "test"}',
+        )
+
+        assert "x-content-sha256" in headers["Authorization"]
+        assert "content-type" in headers["Authorization"]
+
+
+class TestListResources:
+    """Tests for list_resources."""
+
+    @patch("infrafoundry.providers.oci.api_client.requests.get")
+    def test_success(self, mock_get, client):
+        """Successful list returns parsed JSON array."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = [
+            {"id": "ocid1.vcn.oc1..aaa", "displayName": "my-vcn"},
+        ]
+        mock_get.return_value = mock_response
+
+        result = client.list_resources(
+            "https://iaas.us-ashburn-1.oraclecloud.com",
+            "/20160918/vcns?compartmentId=test",
+        )
+
+        assert result == [{"id": "ocid1.vcn.oc1..aaa", "displayName": "my-vcn"}]
+
+    @patch("infrafoundry.providers.oci.api_client.requests.get")
+    def test_http_error_raises_api_error(self, mock_get, client):
+        """HTTP error raises APIError."""
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_get.return_value = mock_response
+
+        with pytest.raises(APIError) as exc_info:
+            client.list_resources(
+                "https://iaas.us-ashburn-1.oraclecloud.com",
+                "/20160918/vcns?compartmentId=test",
+            )
+
+        assert exc_info.value.status_code == 500
+
+    @patch("infrafoundry.providers.oci.api_client.requests.get")
+    def test_connection_error_raises_api_error(self, mock_get, client):
+        """Connection error raises APIError."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("refused")
+
+        with pytest.raises(APIError):
+            client.list_resources(
+                "https://iaas.us-ashburn-1.oraclecloud.com",
+                "/20160918/vcns?compartmentId=test",
+            )
+
+    @patch("infrafoundry.providers.oci.api_client.requests.get")
+    def test_non_list_response_raises_api_error(self, mock_get, client):
+        """Non-list JSON response raises APIError."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {"error": "unexpected"}
+        mock_get.return_value = mock_response
+
+        with pytest.raises(APIError, match="unexpected format"):
+            client.list_resources(
+                "https://iaas.us-ashburn-1.oraclecloud.com",
+                "/20160918/vcns?compartmentId=test",
+            )
+
+    @patch("infrafoundry.providers.oci.api_client.requests.get")
+    def test_invalid_json_raises_api_error(self, mock_get, client):
+        """Invalid JSON raises APIError."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.side_effect = ValueError("bad json")
+        mock_get.return_value = mock_response
+
+        with pytest.raises(APIError, match="Invalid JSON"):
+            client.list_resources(
+                "https://iaas.us-ashburn-1.oraclecloud.com",
+                "/20160918/vcns?compartmentId=test",
+            )
+
+
+class TestFromProviderSettings:
+    """Tests for from_provider_settings."""
+
+    def test_extracts_fields(self, rsa_key_path):
+        """Creates client with correct fields from settings."""
+        settings = {
+            "tenancy_ocid": "ocid1.tenancy.oc1..test",
+            "user_ocid": "ocid1.user.oc1..test",
+            "private_key_path": rsa_key_path,
+            "fingerprint": "aa:bb:cc",
+            "region": "us-phoenix-1",
+        }
+
+        client = OCIClient.from_provider_settings(settings)
+
+        assert client.tenancy_ocid == "ocid1.tenancy.oc1..test"
+        assert client.region == "us-phoenix-1"
+
+    def test_missing_key_raises(self):
+        """Raises ConfigurationError when key path is invalid."""
+        settings = {
+            "tenancy_ocid": "t",
+            "user_ocid": "u",
+            "private_key_path": "/nonexistent",
+            "fingerprint": "f",
+            "region": "r",
+        }
+
+        with pytest.raises(ConfigurationError):
+            OCIClient.from_provider_settings(settings)
+
+
+class TestUrlHelpers:
+    """Tests for URL helper methods."""
+
+    def test_identity_url(self, client):
+        """identity_url returns correct URL."""
+        assert client.identity_url() == "https://identity.us-ashburn-1.oraclecloud.com"
+
+    def test_iaas_url(self, client):
+        """iaas_url returns correct URL."""
+        assert client.iaas_url() == "https://iaas.us-ashburn-1.oraclecloud.com"

--- a/tests/unit/providers/oci/test_validator.py
+++ b/tests/unit/providers/oci/test_validator.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from infrafoundry.core.exceptions import APIError, ConfigurationError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationReport
 from infrafoundry.providers.oci.validator import OCIValidator
@@ -252,11 +253,11 @@ class TestValidateAPIReferences:
             }
         }
         validator = OCIValidator(env_config, report)
-        validator._fetch_oci_list = MagicMock()
 
-        validator._validate_api_references([])
-
-        validator._fetch_oci_list.assert_not_called()
+        # Should not attempt to create client
+        with patch.object(validator, "_create_client") as mock_create:
+            validator._validate_api_references([])
+            mock_create.assert_not_called()
 
     def test_skipped_when_no_region(self, report):
         """API validation skipped when region is missing."""
@@ -273,15 +274,14 @@ class TestValidateAPIReferences:
             }
         }
         validator = OCIValidator(env_config, report)
-        validator._fetch_oci_list = MagicMock()
 
-        validator._validate_api_references([])
+        with patch.object(validator, "_create_client") as mock_create:
+            validator._validate_api_references([])
+            mock_create.assert_not_called()
 
-        validator._fetch_oci_list.assert_not_called()
-
-    def test_skipped_when_signing_fails(self, validator):
-        """API validation skips gracefully when signing fails."""
-        validator._build_signed_headers = MagicMock(return_value=None)
+    def test_skipped_when_client_creation_fails(self, validator):
+        """API validation skips gracefully when client creation fails."""
+        validator._create_client = MagicMock(return_value=None)
 
         resources = [
             ResourceConfig(
@@ -297,17 +297,16 @@ class TestValidateAPIReferences:
 
     def test_fetches_and_delegates_to_validators(self, validator):
         """API references fetches data and delegates to specialized validators."""
-        # Mock _fetch_oci_list to return test data
+        mock_client = MagicMock()
+        mock_client.identity_url.return_value = "https://identity.us-ashburn-1.oraclecloud.com"
+        mock_client.iaas_url.return_value = "https://iaas.us-ashburn-1.oraclecloud.com"
+
         compartments = [{"id": "ocid1.compartment.oc1..example", "name": "root"}]
         vcns = [{"displayName": "existing-vcn", "id": "ocid1.vcn.oc1..aaa"}]
         subnets = [{"displayName": "existing-subnet", "id": "ocid1.subnet.oc1..aaa"}]
         images = [{"id": "ocid1.image.oc1..aaa", "displayName": "Oracle-Linux-8"}]
 
-        call_count = 0
-
-        def mock_fetch(base_url, path, check_name):
-            nonlocal call_count
-            call_count += 1
+        def mock_list(base_url, path):
             if "compartments" in path:
                 return compartments
             elif "vcns" in path:
@@ -316,9 +315,10 @@ class TestValidateAPIReferences:
                 return subnets
             elif "images" in path:
                 return images
-            return None
+            return []
 
-        validator._fetch_oci_list = MagicMock(side_effect=mock_fetch)
+        mock_client.list_resources.side_effect = mock_list
+        validator._create_client = MagicMock(return_value=mock_client)
         validator.compartment_validator.validate = MagicMock()
         validator.network_validator.validate = MagicMock()
         validator.image_validator.validate = MagicMock()
@@ -335,7 +335,7 @@ class TestValidateAPIReferences:
         validator._validate_api_references(resources)
 
         # All four list endpoints should be called
-        assert validator._fetch_oci_list.call_count == 4
+        assert mock_client.list_resources.call_count == 4
 
         # Specialized validators should be called with pre-fetched data
         validator.compartment_validator.validate.assert_called_once_with(
@@ -345,81 +345,24 @@ class TestValidateAPIReferences:
         validator.image_validator.validate.assert_called_once_with(resources, images)
 
 
-class TestFetchOCIList:
-    """Tests for _fetch_oci_list helper."""
+class TestSafeList:
+    """Tests for _safe_list helper."""
 
     def test_returns_list_on_success(self, validator):
-        """Returns list when API returns a JSON array."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = [
-            {"id": "ocid1.vcn.oc1..aaa", "displayName": "my-vcn"},
-        ]
+        """Returns list when client succeeds."""
+        mock_client = MagicMock()
+        mock_client.list_resources.return_value = [{"id": "test"}]
 
-        validator._build_signed_headers = MagicMock(return_value={"Authorization": "test"})
-        validator.api_validator.api_request = MagicMock(return_value=mock_response)
+        result = validator._safe_list(mock_client, "https://example.com", "/path")
 
-        result = validator._fetch_oci_list(
-            base_url="https://iaas.us-ashburn-1.oraclecloud.com",
-            path="/20160918/vcns?compartmentId=test",
-            check_name="oci_list_vcns",
-        )
+        assert result == [{"id": "test"}]
 
-        assert result == [{"id": "ocid1.vcn.oc1..aaa", "displayName": "my-vcn"}]
+    def test_returns_none_on_api_error(self, validator):
+        """Returns None when client raises APIError."""
+        mock_client = MagicMock()
+        mock_client.list_resources.side_effect = APIError("failed", provider="oci")
 
-    def test_returns_none_when_signing_fails(self, validator):
-        """Returns None when signing fails."""
-        validator._build_signed_headers = MagicMock(return_value=None)
-
-        result = validator._fetch_oci_list(
-            base_url="https://iaas.us-ashburn-1.oraclecloud.com",
-            path="/20160918/vcns?compartmentId=test",
-            check_name="oci_list_vcns",
-        )
-
-        assert result is None
-
-    def test_returns_none_when_request_fails(self, validator):
-        """Returns None when API request fails."""
-        validator._build_signed_headers = MagicMock(return_value={"Authorization": "test"})
-        validator.api_validator.api_request = MagicMock(return_value=None)
-
-        result = validator._fetch_oci_list(
-            base_url="https://iaas.us-ashburn-1.oraclecloud.com",
-            path="/20160918/vcns?compartmentId=test",
-            check_name="oci_list_vcns",
-        )
-
-        assert result is None
-
-    def test_returns_none_on_json_error(self, validator):
-        """Returns None when JSON parsing fails."""
-        mock_response = MagicMock()
-        mock_response.json.side_effect = ValueError("bad json")
-
-        validator._build_signed_headers = MagicMock(return_value={"Authorization": "test"})
-        validator.api_validator.api_request = MagicMock(return_value=mock_response)
-
-        result = validator._fetch_oci_list(
-            base_url="https://iaas.us-ashburn-1.oraclecloud.com",
-            path="/20160918/vcns?compartmentId=test",
-            check_name="oci_list_vcns",
-        )
-
-        assert result is None
-
-    def test_returns_none_on_dict_response(self, validator):
-        """Returns None when API returns a dict instead of a list."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"error": "unexpected format"}
-
-        validator._build_signed_headers = MagicMock(return_value={"Authorization": "test"})
-        validator.api_validator.api_request = MagicMock(return_value=mock_response)
-
-        result = validator._fetch_oci_list(
-            base_url="https://iaas.us-ashburn-1.oraclecloud.com",
-            path="/20160918/vcns?compartmentId=test",
-            check_name="oci_list_vcns",
-        )
+        result = validator._safe_list(mock_client, "https://example.com", "/path")
 
         assert result is None
 
@@ -437,8 +380,7 @@ class TestValidateConnectivity:
         # Should not crash, credentials check should fail gracefully
 
     def test_connectivity_with_valid_credentials(self, validator, report):
-        """Test that connectivity calls the API validator."""
-        # Mock the api_validator methods
+        """Test that connectivity creates a client and calls list_resources."""
         validator.api_validator.get_credentials = MagicMock(
             return_value={
                 "tenancy_ocid": "ocid1.tenancy.oc1..example",
@@ -448,14 +390,19 @@ class TestValidateConnectivity:
                 "region": "us-ashburn-1",
             }
         )
-        validator._build_signed_headers = MagicMock(return_value=None)
+        mock_client = MagicMock()
+        mock_client.identity_url.return_value = "https://identity.us-ashburn-1.oraclecloud.com"
+        mock_client.list_resources.return_value = [{"name": "AD-1"}]
+        validator._create_client = MagicMock(return_value=mock_client)
+        validator.api_validator.add_success = MagicMock()
 
         validator.validate_connectivity()
 
-        validator.api_validator.get_credentials.assert_called_once()
+        mock_client.list_resources.assert_called_once()
+        validator.api_validator.add_success.assert_called()
 
-    def test_connectivity_no_headers_built(self, validator, report):
-        """Test connectivity when header signing fails."""
+    def test_connectivity_client_creation_fails(self, validator, report):
+        """Test connectivity when client creation fails."""
         validator.api_validator.get_credentials = MagicMock(
             return_value={
                 "tenancy_ocid": "t",
@@ -465,65 +412,35 @@ class TestValidateConnectivity:
                 "region": "us-ashburn-1",
             }
         )
-        validator._build_signed_headers = MagicMock(return_value=None)
+        validator._create_client = MagicMock(return_value=None)
 
         validator.validate_connectivity()
 
-        # Should not call check_api_connectivity when headers are None
-        validator.api_validator.check_api_connectivity = MagicMock()
-        validator.api_validator.check_api_connectivity.assert_not_called()
+        # Should not crash
 
 
-class TestBuildSignedHeaders:
-    """Tests for _build_signed_headers method."""
+class TestCreateClient:
+    """Tests for _create_client helper."""
 
-    def test_missing_key_file(self, validator):
-        """Test that missing key file returns None."""
-        result = validator._build_signed_headers("get", "https://example.com/test")
-        assert result is None
-
-    def test_missing_cryptography_package(self, validator, tmp_path):
-        """Test graceful handling when cryptography is not available."""
-        # Create a dummy key file
-        key_file = tmp_path / "key.pem"
-        key_file.write_text("dummy")
-        validator.provider_settings["private_key_path"] = str(key_file)
-
-        with patch.dict(
-            "sys.modules", {"cryptography": None, "cryptography.hazmat.primitives": None}
+    def test_returns_none_on_configuration_error(self, validator):
+        """Returns None and reports warning when client creation fails."""
+        validator.api_validator.add_error = MagicMock()
+        with patch(
+            "infrafoundry.providers.oci.validator.OCIClient.from_provider_settings",
+            side_effect=ConfigurationError("key not found"),
         ):
-            # This should handle the ImportError gracefully
-            # Since we can't easily mock the import inside the method,
-            # we test the key file existence check instead
-            pass
+            result = validator._create_client()
 
-    def test_valid_key_signs_request(self, validator, tmp_path):
-        """Test successful signing with a valid key."""
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
+        assert result is None
+        validator.api_validator.add_error.assert_called_once()
 
-        # Generate a test RSA key
-        private_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=2048,
-        )
-        key_path = tmp_path / "test_key.pem"
-        key_path.write_bytes(
-            private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
-        )
+    def test_returns_client_on_success(self, validator, tmp_path):
+        """Returns OCIClient when creation succeeds."""
+        mock_client = MagicMock()
+        with patch(
+            "infrafoundry.providers.oci.validator.OCIClient.from_provider_settings",
+            return_value=mock_client,
+        ):
+            result = validator._create_client()
 
-        validator.provider_settings["private_key_path"] = str(key_path)
-
-        result = validator._build_signed_headers(
-            "get", "https://identity.us-ashburn-1.oraclecloud.com/20160918/availabilityDomains"
-        )
-
-        assert result is not None
-        assert "Authorization" in result
-        assert "date" in result
-        assert "Signature" in result["Authorization"]
-        assert "rsa-sha256" in result["Authorization"]
+        assert result is mock_client

--- a/tests/unit/providers/proxmox/test_api_client.py
+++ b/tests/unit/providers/proxmox/test_api_client.py
@@ -1,0 +1,193 @@
+"""Unit tests for Proxmox API client."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from infrafoundry.core.exceptions import APIError, AuthenticationError
+from infrafoundry.providers.proxmox.api_client import ProxmoxClient
+
+
+@pytest.fixture
+def client():
+    """Create a ProxmoxClient instance."""
+    return ProxmoxClient(
+        api_url="https://proxmox.example.com:8006/api2/json",
+        api_token="user@pam!token=secret-value",
+    )
+
+
+class TestGetJson:
+    """Tests for ProxmoxClient.get_json."""
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_success(self, mock_get, client):
+        """Successful GET returns parsed JSON dict."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": {"version": "8.1"}}
+        mock_get.return_value = mock_response
+
+        result = client.get_json("version")
+
+        assert result == {"data": {"version": "8.1"}}
+        mock_get.assert_called_once_with(
+            "https://proxmox.example.com:8006/api2/json/version",
+            headers={"Authorization": "PVEAPIToken=user@pam!token=secret-value"},
+            verify=False,
+            timeout=10,
+        )
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_http_401_raises_authentication_error(self, mock_get, client):
+        """HTTP 401 raises AuthenticationError."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.ok = False
+        mock_response.text = "Unauthorized"
+        mock_get.return_value = mock_response
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            client.get_json("version")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.provider == "proxmox"
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_http_403_raises_authentication_error(self, mock_get, client):
+        """HTTP 403 raises AuthenticationError."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.ok = False
+        mock_response.text = "Forbidden"
+        mock_get.return_value = mock_response
+
+        with pytest.raises(AuthenticationError):
+            client.get_json("version")
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_http_500_raises_api_error(self, mock_get, client):
+        """HTTP 500 raises APIError with status code."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.ok = False
+        mock_response.text = "Internal Server Error"
+        mock_get.return_value = mock_response
+
+        with pytest.raises(APIError) as exc_info:
+            client.get_json("version")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.provider == "proxmox"
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_connection_error_raises_api_error(self, mock_get, client):
+        """Connection error raises APIError."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+        with pytest.raises(APIError) as exc_info:
+            client.get_json("version")
+
+        assert "connection failed" in exc_info.value.message.lower()
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_timeout_raises_api_error(self, mock_get, client):
+        """Timeout raises APIError."""
+        mock_get.side_effect = requests.exceptions.Timeout("Request timed out")
+
+        with pytest.raises(APIError) as exc_info:
+            client.get_json("version")
+
+        assert "timed out" in exc_info.value.message.lower()
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_invalid_json_raises_api_error(self, mock_get, client):
+        """Invalid JSON response raises APIError."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_get.return_value = mock_response
+
+        with pytest.raises(APIError) as exc_info:
+            client.get_json("version")
+
+        assert "Invalid JSON" in exc_info.value.message
+
+    @patch("infrafoundry.providers.proxmox.api_client.requests.get")
+    def test_passes_extra_kwargs(self, mock_get, client):
+        """Extra kwargs are passed through to requests.get."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+        mock_get.return_value = mock_response
+
+        client.get_json("cluster/resources", params={"type": "vm"})
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] == {"type": "vm"}
+
+
+class TestFromProviderSettings:
+    """Tests for ProxmoxClient.from_provider_settings."""
+
+    def test_with_api_token(self):
+        """Creates client from api_token setting."""
+        settings = {
+            "api_url": "https://pve.example.com:8006/api2/json",
+            "api_token": "user@pam!token=secret",
+            "node": "pve1",
+        }
+
+        client = ProxmoxClient.from_provider_settings(settings)
+
+        assert client is not None
+        assert client.base_url == "https://pve.example.com:8006/api2/json"
+        assert client.headers["Authorization"] == "PVEAPIToken=user@pam!token=secret"
+
+    def test_with_token_id_and_secret(self):
+        """Creates client from api_token_id + api_token_secret."""
+        settings = {
+            "api_url": "https://pve.example.com:8006/api2/json",
+            "api_token_id": "user@pam!mytoken",
+            "api_token_secret": "12345-abcde",
+            "node": "pve1",
+        }
+
+        client = ProxmoxClient.from_provider_settings(settings)
+
+        assert client is not None
+        assert client.headers["Authorization"] == "PVEAPIToken=user@pam!mytoken=12345-abcde"
+
+    def test_no_token_returns_none(self):
+        """Returns None when no token is available."""
+        settings = {
+            "api_url": "https://pve.example.com:8006/api2/json",
+            "node": "pve1",
+        }
+
+        client = ProxmoxClient.from_provider_settings(settings)
+
+        assert client is None
+
+    def test_no_api_url_returns_none(self):
+        """Returns None when api_url is missing."""
+        settings = {
+            "api_token": "user@pam!token=secret",
+            "node": "pve1",
+        }
+
+        client = ProxmoxClient.from_provider_settings(settings)
+
+        assert client is None
+
+
+class TestBaseUrl:
+    """Tests for the base_url property."""
+
+    def test_returns_api_url(self, client):
+        """base_url property returns the API URL."""
+        assert client.base_url == "https://proxmox.example.com:8006/api2/json"

--- a/tests/unit/providers/proxmox/test_network_validator.py
+++ b/tests/unit/providers/proxmox/test_network_validator.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.validation import ValidationReport
-from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.proxmox.api_client import ProxmoxClient
 from infrafoundry.providers.proxmox.validators.network_validator import NetworkValidator
 
 
@@ -16,30 +17,26 @@ def report():
 
 
 @pytest.fixture
-def api_validator():
-    """Create a mock API validator."""
-    return MagicMock(spec=BaseAPIValidator)
+def client():
+    """Create a mock Proxmox API client."""
+    return MagicMock(spec=ProxmoxClient)
 
 
 @pytest.fixture
-def validator(api_validator, report):
+def validator(report):
     """Create a NetworkValidator instance."""
-    return NetworkValidator(api_validator, report)
+    return NetworkValidator(report)
 
 
-def test_validate_bridge_exists(validator, api_validator, report):
+def test_validate_bridge_exists(validator, client, report):
     """Test validation of existing bridge."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"type": "bridge", "iface": "vmbr0"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "vmbr0")},
-    )
+    validator.validate(client, {("pve1", "vmbr0")})
 
     report.add_check.assert_called_once()
     call_args = report.add_check.call_args[1]
@@ -48,19 +45,15 @@ def test_validate_bridge_exists(validator, api_validator, report):
     assert "exists" in call_args["message"]
 
 
-def test_validate_bridge_not_found(validator, api_validator, report):
+def test_validate_bridge_not_found(validator, client, report):
     """Test validation of non-existent bridge."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"type": "bridge", "iface": "vmbr0"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "vmbr1")},
-    )
+    validator.validate(client, {("pve1", "vmbr1")})
 
     report.add_check.assert_called_once()
     call_args = report.add_check.call_args[1]
@@ -69,82 +62,65 @@ def test_validate_bridge_not_found(validator, api_validator, report):
     assert "vmbr0" in str(call_args["message"])  # Shows available bridges
 
 
-def test_validate_non_bridge_interfaces_ignored(validator, api_validator, report):
+def test_validate_non_bridge_interfaces_ignored(validator, client, report):
     """Test that non-bridge interfaces are ignored."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"type": "eth", "iface": "eth0"},
             {"type": "bridge", "iface": "vmbr0"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "vmbr0")},
-    )
+    validator.validate(client, {("pve1", "vmbr0")})
 
     # Should find vmbr0 (bridge type)
     call_args = report.add_check.call_args[1]
     assert call_args["passed"] is True
 
 
-def test_validate_api_fetch_failure(validator, api_validator, report):
+def test_validate_api_fetch_failure(validator, client, report):
     """Test validation when API fetch fails."""
-    api_validator.fetch_json.return_value = None
+    client.get_json.side_effect = APIError("failed", provider="proxmox")
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "vmbr0")},
-    )
+    validator.validate(client, {("pve1", "vmbr0")})
 
-    report.add_check.assert_not_called()
+    report.add_check.assert_called_once()
+    call_args = report.add_check.call_args[1]
+    assert call_args["passed"] is False
+    assert "not accessible" in call_args["message"]
 
 
-def test_validate_duplicate_bridges(validator, api_validator, report):
+def test_validate_duplicate_bridges(validator, client, report):
     """Test that duplicate bridges are only checked once."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"type": "bridge", "iface": "vmbr0"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "vmbr0"), ("pve1", "vmbr0")},
-    )
+    validator.validate(client, {("pve1", "vmbr0"), ("pve1", "vmbr0")})
 
     # Should only check once despite duplicate in set
-    api_validator.fetch_json.assert_called_once()
+    client.get_json.assert_called_once()
     report.add_check.assert_called_once()
 
 
-def test_validate_multiple_bridges(validator, api_validator, report):
+def test_validate_multiple_bridges(validator, client, report):
     """Test validation of multiple bridges."""
-    api_validator.fetch_json.side_effect = [
+    client.get_json.side_effect = [
         {"data": [{"type": "bridge", "iface": "vmbr0"}]},
         {"data": [{"type": "bridge", "iface": "vmbr1"}]},
     ]
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "vmbr0"), ("pve2", "vmbr1")},
-    )
+    validator.validate(client, {("pve1", "vmbr0"), ("pve2", "vmbr1")})
 
-    assert api_validator.fetch_json.call_count == 2
+    assert client.get_json.call_count == 2
     assert report.add_check.call_count == 2
 
 
-def test_validate_empty_bridges(validator, api_validator, report):
+def test_validate_empty_bridges(validator, client, report):
     """Test validation with empty bridge set."""
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        set(),
-    )
+    validator.validate(client, set())
 
-    api_validator.fetch_json.assert_not_called()
+    client.get_json.assert_not_called()
     report.add_check.assert_not_called()

--- a/tests/unit/providers/proxmox/test_node_validator.py
+++ b/tests/unit/providers/proxmox/test_node_validator.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.validation import ValidationReport
-from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.proxmox.api_client import ProxmoxClient
 from infrafoundry.providers.proxmox.validators.node_validator import NodeValidator
 
 
@@ -16,33 +17,24 @@ def report():
 
 
 @pytest.fixture
-def api_validator():
-    """Create a mock API validator."""
-    return MagicMock(spec=BaseAPIValidator)
+def client():
+    """Create a mock Proxmox API client."""
+    return MagicMock(spec=ProxmoxClient)
 
 
 @pytest.fixture
-def validator(api_validator, report):
+def validator(report):
     """Create a NodeValidator instance."""
-    return NodeValidator(api_validator, report)
+    return NodeValidator(report)
 
 
-def test_validate_node_online(validator, api_validator, report):
+def test_validate_node_online(validator, client, report):
     """Test validation of online node."""
-    api_validator.fetch_json.return_value = {"data": {"uptime": 3600}}
+    client.get_json.return_value = {"data": {"uptime": 3600}}
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json", {"Authorization": "token"}, {"pve1"}
-    )
+    validator.validate(client, {"pve1"})
 
-    api_validator.fetch_json.assert_called_once_with(
-        url="https://proxmox.example.com/api2/json/nodes/pve1/status",
-        headers={"Authorization": "token"},
-        verify_ssl=False,
-        timeout=10,
-        check_name="proxmox_node_pve1",
-        error_message="Node 'pve1' not accessible (status {status})",
-    )
+    client.get_json.assert_called_once_with("nodes/pve1/status")
     report.add_check.assert_called_once()
     call_args = report.add_check.call_args[1]
     assert call_args["passed"] is True
@@ -50,29 +42,28 @@ def test_validate_node_online(validator, api_validator, report):
     assert "online" in call_args["message"]
 
 
-def test_validate_node_not_accessible(validator, api_validator, report):
+def test_validate_node_not_accessible(validator, client, report):
     """Test validation when node is not accessible."""
-    api_validator.fetch_json.return_value = None
+    client.get_json.side_effect = APIError("not accessible", provider="proxmox")
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json", {"Authorization": "token"}, {"pve1"}
-    )
+    validator.validate(client, {"pve1"})
 
-    report.add_check.assert_not_called()
+    report.add_check.assert_called_once()
+    call_args = report.add_check.call_args[1]
+    assert call_args["passed"] is False
+    assert "not accessible" in call_args["message"]
 
 
-def test_validate_multiple_nodes(validator, api_validator, report):
+def test_validate_multiple_nodes(validator, client, report):
     """Test validation of multiple nodes."""
-    api_validator.fetch_json.side_effect = [
+    client.get_json.side_effect = [
         {"data": {"uptime": 3600}},
         {"data": {"uptime": 7200}},
     ]
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json", {"Authorization": "token"}, {"pve1", "pve2"}
-    )
+    validator.validate(client, {"pve1", "pve2"})
 
-    assert api_validator.fetch_json.call_count == 2
+    assert client.get_json.call_count == 2
     assert report.add_check.call_count == 2
 
 
@@ -98,9 +89,9 @@ def test_format_uptime_days(validator):
     assert validator._format_uptime(90000) == "1 days, 1 hours"
 
 
-def test_validate_empty_nodes(validator, api_validator, report):
+def test_validate_empty_nodes(validator, client, report):
     """Test validation with empty node set."""
-    validator.validate("https://proxmox.example.com/api2/json", {"Authorization": "token"}, set())
+    validator.validate(client, set())
 
-    api_validator.fetch_json.assert_not_called()
+    client.get_json.assert_not_called()
     report.add_check.assert_not_called()

--- a/tests/unit/providers/proxmox/test_storage_validator.py
+++ b/tests/unit/providers/proxmox/test_storage_validator.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.validation import ValidationReport
-from infrafoundry.core.validation_helpers import BaseAPIValidator
+from infrafoundry.providers.proxmox.api_client import ProxmoxClient
 from infrafoundry.providers.proxmox.validators.storage_validator import StorageValidator
 
 
@@ -16,30 +17,26 @@ def report():
 
 
 @pytest.fixture
-def api_validator():
-    """Create a mock API validator."""
-    return MagicMock(spec=BaseAPIValidator)
+def client():
+    """Create a mock Proxmox API client."""
+    return MagicMock(spec=ProxmoxClient)
 
 
 @pytest.fixture
-def validator(api_validator, report):
+def validator(report):
     """Create a StorageValidator instance."""
-    return StorageValidator(api_validator, report)
+    return StorageValidator(report)
 
 
-def test_validate_active_storage(validator, api_validator, report):
+def test_validate_active_storage(validator, client, report):
     """Test validation of active storage."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"storage": "local", "active": 1, "type": "dir"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "local")},
-    )
+    validator.validate(client, {("pve1", "local")})
 
     report.add_check.assert_called_once()
     call_args = report.add_check.call_args[1]
@@ -48,19 +45,15 @@ def test_validate_active_storage(validator, api_validator, report):
     assert "active" in call_args["message"]
 
 
-def test_validate_inactive_storage(validator, api_validator, report):
+def test_validate_inactive_storage(validator, client, report):
     """Test validation of inactive storage."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"storage": "local", "active": 0, "type": "dir"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "local")},
-    )
+    validator.validate(client, {("pve1", "local")})
 
     report.add_check.assert_called_once()
     call_args = report.add_check.call_args[1]
@@ -68,19 +61,15 @@ def test_validate_inactive_storage(validator, api_validator, report):
     assert "inactive" in call_args["message"]
 
 
-def test_validate_missing_storage(validator, api_validator, report):
+def test_validate_missing_storage(validator, client, report):
     """Test validation of non-existent storage."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"storage": "local", "active": 1, "type": "dir"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "missing-storage")},
-    )
+    validator.validate(client, {("pve1", "missing-storage")})
 
     report.add_check.assert_called_once()
     call_args = report.add_check.call_args[1]
@@ -88,62 +77,49 @@ def test_validate_missing_storage(validator, api_validator, report):
     assert "not found" in call_args["message"]
 
 
-def test_validate_api_fetch_failure(validator, api_validator, report):
+def test_validate_api_fetch_failure(validator, client, report):
     """Test validation when API fetch fails."""
-    api_validator.fetch_json.return_value = None
+    client.get_json.side_effect = APIError("failed", provider="proxmox")
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "local")},
-    )
+    validator.validate(client, {("pve1", "local")})
 
-    report.add_check.assert_not_called()
+    report.add_check.assert_called_once()
+    call_args = report.add_check.call_args[1]
+    assert call_args["passed"] is False
+    assert "not accessible" in call_args["message"]
 
 
-def test_validate_duplicate_storage_pools(validator, api_validator, report):
+def test_validate_duplicate_storage_pools(validator, client, report):
     """Test that duplicate storage pools are only checked once."""
-    api_validator.fetch_json.return_value = {
+    client.get_json.return_value = {
         "data": [
             {"storage": "local", "active": 1, "type": "dir"},
         ]
     }
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "local"), ("pve1", "local")},
-    )
+    validator.validate(client, {("pve1", "local"), ("pve1", "local")})
 
     # Should only check once despite duplicate in set
-    api_validator.fetch_json.assert_called_once()
+    client.get_json.assert_called_once()
     report.add_check.assert_called_once()
 
 
-def test_validate_multiple_storage_pools(validator, api_validator, report):
+def test_validate_multiple_storage_pools(validator, client, report):
     """Test validation of multiple storage pools."""
-    api_validator.fetch_json.side_effect = [
+    client.get_json.side_effect = [
         {"data": [{"storage": "local", "active": 1, "type": "dir"}]},
         {"data": [{"storage": "shared", "active": 1, "type": "nfs"}]},
     ]
 
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        {("pve1", "local"), ("pve2", "shared")},
-    )
+    validator.validate(client, {("pve1", "local"), ("pve2", "shared")})
 
-    assert api_validator.fetch_json.call_count == 2
+    assert client.get_json.call_count == 2
     assert report.add_check.call_count == 2
 
 
-def test_validate_empty_storage_pools(validator, api_validator, report):
+def test_validate_empty_storage_pools(validator, client, report):
     """Test validation with empty storage pool set."""
-    validator.validate(
-        "https://proxmox.example.com/api2/json",
-        {"Authorization": "token"},
-        set(),
-    )
+    validator.validate(client, set())
 
-    api_validator.fetch_json.assert_not_called()
+    client.get_json.assert_not_called()
     report.add_check.assert_not_called()

--- a/tests/unit/test_provider_validation.py
+++ b/tests/unit/test_provider_validation.py
@@ -45,15 +45,16 @@ class TestProxmoxValidation:
         summary = report.get_summary()
         assert summary["errors"] == 1
 
-    @patch("requests.request")
-    def test_validate_connectivity_success(self, mock_request, proxmox_provider, env_config):
+    @patch("requests.get")
+    def test_validate_connectivity_success(self, mock_get, proxmox_provider, env_config):
         """Test successful API connectivity validation."""
         # Mock successful API responses
         mock_response = Mock()
         mock_response.status_code = 200
+        mock_response.ok = True
         mock_response.json.return_value = {"data": {"version": "7.4"}}
 
-        mock_request.return_value = mock_response
+        mock_get.return_value = mock_response
 
         report = ValidationReport()
         proxmox_provider.validate_connectivity(env_config, report)
@@ -62,54 +63,55 @@ class TestProxmoxValidation:
         summary = report.get_summary()
         assert summary["passed"] >= 1
 
-    @patch("requests.request")
-    def test_validate_connectivity_api_error(self, mock_request, proxmox_provider, env_config):
+    @patch("requests.get")
+    def test_validate_connectivity_api_error(self, mock_get, proxmox_provider, env_config):
         """Test validation handles API errors."""
         # Mock failed API response
         mock_response = Mock()
         mock_response.status_code = 401
+        mock_response.ok = False
+        mock_response.text = "Unauthorized"
         mock_response.json.return_value = {}
-        mock_request.return_value = mock_response
+        mock_get.return_value = mock_response
 
         report = ValidationReport()
         proxmox_provider.validate_connectivity(env_config, report)
 
         assert report.has_errors()
 
-    @patch("requests.request")
-    def test_validate_connectivity_timeout(self, mock_request, proxmox_provider, env_config):
+    @patch("requests.get")
+    def test_validate_connectivity_timeout(self, mock_get, proxmox_provider, env_config):
         """Test validation handles connection timeout."""
         import requests
 
-        mock_request.side_effect = requests.exceptions.Timeout()
+        mock_get.side_effect = requests.exceptions.Timeout()
 
         report = ValidationReport()
         proxmox_provider.validate_connectivity(env_config, report)
 
         assert report.has_errors()
 
-    @patch("requests.request")
-    def test_validate_connectivity_connection_error(
-        self, mock_request, proxmox_provider, env_config
-    ):
+    @patch("requests.get")
+    def test_validate_connectivity_connection_error(self, mock_get, proxmox_provider, env_config):
         """Test validation handles connection errors."""
         import requests
 
-        mock_request.side_effect = requests.exceptions.ConnectionError("Cannot connect")
+        mock_get.side_effect = requests.exceptions.ConnectionError("Cannot connect")
 
         report = ValidationReport()
         proxmox_provider.validate_connectivity(env_config, report)
 
         assert report.has_errors()
 
-    @patch("requests.request")
-    def test_validate_references_template_exists(self, mock_request, proxmox_provider, env_config):
+    @patch("requests.get")
+    def test_validate_references_template_exists(self, mock_get, proxmox_provider, env_config):
         """Test validation passes when referenced template exists."""
 
         # Mock different API responses based on URL
         def mock_get_side_effect(url, **kwargs):
             mock_response = Mock()
             mock_response.status_code = 200
+            mock_response.ok = True
 
             if "/nodes/pve01/status" in url:
                 # Node status - data is dict
@@ -134,7 +136,7 @@ class TestProxmoxValidation:
 
             return mock_response
 
-        mock_request.side_effect = mock_get_side_effect
+        mock_get.side_effect = mock_get_side_effect
 
         # Create resources that reference templates
         resources = [
@@ -151,14 +153,15 @@ class TestProxmoxValidation:
 
         assert not report.has_errors()
 
-    @patch("requests.request")
-    def test_validate_references_template_missing(self, mock_request, proxmox_provider, env_config):
+    @patch("requests.get")
+    def test_validate_references_template_missing(self, mock_get, proxmox_provider, env_config):
         """Test validation fails when referenced template doesn't exist."""
 
         # Mock different API responses based on URL
         def mock_get_side_effect(url, **kwargs):
             mock_response = Mock()
             mock_response.status_code = 200
+            mock_response.ok = True
 
             if "/nodes/pve01/status" in url:
                 mock_response.json.return_value = {"data": {"uptime": 12345}}
@@ -176,7 +179,7 @@ class TestProxmoxValidation:
 
             return mock_response
 
-        mock_request.side_effect = mock_get_side_effect
+        mock_get.side_effect = mock_get_side_effect
 
         # Create resources that reference missing template
         resources = [
@@ -215,16 +218,15 @@ class TestProxmoxValidation:
         summary = report.get_summary()
         assert summary["total"] == 0
 
-    @patch("requests.request")
-    def test_validate_references_multiple_templates(
-        self, mock_request, proxmox_provider, env_config
-    ):
+    @patch("requests.get")
+    def test_validate_references_multiple_templates(self, mock_get, proxmox_provider, env_config):
         """Test validation of multiple template references."""
 
         # Mock different API responses based on URL
         def mock_get_side_effect(url, **kwargs):
             mock_response = Mock()
             mock_response.status_code = 200
+            mock_response.ok = True
 
             if "/nodes/pve01/status" in url:
                 mock_response.json.return_value = {"data": {"uptime": 12345}}
@@ -242,7 +244,7 @@ class TestProxmoxValidation:
 
             return mock_response
 
-        mock_request.side_effect = mock_get_side_effect
+        mock_get.side_effect = mock_get_side_effect
 
         # Create multiple VMs with different templates
         resources = [
@@ -274,8 +276,8 @@ class TestProxmoxValidation:
         summary = report.get_summary()
         assert summary["passed"] >= 2
 
-    @patch("requests.request")
-    def test_validate_references_api_error(self, mock_request, proxmox_provider, env_config):
+    @patch("requests.get")
+    def test_validate_references_api_error(self, mock_get, proxmox_provider, env_config):
         """Test validation handles API errors gracefully."""
 
         # Mock different API responses based on URL
@@ -285,19 +287,23 @@ class TestProxmoxValidation:
             if "/nodes/pve01/status" in url:
                 # Node check succeeds
                 mock_response.status_code = 200
+                mock_response.ok = True
                 mock_response.json.return_value = {"data": {"uptime": 12345}}
             elif "/cluster/resources" in url:
                 # Template check fails
                 mock_response.status_code = 500
+                mock_response.ok = False
+                mock_response.text = "Internal Server Error"
                 mock_response.json.return_value = {}
             else:
                 # Other checks succeed
                 mock_response.status_code = 200
+                mock_response.ok = True
                 mock_response.json.return_value = {"data": []}
 
             return mock_response
 
-        mock_request.side_effect = mock_get_side_effect
+        mock_get.side_effect = mock_get_side_effect
 
         resources = [
             ResourceConfig(


### PR DESCRIPTION
## Description

Extract dedicated API clients (ProxmoxClient and OCIClient) from the validators, following the pattern established by the OPNsense provider. Validators now delegate all HTTP/API interaction to client classes, keeping BaseAPIValidator focused on reporting only.

## Related Issue

Addresses #474

## Type of Change

- [x] Code refactoring

## Changes Made

- **New:** `src/infrafoundry/providers/proxmox/api_client.py` — ProxmoxClient with PVE token authentication and `get_json()` method
- **New:** `src/infrafoundry/providers/oci/api_client.py` — OCIClient with RSA-SHA256 HTTP Signature auth and `list_resources()` method
- **New:** `tests/unit/providers/proxmox/test_api_client.py` — 12 tests for ProxmoxClient
- **New:** `tests/unit/providers/oci/test_api_client.py` — 15 tests for OCIClient
- **Modified:** `src/infrafoundry/providers/proxmox/validator.py` — uses ProxmoxClient instead of direct HTTP calls
- **Modified:** `src/infrafoundry/providers/oci/validator.py` — uses OCIClient instead of direct HTTP calls
- **Modified:** Proxmox specialized validators (network, node, storage) — use ProxmoxClient
- **Modified:** Test files updated to mock client classes instead of raw HTTP

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (27 new tests across 2 test files)
- [x] `doit check` passes (lint, type-check, format, security, spell, tests)

## Breaking Change

BREAKING CHANGE: Internal validator constructor and method signatures changed. These are internal provider classes, not public user-facing APIs.

**Changed signatures:**
- `NodeValidator.__init__(report)` — removed `api_validator` parameter
- `StorageValidator.__init__(report)` — removed `api_validator` parameter
- `NetworkValidator.__init__(report)` — removed `api_validator` parameter
- `NodeValidator.validate(client, nodes)` — replaced `api_url, headers, nodes` with `client, nodes`
- `StorageValidator.validate(client, storage_pools)` — replaced `api_url, headers, storage_pools` with `client, storage_pools`
- `NetworkValidator.validate(client, bridges)` — replaced `api_url, headers, bridges` with `client, bridges`
- `OCIValidator.OCI_API_BASE` and `IDENTITY_API_BASE` — moved to `OCIClient`

**Migration:** Use `ProxmoxClient` or `OCIClient` instead of passing raw URL/headers to validators. All validators now accept a client instance.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
