### PR TITLE
fix: always run terraform init so provider.tf changes are detected

### DIFF
--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -85,10 +85,10 @@ class TerraformRunner(BaseRunner):
         migrate_state = kwargs.get("migrate_state", False)
         upgrade = kwargs.get("upgrade", False)
 
-        # If already initialized and no special flags, check if backend changed
+        # If already initialized, sniff the state file to detect a backend
+        # swap so we can preemptively add -reconfigure (terraform would
+        # otherwise error on the first re-init after a swap).
         if is_initialized and not (reconfigure or migrate_state or upgrade):
-            # If backend.tf exists now but wasn't used before, or vice versa,
-            # we need to reconfigure
             terraform_state = working_dir / ".terraform" / "terraform.tfstate"
             if terraform_state.exists():
                 import json
@@ -111,10 +111,10 @@ class TerraformRunner(BaseRunner):
                 except (json.JSONDecodeError, FileNotFoundError):
                     pass
 
-            if not reconfigure:
-                return {"success": True, "message": "Already initialized"}
-
-        # Build init command using full path to terraform binary
+        # Always run terraform init. It's idempotent for unchanged configs
+        # and cheap (~100ms no-op). Running it unconditionally avoids a
+        # class of stale-lock / stale-.terraform bugs that arose when we
+        # trusted .terraform/ presence as proof of consistency. See #524.
         cmd = [self.tool_path, "init"]
         if reconfigure:
             cmd.append("-reconfigure")
@@ -124,11 +124,14 @@ class TerraformRunner(BaseRunner):
             cmd.append("-upgrade")
 
         try:
-            msg = "Initializing Terraform..."
             if reconfigure:
                 msg = "Reconfiguring Terraform backend..."
             elif migrate_state:
                 msg = "Migrating Terraform state..."
+            elif is_initialized:
+                msg = "Refreshing Terraform init..."
+            else:
+                msg = "Initializing Terraform..."
             self.console.print(f"[dim]{msg}[/dim]")
 
             result = subprocess.run(  # nosec B603

--- a/tests/unit/test_runner_terraform.py
+++ b/tests/unit/test_runner_terraform.py
@@ -36,15 +36,131 @@ def test_is_available(runner: TerraformRunner) -> None:
         assert not runner.is_available()
 
 
-def test_initialize_skips_when_already_initialized(
+def test_initialize_runs_init_even_when_already_initialized(
     runner: TerraformRunner, provider: MagicMock
 ) -> None:
-    """Initialization short-circuits when .terraform exists."""
+    """Init is always invoked, even when ``.terraform/`` is already present.
+
+    Regression test for #524: the previous short-circuit trusted
+    ``.terraform/`` presence as proof of consistency and hid ``provider.tf``
+    changes (e.g. a newly-declared provider) until apply time, producing
+    an ``Inconsistent dependency lock file`` error. ``terraform init`` is
+    idempotent and cheap, so we always run it.
+    """
     (provider.terraform_dir / ".terraform").mkdir()
-    with patch("shutil.which", return_value="/usr/bin/terraform"):
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
         result = runner.initialize(provider.terraform_dir)
     assert result["success"]
-    assert "Already initialized" in result["message"]
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0][1] == "init"
+    # No special flags should be added in the default re-init case
+    assert "-reconfigure" not in mock_run.call_args[0][0]
+    assert "-upgrade" not in mock_run.call_args[0][0]
+
+
+def test_initialize_detects_stale_provider_lock_scenario(
+    runner: TerraformRunner, provider: MagicMock
+) -> None:
+    """Documents the #524 repro: stale ``.terraform.lock.hcl`` after a new provider is added.
+
+    Creates a working dir with ``.terraform/``, a stale lock file containing
+    only provider A, and a ``provider.tf`` declaring both A and B. Before
+    the fix, initialize short-circuited and apply later failed with
+    ``Inconsistent dependency lock file``. After the fix, init runs and
+    (in a real terraform invocation) would download B and update the lock.
+    Here we mock subprocess and assert init is actually called.
+    """
+    (provider.terraform_dir / ".terraform").mkdir()
+    (provider.terraform_dir / ".terraform.lock.hcl").write_text(
+        'provider "registry.terraform.io/bpg/proxmox" {\n  version = "0.98.1"\n}\n'
+    )
+    (provider.terraform_dir / "provider.tf").write_text(
+        "terraform {\n  required_providers {\n"
+        '    proxmox = { source = "bpg/proxmox" }\n'
+        '    cloudinit = { source = "hashicorp/cloudinit" }\n'
+        "  }\n}\n"
+    )
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        result = runner.initialize(provider.terraform_dir)
+    assert result["success"]
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0][1] == "init"
+
+
+def test_initialize_preserves_backend_change_reconfigure(
+    runner: TerraformRunner, provider: MagicMock
+) -> None:
+    """Backend swap detection still adds ``-reconfigure`` to the init command."""
+    (provider.terraform_dir / ".terraform").mkdir()
+    # Simulate prior local-backend state + a new backend.tf (i.e. a swap TO remote)
+    (provider.terraform_dir / ".terraform" / "terraform.tfstate").write_text(
+        json.dumps({"backend": {"type": "local"}})
+    )
+    (provider.terraform_dir / "backend.tf").write_text('terraform { backend "s3" {} }\n')
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        result = runner.initialize(provider.terraform_dir)
+    assert result["success"]
+    args = mock_run.call_args[0][0]
+    assert "-reconfigure" in args
+
+
+def test_initialize_honors_explicit_upgrade_flag(
+    runner: TerraformRunner, provider: MagicMock
+) -> None:
+    """Explicit ``upgrade=True`` still triggers ``terraform init -upgrade``."""
+    (provider.terraform_dir / ".terraform").mkdir()
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        runner.initialize(provider.terraform_dir, upgrade=True)
+    args = mock_run.call_args[0][0]
+    assert "-upgrade" in args
+
+
+def test_initialize_honors_explicit_reconfigure_flag(
+    runner: TerraformRunner, provider: MagicMock
+) -> None:
+    """Explicit ``reconfigure=True`` still triggers ``terraform init -reconfigure``."""
+    (provider.terraform_dir / ".terraform").mkdir()
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        runner.initialize(provider.terraform_dir, reconfigure=True)
+    args = mock_run.call_args[0][0]
+    assert "-reconfigure" in args
+
+
+def test_initialize_fresh_directory(runner: TerraformRunner, provider: MagicMock) -> None:
+    """Fresh directory (no ``.terraform/``) runs plain ``terraform init``."""
+    # provider fixture already leaves .terraform absent
+    assert not (provider.terraform_dir / ".terraform").exists()
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        result = runner.initialize(provider.terraform_dir)
+    assert result["success"]
+    args = mock_run.call_args[0][0]
+    assert args[1] == "init"
+    assert "-reconfigure" not in args
+    assert "-upgrade" not in args
 
 
 def test_initialize_missing_binary(runner: TerraformRunner, provider: MagicMock) -> None:
@@ -180,19 +296,21 @@ class TestResolveTargets:
     def test_unmatched_filter_skips_terraform(
         self, runner: TerraformRunner, provider: MagicMock
     ) -> None:
-        """When no targets match, terraform is skipped instead of running unfiltered."""
+        """When no targets match, the apply subprocess is skipped."""
         (provider.terraform_dir / "main.tf").write_text('resource "esxi_guest" "other_vm" {\n}\n')
         (provider.terraform_dir / ".terraform").mkdir()
         with (
             patch("shutil.which", return_value="/usr/bin/terraform"),
             patch("subprocess.run") as mock_run,
+            patch("subprocess.Popen") as mock_popen,
         ):
             mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
             result = runner.apply(provider, auto_approve=True, target_resources=["no-match"])
 
         assert result["success"]
-        # subprocess.run should NOT have been called (no init, no apply)
-        mock_run.assert_not_called()
+        # Init runs (via subprocess.run) regardless, but the apply itself
+        # (via subprocess.Popen) must be skipped when the filter matches nothing.
+        mock_popen.assert_not_called()
 
 
 class TestDestroyFailureCapture:
@@ -224,8 +342,10 @@ class TestDestroyFailureCapture:
 
         with (
             patch("shutil.which", return_value="/usr/bin/terraform"),
+            patch("subprocess.run") as mock_run,
             patch("subprocess.Popen", return_value=process),
         ):
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
             result = runner.destroy(provider, auto_approve=True)
 
         assert result["success"] is False
@@ -257,8 +377,10 @@ class TestDestroyFailureCapture:
 
         with (
             patch("shutil.which", return_value="/usr/bin/terraform"),
+            patch("subprocess.run") as mock_run,
             patch("subprocess.Popen", return_value=process),
         ):
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
             result = runner.destroy(provider, auto_approve=True)
 
         assert result["success"] is False


### PR DESCRIPTION
## Description

`TerraformRunner.initialize()` had a fast-path that returned `{"success": True, "message": "Already initialized"}` whenever `.terraform/` existed, without running `terraform init`. The only exception was backend-swap detection. **The fast-path did not detect changes to `required_providers` in `provider.tf`**, so when a generated `provider.tf` added or removed a provider (exactly what PR #519 did by adding `hashicorp/cloudinit` to the proxmox provider.tf for the Tailscale module), the old `.terraform/` and `.terraform.lock.hcl` became stale. Apply then failed with `Inconsistent dependency lock file`.

This PR **drops the fast-path entirely**. `terraform init` is idempotent and fast (~100ms no-op) for unchanged directories, so running it unconditionally eliminates an entire class of "framework thought it was initialized but wasn't" bugs. The backend-swap detection logic is preserved — it still sets `reconfigure=True` preemptively so `terraform init -reconfigure` is used when a swap is detected.

## Related Issue

Addresses #524

**Reproduction encountered today** while applying the prod homelab `k3s-cluster` package for the first time after PR #519 landed. #510's error handling correctly surfaced the failure as a `TerraformError` instead of a green checkmark — first real-world validation of that fix — but the root cause is this init-time staleness. This PR unblocks the paused k3s-cluster apply test.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Removed the `if not reconfigure: return {"success": True, "message": "Already initialized"}` early return in `TerraformRunner.initialize()`.
- Preserved the backend-change detection block (it now runs without gating the init call; its sole purpose is to set `reconfigure=True` preemptively on detected backend swaps).
- Added a `"Refreshing Terraform init..."` user-facing message for the no-op re-init case so it's visually distinct from a fresh init.
- Replaced `test_initialize_skips_when_already_initialized` (which asserted the old buggy short-circuit) with 6 new tests covering the new behavior.
- Fixed 3 pre-existing tests that were passively depending on the fast-path (they mocked `Popen` but not `subprocess.run`, and worked only because init was being skipped).

## Testing

- [x] All existing tests pass (`doit check` clean — 2636 tests, +6 net)
- [x] Added new tests for new functionality
- [ ] Manually tested — the verification is retrying the paused k3s-cluster apply after this PR merges. **Not run as part of this PR.**

### New tests

All in `tests/unit/test_runner_terraform.py`:

- `test_initialize_runs_init_even_when_already_initialized` — direct #524 regression: assert `subprocess.run` is invoked with `terraform init` when `.terraform/` already exists
- `test_initialize_detects_stale_provider_lock_scenario` — documents the real bug shape: stale `.terraform.lock.hcl` with only provider A, `provider.tf` declaring A+B; asserts init runs
- `test_initialize_preserves_backend_change_reconfigure` — backend swap (local → remote) still triggers `terraform init -reconfigure`
- `test_initialize_honors_explicit_upgrade_flag` — explicit `upgrade=True` kwarg still adds `-upgrade`
- `test_initialize_honors_explicit_reconfigure_flag` — explicit `reconfigure=True` kwarg still adds `-reconfigure`
- `test_initialize_fresh_directory` — fresh dir (no `.terraform/`) runs plain `terraform init`

### Updated existing tests

- `test_unmatched_filter_skips_terraform` — assertion changed from `mock_run.assert_not_called()` to `mock_popen.assert_not_called()`. Init via `subprocess.run` now legitimately runs; the apply itself (via `subprocess.Popen`) still must be skipped when the filter resolves to zero targets. The test's actual intent — "unmatched filter skips the apply call" — is preserved.
- `test_run_terraform_destroy_includes_stderr_in_response` — added `patch("subprocess.run")` so init's subprocess call is mocked alongside the `Popen`-based destroy call.
- `test_run_terraform_destroy_extracts_diagnostic_summary` — same fix.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — **N/A**: correctness fix to existing plumbing; no user-facing behavior documentation describes the init-time fast-path.
- [ ] CHANGELOG.md — N/A, project does not maintain a manual CHANGELOG
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required: #524 has no `needs-adr` label, and the change is a correctness fix to existing plumbing rather than a new architectural decision.
- **Performance impact:** init runs ~100ms per provider per `infra plan`/`infra apply` invocation now (previously skipped on cached dirs). Trivial for the framework's use cases. The optimization the fast-path was attempting to preserve isn't load-bearing.
- **Alternative considered:** hashing `provider.tf` and comparing to a cached hash to preserve the fast-path for the genuinely unchanged case. Rejected in favor of the simpler "always run init" approach — the added complexity isn't justified by the ~100ms savings.
- This is the final framework gap identified during the session audit. #515, #510, #516, #517, and now #524 all close together. The paused k3s-cluster apply test resumes after merge.
