### PR TITLE
fix: populate cloud_init_vars.HOSTNAME in proxmox-k3s-cluster blueprint

### DIFF
--- a/blueprints/proxmox-k3s-cluster/vm.yaml
+++ b/blueprints/proxmox-k3s-cluster/vm.yaml
@@ -25,6 +25,8 @@ vms:
       - users/ansible
       - network/dhcp
       - packages/qemu-agent
+    cloud_init_vars:
+      HOSTNAME: "{{ server_name }}"
     tags: [k3s, k3s-server]
     onboot: true
 
@@ -51,6 +53,8 @@ vms:
       - users/ansible
       - network/dhcp
       - packages/qemu-agent
+    cloud_init_vars:
+      HOSTNAME: "{{ agent.name }}"
     tags: [k3s, k3s-agent]
     onboot: true
 {% endfor %}

--- a/tests/unit/test_proxmox_k3s_cluster_blueprint.py
+++ b/tests/unit/test_proxmox_k3s_cluster_blueprint.py
@@ -136,6 +136,34 @@ def test_proxmox_k3s_cluster_example_vm_configs(loader: PackageLoader) -> None:
     assert agent2["tags"] == ["k3s", "k3s-agent"]
 
 
+def test_proxmox_k3s_cluster_example_sets_per_vm_cloud_init_hostname(
+    loader: PackageLoader,
+) -> None:
+    """Each VM resource carries a ``cloud_init_vars['HOSTNAME']`` matching its own name.
+
+    Regression guard for #526. The blueprint references the shared
+    ``system/hostname`` cloud-init snippet which contains a ``${HOSTNAME}``
+    placeholder. Before this fix the blueprint never populated
+    ``cloud_init_vars`` so the placeholder was never substituted and every VM
+    came up with the same broken hostname, causing k3s cluster formation to
+    fail with node-name collisions.
+    """
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+    vms = [r for r in resources if r.type == "vm"]
+    assert vms, "expected at least one VM resource"
+    for vm in vms:
+        assert "cloud_init_vars" in vm.config, (
+            f"VM {vm.name} is missing cloud_init_vars; system/hostname snippet "
+            f"substitution will fail"
+        )
+        assert vm.config["cloud_init_vars"]["HOSTNAME"] == vm.name, (
+            f"VM {vm.name}'s HOSTNAME cloud_init_var must match its own name "
+            f"(got {vm.config['cloud_init_vars']['HOSTNAME']!r})"
+        )
+
+
 def test_proxmox_k3s_cluster_example_dhcp_configs(loader: PackageLoader) -> None:
     """Each rendered kea_reservation matches its corresponding VM."""
     resources, _events, _variables = loader.load_package(


### PR DESCRIPTION
## Description

The `proxmox-k3s-cluster` blueprint references a shared cloud-init snippet `system/hostname` that contains a `${HOSTNAME}` placeholder, but the blueprint never populated `cloud_init_vars` to tell the framework what to substitute. The placeholder fell through to the generated cloud-init YAML as a literal string, every VM came up with the same broken hostname, k3s nodes collided on registration, and the on_create handler timed out after 30 minutes waiting for agents to become Ready.

**The framework already had the substitution mechanism** — `_merge_cloud_init_snippets()` at `provider_mixins.py:969-1020` reads `config.get("cloud_init_vars", {})` and does `snippet_content.replace(f"${{{var_name}}}", str(var_value))` on every loaded snippet before merging. This is tested at `tests/unit/test_cloud_init_mixin.py:96-107` which literally substitutes `${HOSTNAME}` → `web-01`. The blueprint just wasn't using it.

This PR adds the missing 6 lines of YAML that wire the per-VM hostname into the snippet substitution context. No framework changes.

## Related Issue

Addresses #526

**Reproduced live in this session** during the first attempt to apply the prod homelab `k3s-cluster` package after the framework gap fixes (#515, #510, #516, #517, #524) all landed. 4 VMs were created successfully, k3s installed on server + 2 agents, third agent timed out, the cluster had to be destroyed, and #526 was filed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `blueprints/proxmox-k3s-cluster/vm.yaml` — added `cloud_init_vars: { HOSTNAME: "{{ server_name }}" }` to the server VM entry and `cloud_init_vars: { HOSTNAME: "{{ agent.name }}" }` inside the `{% for agent in agents %}` loop. The blueprint's existing Jinja resolves these to per-VM consumer values, the framework's existing snippet merge substitutes `${HOSTNAME}` in the loaded `system/hostname.yaml` snippet, and each generated cloud-init user-data ends up with its own correct hostname.
- `tests/unit/test_proxmox_k3s_cluster_blueprint.py` — added `test_proxmox_k3s_cluster_example_sets_per_vm_cloud_init_hostname` regression guard. Loads the example consumer, asserts every VM resource has `config["cloud_init_vars"]["HOSTNAME"]` matching its own name.

**Not changed:**
- The `system/hostname.yaml` snippet itself — it's architecturally correct as a parameterized template; the bug was that the blueprint never told it what to substitute.
- Framework code — the substitution mechanism already exists and is tested.
- The `oci-k3s-cluster` blueprint — it sets `hostname: "{{ control_name }}"` directly in `instance.yaml` via the OCI provider's native cloud-init field, bypassing the snippet pathway. Not affected.

## Testing

- [x] All existing tests pass (`doit check` clean)
- [x] Added new regression test
- [ ] Manually tested end-to-end — **the verification IS the resumed k3s apply**. After this merges, re-running `infra apply --env prod --package k3s-cluster` against the homelab should produce 4 VMs with distinct correct hostnames, the on_create ansible handler should install k3s on all 4, and the cluster should form cleanly. **Not run as part of this PR.**

### New tests

- `test_proxmox_k3s_cluster_example_sets_per_vm_cloud_init_hostname` — for each VM resource loaded from the example consumer, asserts `cloud_init_vars["HOSTNAME"] == vm.name`. Catches regression where the blueprint stops populating the variable.

The framework-level test that proves the substitution itself works (`test_cloud_init_mixin.py::test_variable_substitution`) already exists and passes unchanged.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — **N/A**: no doc described this snippet contract or the `cloud_init_vars` mechanism in user-facing form. The blueprint README doesn't mention either.
- [ ] CHANGELOG.md — N/A, project does not maintain a manual CHANGELOG
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required: configuration fix to a specific blueprint, not an architectural decision.
- **Known follow-up (out of scope):** during this same apply, the on_create event handler's failure (`✗ Event handler k3s-install failed: Timeout after 1800 seconds`) did NOT prevent the overall apply from reporting `✓ Apply complete!` with exit 0. That's a third instance of the "framework reports success when something failed" bug class, same shape as #510 (terraform runner failure → success report) but for event handlers instead. Worth a follow-up issue after this PR merges and the k3s apply test resumes.
- **Session context:** this is the sixth framework gap fix in the audit cycle that started today. #515, #510, #516, #517, #524, and now #526. After this lands, the only known follow-up is the event-handler-honors-failure bug class noted above.
