### PR TITLE
feat: add per-environment state locking for apply and destroy

### DIFF
--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -232,6 +232,11 @@ InfraFoundry automatically detects backend configuration changes and triggers re
 
 ### State Locking
 
+State locking happens at **two** layers in InfraFoundry. Both are needed for
+correctness; one does not replace the other.
+
+#### 1. Terraform backend locking
+
 **Why Locking Matters:**
 - Prevents concurrent modifications to infrastructure state
 - Avoids race conditions in team environments
@@ -250,6 +255,55 @@ infra backend validate --env prod
 # Check generated backend.tf
 cat generated/prod/terraform/proxmox/backend.tf
 ```
+
+#### 2. InfraFoundry-level locking
+
+Terraform backend locks only protect the `.tfstate` file. InfraFoundry's own
+state DB, event log, and multi-runner workflow sit *outside* that lock, so
+concurrent `foundry infra apply --env prod` runs can corrupt the deployment
+history, duplicate resource tracking rows, and race on runner execution even
+when the Terraform backend is locking correctly.
+
+InfraFoundry therefore wraps `apply` and `destroy` in a second lock, stored in
+the `deployment_locks` table in the state DB. The unique constraint on
+`environment` is the atomic primitive - exactly one writer wins.
+
+Key behavior:
+
+- **`plan` is not locked.** Preview jobs never queue behind an apply.
+- **Fail fast by default.** `foundry infra apply --env prod` rejects
+  immediately if another run holds the lock. Pass `--lock-timeout <seconds>`
+  to wait instead.
+- **TTL-based stale recovery.** Locks carry an `expires_at` (default 1 hour,
+  tunable via `--lock-ttl <seconds>`). A crashed run stops blocking new runs
+  once its lock expires.
+- **Holder identity.** Each lock records `user@host:pid` in `locked_by` and a
+  timestamp in `acquired_at`.
+- **Event emission.** `LOCK_ACQUIRED`, `LOCK_RELEASED`, and `LOCK_TIMEOUT`
+  events flow through the existing `EventManager` for auditing and
+  notifications.
+
+Managing locks from the CLI:
+
+```bash
+# List all currently held locks (shows active vs. expired)
+foundry infra unlock --list
+
+# Release an expired lock (safe — refuses active locks)
+foundry infra unlock --env prod
+
+# Force-release an active lock after confirming the holder is dead
+foundry infra unlock --env prod --force           # prompts for confirmation
+foundry infra unlock --env prod --force --yes     # skip the prompt (scripts)
+```
+
+Emergency escape hatch: set `INFRAFOUNDRY_SKIP_LOCK=1` to bypass locking
+entirely. A loud warning is logged. Only use this when the state DB itself is
+inaccessible — it defeats the correctness guarantee that this feature exists
+to provide.
+
+See [ADR-0002: State locking via deployment_locks table](../decisions/0002-state-locking.md)
+for the full rationale and trade-offs.
 
 ## Validation and Checks
 

--- a/docs/decisions/0002-state-locking.md
+++ b/docs/decisions/0002-state-locking.md
@@ -1,0 +1,69 @@
+# ADR-0002: State locking via deployment_locks table
+
+## Status
+
+Accepted
+
+## Context
+
+`StateManager` coordinates deployment history, resource tracking, and events for every `infra apply` / `infra destroy`, but it has no mutual-exclusion mechanism across concurrent runs. When two operators (or two CI jobs) kick off an apply against the same environment simultaneously, both runs race on resource creation, state updates, and Terraform backend writes. The outcome is corrupted InfraFoundry state, duplicated resources, and unpredictable infrastructure drift.
+
+Terraform backends provide their own lock for the generated `.tfstate` files, but InfraFoundry's own state DB, event log, and multi-runner workflow sit *outside* that lock - so relying on it is insufficient. See `docs/architecture/state-management.md` for the wider state model.
+
+We need a correctness primitive that:
+- Works against both SQLite (default) and PostgreSQL.
+- Fails fast by default so operators see contention instead of silent waits.
+- Has a stale-lock recovery path for crashed processes.
+- Leaves `plan` unlocked (CI plan jobs should never queue behind an apply).
+- Offers an audited escape hatch for emergencies.
+
+Addresses #246.
+
+## Decision
+
+Introduce a `deployment_locks` table with a unique index on `environment`. Wrap `Orchestrator.apply()` and `Orchestrator.destroy()` in a context manager (`environment_lock`) that:
+
+1. Inserts a lock row keyed by `environment`. The unique constraint is the atomic primitive - exactly one writer wins.
+2. Records `locked_by` (`user@host:pid`), `acquired_at`, and `expires_at` (TTL-based, default 1 hour).
+3. On contention, immediately raises `LockAcquisitionError` (default `--lock-timeout 0`). Operators can opt into blocking waits with `--lock-timeout <seconds>`.
+4. Recovers automatically from expired locks: the next acquirer updates the row in place rather than refusing.
+5. Always releases in `finally`, even on exception.
+6. Emits `LOCK_ACQUIRED` / `LOCK_RELEASED` / `LOCK_TIMEOUT` events through the existing `EventManager`.
+
+Management surface:
+- `foundry infra unlock --env <name>` refuses active locks, releases expired ones.
+- `foundry infra unlock --env <name> --force` force-releases (with confirm prompt unless `--yes`).
+- `foundry infra unlock --list` shows all current locks.
+- `INFRAFOUNDRY_SKIP_LOCK=1` environment variable bypasses locking entirely, with a loud warning. Used only in emergencies when the state DB is inaccessible.
+
+`plan` is intentionally **not** locked - it only reads state and generates files, so running it in parallel with an active apply on the same env is safe and useful.
+
+Schema change is delivered through `Base.metadata.create_all()` - the existing initialization path. No Alembic migration is introduced; the broader Alembic tracking work is scoped to #196.
+
+## Consequences
+
+**Positive**
+
+- Concurrent applies/destroys on the same environment now fail fast with a clear, actionable error message (`foundry infra unlock --env <name>`).
+- `plan` stays lock-free, preserving CI preview workflows.
+- Works identically on SQLite and PostgreSQL - both honor the unique constraint.
+- Stale lock recovery means a crashed apply does not permanently block future runs (at worst, the next operator waits for `lock_ttl` seconds or uses `--force`).
+- All lock transitions are observable via the existing event system.
+
+**Negative / trade-offs**
+
+- TTL-based recovery introduces a time window where a truly alive but slow process may have its lock taken over. The default TTL (1 hour) is conservative for realistic apply durations, but operations running longer than the TTL need to supply `--lock-ttl`.
+- The lock is advisory from Terraform's perspective - if someone runs `terraform apply` directly against the same generated files while a foundry apply holds the lock, the direct invocation is not blocked. See feedback `feedback_use_infra_not_terraform.md` for the mitigating user contract.
+- Requires manual intervention (`unlock --force`) when a process dies holding a lock and TTL has not yet expired.
+- `INFRAFOUNDRY_SKIP_LOCK` exists and can be abused; this is an accepted trade-off for emergencies.
+
+**Out of scope (follow-ups)**
+
+- Lock heartbeat / TTL extension during long applies.
+- Distributed coordination backends (Redis, etcd).
+- Locking `plan`.
+- Alembic migrations (tracked separately under #196).
+
+## Implementation
+
+See `docs/architecture/state-management.md` (section "InfraFoundry-level locking") for the user-facing description and the `src/infrafoundry/core/state/lock_repository.py`, `lock_context.py`, and `src/infrafoundry/cli/commands/infra/unlock.py` modules for the code.

--- a/docs/usage/cli-reference.md
+++ b/docs/usage/cli-reference.md
@@ -57,9 +57,17 @@ infra destroy --env dev --auto-approve
   - `infra diff --env-a <env1> --env-b <env2> [--provider ...] [--verbose]` — compare configurations between two environments.
 - **Plan/Apply/Destroy**
   - `infra plan --env <env> [--resource ...] [--package <name>] [--dry-run]`
-  - `infra apply --env <env> [--resource ...] [--package <name>] [--auto-approve]`
-  - `infra destroy --env <env> [--resource ...] [--package <name>] [--auto-approve]`
+  - `infra apply --env <env> [--resource ...] [--package <name>] [--auto-approve] [--lock-timeout <seconds>] [--lock-ttl <seconds>]`
+  - `infra destroy --env <env> [--resource ...] [--package <name>] [--auto-approve] [--lock-timeout <seconds>] [--lock-ttl <seconds>]`
   - `infra reset --env <env> --provider <provider> --component <component> [--auto-approve]` — completely remove component configuration from provider for clean reapply.
+  - **Lock options on apply/destroy:**
+    - `--lock-timeout <seconds>` — how long to wait for an existing lock before failing. Default `0` (fail fast).
+    - `--lock-ttl <seconds>` — how long the acquired lock is valid before it is considered stale. Default `3600` (1 hour).
+- **Locking**
+  - `infra unlock --env <env>` — release an expired lock for the environment (refuses to release active locks).
+  - `infra unlock --env <env> --force [--yes]` — force-release an active lock; prompts for confirmation unless `--yes` is supplied.
+  - `infra unlock --list` — list all current deployment locks across environments.
+  - Set `INFRAFOUNDRY_SKIP_LOCK=1` to bypass locking entirely (emergency use only — emits a loud warning).
 - **Rollback and Recovery**
   - `infra rollback-points --env <env> [--limit <n>]` — list available rollback points for an environment.
   - `infra rollback --deployment-id <id> [--auto-approve]` — rollback infrastructure to a previous deployment state.
@@ -183,6 +191,23 @@ infra destroy --env dev --auto-approve
   ```bash
   infra drift --env prod
   ```
+- **Manage deployment locks:**
+  ```bash
+  # Wait up to 5 minutes for an active lock before failing
+  infra apply --env prod --lock-timeout 300
+
+  # Use a longer TTL for a slow apply
+  infra apply --env prod --lock-ttl 7200
+
+  # Inspect current locks
+  infra unlock --list
+
+  # Release an expired lock
+  infra unlock --env prod
+
+  # Force-release an active lock (use with caution)
+  infra unlock --env prod --force --yes
+  ```
 - **Graph dependencies:**
   ```bash
   infra graph --env dev --format mermaid > graph.mmd
@@ -210,7 +235,7 @@ infra destroy --env dev --auto-approve
 
 ---
 
-Last updated: 2025-12-27 13:45 GMT
+Last updated: 2026-04-06 GMT
 
 
 ---

--- a/src/infrafoundry/cli/commands/infra/__init__.py
+++ b/src/infrafoundry/cli/commands/infra/__init__.py
@@ -12,6 +12,7 @@ from .rollback import rollback
 from .security import security
 from .status import status
 from .test import test
+from .unlock import unlock
 
 
 @click.group()
@@ -31,6 +32,7 @@ infra.add_command(security)
 infra.add_command(status)
 infra.add_command(test)
 infra.add_command(history)
+infra.add_command(unlock)
 
 
 __all__ = ["infra"]

--- a/src/infrafoundry/cli/commands/infra/apply.py
+++ b/src/infrafoundry/cli/commands/infra/apply.py
@@ -35,6 +35,18 @@ from ...utils import console
     default=4,
     help="Maximum number of parallel workers (default: 4)",
 )
+@click.option(
+    "--lock-timeout",
+    type=int,
+    default=0,
+    help="Seconds to wait for the environment lock before failing (0 = fail fast).",
+)
+@click.option(
+    "--lock-ttl",
+    type=int,
+    default=3600,
+    help="Lock TTL in seconds for stale-lock recovery (default: 3600).",
+)
 @with_orchestrator("Apply failed")
 def apply(
     _ctx: click.Context,
@@ -45,6 +57,8 @@ def apply(
     package_name: str | None,
     parallel: bool,
     max_workers: int,
+    lock_timeout: int,
+    lock_ttl: int,
 ) -> None:
     """Apply infrastructure changes."""
     if package_name and resource:
@@ -82,5 +96,7 @@ def apply(
             parallel=parallel,
             max_workers=max_workers,
             package_filter=package_name,
+            lock_timeout=lock_timeout,
+            lock_ttl=lock_ttl,
         )
     console.success(f"Apply complete! ({timer.elapsed_str})")

--- a/src/infrafoundry/cli/commands/infra/destroy.py
+++ b/src/infrafoundry/cli/commands/infra/destroy.py
@@ -24,6 +24,18 @@ from ...utils import console
     "package_name",
     help="Target a specific package by name (mutually exclusive with -r)",
 )
+@click.option(
+    "--lock-timeout",
+    type=int,
+    default=0,
+    help="Seconds to wait for the environment lock before failing (0 = fail fast).",
+)
+@click.option(
+    "--lock-ttl",
+    type=int,
+    default=3600,
+    help="Lock TTL in seconds for stale-lock recovery (default: 3600).",
+)
 @with_orchestrator("Destroy failed")
 def destroy(
     _ctx: click.Context,
@@ -32,6 +44,8 @@ def destroy(
     auto_approve: bool,
     resource: tuple[str, ...],
     package_name: str | None,
+    lock_timeout: int,
+    lock_ttl: int,
 ) -> None:
     """Destroy infrastructure."""
     if package_name and resource:
@@ -66,5 +80,7 @@ def destroy(
             auto_approve=auto_approve,
             resource_filter=resource_filter,
             package_filter=package_name,
+            lock_timeout=lock_timeout,
+            lock_ttl=lock_ttl,
         )
     console.success(f"Destroy complete! ({timer.elapsed_str})")

--- a/src/infrafoundry/cli/commands/infra/unlock.py
+++ b/src/infrafoundry/cli/commands/infra/unlock.py
@@ -1,0 +1,100 @@
+"""Release (or list) deployment locks for an environment."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import click
+from rich.table import Table
+
+from infrafoundry.core.orchestrator import Orchestrator
+
+from ...decorators import with_orchestrator
+from ...utils import console
+
+
+@click.command()
+@click.option("--env", "-e", help="Environment name to unlock (required unless --list).")
+@click.option("--force", is_flag=True, help="Release even if the lock is still active.")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt for --force.")
+@click.option("--list", "list_locks", is_flag=True, help="List all current locks.")
+@with_orchestrator("Unlock failed", require_env=False, load_credentials=False)
+def unlock(
+    _ctx: click.Context,
+    orchestrator: Orchestrator,
+    env: str | None,
+    force: bool,
+    yes: bool,
+    list_locks: bool,
+) -> None:
+    """Release or inspect deployment locks."""
+    state_manager = orchestrator.state_manager
+
+    if list_locks:
+        locks = state_manager.list_locks()
+        if not locks:
+            console.info("No deployment locks are currently held.")
+            return
+        table = Table(title="Deployment Locks")
+        table.add_column("Environment", style="cyan")
+        table.add_column("Locked By", style="green")
+        table.add_column("Acquired", style="dim")
+        table.add_column("Expires", style="dim")
+        table.add_column("Status", style="magenta")
+        now = datetime.now(UTC)
+        for lock in locks:
+            expires = lock.expires_at
+            if expires.tzinfo is None:
+                expires = expires.replace(tzinfo=UTC)
+            status = "expired" if expires <= now else "active"
+            table.add_row(
+                lock.environment,
+                lock.locked_by,
+                str(lock.acquired_at),
+                str(lock.expires_at),
+                status,
+            )
+        console.print(table)
+        return
+
+    if not env:
+        raise click.UsageError("--env is required unless --list is given.")
+
+    current = state_manager.get_lock(env)
+    if current is None:
+        console.info(f"No lock held on environment '{env}'.")
+        return
+
+    expires = current.expires_at
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=UTC)
+    now = datetime.now(UTC)
+    is_expired = expires <= now
+
+    if force:
+        if not yes and not click.confirm(
+            f"Force-release lock on '{env}' held by {current.locked_by}?",
+            default=False,
+        ):
+            console.warning("Unlock cancelled.")
+            return
+        released = state_manager.release_lock(env, force=True)
+        if released:
+            console.success(f"Lock on '{env}' released.")
+        else:
+            console.warning(f"No lock found on '{env}'.")
+        return
+
+    if is_expired:
+        released = state_manager.release_lock(env, force=True)
+        if released:
+            console.success(f"Expired lock on '{env}' released.")
+        else:
+            console.warning(f"No lock found on '{env}'.")
+        return
+
+    # Active lock, no --force: refuse.
+    raise click.ClickException(
+        f"Environment '{env}' is locked by {current.locked_by} "
+        f"(expires {current.expires_at}). Re-run with --force to release anyway."
+    )

--- a/src/infrafoundry/cli/decorators.py
+++ b/src/infrafoundry/cli/decorators.py
@@ -13,6 +13,7 @@ from infrafoundry.core.exceptions import (
     ConfigurationError,
     EnvironmentNotFoundError,
     InfraFoundryError,
+    LockAcquisitionError,
 )
 
 from .utils import raise_cli_error
@@ -74,6 +75,15 @@ def with_orchestrator(
             except (EnvironmentNotFoundError, ConfigurationError) as exc:
                 # Configuration errors - show helpful message with error codes
                 raise_cli_error(action, exc)
+            except LockAcquisitionError as exc:
+                # Lock contention - render actionable unlock instructions.
+                msg = (
+                    f"Environment '{exc.environment}' is locked by "
+                    f"{exc.locked_by} since {exc.acquired_at} "
+                    f"(expires {exc.expires_at}). Use 'foundry infra unlock "
+                    f"--env {exc.environment}' to release."
+                )
+                raise click.ClickException(msg) from exc
             except InfraFoundryError as exc:
                 # Other InfraFoundry errors - show with error codes
                 raise_cli_error(action, exc)

--- a/src/infrafoundry/core/events/types.py
+++ b/src/infrafoundry/core/events/types.py
@@ -73,6 +73,11 @@ class EventType(StrEnum):
     HOOK_COMPLETED = "hook_completed"
     HOOK_FAILED = "hook_failed"
 
+    # Lock lifecycle
+    LOCK_ACQUIRED = "lock_acquired"
+    LOCK_RELEASED = "lock_released"
+    LOCK_TIMEOUT = "lock_timeout"
+
 
 class HandlerType(StrEnum):
     """Types of event handlers."""

--- a/src/infrafoundry/core/exceptions.py
+++ b/src/infrafoundry/core/exceptions.py
@@ -157,6 +157,48 @@ class StateInconsistencyError(StateError):
     """State database is inconsistent."""
 
 
+class LockAcquisitionError(InfraFoundryError):
+    """Raised when a deployment lock cannot be acquired.
+
+    Carries metadata about the currently-held lock so callers and CLI
+    error handlers can render actionable messages.
+    """
+
+    def __init__(
+        self,
+        environment: str,
+        locked_by: str,
+        acquired_at: Any,
+        expires_at: Any,
+        message: str | None = None,
+    ) -> None:
+        """Initialize lock acquisition error.
+
+        Args:
+            environment: Environment whose lock could not be acquired.
+            locked_by: Identifier of the lock holder (``user@host:pid``).
+            acquired_at: When the existing lock was acquired (``datetime``).
+            expires_at: When the existing lock expires (``datetime``).
+            message: Optional override message; a default is generated otherwise.
+        """
+        self.environment = environment
+        self.locked_by = locked_by
+        self.acquired_at = acquired_at
+        self.expires_at = expires_at
+        if message is None:
+            message = (
+                f"Environment '{environment}' is locked by {locked_by} "
+                f"since {acquired_at} (expires {expires_at})"
+            )
+        context: dict[str, Any] = {
+            "environment": environment,
+            "locked_by": locked_by,
+            "acquired_at": str(acquired_at),
+            "expires_at": str(expires_at),
+        }
+        super().__init__(message, context)
+
+
 # Resource Filter Errors
 
 
@@ -314,6 +356,7 @@ __all__ = [
     "InfraFoundryError",
     "InvalidConfigurationError",
     "InvalidCredentialError",
+    "LockAcquisitionError",
     "MissingConfigurationError",
     "MissingCredentialError",
     "MissingDependencyError",

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -1,6 +1,8 @@
 """Core orchestration for infrastructure deployment."""
 
+import getpass
 import os
+import socket
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -35,6 +37,7 @@ from infrafoundry.core.provider_registry_service import ProviderRegistryService
 from infrafoundry.core.runners import RunnerRegistry
 from infrafoundry.core.secrets.secret_manager import SecretManager
 from infrafoundry.core.state import StateManager
+from infrafoundry.core.state.lock_context import environment_lock
 
 
 @dataclass(slots=True)
@@ -535,6 +538,8 @@ class Orchestrator:
         parallel: bool = False,
         max_workers: int = 4,
         package_filter: str | None = None,
+        lock_timeout: int = 0,
+        lock_ttl: int = 3600,
     ) -> dict[str, Any]:
         """Apply infrastructure changes.
 
@@ -545,22 +550,37 @@ class Orchestrator:
             parallel: If True, apply resources in parallel where possible
             max_workers: Maximum number of parallel workers (default: 4)
             package_filter: Optional package name to restrict event handlers
+            lock_timeout: Seconds to wait for the environment lock before
+                failing. ``0`` (default) fails fast.
+            lock_ttl: Lock TTL in seconds (default: 1 hour).
 
         Returns:
             Dict with apply results per provider
         """
-        # First, generate the plans
-        self.plan(
-            env_name, dry_run=False, resource_filter=resource_filter, package_filter=package_filter
-        )
-        return self.apply_orchestrator.apply(
-            env_name=env_name,
-            resource_filter=resource_filter,
-            auto_approve=auto_approve,
-            parallel=parallel,
-            max_workers=max_workers,
-            package_filter=package_filter,
-        )
+        locked_by = _build_lock_holder_id()
+        with environment_lock(
+            self.state_manager,
+            env_name,
+            ttl=lock_ttl,
+            locked_by=locked_by,
+            timeout=lock_timeout,
+            event_manager=self.event_manager,
+        ):
+            # First, generate the plans
+            self.plan(
+                env_name,
+                dry_run=False,
+                resource_filter=resource_filter,
+                package_filter=package_filter,
+            )
+            return self.apply_orchestrator.apply(
+                env_name=env_name,
+                resource_filter=resource_filter,
+                auto_approve=auto_approve,
+                parallel=parallel,
+                max_workers=max_workers,
+                package_filter=package_filter,
+            )
 
     def _apply_providers_serial(
         self,
@@ -646,6 +666,8 @@ class Orchestrator:
         resource_filter: list[str] | None = None,
         confirm_callback: Callable[[], bool] | None = None,
         package_filter: str | None = None,
+        lock_timeout: int = 0,
+        lock_ttl: int = 3600,
     ) -> dict[str, Any]:
         """Destroy infrastructure.
 
@@ -655,13 +677,25 @@ class Orchestrator:
             resource_filter: Optional list of resource names to target
             confirm_callback: Optional callback for user confirmation
             package_filter: Optional package name to restrict event handlers
+            lock_timeout: Seconds to wait for the environment lock before
+                failing. ``0`` (default) fails fast.
+            lock_ttl: Lock TTL in seconds (default: 1 hour).
 
         Returns:
             Dict with destroy results per provider
         """
-        return self.destroy_orchestrator.destroy(
-            env_name, resource_filter, auto_approve, confirm_callback, package_filter
-        )
+        locked_by = _build_lock_holder_id()
+        with environment_lock(
+            self.state_manager,
+            env_name,
+            ttl=lock_ttl,
+            locked_by=locked_by,
+            timeout=lock_timeout,
+            event_manager=self.event_manager,
+        ):
+            return self.destroy_orchestrator.destroy(
+                env_name, resource_filter, auto_approve, confirm_callback, package_filter
+            )
 
     def rollback(
         self,
@@ -691,3 +725,16 @@ class Orchestrator:
             env_name: Environment name
         """
         self.status_orchestrator.show(env_name)
+
+
+def _build_lock_holder_id() -> str:
+    """Construct a ``user@host:pid`` identifier for the current process."""
+    try:
+        user = getpass.getuser()
+    except Exception:
+        user = os.environ.get("USER", "unknown")
+    try:
+        host = socket.gethostname()
+    except Exception:
+        host = "unknown"
+    return f"{user}@{host}:{os.getpid()}"

--- a/src/infrafoundry/core/state/__init__.py
+++ b/src/infrafoundry/core/state/__init__.py
@@ -1,10 +1,12 @@
 """State management package for InfraFoundry."""
 
 from infrafoundry.core.state.deployment_repository import DeploymentRepository
+from infrafoundry.core.state.lock_repository import LockRepository
 from infrafoundry.core.state.models import (
     Base,
     Deployment,
     DeploymentEvent,
+    DeploymentLock,
     DeploymentStatus,
     Resource,
     ResourceDependency,
@@ -17,8 +19,10 @@ __all__ = [
     "Base",
     "Deployment",
     "DeploymentEvent",
+    "DeploymentLock",
     "DeploymentRepository",
     "DeploymentStatus",
+    "LockRepository",
     "Resource",
     "ResourceDependency",
     "ResourceRepository",

--- a/src/infrafoundry/core/state/lock_context.py
+++ b/src/infrafoundry/core/state/lock_context.py
@@ -1,0 +1,163 @@
+"""Context manager for acquiring and releasing deployment locks.
+
+Provides :func:`environment_lock`, the public entrypoint used by
+:class:`Orchestrator` to wrap ``apply`` and ``destroy`` in an exclusive
+per-environment lock backed by :class:`LockRepository`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from infrafoundry.core.events.types import EventType
+from infrafoundry.core.exceptions import LockAcquisitionError
+
+if TYPE_CHECKING:
+    from infrafoundry.core.events import EventManager
+    from infrafoundry.core.state.models import DeploymentLock
+    from infrafoundry.core.state.state_manager import StateManager
+
+
+logger = logging.getLogger(__name__)
+
+SKIP_LOCK_ENV = "INFRAFOUNDRY_SKIP_LOCK"
+
+
+@contextmanager
+def environment_lock(
+    state_manager: StateManager,
+    env_name: str,
+    ttl: int,
+    locked_by: str,
+    deployment_id: int | None = None,
+    timeout: int = 0,
+    poll_interval: float = 2.0,
+    event_manager: EventManager | None = None,
+) -> Iterator[None]:
+    """Acquire an exclusive lock on ``env_name`` for the duration of the block.
+
+    If ``timeout`` is 0 (default), acquisition fails fast: any existing
+    active lock immediately raises :class:`LockAcquisitionError`. If ``timeout``
+    is positive, the call polls at ``poll_interval`` seconds until it either
+    acquires the lock or the timeout elapses (in which case it emits a
+    ``LOCK_TIMEOUT`` event and re-raises).
+
+    The lock is always released in the ``finally`` block, even when the wrapped
+    body raises. ``force=True`` is used on release so the release always
+    succeeds regardless of TTL takeover semantics.
+
+    Set the ``INFRAFOUNDRY_SKIP_LOCK`` environment variable to any truthy value
+    to bypass locking entirely (with a loud warning). This is an emergency
+    escape hatch - do not set it in normal operation.
+
+    Args:
+        state_manager: Active :class:`StateManager` whose ``locks`` repository
+            backs this call.
+        env_name: Environment name to lock.
+        ttl: Lock TTL in seconds (how long the lock is valid if the holder
+            crashes before release).
+        locked_by: Identifier for the lock holder (``user@host:pid``).
+        deployment_id: Optional deployment ID to associate with the lock row.
+        timeout: Max seconds to wait when the lock is held. ``0`` means
+            fail fast.
+        poll_interval: Poll interval in seconds when waiting.
+        event_manager: Optional :class:`EventManager` used to emit
+            ``LOCK_ACQUIRED``/``LOCK_RELEASED``/``LOCK_TIMEOUT`` events.
+
+    Yields:
+        None.
+
+    Raises:
+        LockAcquisitionError: If the lock cannot be acquired (either
+            immediately when ``timeout=0`` or after the timeout expires).
+    """
+    if os.environ.get(SKIP_LOCK_ENV):
+        logger.warning(
+            "%s is set - bypassing deployment lock for environment '%s'. "
+            "This should only be used in emergencies.",
+            SKIP_LOCK_ENV,
+            env_name,
+        )
+        yield
+        return
+
+    lock = _acquire_with_timeout(
+        state_manager=state_manager,
+        env_name=env_name,
+        ttl=ttl,
+        locked_by=locked_by,
+        deployment_id=deployment_id,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        event_manager=event_manager,
+    )
+
+    if event_manager is not None:
+        event_manager.emit_event(
+            EventType.LOCK_ACQUIRED,
+            env_name,
+            {
+                "locked_by": locked_by,
+                "acquired_at": str(lock.acquired_at),
+                "expires_at": str(lock.expires_at),
+            },
+        )
+
+    try:
+        yield
+    finally:
+        try:
+            state_manager.release_lock(env_name, locked_by=locked_by, force=True)
+        except Exception:
+            logger.exception("Failed to release lock on environment '%s'", env_name)
+        else:
+            if event_manager is not None:
+                event_manager.emit_event(
+                    EventType.LOCK_RELEASED,
+                    env_name,
+                    {"locked_by": locked_by},
+                )
+
+
+def _acquire_with_timeout(
+    state_manager: StateManager,
+    env_name: str,
+    ttl: int,
+    locked_by: str,
+    deployment_id: int | None,
+    timeout: int,
+    poll_interval: float,
+    event_manager: EventManager | None,
+) -> DeploymentLock:
+    """Acquire a lock, polling when ``timeout`` is positive.
+
+    Returns the acquired :class:`DeploymentLock` on success. Raises
+    :class:`LockAcquisitionError` on failure.
+    """
+    start = time.monotonic()
+    while True:
+        try:
+            return state_manager.acquire_lock(
+                environment=env_name,
+                ttl_seconds=ttl,
+                locked_by=locked_by,
+                deployment_id=deployment_id,
+            )
+        except LockAcquisitionError:
+            if timeout <= 0:
+                raise
+            elapsed = time.monotonic() - start
+            if elapsed >= timeout:
+                if event_manager is not None:
+                    event_manager.emit_event(
+                        EventType.LOCK_TIMEOUT,
+                        env_name,
+                        {"locked_by": locked_by, "timeout": timeout},
+                    )
+                raise
+            time.sleep(poll_interval)

--- a/src/infrafoundry/core/state/lock_repository.py
+++ b/src/infrafoundry/core/state/lock_repository.py
@@ -1,0 +1,222 @@
+"""Repository for deployment lock operations.
+
+Backs the ``deployment_locks`` table used by :mod:`infrafoundry.core.state.lock_context`
+to provide per-environment exclusive locking around ``apply`` and ``destroy``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from infrafoundry.core.exceptions import LockAcquisitionError
+from infrafoundry.core.state.models import DeploymentLock
+
+
+class LockRepository:
+    """Handles all deployment-lock database operations.
+
+    Mirrors :class:`DeploymentRepository` in shape: constructed with a
+    ``sessionmaker``, opens a fresh session per call, and returns detached
+    (expunged) ORM instances so callers do not hold onto closed sessions.
+    """
+
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        """Initialize repository with SQLAlchemy session factory.
+
+        Args:
+            session_factory: SQLAlchemy sessionmaker instance.
+        """
+        self.SessionLocal = session_factory
+
+    def acquire(
+        self,
+        environment: str,
+        ttl_seconds: int,
+        locked_by: str,
+        deployment_id: int | None = None,
+    ) -> DeploymentLock:
+        """Acquire an exclusive lock on ``environment``.
+
+        Behavior:
+        - If no row exists, insert one. Commit, return.
+        - If an active (non-expired) row exists, raise ``LockAcquisitionError``.
+        - If an expired row exists, update it in place (stale takeover).
+        - If a concurrent inserter wins the race, ``IntegrityError`` is caught
+          and converted to ``LockAcquisitionError`` with fresh metadata.
+
+        Args:
+            environment: Environment name to lock.
+            ttl_seconds: How long (seconds) the lock should remain valid.
+            locked_by: Identifier of the lock holder (``user@host:pid``).
+            deployment_id: Optional deployment ID to associate with the lock.
+
+        Returns:
+            The freshly-acquired :class:`DeploymentLock` (detached).
+
+        Raises:
+            LockAcquisitionError: If the lock is already held by another
+                active owner.
+        """
+        now = datetime.now(UTC)
+        expires_at = now + timedelta(seconds=ttl_seconds)
+
+        with self.SessionLocal() as session:
+            existing = (
+                session.query(DeploymentLock)
+                .filter(DeploymentLock.environment == environment)
+                .one_or_none()
+            )
+            if existing is not None:
+                existing_expires = _as_aware(existing.expires_at)
+                if existing_expires > now:
+                    # Active lock held by another owner.
+                    raise LockAcquisitionError(
+                        environment=environment,
+                        locked_by=existing.locked_by,
+                        acquired_at=_as_aware(existing.acquired_at),
+                        expires_at=existing_expires,
+                    )
+                # Stale lock - take it over in place.
+                existing.locked_by = locked_by
+                existing.acquired_at = now
+                existing.expires_at = expires_at
+                existing.deployment_id = deployment_id
+                session.commit()
+                session.refresh(existing)
+                session.expunge(existing)
+                return existing
+
+            # No row - insert a new one. Another process racing us may
+            # succeed first; catch IntegrityError and convert.
+            lock = DeploymentLock(
+                environment=environment,
+                locked_by=locked_by,
+                acquired_at=now,
+                expires_at=expires_at,
+                deployment_id=deployment_id,
+            )
+            session.add(lock)
+            try:
+                session.commit()
+            except IntegrityError as exc:
+                session.rollback()
+                # Re-query to surface the winner's metadata.
+                winner = (
+                    session.query(DeploymentLock)
+                    .filter(DeploymentLock.environment == environment)
+                    .one_or_none()
+                )
+                if winner is None:
+                    # Shouldn't happen, but be defensive.
+                    raise LockAcquisitionError(
+                        environment=environment,
+                        locked_by="unknown",
+                        acquired_at=now,
+                        expires_at=now,
+                        message=(f"Failed to acquire lock on '{environment}': {exc}"),
+                    ) from exc
+                raise LockAcquisitionError(
+                    environment=environment,
+                    locked_by=winner.locked_by,
+                    acquired_at=_as_aware(winner.acquired_at),
+                    expires_at=_as_aware(winner.expires_at),
+                ) from exc
+            session.refresh(lock)
+            session.expunge(lock)
+            return lock
+
+    def release(
+        self,
+        environment: str,
+        locked_by: str | None = None,
+        force: bool = False,
+    ) -> bool:
+        """Release the lock on ``environment``.
+
+        Args:
+            environment: Environment name whose lock should be released.
+            locked_by: Optional owner identifier. If provided (and ``force``
+                is False) the lock is only released when the owner matches.
+            force: If True, release the lock regardless of the owner.
+
+        Returns:
+            ``True`` if a row was actually deleted. ``False`` if no lock
+            existed, or if the owner did not match and ``force`` was False
+            (silent refusal - wrong-owner without force is a no-op).
+        """
+        with self.SessionLocal() as session:
+            lock = (
+                session.query(DeploymentLock)
+                .filter(DeploymentLock.environment == environment)
+                .one_or_none()
+            )
+            if lock is None:
+                return False
+            if not force and locked_by is not None and lock.locked_by != locked_by:
+                # Wrong-owner without force: silent refusal per design.
+                return False
+            session.delete(lock)
+            session.commit()
+            return True
+
+    def get(self, environment: str) -> DeploymentLock | None:
+        """Return the current lock row for ``environment``, if any.
+
+        Args:
+            environment: Environment name.
+
+        Returns:
+            Detached :class:`DeploymentLock` or ``None`` when no row exists.
+        """
+        with self.SessionLocal() as session:
+            lock = (
+                session.query(DeploymentLock)
+                .filter(DeploymentLock.environment == environment)
+                .one_or_none()
+            )
+            if lock is None:
+                return None
+            session.expunge(lock)
+            return lock
+
+    def list_all(self) -> list[DeploymentLock]:
+        """Return all lock rows (detached).
+
+        Returns:
+            List of :class:`DeploymentLock` instances, possibly empty.
+        """
+        with self.SessionLocal() as session:
+            locks = session.query(DeploymentLock).all()
+            for lock in locks:
+                session.expunge(lock)
+            return list(locks)
+
+    def cleanup_stale(self) -> int:
+        """Delete all expired locks.
+
+        Returns:
+            Number of rows removed.
+        """
+        now = datetime.now(UTC)
+        with self.SessionLocal() as session:
+            expired = session.query(DeploymentLock).filter(DeploymentLock.expires_at <= now).all()
+            count = len(expired)
+            for lock in expired:
+                session.delete(lock)
+            if count:
+                session.commit()
+            return count
+
+
+def _as_aware(value: datetime) -> datetime:
+    """Return ``value`` as a timezone-aware UTC datetime.
+
+    SQLite stores naive datetimes even when we pass aware ones in; normalize
+    on read so comparisons and rendered messages are consistent.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value

--- a/src/infrafoundry/core/state/models.py
+++ b/src/infrafoundry/core/state/models.py
@@ -148,3 +148,28 @@ class DeploymentEvent(Base):
 
     # Relationships
     deployment = relationship("Deployment", back_populates="events")
+
+
+class DeploymentLock(Base):
+    """Exclusive per-environment lock for deployment operations.
+
+    A row in this table represents an active lock on a given environment.
+    The unique constraint on ``environment`` provides the atomic primitive
+    that prevents concurrent apply/destroy operations from colliding.
+    Locks carry a ``expires_at`` TTL so stale locks from crashed processes
+    can be taken over automatically.
+    """
+
+    __tablename__ = "deployment_locks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    environment: Mapped[str] = mapped_column(String(100), nullable=False, unique=True, index=True)
+    locked_by: Mapped[str] = mapped_column(String(200), nullable=False)
+    acquired_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    deployment_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("deployments.id"), nullable=True
+    )
+    extra_data: Mapped[dict[str, Any] | None] = mapped_column(JSON)

--- a/src/infrafoundry/core/state/state_manager.py
+++ b/src/infrafoundry/core/state/state_manager.py
@@ -12,9 +12,11 @@ from sqlalchemy.orm import sessionmaker
 
 from infrafoundry.core.base_manager import BaseManager
 from infrafoundry.core.state.deployment_repository import DeploymentRepository
+from infrafoundry.core.state.lock_repository import LockRepository
 from infrafoundry.core.state.models import (
     Base,
     Deployment,
+    DeploymentLock,
     DeploymentStatus,
     Resource,
     ResourceState,
@@ -50,6 +52,7 @@ class StateManager(BaseManager):
         # Initialize repositories
         self.deployments = DeploymentRepository(self.SessionLocal)
         self.resources = ResourceRepository(self.SessionLocal)
+        self.locks = LockRepository(self.SessionLocal)
         self._log_debug("StateManager initialized successfully")
 
     def initialize(self) -> None:
@@ -289,6 +292,57 @@ class StateManager(BaseManager):
             Resource object or None
         """
         return self.resources.get_by_name(environment, provider, name)
+
+    # Lock operations - delegate to LockRepository
+    def acquire_lock(
+        self,
+        environment: str,
+        ttl_seconds: int,
+        locked_by: str,
+        deployment_id: int | None = None,
+    ) -> DeploymentLock:
+        """Acquire an exclusive deployment lock for ``environment``.
+
+        Args:
+            environment: Environment name.
+            ttl_seconds: Lock TTL in seconds.
+            locked_by: Lock holder identifier (e.g. ``user@host:pid``).
+            deployment_id: Optional deployment ID to associate with the lock.
+
+        Returns:
+            The acquired :class:`DeploymentLock`.
+        """
+        return self.locks.acquire(environment, ttl_seconds, locked_by, deployment_id)
+
+    def release_lock(
+        self,
+        environment: str,
+        locked_by: str | None = None,
+        force: bool = False,
+    ) -> bool:
+        """Release the deployment lock on ``environment``.
+
+        Args:
+            environment: Environment name.
+            locked_by: Optional owner identifier used to guard release.
+            force: If True, release regardless of owner.
+
+        Returns:
+            True if a lock row was removed, False otherwise.
+        """
+        return self.locks.release(environment, locked_by=locked_by, force=force)
+
+    def get_lock(self, environment: str) -> DeploymentLock | None:
+        """Return the current lock row for ``environment`` if any."""
+        return self.locks.get(environment)
+
+    def list_locks(self) -> list[DeploymentLock]:
+        """Return all deployment lock rows."""
+        return self.locks.list_all()
+
+    def cleanup_stale_locks(self) -> int:
+        """Remove all expired locks; return count removed."""
+        return self.locks.cleanup_stale()
 
     def cleanup(self) -> None:
         """Cleanup database resources (required by BaseManager).

--- a/tests/unit/test_cli_apply.py
+++ b/tests/unit/test_cli_apply.py
@@ -38,6 +38,8 @@ def test_apply_with_confirmation(cli_runner, mock_orchestrator):
             parallel=False,
             max_workers=4,
             package_filter=None,
+            lock_timeout=0,
+            lock_ttl=3600,
         )
 
 
@@ -66,6 +68,8 @@ def test_apply_with_auto_approve(cli_runner, mock_orchestrator):
             parallel=False,
             max_workers=4,
             package_filter=None,
+            lock_timeout=0,
+            lock_ttl=3600,
         )
 
 
@@ -85,6 +89,8 @@ def test_apply_with_resource_filter(cli_runner, mock_orchestrator):
             parallel=False,
             max_workers=4,
             package_filter=None,
+            lock_timeout=0,
+            lock_ttl=3600,
         )
 
 
@@ -113,6 +119,8 @@ def test_apply_with_parallel(cli_runner, mock_orchestrator):
             parallel=True,
             max_workers=8,
             package_filter=None,
+            lock_timeout=0,
+            lock_ttl=3600,
         )
 
 

--- a/tests/unit/test_cli_infra_unlock.py
+++ b/tests/unit/test_cli_infra_unlock.py
@@ -1,0 +1,107 @@
+"""Unit tests for the 'infra unlock' CLI command."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from infrafoundry.cli.main import main
+from infrafoundry.core.orchestrator import Orchestrator
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_orchestrator():
+    mock = Mock(spec=Orchestrator)
+    mock.state_manager = Mock()
+    return mock
+
+
+def _make_lock(
+    environment: str = "dev",
+    locked_by: str = "alice@host:1",
+    expires_delta: timedelta = timedelta(hours=1),
+):
+    lock = Mock()
+    lock.environment = environment
+    lock.locked_by = locked_by
+    lock.acquired_at = datetime.now(UTC)
+    lock.expires_at = datetime.now(UTC) + expires_delta
+    return lock
+
+
+def test_unlock_active_lock_refused(cli_runner, mock_orchestrator):
+    mock_orchestrator.state_manager.get_lock.return_value = _make_lock()
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "unlock", "--env", "dev"])
+
+    assert result.exit_code != 0
+    assert "locked by alice@host:1" in result.output
+    mock_orchestrator.state_manager.release_lock.assert_not_called()
+
+
+def test_unlock_force_releases_active_lock(cli_runner, mock_orchestrator):
+    mock_orchestrator.state_manager.get_lock.return_value = _make_lock()
+    mock_orchestrator.state_manager.release_lock.return_value = True
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "unlock", "--env", "dev", "--force", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    mock_orchestrator.state_manager.release_lock.assert_called_once_with("dev", force=True)
+
+
+def test_unlock_expired_lock_succeeds_without_force(cli_runner, mock_orchestrator):
+    expired = _make_lock(expires_delta=timedelta(hours=-1))
+    mock_orchestrator.state_manager.get_lock.return_value = expired
+    mock_orchestrator.state_manager.release_lock.return_value = True
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "unlock", "--env", "dev"])
+
+    assert result.exit_code == 0, result.output
+    assert "Expired lock" in result.output
+    mock_orchestrator.state_manager.release_lock.assert_called_once_with("dev", force=True)
+
+
+def test_unlock_list_shows_all_locks(cli_runner, mock_orchestrator):
+    mock_orchestrator.state_manager.list_locks.return_value = [
+        _make_lock(environment="dev"),
+        _make_lock(environment="prod", expires_delta=timedelta(hours=-1)),
+    ]
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "unlock", "--list"])
+
+    assert result.exit_code == 0, result.output
+    assert "dev" in result.output
+    assert "prod" in result.output
+    assert "active" in result.output
+    assert "expired" in result.output
+
+
+def test_unlock_nonexistent_env_reports_no_lock(cli_runner, mock_orchestrator):
+    mock_orchestrator.state_manager.get_lock.return_value = None
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "unlock", "--env", "dev"])
+
+    assert result.exit_code == 0, result.output
+    assert "No lock held" in result.output
+    mock_orchestrator.state_manager.release_lock.assert_not_called()
+
+
+def test_unlock_without_env_or_list_errors(cli_runner, mock_orchestrator):
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "unlock"])
+
+    assert result.exit_code != 0
+    assert "--env" in result.output

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -519,3 +519,91 @@ class TestIterProviderBatchesResourceFilter:
         assert len(batches) == 2
         all_names = {r.name for b in batches for r in b.resources}
         assert all_names == {"vm1", "fw1"}
+
+
+class TestOrchestratorLocking:
+    """Tests for environment locking around apply/destroy."""
+
+    def _make_orchestrator(self, tmp_path):
+        from infrafoundry.core.state import StateManager
+
+        config_manager = Mock(spec=ConfigManager)
+        config_manager.base_dir = tmp_path
+        state_manager = StateManager(connection_string=f"sqlite:///{tmp_path / 'state.db'}")
+        state_manager.initialize()
+        orchestrator = Orchestrator(
+            config_manager=config_manager,
+            state_manager=state_manager,
+        )
+        # Stub sub-orchestrators to avoid running real workflows.
+        orchestrator.plan_orchestrator = Mock()
+        orchestrator.plan_orchestrator.plan = Mock(return_value={})
+        orchestrator.apply_orchestrator = Mock()
+        orchestrator.apply_orchestrator.apply = Mock(return_value={})
+        orchestrator.destroy_orchestrator = Mock()
+        orchestrator.destroy_orchestrator.destroy = Mock(return_value={})
+        return orchestrator
+
+    def test_apply_acquires_lock_around_workflow(self, tmp_path):
+        orchestrator = self._make_orchestrator(tmp_path)
+
+        captured = {}
+
+        def record_apply(**kwargs):
+            captured["lock"] = orchestrator.state_manager.get_lock("dev")
+            return {}
+
+        orchestrator.apply_orchestrator.apply.side_effect = record_apply
+
+        orchestrator.apply("dev", auto_approve=True)
+
+        assert captured["lock"] is not None
+        assert orchestrator.state_manager.get_lock("dev") is None
+
+    def test_apply_releases_lock_on_failure(self, tmp_path):
+        orchestrator = self._make_orchestrator(tmp_path)
+        orchestrator.apply_orchestrator.apply.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            orchestrator.apply("dev", auto_approve=True)
+
+        assert orchestrator.state_manager.get_lock("dev") is None
+
+    def test_apply_fails_when_locked(self, tmp_path):
+        from infrafoundry.core.exceptions import LockAcquisitionError
+
+        orchestrator = self._make_orchestrator(tmp_path)
+        orchestrator.state_manager.acquire_lock("dev", ttl_seconds=60, locked_by="someone@else:99")
+
+        with pytest.raises(LockAcquisitionError):
+            orchestrator.apply("dev", auto_approve=True)
+
+        # Pre-existing lock untouched.
+        lock = orchestrator.state_manager.get_lock("dev")
+        assert lock is not None
+        assert lock.locked_by == "someone@else:99"
+
+    def test_destroy_acquires_lock_around_workflow(self, tmp_path):
+        orchestrator = self._make_orchestrator(tmp_path)
+
+        captured = {}
+
+        def record_destroy(*args, **kwargs):
+            captured["lock"] = orchestrator.state_manager.get_lock("dev")
+            return {}
+
+        orchestrator.destroy_orchestrator.destroy.side_effect = record_destroy
+
+        orchestrator.destroy("dev", auto_approve=True)
+
+        assert captured["lock"] is not None
+        assert orchestrator.state_manager.get_lock("dev") is None
+
+    def test_plan_does_not_acquire_lock(self, tmp_path):
+        orchestrator = self._make_orchestrator(tmp_path)
+        # Pre-seed an active lock; plan should still proceed.
+        orchestrator.state_manager.acquire_lock("dev", ttl_seconds=60, locked_by="someone@else:99")
+
+        result = orchestrator.plan("dev")
+        assert result == {}
+        orchestrator.plan_orchestrator.plan.assert_called_once()

--- a/tests/unit/test_package_filter.py
+++ b/tests/unit/test_package_filter.py
@@ -241,6 +241,8 @@ class TestApplyWithPackage:
                 parallel=False,
                 max_workers=4,
                 package_filter="my-cluster",
+                lock_timeout=0,
+                lock_ttl=3600,
             )
 
     def test_apply_with_package_shows_package_in_prompt(self, cli_runner, mock_orchestrator):

--- a/tests/unit/test_state_lock_context.py
+++ b/tests/unit/test_state_lock_context.py
@@ -1,0 +1,144 @@
+"""Unit tests for the environment_lock context manager."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from infrafoundry.core.events.types import EventType
+from infrafoundry.core.exceptions import LockAcquisitionError
+from infrafoundry.core.state import StateManager
+from infrafoundry.core.state.lock_context import environment_lock
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield f"sqlite:///{Path(tmpdir) / 'lock_ctx.db'}"
+
+
+@pytest.fixture
+def state_manager(temp_db):
+    manager = StateManager(connection_string=temp_db)
+    manager.initialize()
+    return manager
+
+
+class RecordingEventManager:
+    """Minimal stub with an ``emit_event`` method matching EventManager."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[EventType, str, dict[str, Any]]] = []
+
+    def emit_event(self, event_type: EventType, env_name: str, payload: dict[str, Any]) -> None:
+        self.events.append((event_type, env_name, payload))
+
+
+class TestEnvironmentLock:
+    def test_context_acquires_and_releases(self, state_manager: StateManager) -> None:
+        with environment_lock(state_manager, "dev", ttl=60, locked_by="me@h:1"):
+            assert state_manager.get_lock("dev") is not None
+        assert state_manager.get_lock("dev") is None
+
+    def test_context_releases_on_exception(self, state_manager: StateManager) -> None:
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            environment_lock(state_manager, "dev", ttl=60, locked_by="me@h:1"),
+        ):
+            raise RuntimeError("boom")
+        assert state_manager.get_lock("dev") is None
+
+    def test_context_timeout_polls_and_raises(self, state_manager: StateManager) -> None:
+        # Pre-seed a lock held by another owner.
+        state_manager.acquire_lock("dev", ttl_seconds=60, locked_by="holder@h:9")
+        start = time.monotonic()
+        with (
+            pytest.raises(LockAcquisitionError),
+            environment_lock(
+                state_manager,
+                "dev",
+                ttl=60,
+                locked_by="me@h:1",
+                timeout=1,
+                poll_interval=0.2,
+            ),
+        ):
+            pytest.fail("should not enter body")
+        elapsed = time.monotonic() - start
+        # Should have waited at least ~1 second before timing out.
+        assert elapsed >= 0.9
+
+    def test_context_timeout_succeeds_on_release(self, state_manager: StateManager) -> None:
+        state_manager.acquire_lock("dev", ttl_seconds=60, locked_by="holder@h:9")
+
+        def release_soon() -> None:
+            time.sleep(0.4)
+            state_manager.release_lock("dev", force=True)
+
+        t = threading.Thread(target=release_soon)
+        t.start()
+        try:
+            with environment_lock(
+                state_manager,
+                "dev",
+                ttl=60,
+                locked_by="me@h:1",
+                timeout=5,
+                poll_interval=0.1,
+            ):
+                assert state_manager.get_lock("dev").locked_by == "me@h:1"
+        finally:
+            t.join()
+        assert state_manager.get_lock("dev") is None
+
+    def test_skip_lock_env_var(
+        self, state_manager: StateManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("INFRAFOUNDRY_SKIP_LOCK", "1")
+        # Even with an active lock pre-held, skip should bypass it entirely.
+        state_manager.acquire_lock("dev", ttl_seconds=60, locked_by="other@h:2")
+        with environment_lock(state_manager, "dev", ttl=60, locked_by="me@h:1"):
+            # The existing lock is untouched.
+            lock = state_manager.get_lock("dev")
+            assert lock is not None
+            assert lock.locked_by == "other@h:2"
+        # Still there after.
+        assert state_manager.get_lock("dev") is not None
+
+    def test_lock_events_emitted(self, state_manager: StateManager) -> None:
+        ev = RecordingEventManager()
+        with environment_lock(
+            state_manager,
+            "dev",
+            ttl=60,
+            locked_by="me@h:1",
+            event_manager=ev,  # type: ignore[arg-type]
+        ):
+            pass
+        types = [e[0] for e in ev.events]
+        assert EventType.LOCK_ACQUIRED in types
+        assert EventType.LOCK_RELEASED in types
+
+    def test_lock_timeout_event_emitted(self, state_manager: StateManager) -> None:
+        state_manager.acquire_lock("dev", ttl_seconds=60, locked_by="holder@h:9")
+        ev = RecordingEventManager()
+        with (
+            pytest.raises(LockAcquisitionError),
+            environment_lock(
+                state_manager,
+                "dev",
+                ttl=60,
+                locked_by="me@h:1",
+                timeout=1,
+                poll_interval=0.2,
+                event_manager=ev,  # type: ignore[arg-type]
+            ),
+        ):
+            pass
+        types = [e[0] for e in ev.events]
+        assert EventType.LOCK_TIMEOUT in types

--- a/tests/unit/test_state_lock_repository.py
+++ b/tests/unit/test_state_lock_repository.py
@@ -1,0 +1,179 @@
+"""Unit tests for LockRepository."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from infrafoundry.core.exceptions import LockAcquisitionError
+from infrafoundry.core.state import LockRepository, StateManager
+from infrafoundry.core.state.models import Base, DeploymentLock
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test_locks.db"
+        connection_string = f"sqlite:///{db_path}"
+        yield connection_string
+
+
+@pytest.fixture
+def state_manager(temp_db):
+    """Create a StateManager with temporary database."""
+    manager = StateManager(connection_string=temp_db)
+    manager.initialize()
+    return manager
+
+
+@pytest.fixture
+def repo(state_manager: StateManager) -> LockRepository:
+    """Return the state manager's lock repository."""
+    return state_manager.locks
+
+
+class TestLockRepositoryAcquire:
+    def test_acquire_creates_lock(self, repo: LockRepository) -> None:
+        lock = repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        assert lock.environment == "dev"
+        assert lock.locked_by == "alice@host:1"
+        assert lock.expires_at > lock.acquired_at
+
+    def test_acquire_when_held_raises(self, repo: LockRepository) -> None:
+        repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        with pytest.raises(LockAcquisitionError) as excinfo:
+            repo.acquire("dev", ttl_seconds=60, locked_by="bob@host:2")
+        err = excinfo.value
+        assert err.environment == "dev"
+        assert err.locked_by == "alice@host:1"
+        assert err.acquired_at is not None
+        assert err.expires_at is not None
+
+    def test_acquire_takes_over_expired_lock(self, repo: LockRepository) -> None:
+        # Insert an already-expired row directly via the session.
+        past = datetime.now(UTC) - timedelta(hours=1)
+        with repo.SessionLocal() as session:
+            session.add(
+                DeploymentLock(
+                    environment="dev",
+                    locked_by="stale@host:99",
+                    acquired_at=past - timedelta(seconds=60),
+                    expires_at=past,
+                )
+            )
+            session.commit()
+
+        lock = repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        assert lock.locked_by == "alice@host:1"
+        assert lock.expires_at > datetime.now(UTC).replace(tzinfo=None)
+
+    def test_lock_per_environment_independent(self, repo: LockRepository) -> None:
+        repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        # Different env should still succeed.
+        lock = repo.acquire("prod", ttl_seconds=60, locked_by="alice@host:1")
+        assert lock.environment == "prod"
+
+
+class TestLockRepositoryRelease:
+    def test_release_removes_row(self, repo: LockRepository) -> None:
+        repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        released = repo.release("dev", locked_by="alice@host:1")
+        assert released is True
+        assert repo.get("dev") is None
+
+    def test_release_wrong_owner_refused_without_force(self, repo: LockRepository) -> None:
+        repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        released = repo.release("dev", locked_by="bob@host:2")
+        assert released is False
+        # Lock still present.
+        assert repo.get("dev") is not None
+
+    def test_release_force_succeeds(self, repo: LockRepository) -> None:
+        repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        released = repo.release("dev", locked_by="bob@host:2", force=True)
+        assert released is True
+        assert repo.get("dev") is None
+
+    def test_release_nonexistent_returns_false(self, repo: LockRepository) -> None:
+        assert repo.release("missing") is False
+
+
+class TestLockRepositoryCleanup:
+    def test_cleanup_stale_only_removes_expired(self, repo: LockRepository) -> None:
+        past = datetime.now(UTC) - timedelta(hours=1)
+        with repo.SessionLocal() as session:
+            session.add(
+                DeploymentLock(
+                    environment="expired",
+                    locked_by="stale@host:1",
+                    acquired_at=past - timedelta(seconds=60),
+                    expires_at=past,
+                )
+            )
+            session.commit()
+        # Active lock.
+        repo.acquire("active", ttl_seconds=300, locked_by="alice@host:1")
+
+        count = repo.cleanup_stale()
+        assert count == 1
+        assert repo.get("expired") is None
+        assert repo.get("active") is not None
+
+    def test_list_all_returns_detached(self, repo: LockRepository) -> None:
+        repo.acquire("a", ttl_seconds=60, locked_by="alice@host:1")
+        repo.acquire("b", ttl_seconds=60, locked_by="bob@host:2")
+        locks = repo.list_all()
+        assert {lock.environment for lock in locks} == {"a", "b"}
+
+
+class TestLockRepositoryConcurrency:
+    def test_concurrent_acquire_only_one_wins(self, tmp_path: Path) -> None:
+        """Two threads racing on the same SQLite file: exactly one wins."""
+        db_path = tmp_path / "race.db"
+        url = f"sqlite:///{db_path}"
+
+        # Prepare schema using one engine.
+        init_engine = create_engine(url)
+        Base.metadata.create_all(init_engine)
+        init_engine.dispose()
+
+        # Two independent engines simulating two processes.
+        def make_repo() -> LockRepository:
+            engine = create_engine(
+                url,
+                connect_args={"check_same_thread": False, "timeout": 30},
+            )
+            return LockRepository(sessionmaker(bind=engine))
+
+        repo_a = make_repo()
+        repo_b = make_repo()
+
+        barrier = threading.Barrier(2)
+        results: dict[str, object] = {}
+
+        def worker(name: str, repo: LockRepository) -> None:
+            barrier.wait()
+            try:
+                repo.acquire("shared", ttl_seconds=60, locked_by=name)
+                results[name] = "ok"
+            except LockAcquisitionError as exc:
+                results[name] = exc
+
+        t1 = threading.Thread(target=worker, args=("a@host:1", repo_a))
+        t2 = threading.Thread(target=worker, args=("b@host:2", repo_b))
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        successes = [v for v in results.values() if v == "ok"]
+        failures = [v for v in results.values() if isinstance(v, LockAcquisitionError)]
+        assert len(successes) == 1
+        assert len(failures) == 1


### PR DESCRIPTION
## Description

Adds per-environment state locking to `foundry infra apply` and `foundry infra destroy` so concurrent runs against the same environment can no longer corrupt InfraFoundry state, duplicate resource rows, or race on runner execution.

The lock is implemented as a row in a new `deployment_locks` table with a unique constraint on `environment` — that constraint is the atomic primitive, so the same mechanism works on both SQLite (default) and PostgreSQL backends. `Orchestrator.apply()` and `Orchestrator.destroy()` are wrapped in an `environment_lock` context manager that acquires on entry, releases in `finally`, and emits `LOCK_ACQUIRED` / `LOCK_RELEASED` / `LOCK_TIMEOUT` events through the existing `EventManager`. `plan` is intentionally left unlocked so CI preview workflows keep working alongside an active apply.

A new `foundry infra unlock` command provides operator visibility and recovery: list active locks, release expired ones, or `--force` an active lock with confirmation.

## Related Issue

Addresses #246

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

**Model & schema**
- Added `DeploymentLock` SQLAlchemy model with a unique index on `environment` (`src/infrafoundry/core/state/models.py`).
- Schema is delivered via the existing `Base.metadata.create_all()` path; no Alembic migration introduced (tracked separately under #196).

**Repository & context manager**
- New `LockRepository` for atomic acquire / release / list / force-release / stale-lock takeover (`src/infrafoundry/core/state/lock_repository.py`).
- New `environment_lock` context manager that wraps the repository, honors `--lock-timeout` polling, emits lifecycle events, and always releases in `finally` (`src/infrafoundry/core/state/lock_context.py`).
- `StateManager` now owns a `LockRepository` and exposes delegating methods (`src/infrafoundry/core/state/state_manager.py`).
- New `LockAcquisitionError` exception with operator-facing message (`src/infrafoundry/core/exceptions.py`).
- New event types `LOCK_ACQUIRED`, `LOCK_RELEASED`, `LOCK_TIMEOUT` (`src/infrafoundry/core/events/types.py`).

**Orchestrator**
- `apply()` and `destroy()` now run inside `environment_lock(env, timeout, ttl)`. `plan()` is unchanged.
- `LockAcquisitionError` is surfaced through the CLI decorator with an actionable message pointing to `foundry infra unlock` (`src/infrafoundry/cli/decorators.py`).

**CLI**
- New `foundry infra unlock` command: `--env`, `--force`, `--yes`, `--list` (`src/infrafoundry/cli/commands/infra/unlock.py`).
- `apply` and `destroy` gained `--lock-timeout` (default `0`, fail fast) and `--lock-ttl` (default `3600`).
- `INFRAFOUNDRY_SKIP_LOCK=1` escape hatch with a loud warning, for emergencies when the state DB is inaccessible.

**Docs & ADR**
- New `docs/decisions/0002-state-locking.md` (Status, Context, Decision, Consequences, Implementation pointers; links to #246 and `docs/architecture/state-management.md`).
- `docs/architecture/state-management.md` gained an "InfraFoundry-level locking" section.
- `docs/usage/cli-reference.md` documents `infra unlock`, the new `--lock-timeout` / `--lock-ttl` options on apply/destroy, and adds usage examples.

**Tests (29 new)**
- `tests/unit/test_state_lock_repository.py` (11) — repository acquire/release/expiry/force/list semantics.
- `tests/unit/test_state_lock_context.py` (7) — context manager behavior, polling, event emission, exception path.
- `tests/unit/test_cli_infra_unlock.py` (6) — unlock command (`--env`, `--force`, `--yes`, `--list`, refusing active locks, missing args).
- `TestOrchestratorLocking` in `tests/unit/test_orchestrator.py` (5) — apply/destroy wrapped in lock, contention, and release-on-exception.
- Updated `tests/unit/test_cli_apply.py` and `tests/unit/test_package_filter.py` for the new keyword arguments.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

29 new unit tests cover the repository, context manager, CLI, and orchestrator integration. `doit check` (format, lint, type, security, spell, full pytest) is green on this branch.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (project does not maintain a CHANGELOG.md; release notes are git-tag-based)
- [x] My changes generate no new warnings

## Additional Notes

**Deliberate design decisions**

- **Row-in-table primitive.** A unique constraint on `deployment_locks.environment` is the atomic operation. Works identically on SQLite and PostgreSQL — no backend-specific advisory locks, no extra services.
- **Fail-fast by default (`--lock-timeout 0`).** Operators see contention immediately rather than queueing silently behind another run. Opt into blocking waits with `--lock-timeout <seconds>`.
- **`plan` is intentionally unlocked.** Plan only reads state and writes generated files; CI preview jobs should never queue behind an active apply.
- **TTL-based stale recovery.** A crashed apply does not permanently block future runs. Default TTL is 1 hour; long applies should pass `--lock-ttl`.
- **Audited escape hatches.** `foundry infra unlock --force` (with confirm) for ops; `INFRAFOUNDRY_SKIP_LOCK=1` for emergencies, both noisy.

**Out of scope (follow-ups)**

- Lock heartbeat / TTL extension during long-running applies.
- Alembic migration for the new table — schema is currently created via `Base.metadata.create_all()`; broader Alembic adoption is tracked under #196.
- Direct `terraform`/`ansible` invocations against generated files bypass the foundry lock by design. The mitigating user contract is documented in `feedback_use_infra_not_terraform.md`.
- Distributed coordination backends (Redis, etcd) — not needed for the current single-state-DB model.
