### PR TITLE
feat: add terraform import block support for existing resources

### DIFF
--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -280,6 +280,19 @@ cat generated/prod/terraform/proxmox/backend.tf
   psql infrafoundry < infrafoundry-state-20250108.sql
   ```
 - **Import existing resource into Terraform state:**
+  The preferred approach is to add `import_id` to the resource definition in YAML.
+  InfraFoundry generates Terraform `import` blocks automatically:
+  ```yaml
+  # Resource-centric example
+  resources:
+    - provider: proxmox
+      type: vm
+      name: web-server-01
+      import_id: "100"
+      config:
+        target_node: pve1
+  ```
+  For manual imports (e.g., one-off operations), you can still use the CLI:
   ```bash
   cd generated/dev/terraform/proxmox
   terraform import proxmox_vm_qemu.web_server_01 100

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -80,6 +80,7 @@ InfraFoundry environments are defined entirely in YAML: `settings.yaml` for envi
     - provider: proxmox
       type: vm
       name: web-server-01
+      import_id: "100"  # optional: import existing resource into Terraform state
       config:
         node: pve1
         cores: 4

--- a/docs/configuration/yaml-only-config.md
+++ b/docs/configuration/yaml-only-config.md
@@ -71,6 +71,7 @@ InfraFoundry uses **pure YAML** for all environment, resource, and credential co
     - provider: proxmox
       type: vm
       name: web-server-01
+      import_id: "100"  # optional: import existing resource into Terraform state
       config:
         target_node: pve1
         clone: ubuntu-22-04-template

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -415,6 +415,7 @@ class PackageLoader:
                 provider=item.get("provider", provider),
                 config=item,
                 events=item.get("events"),
+                import_id=item.get("import_id"),
             )
             for item in resource_list
             if isinstance(item, dict) and "name" in item
@@ -452,6 +453,7 @@ class PackageLoader:
                     provider=item.get("provider", default_provider),
                     config=config,
                     events=item.get("events"),
+                    import_id=item.get("import_id"),
                 )
             )
         return result

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -93,6 +93,7 @@ class ProviderCentricLoader:
                 type=resource_type,
                 provider=provider,
                 config=item,
+                import_id=item.get("import_id"),
             )
             for item in resource_list
             if isinstance(item, dict) and "name" in item

--- a/src/infrafoundry/core/config/resource_centric_loader.py
+++ b/src/infrafoundry/core/config/resource_centric_loader.py
@@ -94,6 +94,7 @@ class ResourceCentricLoader:
                     type=item["type"],
                     provider=item["provider"],
                     config=config,
+                    import_id=item.get("import_id"),
                 )
             )
 

--- a/src/infrafoundry/core/provider.py
+++ b/src/infrafoundry/core/provider.py
@@ -21,6 +21,7 @@ class ResourceConfig(BaseModel):
     hooks: HooksConfig | None = None
     events: dict[str, list[dict[str, Any]]] | None = None
     package_variables: dict[str, Any] | None = None
+    import_id: str | None = None
 
 
 class ProviderBase(ABC):

--- a/src/infrafoundry/core/provider_mixins.py
+++ b/src/infrafoundry/core/provider_mixins.py
@@ -6,6 +6,7 @@ reducing code duplication and standardizing provider behavior.
 
 import json
 import logging
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
@@ -18,6 +19,8 @@ from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.exceptions import TemplateError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.security.file_utils import secure_write
+
+_RESOURCE_DECL_RE = re.compile(r'^resource\s+"([^"]+)"\s+"([^"]+)"')
 
 if TYPE_CHECKING:
     # Type stubs for mixin expectations - not used at runtime
@@ -543,6 +546,42 @@ class TerraformGeneratorMixin:
 
         return result
 
+    def _generate_import_blocks(self, rendered: str, context: dict[str, Any]) -> str:
+        """Generate Terraform import blocks for resources with import_id.
+
+        Scans the template context for ResourceConfig objects that have an
+        ``import_id`` set, matches them against ``resource`` declarations in
+        the rendered Terraform output, and returns import blocks to prepend.
+
+        Args:
+            rendered: Already-rendered Terraform content.
+            context: Template context containing ResourceConfig objects.
+
+        Returns:
+            A string of import blocks (possibly empty).
+        """
+        importable: dict[str, str] = {}
+        for value in context.values():
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ResourceConfig) and item.import_id:
+                        importable[item.name.replace("-", "_")] = item.import_id
+
+        if not importable:
+            return ""
+
+        blocks: list[str] = []
+        for line in rendered.splitlines():
+            match = _RESOURCE_DECL_RE.match(line.strip())
+            if match:
+                tf_type, tf_name = match.group(1), match.group(2)
+                if tf_name in importable:
+                    blocks.append(
+                        f'import {{\n  to = {tf_type}.{tf_name}\n  id = "{importable[tf_name]}"\n}}'
+                    )
+
+        return "\n\n".join(blocks)
+
     def render_and_write_terraform(
         self,
         template_name: str,
@@ -572,6 +611,9 @@ class TerraformGeneratorMixin:
             )
 
         rendered = self.render_template(template_name, context or {})
+        import_blocks = self._generate_import_blocks(rendered, context or {})
+        if import_blocks:
+            rendered = import_blocks + "\n\n" + rendered
         self._write_terraform_file(output_name, rendered)
 
     # Files and directories preserved during stale .tf cleanup

--- a/tests/unit/test_import_blocks.py
+++ b/tests/unit/test_import_blocks.py
@@ -1,0 +1,232 @@
+"""Tests for Terraform import block generation."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.provider_mixins import _RESOURCE_DECL_RE, TerraformGeneratorMixin
+
+
+class TestResourceConfigImportId:
+    """Test that ResourceConfig accepts and defaults import_id."""
+
+    def test_import_id_defaults_to_none(self) -> None:
+        rc = ResourceConfig(name="test", type="vm", provider="proxmox", config={})
+        assert rc.import_id is None
+
+    def test_import_id_stores_value(self) -> None:
+        rc = ResourceConfig(
+            name="test", type="vm", provider="proxmox", config={}, import_id="abc-123"
+        )
+        assert rc.import_id == "abc-123"
+
+
+class TestResourceDeclRegex:
+    """Test the module-level _RESOURCE_DECL_RE pattern."""
+
+    def test_matches_standard_resource_declaration(self) -> None:
+        match = _RESOURCE_DECL_RE.match('resource "aws_instance" "my_server"')
+        assert match is not None
+        assert match.group(1) == "aws_instance"
+        assert match.group(2) == "my_server"
+
+    def test_matches_with_opening_brace(self) -> None:
+        match = _RESOURCE_DECL_RE.match('resource "opnsense_kea_subnet" "subnet_mgmt" {')
+        assert match is not None
+        assert match.group(1) == "opnsense_kea_subnet"
+        assert match.group(2) == "subnet_mgmt"
+
+    def test_does_not_match_non_resource_lines(self) -> None:
+        assert _RESOURCE_DECL_RE.match('variable "name" {') is None
+        assert _RESOURCE_DECL_RE.match("# resource comment") is None
+        assert _RESOURCE_DECL_RE.match("") is None
+
+
+class _MixinHarness(TerraformGeneratorMixin):
+    """Minimal harness to test TerraformGeneratorMixin methods in isolation."""
+
+    def __init__(self) -> None:
+        self.terraform_dir = Path("/tmp/tf")
+        self.config_dir = Path("/tmp/cfg")
+        self._written_files: dict[str, str] = {}
+
+    def render_template(self, template_name: str, context: dict[str, Any]) -> str:
+        raise NotImplementedError("must be mocked")
+
+    def _write_terraform_file(self, filename: str, content: str) -> None:
+        self._written_files[filename] = content
+
+
+class TestGenerateImportBlocks:
+    """Test _generate_import_blocks method."""
+
+    def setup_method(self) -> None:
+        self.mixin = _MixinHarness()
+
+    def test_no_import_id_returns_empty(self) -> None:
+        rc = ResourceConfig(name="srv", type="vm", provider="p", config={})
+        rendered = 'resource "proxmox_vm" "srv" {\n}'
+        result = self.mixin._generate_import_blocks(rendered, {"vms": [rc]})
+        assert result == ""
+
+    def test_single_resource_with_import_id(self) -> None:
+        rc = ResourceConfig(
+            name="subnet-mgmt",
+            type="kea_subnet",
+            provider="opnsense",
+            config={},
+            import_id="uuid-1234",
+        )
+        rendered = 'resource "opnsense_kea_subnet" "subnet_mgmt" {\n  subnet = "10.0.0.0/24"\n}'
+        result = self.mixin._generate_import_blocks(rendered, {"subnets": [rc]})
+        assert "import {" in result
+        assert "to = opnsense_kea_subnet.subnet_mgmt" in result
+        assert 'id = "uuid-1234"' in result
+
+    def test_hyphen_to_underscore_matching(self) -> None:
+        rc = ResourceConfig(
+            name="my-server",
+            type="vm",
+            provider="proxmox",
+            config={},
+            import_id="id-99",
+        )
+        rendered = 'resource "proxmox_vm" "my_server" {\n}'
+        result = self.mixin._generate_import_blocks(rendered, {"vms": [rc]})
+        assert "to = proxmox_vm.my_server" in result
+        assert 'id = "id-99"' in result
+
+    def test_multiple_resources_mixed(self) -> None:
+        rc_with = ResourceConfig(
+            name="a",
+            type="t",
+            provider="p",
+            config={},
+            import_id="id-a",
+        )
+        rc_without = ResourceConfig(name="b", type="t", provider="p", config={})
+        rendered = 'resource "p_t" "a" {\n}\n\nresource "p_t" "b" {\n}'
+        result = self.mixin._generate_import_blocks(rendered, {"items": [rc_with, rc_without]})
+        assert "to = p_t.a" in result
+        assert 'id = "id-a"' in result
+        assert "b" not in result
+
+    def test_empty_context(self) -> None:
+        rendered = 'resource "aws_s3" "bucket" {\n}'
+        result = self.mixin._generate_import_blocks(rendered, {})
+        assert result == ""
+
+    def test_non_list_context_values_ignored(self) -> None:
+        rendered = 'resource "aws_s3" "bucket" {\n}'
+        result = self.mixin._generate_import_blocks(rendered, {"scalar": "value", "num": 42})
+        assert result == ""
+
+    def test_import_blocks_appear_before_resource_blocks(self) -> None:
+        rc = ResourceConfig(
+            name="srv",
+            type="vm",
+            provider="p",
+            config={},
+            import_id="id-1",
+        )
+        rendered = 'resource "p_vm" "srv" {\n  name = "srv"\n}'
+        result = self.mixin._generate_import_blocks(rendered, {"vms": [rc]})
+        assert result.startswith("import {")
+
+
+class TestRenderAndWriteTerraformWithImport:
+    """Test that render_and_write_terraform integrates import blocks."""
+
+    def setup_method(self) -> None:
+        self.mixin = _MixinHarness()
+
+    def test_import_blocks_prepended_to_output(self) -> None:
+        rc = ResourceConfig(
+            name="subnet-mgmt",
+            type="kea_subnet",
+            provider="opnsense",
+            config={},
+            import_id="uuid-abc",
+        )
+        rendered_tf = 'resource "opnsense_kea_subnet" "subnet_mgmt" {\n  subnet = "10.0.0.0/24"\n}'
+        context = {"subnets": [rc]}
+
+        with patch.object(self.mixin, "render_template", return_value=rendered_tf):
+            self.mixin.render_and_write_terraform(
+                "test.tf.j2", context=context, output_name="kea_subnet.tf"
+            )
+
+        written = self.mixin._written_files["kea_subnet.tf"]
+        # Import block comes first
+        assert written.startswith("import {")
+        assert "to = opnsense_kea_subnet.subnet_mgmt" in written
+        assert 'id = "uuid-abc"' in written
+        # Original resource block follows
+        assert 'resource "opnsense_kea_subnet" "subnet_mgmt"' in written
+
+    def test_no_import_id_leaves_output_unchanged(self) -> None:
+        rc = ResourceConfig(name="srv", type="vm", provider="p", config={})
+        rendered_tf = 'resource "p_vm" "srv" {\n}'
+        context = {"vms": [rc]}
+
+        with patch.object(self.mixin, "render_template", return_value=rendered_tf):
+            self.mixin.render_and_write_terraform(
+                "test.tf.j2", context=context, output_name="vm.tf"
+            )
+
+        written = self.mixin._written_files["vm.tf"]
+        assert written == rendered_tf
+
+
+class TestLoaderImportId:
+    """Test that config loaders pass import_id through to ResourceConfig."""
+
+    def test_provider_centric_loader(self, tmp_path: Path) -> None:
+        from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
+
+        env_dir = tmp_path / "prod" / "opnsense"
+        env_dir.mkdir(parents=True)
+        config_file = env_dir / "kea_subnet.yaml"
+        config_file.write_text(
+            "kea_subnet:\n"
+            "  - name: subnet-mgmt\n"
+            "    import_id: uuid-123\n"
+            "    subnet: '10.0.0.0/24'\n"
+        )
+        loader = ProviderCentricLoader(tmp_path)
+        resources = loader.load_resources("prod", "opnsense", "kea_subnet")
+        assert len(resources) == 1
+        assert resources[0].import_id == "uuid-123"
+
+    def test_provider_centric_loader_no_import_id(self, tmp_path: Path) -> None:
+        from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
+
+        env_dir = tmp_path / "prod" / "opnsense"
+        env_dir.mkdir(parents=True)
+        config_file = env_dir / "kea_subnet.yaml"
+        config_file.write_text("kea_subnet:\n  - name: subnet-mgmt\n    subnet: '10.0.0.0/24'\n")
+        loader = ProviderCentricLoader(tmp_path)
+        resources = loader.load_resources("prod", "opnsense", "kea_subnet")
+        assert len(resources) == 1
+        assert resources[0].import_id is None
+
+    def test_resource_centric_loader(self, tmp_path: Path) -> None:
+        from infrafoundry.core.config.resource_centric_loader import ResourceCentricLoader
+
+        env_dir = tmp_path / "prod" / "resources"
+        env_dir.mkdir(parents=True)
+        config_file = env_dir / "infra.yaml"
+        config_file.write_text(
+            "resources:\n"
+            "  - provider: opnsense\n"
+            "    type: kea_subnet\n"
+            "    name: subnet-mgmt\n"
+            "    import_id: uuid-456\n"
+            "    config:\n"
+            "      subnet: '10.0.0.0/24'\n"
+        )
+        loader = ResourceCentricLoader(tmp_path)
+        resources = loader.load_resources("prod")
+        assert len(resources) == 1
+        assert resources[0].import_id == "uuid-456"


### PR DESCRIPTION
## Description

Add support for Terraform `import` blocks via a new `import_id` field on resource configurations. When a resource has `import_id` set, InfraFoundry automatically generates the corresponding Terraform `import {}` block in the output, allowing users to adopt existing infrastructure into Terraform state without running manual `terraform import` commands.

The implementation is framework-level in `TerraformGeneratorMixin.render_and_write_terraform`, so it works across all providers with no per-provider changes.

## Related Issue

Addresses #387

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `import_id: str | None` field to `ResourceConfig` model
- Added `_generate_import_blocks` method to `TerraformGeneratorMixin` that scans rendered Terraform for resource declarations and matches them against resources with `import_id`
- Updated `render_and_write_terraform` to prepend import blocks when present
- Passed `import_id` through all three config loaders (provider-centric, resource-centric, package)
- Added 17 unit tests covering import block generation, multiple resources, no-op when absent, regex matching, and integration with render_and_write_terraform
- Updated configuration docs (overview, YAML-only config, state management) to document `import_id`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (17 tests in `tests/unit/test_import_blocks.py`)
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
