### PR TITLE
fix: render full timestamps in 'infra unlock --list'

### DIFF
--- a/src/infrafoundry/cli/commands/infra/unlock.py
+++ b/src/infrafoundry/cli/commands/infra/unlock.py
@@ -43,6 +43,9 @@ def unlock(
         table.add_column("Status", style="magenta")
         now = datetime.now(UTC)
         for lock in locks:
+            acquired = lock.acquired_at
+            if acquired.tzinfo is None:
+                acquired = acquired.replace(tzinfo=UTC)
             expires = lock.expires_at
             if expires.tzinfo is None:
                 expires = expires.replace(tzinfo=UTC)
@@ -50,8 +53,8 @@ def unlock(
             table.add_row(
                 lock.environment,
                 lock.locked_by,
-                str(lock.acquired_at),
-                str(lock.expires_at),
+                acquired.strftime("%Y-%m-%d %H:%M:%S %Z"),
+                expires.strftime("%Y-%m-%d %H:%M:%S %Z"),
                 status,
             )
         console.print(table)

--- a/tests/unit/test_cli_infra_unlock.py
+++ b/tests/unit/test_cli_infra_unlock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
@@ -79,13 +80,19 @@ def test_unlock_list_shows_all_locks(cli_runner, mock_orchestrator):
     ]
 
     with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
-        result = cli_runner.invoke(main, ["infra", "unlock", "--list"])
+        # Wider terminal so rich does not squeeze the auto-sized columns and we
+        # can assert on the full rendered output.
+        result = cli_runner.invoke(main, ["infra", "unlock", "--list"], env={"COLUMNS": "200"})
 
     assert result.exit_code == 0, result.output
     assert "dev" in result.output
     assert "prod" in result.output
     assert "active" in result.output
     assert "expired" in result.output
+    # Timestamps must render with full HH:MM:SS UTC, not be truncated to a date.
+    # The pattern is enforced so a regression to bare str(datetime) (which gets
+    # truncated by rich's column auto-sizing) is caught.
+    assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC", result.output)
 
 
 def test_unlock_nonexistent_env_reports_no_lock(cli_runner, mock_orchestrator):


### PR DESCRIPTION
## Description

`foundry infra unlock --list` previously rendered the Acquired and Expires
columns via `str(datetime)`, producing strings like
`2026-04-07 10:56:37.352233+00:00` (~32 characters). Rich's auto-sized
table columns squeezed those down to just the date:

```
│ prod        │ endavis@ericfw1… │ 2026-04-07       │ 2026-04-07      │ active │
```

This defeats the diagnostic purpose of `--list`, which exists to watch the
heartbeat advance `expires_at` over time during a long apply.

The fix formats both columns as `YYYY-MM-DD HH:MM:SS UTC` (~23 characters)
via `strftime`. The shorter strings fit in rich's auto-sized column without
truncation in any reasonably-wide terminal. Naive datetimes are normalized
to UTC first, mirroring the existing pattern at the top of the listing
loop. No change to the underlying lock model — purely a presentation fix.

Verified live during an in-progress apply with `--lock-ttl 30`: the
Expires column visibly walks forward as the heartbeat extends the lock,
which is exactly the workflow #498 enabled and the column needs to
support.

## Related Issue

Addresses #500

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/infrafoundry/cli/commands/infra/unlock.py`: format Acquired and
  Expires via `strftime("%Y-%m-%d %H:%M:%S %Z")`. Normalize naive
  `acquired_at` to UTC (parallel to the existing `expires_at`
  normalization).
- `tests/unit/test_cli_infra_unlock.py`: regression assertion that the
  rendered output contains a full `YYYY-MM-DD HH:MM:SS UTC` timestamp,
  so a future regression to bare `str(datetime)` is caught. Test invokes
  the CLI with `COLUMNS=200` so rich does not squeeze the auto-sized
  columns under the runner's default 80-col width.

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Updated `test_unlock_list_shows_all_locks` with the new regression
      assertion
- [x] Live smoke-tested against an active apply lock — timestamps render
      with full date and time, heartbeat extension visible

## Checklist

- [x] Code follows project style (`doit format` clean)
- [x] Linting passes (`doit lint`)
- [x] Type checking passes (`doit type_check`)
- [x] Tests added and passing (`doit test`)
- [x] No documentation update needed (purely a presentation fix to an
      existing command; CLI reference does not document the table layout)

Addresses #500
