### PR TITLE
feat: support jinja control-flow loops in inventory schemas

### DIFF
--- a/src/infrafoundry/core/config/blueprint_resolver.py
+++ b/src/infrafoundry/core/config/blueprint_resolver.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import yaml
 
+from infrafoundry.core.config.manifest_utils import extract_inventory_block
 from infrafoundry.core.exceptions import InvalidConfigurationError
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,7 @@ class BlueprintResolver:
         if not manifest_path.exists():
             raise InvalidConfigurationError(f"Blueprint manifest not found: {manifest_path}")
 
-        data = self._load_manifest(manifest_path)
+        data, inventory_raw = self._load_manifest(manifest_path)
         self._validate_manifest(data, manifest_path)
 
         # Normalise optional fields
@@ -91,6 +92,7 @@ class BlueprintResolver:
             "resources": data.get("resources", []),
             "events": data.get("events", {}),
             "inventory": data.get("inventory"),
+            "inventory_raw": inventory_raw,
             "blueprint_dir": blueprint_dir,
         }
 
@@ -167,21 +169,33 @@ class BlueprintResolver:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    def _load_manifest(manifest_path: Path) -> tuple[dict[str, Any], str | None]:
         """Load a blueprint.yaml file.
+
+        Extracts the top-level ``inventory:`` block as raw text before
+        YAML parsing so that Jinja control-flow tags can survive to the
+        inventory generator.
 
         Args:
             manifest_path: Path to the blueprint.yaml file.
 
         Returns:
-            Parsed YAML data.
+            Tuple of ``(parsed_data, inventory_raw)``.
 
         Raises:
             InvalidConfigurationError: On YAML errors.
         """
         try:
-            with open(manifest_path) as f:
-                data = yaml.safe_load(f)
+            file_text = manifest_path.read_text()
+        except OSError as e:
+            raise InvalidConfigurationError(
+                f"Failed to read blueprint manifest {manifest_path}: {e}"
+            ) from e
+
+        text_without_inventory, inventory_raw = extract_inventory_block(file_text)
+
+        try:
+            data = yaml.safe_load(text_without_inventory)
         except yaml.YAMLError as e:
             raise InvalidConfigurationError(
                 f"Invalid YAML in blueprint manifest {manifest_path}: {e}"
@@ -193,7 +207,7 @@ class BlueprintResolver:
             )
 
         result: dict[str, Any] = data
-        return result
+        return result, inventory_raw
 
     @staticmethod
     def _validate_manifest(data: dict[str, Any], manifest_path: Path) -> None:

--- a/src/infrafoundry/core/config/inventory_generator.py
+++ b/src/infrafoundry/core/config/inventory_generator.py
@@ -21,32 +21,26 @@ GENERATED_INVENTORY_FILENAME = ".generated-inventory.yml"
 class InventoryGenerator:
     """Generates Ansible inventory files from manifest declarations.
 
-    The ``inventory`` section of a package manifest (or blueprint) declares
-    host groups with optional Jinja2 templating.  This class renders those
-    declarations with the merged variable set and writes the result to
-    the package directory.
+    The ``inventory`` section of a package manifest (or blueprint) is
+    extracted from the manifest file as raw YAML text before parsing.
+    This class renders that raw text through Jinja2 (with full control
+    flow support including ``{% for %}`` and ``{% if %}``), parses the
+    rendered YAML, and writes the result to the package directory.
     """
 
     def generate(
         self,
-        inventory_schema: dict[str, Any],
+        inventory_raw: str,
         variables: dict[str, Any],
         output_dir: Path,
     ) -> Path:
-        """Render an inventory declaration and write it to disk.
+        """Render a raw inventory YAML block and write the result.
 
         Args:
-            inventory_schema: The ``inventory`` dict from the manifest.
-                Expected structure::
-
-                    groups:
-                      group_name:
-                        hosts:
-                          host_name:
-                            ansible_host: "{{ some_var }}"
-                        vars:
-                          key: value
-
+            inventory_raw: Raw YAML text of the inventory block as
+                extracted from the manifest file.  The text is the
+                *body* of the ``inventory:`` key (dedented); it should
+                not include the leading ``inventory:`` line.
             variables: Merged variables for Jinja2 rendering.
             output_dir: Directory to write the generated inventory file.
 
@@ -56,7 +50,7 @@ class InventoryGenerator:
         Raises:
             InvalidConfigurationError: If rendering or writing fails.
         """
-        rendered = self._render_inventory(inventory_schema, variables)
+        rendered = self._render_inventory(inventory_raw, variables)
         output_path = output_dir / GENERATED_INVENTORY_FILENAME
         self._write_inventory(rendered, output_path)
 
@@ -69,32 +63,34 @@ class InventoryGenerator:
 
     def _render_inventory(
         self,
-        inventory_schema: dict[str, Any],
+        inventory_raw: str,
         variables: dict[str, Any],
     ) -> dict[str, Any]:
-        """Render Jinja2 templates in an inventory schema.
+        """Render Jinja2 templates in raw inventory YAML text.
 
-        Serialises the inventory dict to YAML, renders Jinja2, then
-        parses back to a dict.  This allows templates anywhere in the
-        structure (host names, vars, etc.).
+        Runs the raw inventory text through Jinja2 (with
+        ``StrictUndefined``) and then parses the rendered output as
+        YAML.  This allows full control-flow templating (``{% for %}``,
+        ``{% if %}``) that would otherwise be impossible because Jinja
+        control-flow tags are not valid YAML and cannot survive a
+        dict-first pipeline.
 
         Args:
-            inventory_schema: Raw inventory declaration.
+            inventory_raw: Raw YAML text of the inventory block.
             variables: Template variables.
 
         Returns:
             Rendered inventory as a dict.
 
         Raises:
-            InvalidConfigurationError: On template or YAML errors.
+            InvalidConfigurationError: On template or YAML errors, or
+                when the rendered output is not a YAML mapping.
         """
-        raw_yaml = yaml.dump(inventory_schema, default_flow_style=False)
-
         try:
             env = jinja2.Environment(
                 undefined=jinja2.StrictUndefined,
             )  # nosec B701 - rendering YAML, not HTML
-            template = env.from_string(raw_yaml)
+            template = env.from_string(inventory_raw)
             rendered_yaml = template.render(**variables)
         except jinja2.UndefinedError as e:
             raise InvalidConfigurationError(

--- a/src/infrafoundry/core/config/manifest_utils.py
+++ b/src/infrafoundry/core/config/manifest_utils.py
@@ -1,0 +1,116 @@
+"""Manifest text utilities.
+
+Provides helpers that operate on the raw text of manifest files before
+they are parsed as YAML.  The primary use case is extracting the raw
+``inventory:`` block so it can be rendered through Jinja2 as a full
+template (including ``{% for %}`` and ``{% if %}`` control flow) before
+YAML parsing.  This is required because Jinja control-flow tags are not
+valid YAML and cannot survive a ``yaml.safe_load`` pass.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+_INVENTORY_KEY = "inventory:"
+
+
+def extract_inventory_block(file_text: str) -> tuple[str, str | None]:
+    """Strip the top-level ``inventory:`` block from manifest text.
+
+    Performs a line-based scan for a column-0 ``inventory:`` key.  When
+    found, all subsequent indented (or blank/comment) lines are captured
+    as the block body up to the next column-0 non-blank non-comment line
+    (or EOF).  The leading ``inventory:`` line is removed from the
+    captured body which is then de-dented with :func:`textwrap.dedent` so
+    the caller receives a standalone YAML fragment.
+
+    To keep YAML parser error messages pointing at correct original
+    source lines, the captured slice in the returned ``text_without_inventory``
+    is replaced with ``inventory: null`` followed by blank-line padding
+    that preserves the original line count.
+
+    A single-line flow-style declaration (``inventory: {groups: ...}``)
+    is rejected with :class:`InvalidConfigurationError` because flow
+    style cannot contain Jinja control-flow and the render-then-parse
+    pipeline does not support it.
+
+    This extractor is intentionally simple and is NOT safe for
+    pathological input (e.g., a top-level key whose multi-line string
+    value happens to contain a line starting with ``inventory:``).  The
+    manifest format is well-defined and the loader is the only consumer.
+
+    Args:
+        file_text: Full raw text of the manifest file.
+
+    Returns:
+        A tuple ``(text_without_inventory, inventory_raw)`` where
+        ``inventory_raw`` is the dedented body of the inventory block,
+        or ``None`` when no ``inventory:`` block is present.
+
+    Raises:
+        InvalidConfigurationError: If the ``inventory:`` declaration
+            uses flow style.
+    """
+    lines = file_text.splitlines(keepends=True)
+
+    # Locate the column-0 ``inventory:`` line.
+    start_idx: int | None = None
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # Must start at column 0 (no leading whitespace) and match the key.
+        if line.startswith(_INVENTORY_KEY):
+            start_idx = idx
+            break
+
+    if start_idx is None:
+        return file_text, None
+
+    header_line = lines[start_idx]
+    after_key = header_line[len(_INVENTORY_KEY) :].strip()
+
+    # Reject flow-style single-line declarations.  A bare ``inventory:``
+    # or ``inventory:  # comment`` is fine; anything else on the same
+    # line means the value is inline.
+    if after_key and not after_key.startswith("#"):
+        raise InvalidConfigurationError(
+            "Inventory declaration must use block style, not flow style. "
+            "Use a multi-line 'inventory:' block with indented children."
+        )
+
+    # Capture body: subsequent lines that are blank, comment, or indented.
+    end_idx = len(lines)
+    for idx in range(start_idx + 1, len(lines)):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        # A non-blank non-comment line at column 0 terminates the block.
+        if not line[0].isspace():
+            end_idx = idx
+            break
+
+    body_lines = lines[start_idx + 1 : end_idx]
+    body_text = "".join(body_lines)
+    inventory_raw = textwrap.dedent(body_text) if body_text else ""
+
+    # Build replacement that preserves line numbers: ``inventory: null``
+    # then (end_idx - start_idx - 1) blank lines.
+    replacement_lines: list[str] = ["inventory: null\n"]
+    replacement_lines.extend("\n" for _ in range(end_idx - start_idx - 1))
+    # Handle final-line case where the header had no trailing newline.
+    if not header_line.endswith("\n"):
+        replacement_lines[0] = "inventory: null"
+        if replacement_lines[1:]:
+            replacement_lines[1] = "\n"
+
+    new_lines = lines[:start_idx] + replacement_lines + lines[end_idx:]
+    text_without_inventory = "".join(new_lines)
+
+    return text_without_inventory, inventory_raw

--- a/src/infrafoundry/core/config/models.py
+++ b/src/infrafoundry/core/config/models.py
@@ -146,3 +146,8 @@ class PackageManifest(BaseModel):
     resources: list[str] = Field(default_factory=list)
     events: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
     inventory: dict[str, Any] | None = None
+    # Raw YAML text of the manifest's ``inventory:`` block, extracted
+    # before ``yaml.safe_load`` so the generator can render it through
+    # Jinja2 with full control-flow support.  Framework-internal; not
+    # serialised back to disk.
+    inventory_raw: str | None = Field(default=None, exclude=True)

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -23,6 +23,7 @@ import yaml
 
 from infrafoundry.core.config.filters import generate_mac
 from infrafoundry.core.config.inventory_generator import InventoryGenerator
+from infrafoundry.core.config.manifest_utils import extract_inventory_block
 from infrafoundry.core.config.models import PackageManifest
 from infrafoundry.core.exceptions import InvalidConfigurationError
 from infrafoundry.core.provider import ResourceConfig
@@ -203,8 +204,8 @@ class PackageLoader:
                 manifest.events = dict(blueprint["events"])
 
             # Inherit inventory from blueprint if package doesn't declare its own
-            if manifest.inventory is None and blueprint.get("inventory"):
-                manifest.inventory = dict(blueprint["inventory"])
+            if manifest.inventory_raw is None and blueprint.get("inventory_raw"):
+                manifest.inventory_raw = blueprint["inventory_raw"]
 
         # ----- Secrets -----
         secrets_path = package_dir / "secrets.yaml"
@@ -281,9 +282,9 @@ class PackageLoader:
                 )
 
         # ----- Inventory generation -----
-        if manifest.inventory:
+        if manifest.inventory_raw:
             inventory_path = self._inventory_generator.generate(
-                manifest.inventory, manifest.variables, package_dir
+                manifest.inventory_raw, manifest.variables, package_dir
             )
             logger.info("Generated inventory for package '%s': %s", manifest.name, inventory_path)
 
@@ -306,8 +307,16 @@ class PackageLoader:
             raise InvalidConfigurationError(f"Package manifest not found: {manifest_path}")
 
         try:
-            with open(manifest_path) as f:
-                data = yaml.safe_load(f)
+            file_text = manifest_path.read_text()
+        except OSError as e:
+            raise InvalidConfigurationError(
+                f"Failed to read package manifest {manifest_path}: {e}"
+            ) from e
+
+        text_without_inventory, inventory_raw = extract_inventory_block(file_text)
+
+        try:
+            data = yaml.safe_load(text_without_inventory)
         except yaml.YAMLError as e:
             raise InvalidConfigurationError(
                 f"Invalid YAML in package manifest {manifest_path}: {e}"
@@ -318,10 +327,16 @@ class PackageLoader:
                 f"Package manifest must be a YAML mapping: {manifest_path}"
             )
 
+        # ``inventory`` is always ``None`` in ``data`` when an inventory
+        # block existed (extractor replaced it with ``inventory: null``).
+        # The raw text is carried separately for the generator.
         try:
-            return PackageManifest(**data)
+            manifest = PackageManifest(**data)
         except Exception as e:
             raise InvalidConfigurationError(f"Invalid package manifest {manifest_path}: {e}") from e
+
+        manifest.inventory_raw = inventory_raw
+        return manifest
 
     def _render_resource_file(
         self, resource_path: Path, variables: dict[str, Any]

--- a/tests/unit/test_blueprint_resolver.py
+++ b/tests/unit/test_blueprint_resolver.py
@@ -73,7 +73,12 @@ class TestBlueprintResolverResolve:
         assert result["defaults"]["cluster_name"] == "default-cluster"
         assert result["resources"] == ["vm.yaml", "network.yaml"]
         assert len(result["events"]["AFTER_APPLY"]) == 1
-        assert result["inventory"]["groups"]["hosts"]["host1"] == {}
+        # ``inventory`` is stripped from the parsed data; the raw block is
+        # carried separately so the generator can Jinja-render it.
+        assert result["inventory"] is None
+        assert result["inventory_raw"] is not None
+        assert "groups:" in result["inventory_raw"]
+        assert "host1" in result["inventory_raw"]
         assert result["blueprint_dir"].name == "ontap-cluster"
 
     def test_resolve_minimal_blueprint(self, temp_dir):

--- a/tests/unit/test_inventory_generator.py
+++ b/tests/unit/test_inventory_generator.py
@@ -15,24 +15,19 @@ class TestInventoryGeneratorGenerate:
     """Tests for InventoryGenerator.generate."""
 
     def test_generate_simple_inventory(self, temp_dir):
-        """Generates a valid inventory file from a simple schema."""
+        """Generates a valid inventory file from a simple raw block."""
         generator = InventoryGenerator()
-        schema = {
-            "groups": {
-                "webservers": {
-                    "hosts": {
-                        "web-01": {
-                            "ansible_host": "192.168.1.10",
-                        }
-                    },
-                    "vars": {
-                        "ansible_user": "root",
-                    },
-                }
-            }
-        }
+        raw = (
+            "groups:\n"
+            "  webservers:\n"
+            "    hosts:\n"
+            "      web-01:\n"
+            "        ansible_host: 192.168.1.10\n"
+            "    vars:\n"
+            "      ansible_user: root\n"
+        )
 
-        output_path = generator.generate(schema, {}, temp_dir)
+        output_path = generator.generate(raw, {}, temp_dir)
 
         assert output_path == temp_dir / GENERATED_INVENTORY_FILENAME
         assert output_path.exists()
@@ -44,22 +39,18 @@ class TestInventoryGeneratorGenerate:
         assert data["groups"]["webservers"]["vars"]["ansible_user"] == "root"
 
     def test_generate_with_jinja2_variables(self, temp_dir):
-        """Jinja2 templates in schema are rendered with variables."""
+        """Jinja2 string interpolation is rendered with variables."""
         generator = InventoryGenerator()
-        schema = {
-            "groups": {
-                "cluster": {
-                    "hosts": {
-                        "node-01": {
-                            "ansible_host": "{{ node01_ip }}",
-                        }
-                    }
-                }
-            }
-        }
+        raw = (
+            "groups:\n"
+            "  cluster:\n"
+            "    hosts:\n"
+            "      node-01:\n"
+            '        ansible_host: "{{ node01_ip }}"\n'
+        )
         variables = {"node01_ip": "10.0.0.1"}
 
-        output_path = generator.generate(schema, variables, temp_dir)
+        output_path = generator.generate(raw, variables, temp_dir)
 
         with open(output_path) as f:
             data = yaml.safe_load(f)
@@ -67,22 +58,18 @@ class TestInventoryGeneratorGenerate:
         assert data["groups"]["cluster"]["hosts"]["node-01"]["ansible_host"] == "10.0.0.1"
 
     def test_generate_undefined_variable_raises(self, temp_dir):
-        """Undefined variables in schema raise InvalidConfigurationError."""
+        """Undefined variables raise InvalidConfigurationError."""
         generator = InventoryGenerator()
-        schema = {
-            "groups": {
-                "cluster": {
-                    "hosts": {
-                        "node-01": {
-                            "ansible_host": "{{ missing_var }}",
-                        }
-                    }
-                }
-            }
-        }
+        raw = (
+            "groups:\n"
+            "  cluster:\n"
+            "    hosts:\n"
+            "      node-01:\n"
+            '        ansible_host: "{{ missing_var }}"\n'
+        )
 
         with pytest.raises(InvalidConfigurationError, match="Undefined variable"):
-            generator.generate(schema, {}, temp_dir)
+            generator.generate(raw, {}, temp_dir)
 
     def test_generate_overwrites_existing(self, temp_dir):
         """Generating inventory overwrites an existing file."""
@@ -90,8 +77,8 @@ class TestInventoryGeneratorGenerate:
         existing = temp_dir / GENERATED_INVENTORY_FILENAME
         existing.write_text("old: content\n")
 
-        schema = {"groups": {"new": {"hosts": {"h1": {}}}}}
-        generator.generate(schema, {}, temp_dir)
+        raw = "groups:\n  new:\n    hosts:\n      h1: {}\n"
+        generator.generate(raw, {}, temp_dir)
 
         with open(existing) as f:
             data = yaml.safe_load(f)
@@ -104,40 +91,35 @@ class TestInventoryGeneratorGenerate:
         generator = InventoryGenerator()
         output_dir = temp_dir / "deep" / "nested" / "dir"
 
-        schema = {"groups": {"test": {"hosts": {}}}}
-        output_path = generator.generate(schema, {}, output_dir)
+        raw = "groups:\n  test:\n    hosts: {}\n"
+        output_path = generator.generate(raw, {}, output_dir)
 
         assert output_path.exists()
 
     def test_generate_multiple_groups(self, temp_dir):
         """Multiple groups are rendered correctly."""
         generator = InventoryGenerator()
-        schema = {
-            "groups": {
-                "proxmox_hosts": {
-                    "hosts": {
-                        "pve1": {"ansible_host": "{{ pve1_ip }}"},
-                        "pve2": {"ansible_host": "{{ pve2_ip }}"},
-                    },
-                    "vars": {"ansible_user": "root"},
-                },
-                "ontap_cluster": {
-                    "hosts": {
-                        "ontap-mgmt": {
-                            "ansible_host": "{{ cluster_mgmt_ip }}",
-                            "ansible_connection": "local",
-                        }
-                    },
-                },
-            }
-        }
+        raw = (
+            "groups:\n"
+            "  proxmox_hosts:\n"
+            "    hosts:\n"
+            '      pve1: {ansible_host: "{{ pve1_ip }}"}\n'
+            '      pve2: {ansible_host: "{{ pve2_ip }}"}\n'
+            "    vars:\n"
+            "      ansible_user: root\n"
+            "  ontap_cluster:\n"
+            "    hosts:\n"
+            "      ontap-mgmt:\n"
+            '        ansible_host: "{{ cluster_mgmt_ip }}"\n'
+            "        ansible_connection: local\n"
+        )
         variables = {
             "pve1_ip": "192.168.10.1",
             "pve2_ip": "192.168.10.2",
             "cluster_mgmt_ip": "192.168.10.203",
         }
 
-        output_path = generator.generate(schema, variables, temp_dir)
+        output_path = generator.generate(raw, variables, temp_dir)
 
         with open(output_path) as f:
             data = yaml.safe_load(f)
@@ -147,6 +129,100 @@ class TestInventoryGeneratorGenerate:
             "local"
         )
 
+    def test_generate_with_for_loop(self, temp_dir):
+        """A `{% for %}` loop expands into multiple host entries."""
+        generator = InventoryGenerator()
+        raw = (
+            "groups:\n"
+            "  k3s_workers:\n"
+            "    hosts:\n"
+            "      {% for w in workers %}\n"
+            "      {{ w.name }}:\n"
+            '        ansible_host: "{{ w.ip }}"\n'
+            "      {% endfor %}\n"
+        )
+        variables = {
+            "workers": [
+                {"name": "worker-01", "ip": "10.0.0.11"},
+                {"name": "worker-02", "ip": "10.0.0.12"},
+                {"name": "worker-03", "ip": "10.0.0.13"},
+            ]
+        }
+
+        output_path = generator.generate(raw, variables, temp_dir)
+
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        hosts = data["groups"]["k3s_workers"]["hosts"]
+        assert set(hosts.keys()) == {"worker-01", "worker-02", "worker-03"}
+        assert hosts["worker-01"]["ansible_host"] == "10.0.0.11"
+        assert hosts["worker-02"]["ansible_host"] == "10.0.0.12"
+        assert hosts["worker-03"]["ansible_host"] == "10.0.0.13"
+
+    def test_generate_with_if_conditional(self, temp_dir):
+        """`{% if %}` selects between branches."""
+        generator = InventoryGenerator()
+        raw = (
+            "groups:\n"
+            "  server:\n"
+            "    hosts:\n"
+            "      host-01:\n"
+            "        {% if use_public_ip %}\n"
+            '        ansible_host: "{{ public_ip }}"\n'
+            "        {% else %}\n"
+            '        ansible_host: "{{ private_ip }}"\n'
+            "        {% endif %}\n"
+        )
+        variables = {
+            "use_public_ip": True,
+            "public_ip": "203.0.113.5",
+            "private_ip": "10.0.0.5",
+        }
+
+        output_path = generator.generate(raw, variables, temp_dir)
+
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["groups"]["server"]["hosts"]["host-01"]["ansible_host"] == "203.0.113.5"
+
+    def test_generate_with_for_loop_zero_iterations(self, temp_dir):
+        """A loop over an empty list yields no host entries."""
+        generator = InventoryGenerator()
+        raw = (
+            "groups:\n"
+            "  k3s_workers:\n"
+            "    hosts:\n"
+            "      {% for w in workers %}\n"
+            "      {{ w.name }}: {}\n"
+            "      {% endfor %}\n"
+        )
+        variables = {"workers": []}
+
+        output_path = generator.generate(raw, variables, temp_dir)
+
+        with open(output_path) as f:
+            data = yaml.safe_load(f)
+
+        hosts = data["groups"]["k3s_workers"]["hosts"]
+        assert hosts is None or hosts == {}
+
+    def test_generate_with_for_loop_undefined_variable_raises(self, temp_dir):
+        """Looping over an undefined variable raises InvalidConfigurationError."""
+        generator = InventoryGenerator()
+        raw = (
+            "groups:\n"
+            "  workers:\n"
+            "    hosts:\n"
+            "      {% for w in missing_list %}\n"
+            "      {{ w }}: {}\n"
+            "      {% endfor %}\n"
+        )
+
+        with pytest.raises(InvalidConfigurationError, match="Undefined variable"):
+            generator.generate(raw, {}, temp_dir)
+
 
 @pytest.mark.unit
 class TestInventoryGeneratorRenderInventory:
@@ -155,16 +231,15 @@ class TestInventoryGeneratorRenderInventory:
     def test_render_template_syntax_error(self, temp_dir):
         """Template syntax error raises InvalidConfigurationError."""
         generator = InventoryGenerator()
-        schema = {"groups": {"test": {"hosts": {"h1": {"ip": "{{ broken }"}}}}}
+        raw = 'groups:\n  test:\n    hosts:\n      h1:\n        ip: "{{ broken }"\n'
 
         with pytest.raises(InvalidConfigurationError, match="Template syntax error"):
-            generator._render_inventory(schema, {})
+            generator._render_inventory(raw, {})
 
     def test_render_non_dict_result(self, temp_dir):
-        """Non-dict rendering result raises InvalidConfigurationError."""
+        """A rendered result that is not a mapping raises InvalidConfigurationError."""
         generator = InventoryGenerator()
-        # A schema that renders to a list
-        schema = ["item1", "item2"]
+        raw = "- item1\n- item2\n"
 
         with pytest.raises(InvalidConfigurationError, match="must render to a YAML mapping"):
-            generator._render_inventory(schema, {})
+            generator._render_inventory(raw, {})

--- a/tests/unit/test_manifest_utils.py
+++ b/tests/unit/test_manifest_utils.py
@@ -1,0 +1,119 @@
+"""Unit tests for manifest_utils.extract_inventory_block."""
+
+import pytest
+
+from infrafoundry.core.config.manifest_utils import extract_inventory_block
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+
+@pytest.mark.unit
+class TestExtractInventoryBlock:
+    """Tests for extract_inventory_block."""
+
+    def test_no_inventory_returns_original_text_and_none(self):
+        """A manifest without an inventory key returns unchanged text and None."""
+        text = "name: pkg\nvariables:\n  foo: bar\n"
+        stripped, raw = extract_inventory_block(text)
+
+        assert stripped == text
+        assert raw is None
+
+    def test_simple_inventory_is_extracted_and_dedented(self):
+        """A basic block is extracted with its leading key stripped and body dedented."""
+        text = (
+            "name: pkg\n"
+            "inventory:\n"
+            "  groups:\n"
+            "    web:\n"
+            "      hosts:\n"
+            "        web-01:\n"
+            "          ansible_host: 10.0.0.1\n"
+        )
+        stripped, raw = extract_inventory_block(text)
+
+        assert raw is not None
+        # Dedented body: top-level starts at column 0.
+        assert raw.startswith("groups:\n")
+        assert "  web:\n" in raw
+        assert "    hosts:\n" in raw
+        assert "      web-01:\n" in raw
+        # Stripped text has the block replaced by a null placeholder.
+        assert "inventory: null" in stripped
+        assert "web-01" not in stripped
+
+    def test_inventory_with_jinja_for_loop_preserved_literally(self):
+        """Jinja control-flow tags survive extraction unchanged."""
+        text = (
+            "name: pkg\n"
+            "inventory:\n"
+            "  groups:\n"
+            "    workers:\n"
+            "      hosts:\n"
+            "        {% for w in workers %}\n"
+            "        {{ w.name }}:\n"
+            '          ansible_host: "{{ w.ip }}"\n'
+            "        {% endfor %}\n"
+        )
+        _, raw = extract_inventory_block(text)
+
+        assert raw is not None
+        assert "{% for w in workers %}" in raw
+        assert "{% endfor %}" in raw
+        assert "{{ w.name }}" in raw
+
+    def test_inventory_followed_by_other_keys_stops_at_next_column_0(self):
+        """Only the inventory section is captured; trailing top-level keys stay."""
+        text = (
+            "name: pkg\n"
+            "inventory:\n"
+            "  groups:\n"
+            "    g1:\n"
+            "      hosts:\n"
+            "        h1: {}\n"
+            "variables:\n"
+            "  foo: bar\n"
+            "events:\n"
+            "  AFTER_APPLY: []\n"
+        )
+        stripped, raw = extract_inventory_block(text)
+
+        assert raw is not None
+        assert "groups:" in raw
+        assert "variables" not in raw
+        assert "events" not in raw
+        # Trailing keys remain in the stripped text.
+        assert "variables:\n  foo: bar\n" in stripped
+        assert "events:\n  AFTER_APPLY: []\n" in stripped
+
+    def test_inventory_at_eof_captures_to_end(self):
+        """A trailing inventory block is captured all the way to EOF."""
+        text = "name: pkg\ninventory:\n  groups:\n    g1:\n      hosts:\n        h1: {}\n"
+        _, raw = extract_inventory_block(text)
+
+        assert raw is not None
+        assert "groups:" in raw
+        assert "h1: {}" in raw
+
+    def test_preserves_line_count_for_parser_error_messages(self):
+        """The stripped text must have the same line count as the original."""
+        text = (
+            "name: pkg\n"  # line 1
+            "description: hi\n"  # line 2
+            "inventory:\n"  # line 3
+            "  groups:\n"  # line 4
+            "    g1:\n"  # line 5
+            "      hosts:\n"  # line 6
+            "        h1:\n"  # line 7
+            "          ansible_host: 1.2.3.4\n"  # line 8
+            "variables:\n"  # line 9
+            "  foo: bar\n"  # line 10
+        )
+        stripped, _ = extract_inventory_block(text)
+
+        assert text.count("\n") == stripped.count("\n")
+
+    def test_flow_style_inventory_raises(self):
+        """Single-line flow-style inventory declarations are rejected."""
+        text = "name: pkg\ninventory: {groups: {g1: {hosts: {h1: {}}}}}\n"
+        with pytest.raises(InvalidConfigurationError, match="block style"):
+            extract_inventory_block(text)

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -1034,6 +1034,123 @@ class TestBlueprintIntegration:
         assert handler["_blueprint_dir"] == str(bp_dir)
         assert handler["_package"] == "tagged-pkg"
 
+    def test_blueprint_inventory_with_loop_renders_via_consumer_variables(self, temp_dir):
+        """Blueprint inventory `{% for %}` expands using consumer-supplied workers."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+
+        blueprint_dir = temp_dir.parent / "blueprints" / "loop-bp"
+        blueprint_dir.mkdir(parents=True, exist_ok=True)
+        (blueprint_dir / "blueprint.yaml").write_text(
+            "name: loop-bp\n"
+            "inventory:\n"
+            "  groups:\n"
+            "    k3s_workers:\n"
+            "      hosts:\n"
+            "        {% for w in workers %}\n"
+            "        {{ w.name }}:\n"
+            '          ansible_host: "{{ w.ip }}"\n'
+            "        {% endfor %}\n"
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = temp_dir / "dev" / "proxmox" / "loop-pkg"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / "infrafoundry.yml").write_text(
+            "name: loop-pkg\n"
+            "blueprint: loop-bp\n"
+            "variables:\n"
+            "  workers:\n"
+            "    - name: worker-01\n"
+            "      ip: 10.0.0.11\n"
+            "    - name: worker-02\n"
+            "      ip: 10.0.0.12\n"
+        )
+
+        loader.load_package(pkg_dir, "proxmox", "dev")
+
+        inventory_path = pkg_dir / GENERATED_INVENTORY_FILENAME
+        assert inventory_path.exists()
+        with open(inventory_path) as f:
+            data = yaml.safe_load(f)
+        hosts = data["groups"]["k3s_workers"]["hosts"]
+        assert set(hosts.keys()) == {"worker-01", "worker-02"}
+        assert hosts["worker-01"]["ansible_host"] == "10.0.0.11"
+        assert hosts["worker-02"]["ansible_host"] == "10.0.0.12"
+
+    def test_package_inventory_with_loop(self, temp_dir):
+        """Package-level inventory with `{% for %}` expands using package variables."""
+        loader = PackageLoader(temp_dir)
+        pkg_dir = temp_dir / "dev" / "proxmox" / "pkg-loop"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / "infrafoundry.yml").write_text(
+            "name: pkg-loop\n"
+            "variables:\n"
+            "  nodes:\n"
+            "    - name: n1\n"
+            "      addr: 1.1.1.1\n"
+            "    - name: n2\n"
+            "      addr: 2.2.2.2\n"
+            "inventory:\n"
+            "  groups:\n"
+            "    cluster:\n"
+            "      hosts:\n"
+            "        {% for n in nodes %}\n"
+            "        {{ n.name }}:\n"
+            '          ansible_host: "{{ n.addr }}"\n'
+            "        {% endfor %}\n"
+        )
+
+        loader.load_package(pkg_dir, "proxmox", "dev")
+
+        inventory_path = pkg_dir / GENERATED_INVENTORY_FILENAME
+        assert inventory_path.exists()
+        with open(inventory_path) as f:
+            data = yaml.safe_load(f)
+        hosts = data["groups"]["cluster"]["hosts"]
+        assert set(hosts.keys()) == {"n1", "n2"}
+        assert hosts["n1"]["ansible_host"] == "1.1.1.1"
+        assert hosts["n2"]["ansible_host"] == "2.2.2.2"
+
+    def test_blueprint_inventory_raw_inheritance(self, temp_dir):
+        """Blueprint `inventory_raw` is inherited onto a consumer with no inventory."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+
+        blueprint_dir = temp_dir.parent / "blueprints" / "raw-inherit-bp"
+        blueprint_dir.mkdir(parents=True, exist_ok=True)
+        (blueprint_dir / "blueprint.yaml").write_text(
+            "name: raw-inherit-bp\n"
+            "defaults:\n"
+            "  host_ip: 10.0.0.99\n"
+            "inventory:\n"
+            "  groups:\n"
+            "    only:\n"
+            "      hosts:\n"
+            "        sole:\n"
+            '          ansible_host: "{{ host_ip }}"\n'
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "raw-inherit-pkg",
+            {
+                "name": "raw-inherit-pkg",
+                "blueprint": "raw-inherit-bp",
+            },
+        )
+
+        loader.load_package(pkg_dir, "proxmox", "dev")
+
+        inventory_path = pkg_dir / GENERATED_INVENTORY_FILENAME
+        assert inventory_path.exists()
+        with open(inventory_path) as f:
+            data = yaml.safe_load(f)
+        assert data["groups"]["only"]["hosts"]["sole"]["ansible_host"] == "10.0.0.99"
+
     def test_secrets_override_blueprint_defaults(self, temp_dir):
         """Secrets take priority over both blueprint defaults and package vars."""
         resolver = BlueprintResolver(temp_dir)


### PR DESCRIPTION
## Description

`InventoryGenerator` previously serialised the inventory dict back to YAML and only THEN ran Jinja, which made `{% for %}` and `{% if %}` impossible at YAML structural positions: `yaml.safe_load` choked on the control-flow tag long before Jinja got a chance to expand it. Blueprints with variable-cardinality hosts (proxmox-k3s #504, oci-k3s #505) had to fall back to building the inventory in their on_create scripts via `jq` over `INFRAFOUNDRY_PACKAGE_VARS`.

This PR replaces the dict-then-render pipeline with a **render-then-parse** pipeline that mirrors the existing `_render_resource_file()` precedent for `vm.yaml`/`instances.yaml`. The raw YAML substring of the `inventory:` block is extracted from the manifest file *before* `yaml.safe_load` runs, then rendered through Jinja, then parsed. Full Jinja control flow now works at any structural position.

## Related Issue

Addresses #517

Sibling to #516 (which fixed `_package_dir` plumbing for `INFRAFOUNDRY_INVENTORY` injection). With #516 + #517 both landed, blueprints with variable-cardinality inventories can use the framework's intended pathway end-to-end.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring (unified InventoryGenerator on raw-string input; dropped the dict pathway)

## Changes Made

### Extractor
- New module `src/infrafoundry/core/config/manifest_utils.py` with `extract_inventory_block(file_text) -> tuple[str, str | None]`. Line-scans for a column-0 `inventory:` key, captures the indented body, dedents it, and returns the dedented raw text plus the residual manifest text with `inventory: null` plus blank-line padding (preserving line numbers for parser error messages).
- Rejects flow-style `inventory: { ... }` with a clear `InvalidConfigurationError` — block style is required for the render-then-parse pathway.

### Manifest parsers
- `PackageLoader._parse_manifest()` and `BlueprintResolver._load_manifest()` (both have separate manifest parsers — both updated) now read the raw file text, extract the inventory block via the new helper, parse the residual text via `yaml.safe_load`, and store the raw block on the result.
- `PackageManifest` gained `inventory_raw: str | None = Field(default=None, exclude=True)`. The legacy `inventory: dict | None` field stays for back-compat but is always `None` for any manifest with an inventory block (since the raw block is replaced by `inventory: null` before parsing).
- `BlueprintResolver.resolve()` result dict gains `"inventory_raw"` alongside `"inventory"`.

### Inventory generator
- `InventoryGenerator.generate()` signature changed: takes `inventory_raw: str` instead of `inventory_schema: dict`. Internal `_render_inventory()` does Jinja-then-parse on the raw text. The dict pathway has been removed entirely — strictly more capable, since string substitution still works as a subset of full Jinja rendering.
- Existing inventory generator tests were converted to pass raw YAML strings.

### Blueprint inheritance
- `load_package()` blueprint inheritance now propagates `inventory_raw` instead of the dict: `manifest.inventory_raw = blueprint["inventory_raw"]` when the consumer doesn't override.

## Testing

- [x] All existing tests pass (`doit check` clean — 2634 tests)
- [x] Added new tests for new functionality
- [ ] Manually tested — running `infra plan` against the existing `ontap-cluster` blueprint (which uses `inventory:`) on a real env to confirm `.generated-inventory.yml` still renders identically is recommended but was **not** run as part of this PR

### New tests

**Extractor (`tests/unit/test_manifest_utils.py` — 7 tests)**
- No inventory key → returns original text and `None`
- Simple inventory block → returns text with `inventory: null` placeholder and dedented body
- Inventory with `{% for %}` → extraction succeeds, raw block contains literal control-flow text
- Inventory followed by other top-level keys → only the inventory section is captured
- Inventory at EOF → captures everything to EOF
- Line-number preservation → residual text has the same line count as the original
- Flow-style inventory → raises `InvalidConfigurationError`

**Inventory generator (`tests/unit/test_inventory_generator.py` — 4 new tests)**
- `with_for_loop` — `{% for worker in workers %}` over a 3-entry list expands to 3 host entries
- `with_if_conditional` — `{% if use_public_ip %}` selects between two values
- `for_loop_zero_iterations` — empty list renders an empty group cleanly
- `for_loop_undefined_variable_raises` — `StrictUndefined` enforces variable existence

Existing tests in this file were converted from dict literals to raw YAML strings.

**Package loader (`tests/unit/test_package_loader.py` — 3 new tests)**
- Blueprint with `{% for w in workers %}` rendered via consumer-supplied `workers` list
- Package-level inventory with a loop (no blueprint involved)
- Blueprint `inventory_raw` correctly inherited by a consumer that doesn't override

**Blueprint resolver (`tests/unit/test_blueprint_resolver.py` — 1 existing test updated)**
- `test_resolve_full_blueprint` now asserts `inventory is None` and verifies `inventory_raw` content. Semantically equivalent under the new pipeline.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove the feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — **N/A**: no existing doc described inventory templating limitations or claimed "simple substitution only", so there's nothing factually incorrect to fix. `docs/development/event-system.md` already documents `INFRAFOUNDRY_INVENTORY` and the env var description remains accurate.
- [ ] CHANGELOG.md — N/A, project does not maintain a manual CHANGELOG
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required: issue #517 has no `needs-adr` label, and the change is an internal pipeline refactor that unblocks an existing feature, not a new architectural decision.
- **Follow-up (out of scope):** the proxmox-k3s and oci-k3s blueprints currently build their inventories via `jq` over `INFRAFOUNDRY_PACKAGE_VARS` in their on_create scripts. Now that #516 + #517 are both landed, those blueprints can be simplified to declare a real `inventory:` block with `{% for worker in workers %}` and let the framework write `.generated-inventory.yml`. Filing as a separate cleanup issue is recommended.
- The legacy `manifest.inventory` dict field is now vestigial (always `None` for any manifest that had an inventory block). Kept for back-compat to avoid touching unrelated code that might read it; a separate cleanup PR could remove it once a grep confirms no consumers remain.
