### PR TITLE
feat: add lock heartbeat for long-running applies

### DIFF
--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -274,14 +274,40 @@ Key behavior:
 - **Fail fast by default.** `foundry infra apply --env prod` rejects
   immediately if another run holds the lock. Pass `--lock-timeout <seconds>`
   to wait instead.
-- **TTL-based stale recovery.** Locks carry an `expires_at` (default 1 hour,
-  tunable via `--lock-ttl <seconds>`). A crashed run stops blocking new runs
-  once its lock expires.
+- **TTL-based stale recovery.** Locks carry an `expires_at` (default 10
+  minutes, tunable via `--lock-ttl <seconds>`). A crashed run stops blocking
+  new runs once its lock expires. Live runs are kept alive past the TTL by
+  the heartbeat (see below).
 - **Holder identity.** Each lock records `user@host:pid` in `locked_by` and a
   timestamp in `acquired_at`.
-- **Event emission.** `LOCK_ACQUIRED`, `LOCK_RELEASED`, and `LOCK_TIMEOUT`
-  events flow through the existing `EventManager` for auditing and
-  notifications.
+- **Event emission.** `LOCK_ACQUIRED`, `LOCK_RELEASED`, `LOCK_TIMEOUT`, and
+  `LOCK_HEARTBEAT_FAILED` events flow through the existing `EventManager` for
+  auditing and notifications.
+
+##### Heartbeat
+
+While `apply` or `destroy` is running, a background daemon thread
+auto-extends the lock every `ttl / 3` seconds. With the default TTL of 600 s
+the heartbeat fires every ~200 s, giving three chances to refresh before
+expiry. This decouples "how long can an apply run" from "how long is a
+crashed holder considered dead":
+
+- Long applies (hours) keep their lock indefinitely while the process is
+  alive — there is no need to guess a TTL upfront.
+- Crashed holders free the lock within the TTL window instead of within an
+  hour, so the next run recovers quickly.
+
+If the heartbeat cannot extend the lock (DB hiccup, row taken over after a
+previous expiry, etc.), it logs the failure and emits a
+`LOCK_HEARTBEAT_FAILED` event, then **continues looping**. The in-flight
+apply is deliberately **not** aborted — aborting on a transient DB failure
+is strictly worse than letting the apply finish under a still-ticking TTL.
+
+If you see `LOCK_HEARTBEAT_FAILED` events in your logs, investigate the
+state DB connectivity. The apply itself is unaffected as long as it finishes
+before the TTL elapses; if it does not, another process may take over the
+stale row. There is no knob to disable or reconfigure the heartbeat — the
+interval is always `ttl / 3`.
 
 Managing locks from the CLI:
 

--- a/docs/decisions/0002-state-locking.md
+++ b/docs/decisions/0002-state-locking.md
@@ -28,7 +28,9 @@ Introduce a `deployment_locks` table with a unique index on `environment`. Wrap 
 3. On contention, immediately raises `LockAcquisitionError` (default `--lock-timeout 0`). Operators can opt into blocking waits with `--lock-timeout <seconds>`.
 4. Recovers automatically from expired locks: the next acquirer updates the row in place rather than refusing.
 5. Always releases in `finally`, even on exception.
-6. Emits `LOCK_ACQUIRED` / `LOCK_RELEASED` / `LOCK_TIMEOUT` events through the existing `EventManager`.
+6. Emits `LOCK_ACQUIRED` / `LOCK_RELEASED` / `LOCK_TIMEOUT` / `LOCK_HEARTBEAT_FAILED` events through the existing `EventManager`.
+
+A background heartbeat thread started by `environment_lock` auto-extends the lock every `ttl/3` seconds while the holding process is alive, so a long-running apply never self-evicts. Because the heartbeat decouples "how long can an apply run" from "how long must we wait before considering a crashed holder dead", the default TTL was lowered from 1 hour to **10 minutes** (600 s). Heartbeat failures (DB hiccup, row taken over after a prior expiry) are logged and emitted as `LOCK_HEARTBEAT_FAILED` but do **not** abort the in-flight apply — aborting on a transient failure is worse than continuing under a ticking TTL.
 
 Management surface:
 - `foundry infra unlock --env <name>` refuses active locks, releases expired ones.
@@ -52,14 +54,17 @@ Schema change is delivered through `Base.metadata.create_all()` - the existing i
 
 **Negative / trade-offs**
 
-- TTL-based recovery introduces a time window where a truly alive but slow process may have its lock taken over. The default TTL (1 hour) is conservative for realistic apply durations, but operations running longer than the TTL need to supply `--lock-ttl`.
+- TTL-based recovery introduces a time window where a truly alive but slow process may have its lock taken over. With the heartbeat in place the default TTL is 10 minutes — small enough for fast crash recovery, and the heartbeat keeps live applies from self-evicting. Operators can still raise `--lock-ttl` if their environment has sustained DB connectivity issues that block heartbeats.
 - The lock is advisory from Terraform's perspective - if someone runs `terraform apply` directly against the same generated files while a foundry apply holds the lock, the direct invocation is not blocked. See feedback `feedback_use_infra_not_terraform.md` for the mitigating user contract.
 - Requires manual intervention (`unlock --force`) when a process dies holding a lock and TTL has not yet expired.
 - `INFRAFOUNDRY_SKIP_LOCK` exists and can be abused; this is an accepted trade-off for emergencies.
 
+**Follow-ups (resolved)**
+
+- Lock heartbeat / TTL extension during long applies — delivered in #498. See the "Decision" section above and `docs/architecture/state-management.md` (section "Heartbeat").
+
 **Out of scope (follow-ups)**
 
-- Lock heartbeat / TTL extension during long applies.
 - Distributed coordination backends (Redis, etcd).
 - Locking `plan`.
 - Alembic migrations (tracked separately under #196).

--- a/docs/usage/cli-reference.md
+++ b/docs/usage/cli-reference.md
@@ -62,7 +62,7 @@ infra destroy --env dev --auto-approve
   - `infra reset --env <env> --provider <provider> --component <component> [--auto-approve]` — completely remove component configuration from provider for clean reapply.
   - **Lock options on apply/destroy:**
     - `--lock-timeout <seconds>` — how long to wait for an existing lock before failing. Default `0` (fail fast).
-    - `--lock-ttl <seconds>` — how long the acquired lock is valid before it is considered stale. Default `3600` (1 hour).
+    - `--lock-ttl <seconds>` — how long the acquired lock is valid before it is considered stale. The lock is auto-extended every `ttl / 3` seconds while the process runs, so this only governs stale-lock recovery after a crash. Default `600` (10 minutes).
 - **Locking**
   - `infra unlock --env <env>` — release an expired lock for the environment (refuses to release active locks).
   - `infra unlock --env <env> --force [--yes]` — force-release an active lock; prompts for confirmation unless `--yes` is supplied.
@@ -196,8 +196,9 @@ infra destroy --env dev --auto-approve
   # Wait up to 5 minutes for an active lock before failing
   infra apply --env prod --lock-timeout 300
 
-  # Use a longer TTL for a slow apply
-  infra apply --env prod --lock-ttl 7200
+  # Use a longer TTL as a safety net (the lock is auto-extended while the
+  # process runs; this only matters for recovering from a crashed holder).
+  infra apply --env prod --lock-ttl 1800
 
   # Inspect current locks
   infra unlock --list

--- a/src/infrafoundry/cli/commands/infra/apply.py
+++ b/src/infrafoundry/cli/commands/infra/apply.py
@@ -44,8 +44,12 @@ from ...utils import console
 @click.option(
     "--lock-ttl",
     type=int,
-    default=3600,
-    help="Lock TTL in seconds for stale-lock recovery (default: 3600).",
+    default=600,
+    help=(
+        "Lock TTL in seconds. The lock is auto-extended while the process "
+        "runs; this only governs stale-lock recovery after a crash "
+        "(default: 600)."
+    ),
 )
 @with_orchestrator("Apply failed")
 def apply(

--- a/src/infrafoundry/cli/commands/infra/destroy.py
+++ b/src/infrafoundry/cli/commands/infra/destroy.py
@@ -33,8 +33,12 @@ from ...utils import console
 @click.option(
     "--lock-ttl",
     type=int,
-    default=3600,
-    help="Lock TTL in seconds for stale-lock recovery (default: 3600).",
+    default=600,
+    help=(
+        "Lock TTL in seconds. The lock is auto-extended while the process "
+        "runs; this only governs stale-lock recovery after a crash "
+        "(default: 600)."
+    ),
 )
 @with_orchestrator("Destroy failed")
 def destroy(

--- a/src/infrafoundry/core/events/types.py
+++ b/src/infrafoundry/core/events/types.py
@@ -77,6 +77,7 @@ class EventType(StrEnum):
     LOCK_ACQUIRED = "lock_acquired"
     LOCK_RELEASED = "lock_released"
     LOCK_TIMEOUT = "lock_timeout"
+    LOCK_HEARTBEAT_FAILED = "lock_heartbeat_failed"
 
 
 class HandlerType(StrEnum):

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -539,7 +539,7 @@ class Orchestrator:
         max_workers: int = 4,
         package_filter: str | None = None,
         lock_timeout: int = 0,
-        lock_ttl: int = 3600,
+        lock_ttl: int = 600,
     ) -> dict[str, Any]:
         """Apply infrastructure changes.
 
@@ -552,7 +552,9 @@ class Orchestrator:
             package_filter: Optional package name to restrict event handlers
             lock_timeout: Seconds to wait for the environment lock before
                 failing. ``0`` (default) fails fast.
-            lock_ttl: Lock TTL in seconds (default: 1 hour).
+            lock_ttl: Lock TTL in seconds (default: 10 minutes). The lock is
+                extended automatically while the process runs, so this only
+                governs stale-lock recovery after a crash.
 
         Returns:
             Dict with apply results per provider
@@ -667,7 +669,7 @@ class Orchestrator:
         confirm_callback: Callable[[], bool] | None = None,
         package_filter: str | None = None,
         lock_timeout: int = 0,
-        lock_ttl: int = 3600,
+        lock_ttl: int = 600,
     ) -> dict[str, Any]:
         """Destroy infrastructure.
 
@@ -679,7 +681,9 @@ class Orchestrator:
             package_filter: Optional package name to restrict event handlers
             lock_timeout: Seconds to wait for the environment lock before
                 failing. ``0`` (default) fails fast.
-            lock_ttl: Lock TTL in seconds (default: 1 hour).
+            lock_ttl: Lock TTL in seconds (default: 10 minutes). The lock is
+                extended automatically while the process runs, so this only
+                governs stale-lock recovery after a crash.
 
         Returns:
             Dict with destroy results per provider

--- a/src/infrafoundry/core/state/lock_context.py
+++ b/src/infrafoundry/core/state/lock_context.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from infrafoundry.core.events.types import EventType
@@ -108,9 +110,33 @@ def environment_lock(
             },
         )
 
+    # Start the heartbeat thread that periodically extends the lock so a
+    # long-running apply does not self-evict when it exceeds ``ttl``.
+    heartbeat_interval = max(1.0, ttl / 3)
+    stop_event = threading.Event()
+    heartbeat_thread = threading.Thread(
+        target=_heartbeat_loop,
+        args=(
+            stop_event,
+            state_manager,
+            env_name,
+            locked_by,
+            ttl,
+            heartbeat_interval,
+            event_manager,
+        ),
+        daemon=True,
+        name=f"lock-heartbeat-{env_name}",
+    )
+    heartbeat_thread.start()
+
     try:
         yield
     finally:
+        # Signal the heartbeat thread to stop before releasing the lock so a
+        # final in-flight extend cannot race the delete.
+        stop_event.set()
+        heartbeat_thread.join(timeout=heartbeat_interval + 1)
         try:
             state_manager.release_lock(env_name, locked_by=locked_by, force=True)
         except Exception:
@@ -122,6 +148,62 @@ def environment_lock(
                     env_name,
                     {"locked_by": locked_by},
                 )
+
+
+def _heartbeat_loop(
+    stop_event: threading.Event,
+    state_manager: StateManager,
+    env_name: str,
+    locked_by: str,
+    ttl: int,
+    interval: float,
+    event_manager: EventManager | None,
+) -> None:
+    """Periodically extend the environment lock until signaled to stop.
+
+    Runs in a daemon thread. Each iteration waits ``interval`` seconds on
+    ``stop_event`` (which atomically returns True when set). On wakeup it
+    attempts to extend the lock. Any failure is logged and emitted as a
+    ``LOCK_HEARTBEAT_FAILED`` event, but the loop continues — aborting an
+    in-flight apply on a transient DB hiccup is worse than letting it run.
+    The outer ``try/except Exception`` ensures a bug inside this loop can
+    never kill the daemon thread silently.
+    """
+    while True:
+        if stop_event.wait(interval):
+            return
+        try:
+            new_expires_at = datetime.now(UTC) + timedelta(seconds=ttl)
+            extended = state_manager.extend_lock(env_name, locked_by, new_expires_at)
+            if not extended:
+                logger.warning(
+                    "Failed to extend lock on environment '%s' "
+                    "(row missing or owned by another holder); continuing.",
+                    env_name,
+                )
+                if event_manager is not None:
+                    event_manager.emit_event(
+                        EventType.LOCK_HEARTBEAT_FAILED,
+                        env_name,
+                        {
+                            "locked_by": locked_by,
+                            "reason": "extend_returned_false",
+                        },
+                    )
+        except Exception as exc:
+            logger.exception("Heartbeat for environment '%s' raised; continuing.", env_name)
+            if event_manager is not None:
+                try:
+                    event_manager.emit_event(
+                        EventType.LOCK_HEARTBEAT_FAILED,
+                        env_name,
+                        {
+                            "locked_by": locked_by,
+                            "reason": f"exception: {exc}",
+                        },
+                    )
+                except Exception:
+                    logger.exception("Failed to emit LOCK_HEARTBEAT_FAILED for '%s'.", env_name)
 
 
 def _acquire_with_timeout(

--- a/src/infrafoundry/core/state/lock_repository.py
+++ b/src/infrafoundry/core/state/lock_repository.py
@@ -162,6 +162,44 @@ class LockRepository:
             session.commit()
             return True
 
+    def extend(
+        self,
+        environment: str,
+        locked_by: str,
+        new_expires_at: datetime,
+    ) -> bool:
+        """Extend the expiration of an owned lock.
+
+        Args:
+            environment: Environment name whose lock should be extended.
+            locked_by: Owner identifier; the row is only updated when this
+                matches the current ``locked_by`` value.
+            new_expires_at: New absolute expiration timestamp.
+
+        Returns:
+            ``True`` if the row was updated. ``False`` if the row is missing
+            or owned by a different holder (e.g. it was taken over after
+            expiry by another process). Caller is responsible for deciding
+            what to do with a ``False`` return — typically: log, emit a
+            ``LOCK_HEARTBEAT_FAILED`` event, and continue. No exception path
+            is taken for "wrong owner" — heartbeat must not raise into the
+            caller's apply loop.
+        """
+        with self.SessionLocal() as session:
+            lock = (
+                session.query(DeploymentLock)
+                .filter(DeploymentLock.environment == environment)
+                .one_or_none()
+            )
+            if lock is None:
+                return False
+            if lock.locked_by != locked_by:
+                # Wrong owner: silent refusal, caller handles via return value.
+                return False
+            lock.expires_at = new_expires_at
+            session.commit()
+            return True
+
     def get(self, environment: str) -> DeploymentLock | None:
         """Return the current lock row for ``environment``, if any.
 

--- a/src/infrafoundry/core/state/state_manager.py
+++ b/src/infrafoundry/core/state/state_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -331,6 +332,26 @@ class StateManager(BaseManager):
             True if a lock row was removed, False otherwise.
         """
         return self.locks.release(environment, locked_by=locked_by, force=force)
+
+    def extend_lock(
+        self,
+        environment: str,
+        locked_by: str,
+        new_expires_at: datetime,
+    ) -> bool:
+        """Extend the expiration of an owned deployment lock.
+
+        Args:
+            environment: Environment name.
+            locked_by: Owner identifier; extension only succeeds when it
+                matches the current holder.
+            new_expires_at: New absolute expiration timestamp.
+
+        Returns:
+            True if the row was updated, False when missing or owned by
+            another holder.
+        """
+        return self.locks.extend(environment, locked_by, new_expires_at)
 
     def get_lock(self, environment: str) -> DeploymentLock | None:
         """Return the current lock row for ``environment`` if any."""

--- a/tests/unit/test_cli_apply.py
+++ b/tests/unit/test_cli_apply.py
@@ -39,7 +39,7 @@ def test_apply_with_confirmation(cli_runner, mock_orchestrator):
             max_workers=4,
             package_filter=None,
             lock_timeout=0,
-            lock_ttl=3600,
+            lock_ttl=600,
         )
 
 
@@ -69,7 +69,7 @@ def test_apply_with_auto_approve(cli_runner, mock_orchestrator):
             max_workers=4,
             package_filter=None,
             lock_timeout=0,
-            lock_ttl=3600,
+            lock_ttl=600,
         )
 
 
@@ -90,7 +90,7 @@ def test_apply_with_resource_filter(cli_runner, mock_orchestrator):
             max_workers=4,
             package_filter=None,
             lock_timeout=0,
-            lock_ttl=3600,
+            lock_ttl=600,
         )
 
 
@@ -120,7 +120,7 @@ def test_apply_with_parallel(cli_runner, mock_orchestrator):
             max_workers=8,
             package_filter=None,
             lock_timeout=0,
-            lock_ttl=3600,
+            lock_ttl=600,
         )
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -599,6 +599,34 @@ class TestOrchestratorLocking:
         assert captured["lock"] is not None
         assert orchestrator.state_manager.get_lock("dev") is None
 
+    def test_apply_default_ttl_is_600(self, tmp_path):
+        from datetime import UTC
+
+        orchestrator = self._make_orchestrator(tmp_path)
+
+        captured: dict = {}
+
+        def record_apply(**kwargs):
+            captured["lock"] = orchestrator.state_manager.get_lock("dev")
+            return {}
+
+        orchestrator.apply_orchestrator.apply.side_effect = record_apply
+
+        orchestrator.apply("dev", auto_approve=True)
+
+        lock = captured["lock"]
+        assert lock is not None
+        acquired = lock.acquired_at
+        expires = lock.expires_at
+        if acquired.tzinfo is None:
+            acquired = acquired.replace(tzinfo=UTC)
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=UTC)
+        delta = (expires - acquired).total_seconds()
+        # Default TTL is 600s; allow a small tolerance for heartbeat
+        # extensions that might have fired before we captured the row.
+        assert 590 <= delta <= 1200
+
     def test_plan_does_not_acquire_lock(self, tmp_path):
         orchestrator = self._make_orchestrator(tmp_path)
         # Pre-seed an active lock; plan should still proceed.

--- a/tests/unit/test_package_filter.py
+++ b/tests/unit/test_package_filter.py
@@ -242,7 +242,7 @@ class TestApplyWithPackage:
                 max_workers=4,
                 package_filter="my-cluster",
                 lock_timeout=0,
-                lock_ttl=3600,
+                lock_ttl=600,
             )
 
     def test_apply_with_package_shows_package_in_prompt(self, cli_runner, mock_orchestrator):

--- a/tests/unit/test_state_lock_context.py
+++ b/tests/unit/test_state_lock_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 import threading
 import time
+from datetime import UTC
 from pathlib import Path
 from typing import Any
 
@@ -142,3 +143,124 @@ class TestEnvironmentLock:
             pass
         types = [e[0] for e in ev.events]
         assert EventType.LOCK_TIMEOUT in types
+
+
+def _as_utc(value):
+    """Normalize a (possibly naive) datetime to UTC for comparison."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+class TestEnvironmentLockHeartbeat:
+    """Tests for the background heartbeat that auto-extends the lock."""
+
+    def test_heartbeat_extends_lock_during_hold(self, state_manager: StateManager) -> None:
+        # ttl=3 => heartbeat interval == 1s. Sleep 2.5s so at least two
+        # heartbeats fire and we can observe the expiration advance past
+        # the initial value.
+        with environment_lock(state_manager, "dev", ttl=3, locked_by="me@h:1"):
+            initial = state_manager.get_lock("dev")
+            assert initial is not None
+            initial_expires = _as_utc(initial.expires_at)
+            time.sleep(2.5)
+            current = state_manager.get_lock("dev")
+            assert current is not None
+            current_expires = _as_utc(current.expires_at)
+            assert current_expires > initial_expires
+        assert state_manager.get_lock("dev") is None
+
+    def test_heartbeat_stops_on_context_exit(self, state_manager: StateManager) -> None:
+        calls: list[tuple[str, str]] = []
+        original = state_manager.extend_lock
+
+        def recording_extend(env_name, locked_by, new_expires_at):
+            calls.append((env_name, locked_by))
+            return original(env_name, locked_by, new_expires_at)
+
+        state_manager.extend_lock = recording_extend  # type: ignore[method-assign]
+        try:
+            with environment_lock(state_manager, "dev", ttl=3, locked_by="me@h:1"):
+                time.sleep(1.3)
+            calls_after_exit = len(calls)
+            # Give the daemon thread some extra time; if it's really
+            # stopped, no further DB writes should occur.
+            time.sleep(2.0)
+            assert len(calls) == calls_after_exit
+        finally:
+            state_manager.extend_lock = original  # type: ignore[method-assign]
+
+    def test_heartbeat_failure_emits_event(self, state_manager: StateManager) -> None:
+        ev = RecordingEventManager()
+        original = state_manager.extend_lock
+        state_manager.extend_lock = (  # type: ignore[method-assign]
+            lambda env_name, locked_by, new_expires_at: False
+        )
+        try:
+            with environment_lock(
+                state_manager,
+                "dev",
+                ttl=3,
+                locked_by="me@h:1",
+                event_manager=ev,  # type: ignore[arg-type]
+            ):
+                # Wait long enough for at least one heartbeat iteration.
+                time.sleep(1.3)
+                # Apply body continues uninterrupted — no exception raised.
+                assert state_manager.get_lock("dev") is not None
+        finally:
+            state_manager.extend_lock = original  # type: ignore[method-assign]
+
+        types = [e[0] for e in ev.events]
+        assert EventType.LOCK_HEARTBEAT_FAILED in types
+
+    def test_heartbeat_continues_after_transient_failure(self, state_manager: StateManager) -> None:
+        ev = RecordingEventManager()
+        original = state_manager.extend_lock
+        call_count = {"n": 0}
+
+        def flaky_extend(env_name, locked_by, new_expires_at):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return False  # transient failure
+            return original(env_name, locked_by, new_expires_at)
+
+        state_manager.extend_lock = flaky_extend  # type: ignore[method-assign]
+        try:
+            with environment_lock(
+                state_manager,
+                "dev",
+                ttl=3,
+                locked_by="me@h:1",
+                event_manager=ev,  # type: ignore[arg-type]
+            ):
+                # Wait long enough for at least two heartbeat iterations
+                # so we see both the failure and a subsequent success.
+                time.sleep(2.3)
+        finally:
+            state_manager.extend_lock = original  # type: ignore[method-assign]
+
+        # At least one failure event emitted, and at least two calls made.
+        failure_events = [e for e in ev.events if e[0] == EventType.LOCK_HEARTBEAT_FAILED]
+        assert len(failure_events) >= 1
+        assert call_count["n"] >= 2
+        # Lock was released cleanly.
+        assert state_manager.get_lock("dev") is None
+
+    def test_long_running_lock_does_not_self_evict(self, state_manager: StateManager) -> None:
+        # ttl=2 => heartbeat every ~0.67s. Hold for 4s (> 2 * ttl) so
+        # without a heartbeat the lock would expire mid-hold. With
+        # heartbeat, it must remain continuously active.
+        with environment_lock(state_manager, "dev", ttl=2, locked_by="me@h:1"):
+            deadline = time.monotonic() + 4.0
+            while time.monotonic() < deadline:
+                lock = state_manager.get_lock("dev")
+                assert lock is not None
+                # Lock's expires_at must remain in the future throughout.
+                from datetime import datetime
+
+                now = datetime.now(UTC)
+                expires = _as_utc(lock.expires_at)
+                assert expires > now
+                time.sleep(0.3)
+        assert state_manager.get_lock("dev") is None

--- a/tests/unit/test_state_lock_repository.py
+++ b/tests/unit/test_state_lock_repository.py
@@ -133,6 +133,47 @@ class TestLockRepositoryCleanup:
         assert {lock.environment for lock in locks} == {"a", "b"}
 
 
+class TestLockRepositoryExtend:
+    def test_extend_advances_expires_at(self, repo: LockRepository) -> None:
+        lock = repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        original_expires = lock.expires_at
+        new_expires = datetime.now(UTC) + timedelta(seconds=600)
+        assert repo.extend("dev", "alice@host:1", new_expires) is True
+
+        current = repo.get("dev")
+        assert current is not None
+        current_expires = current.expires_at
+        if current_expires.tzinfo is None:
+            current_expires = current_expires.replace(tzinfo=UTC)
+        if original_expires.tzinfo is None:
+            original_expires = original_expires.replace(tzinfo=UTC)
+        assert current_expires > original_expires
+
+    def test_extend_wrong_owner_returns_false(self, repo: LockRepository) -> None:
+        repo.acquire("dev", ttl_seconds=60, locked_by="alice@host:1")
+        before = repo.get("dev")
+        assert before is not None
+        new_expires = datetime.now(UTC) + timedelta(seconds=600)
+        assert repo.extend("dev", "bob@host:2", new_expires) is False
+
+        after = repo.get("dev")
+        assert after is not None
+        # Row unchanged: same owner, same expires_at.
+        assert after.locked_by == "alice@host:1"
+        before_expires = before.expires_at
+        after_expires = after.expires_at
+        if before_expires.tzinfo is None:
+            before_expires = before_expires.replace(tzinfo=UTC)
+        if after_expires.tzinfo is None:
+            after_expires = after_expires.replace(tzinfo=UTC)
+        assert before_expires == after_expires
+
+    def test_extend_missing_row_returns_false(self, repo: LockRepository) -> None:
+        new_expires = datetime.now(UTC) + timedelta(seconds=600)
+        assert repo.extend("ghost", "alice@host:1", new_expires) is False
+        assert repo.get("ghost") is None
+
+
 class TestLockRepositoryConcurrency:
     def test_concurrent_acquire_only_one_wins(self, tmp_path: Path) -> None:
         """Two threads racing on the same SQLite file: exactly one wins."""


### PR DESCRIPTION
## Description

Adds an automatic lock heartbeat so long-running `apply` / `destroy`
operations never self-evict from the environment lock, and lowers the
default `--lock-ttl` from 3600 s to 600 s.

Before this change, the environment lock acquired by `Orchestrator.apply()`
/ `destroy()` carried a fixed TTL chosen up-front. Operators had to guess
how long their apply might run and inflate the TTL accordingly — but a
long TTL also meant a crashed holder blocked future runs for just as long.
These two concerns are in direct tension and cannot both be satisfied by a
single static value.

The heartbeat decouples them. A background daemon thread refreshes
`expires_at` every `ttl / 3` seconds while the holding process is alive, so
an apply that runs for hours keeps its lock indefinitely. A crashed holder,
by contrast, stops extending immediately and its row becomes eligible for
takeover within the (now much shorter) TTL window. Because live processes
no longer depend on the TTL to stay alive, the default drops from
**3600 s → 600 s**, shrinking the stale-recovery window by 6×.

**Failure policy:** heartbeat extend failures (DB hiccup, row taken over
after a prior expiry, etc.) are logged and emitted as a new
`LOCK_HEARTBEAT_FAILED` event, but the in-flight apply is **not** aborted.
Aborting a live apply on a transient DB blip is strictly worse than
letting it finish under a still-ticking TTL. If the apply does not finish
before the TTL elapses, another process may legitimately take over.

**Heartbeat interval is not user-tunable.** It is always derived as
`ttl / 3` — three refresh attempts before expiry is a reasonable safety
margin and one less knob for operators to misconfigure.

## Related Issue

Addresses #498

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

**State / lock layer:**
- `lock_repository.py`: new `extend(environment, new_expires_at)` that
  updates `expires_at` only if the caller still owns the row.
- `state_manager.py`: thin `extend_lock()` delegation.
- `lock_context.py`: background daemon `Thread` started on acquire and
  joined on release. Loops on a `threading.Event` with `ttl / 3` timeout.
- `events/types.py`: new `LOCK_HEARTBEAT_FAILED` event.

**Defaults:**
- `orchestrator.py`: `apply()` / `destroy()` `lock_ttl` default 3600 → 600.
- `cli/commands/infra/apply.py` and `destroy.py`: `--lock-ttl` Click
  default 3600 → 600.

**Tests (9 new):**
- `test_state_lock_repository.py`: 3 tests covering `extend()` — success,
  row-not-owned, and expired-row cases.
- `test_state_lock_context.py`: 5 tests covering the heartbeat thread —
  extends on interval, stops cleanly on release, survives extend failures,
  emits `LOCK_HEARTBEAT_FAILED`, and uses `ttl / 3` interval.
- `test_orchestrator.py`: `test_apply_default_ttl_is_600` pins the new
  default so it cannot silently regress.
- `test_cli_apply.py` and `test_package_filter.py`: updated existing
  assertions to expect `600` rather than `3600`.

**Docs:**
- `docs/decisions/0002-state-locking.md`: heartbeat paragraph in the
  Decision section, new "Follow-ups (resolved)" entry linking #498.
- `docs/architecture/state-management.md`: new "Heartbeat" subsection
  explaining the interval, failure policy, and rationale for the TTL
  reduction.
- `docs/usage/cli-reference.md`: updated `--lock-ttl` default and added
  note that the lock auto-extends every `ttl / 3` seconds.

## User-Visible Behavior Change

`--lock-ttl` default changes from **3600 s (1 hour)** to **600 s
(10 minutes)**. This is safe because:

1. Live applies are kept fresh by the heartbeat, so they no longer need
   a TTL large enough to cover their full runtime.
2. Crashed holders are recovered 6× faster.

Operators who previously relied on the 3600 s default without passing
`--lock-ttl` will see no functional difference for successful runs. If
they had a workflow that depended on a longer stale-recovery window, they
can still pass `--lock-ttl 3600` explicitly.

New `LOCK_HEARTBEAT_FAILED` event is emitted on extend failures, giving
operators observability into DB connectivity issues affecting the lock
layer.

## Testing

- [x] All existing tests pass (`doit check` green — 2505 tests passing)
- [x] Added new tests for new functionality (9 new tests)
- [x] Heartbeat behavior verified via unit tests using a real in-memory
      `StateManager` and `threading.Event` coordination

## Checklist

- [x] Code follows project style (`doit format` clean)
- [x] Linting passes (`doit lint`)
- [x] Type checking passes (`doit type_check`)
- [x] Tests added and passing (`doit test`)
- [x] Documentation updated (ADR-0002, state-management.md, cli-reference.md)
- [x] No new warnings

Addresses #498
