### PR TITLE
refactor: standardize ESXi validator to use BaseAPIValidator

### DIFF
--- a/src/infrafoundry/providers/esxi/validator.py
+++ b/src/infrafoundry/providers/esxi/validator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
 
 from .validators import (
     HostConnectivityValidator,
@@ -32,6 +33,8 @@ class EsxiValidator:
         """
         self.env_config = env_config
         self.report = report
+        self.api_validator = BaseAPIValidator("esxi", env_config, report)
+        self.provider_settings = self.api_validator.provider_settings
 
         self.host_connectivity_validator = HostConnectivityValidator(report)
         self.vswitch_reference_validator = VswitchReferenceValidator(report)
@@ -43,13 +46,11 @@ class EsxiValidator:
 
         Checks that each configured ESXi host is reachable on port 22.
         """
-        provider_settings = self.env_config.get("provider_settings", {}).get("esxi", {})
-        hosts_config = provider_settings.get("hosts", {})
+        hosts_config = self.provider_settings.get("hosts", {})
 
         if not hosts_config:
-            self.report.add_check(
+            self.api_validator.add_error(
                 check_name="esxi_hosts_configured",
-                passed=False,
                 message="No ESXi hosts configured in provider_settings.esxi.hosts",
             )
             return

--- a/tests/unit/providers/esxi/test_validator.py
+++ b/tests/unit/providers/esxi/test_validator.py
@@ -6,6 +6,7 @@ import pytest
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationReport
+from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.esxi.validator import EsxiValidator
 
 
@@ -21,6 +22,22 @@ def _make_env_config(hosts: dict | None = None) -> dict:
     if hosts is not None:
         esxi_settings["hosts"] = hosts
     return {"provider_settings": {"esxi": esxi_settings}}
+
+
+class TestComposition:
+    """Tests for validator composition."""
+
+    def test_api_validator_initialized(self, report):
+        """BaseAPIValidator is composed during init."""
+        env_config = _make_env_config(hosts={"esxi-01": {}})
+        validator = EsxiValidator(env_config, report)
+        assert isinstance(validator.api_validator, BaseAPIValidator)
+
+    def test_provider_settings_accessible(self, report):
+        """Provider settings are accessible via api_validator."""
+        env_config = _make_env_config(hosts={"esxi-01": {"hostname": "192.168.1.10"}})
+        validator = EsxiValidator(env_config, report)
+        assert validator.provider_settings.get("hosts") is not None
 
 
 class TestValidateConnectivity:


### PR DESCRIPTION
## Description

Standardize the ESXi validator to compose `BaseAPIValidator`, aligning it with the pattern used by all other providers (Proxmox, OPNsense, Kubernetes, OCI).

## Related Issue

Addresses #476

## Type of Change

- [x] Code refactoring

## Changes Made

- `EsxiValidator` now composes `BaseAPIValidator("esxi", env_config, report)` for consistent settings access and reporting
- Provider settings accessed via `self.provider_settings` instead of raw `env_config.get()` chains
- No-hosts error reported via `self.api_validator.add_error()` instead of `self.report.add_check()`
- Added 2 composition tests verifying `api_validator` initialization

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (lint, type-check, format, security, spell, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
