### PR TITLE
fix: add terraform -parallelism flag support

### DIFF
--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -466,6 +466,7 @@ class DeploymentExecutor:
                     provider,
                     auto_approve=auto_approve,
                     target_resources=resource_filter if resource_filter else None,
+                    parallelism=provider.terraform_parallelism,
                 )
                 runner_results[tool_name] = run_result
 

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -1133,6 +1133,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                             provider,
                             auto_approve=auto_approve,
                             target_resources=resource_filter if resource_filter else None,
+                            parallelism=provider.terraform_parallelism,
                         )
                         provider_results[tool_name] = runner_result
 

--- a/src/infrafoundry/core/provider.py
+++ b/src/infrafoundry/core/provider.py
@@ -44,6 +44,7 @@ class ProviderBase(ABC):
         self.ansible_dir = output_dir / "ansible" / name
         self.pyinfra_dir = output_dir / "pyinfra" / name
         self._current_environment: str | None = None
+        self.terraform_parallelism: int | None = None
 
     def set_environment(self, env_name: str) -> None:
         """Set the current environment and update output directories.

--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -164,15 +164,20 @@ class TerraformRunner(BaseRunner):
 
         Args:
             provider: Provider instance
-            **kwargs: Options including auto_approve, target_resources
+            **kwargs: Options including auto_approve, target_resources, parallelism
 
         Returns:
             Dict with apply results
         """
         auto_approve = kwargs.get("auto_approve", False)
         target_resources = kwargs.get("target_resources")
+        parallelism = kwargs.get("parallelism")
         return self._run_terraform(
-            provider, "apply", auto_approve=auto_approve, target_resources=target_resources
+            provider,
+            "apply",
+            auto_approve=auto_approve,
+            target_resources=target_resources,
+            parallelism=parallelism,
         )
 
     def destroy(self, provider: ProviderBase, **kwargs: Any) -> dict[str, Any]:
@@ -180,15 +185,20 @@ class TerraformRunner(BaseRunner):
 
         Args:
             provider: Provider instance
-            **kwargs: Options including auto_approve, target_resources
+            **kwargs: Options including auto_approve, target_resources, parallelism
 
         Returns:
             Dict with destroy results
         """
         auto_approve = kwargs.get("auto_approve", False)
         target_resources = kwargs.get("target_resources")
+        parallelism = kwargs.get("parallelism")
         return self._run_terraform(
-            provider, "destroy", auto_approve=auto_approve, target_resources=target_resources
+            provider,
+            "destroy",
+            auto_approve=auto_approve,
+            target_resources=target_resources,
+            parallelism=parallelism,
         )
 
     @override
@@ -240,6 +250,7 @@ class TerraformRunner(BaseRunner):
         command: str,
         auto_approve: bool = False,
         target_resources: list[str] | None = None,
+        parallelism: int | None = None,
     ) -> dict[str, Any]:
         """Run Terraform command for a provider.
 
@@ -255,6 +266,11 @@ class TerraformRunner(BaseRunner):
             command: Terraform command (plan, apply, destroy)
             auto_approve: If True, add -auto-approve flag
             target_resources: Optional list of resource names to target with -target
+            parallelism: Max number of concurrent terraform operations. When
+                ``None`` (the default), terraform's built-in default of 10 is
+                used.  Set to 1 to serialize all resource operations — useful
+                for providers like Proxmox where parallel clones cause CFS lock
+                timeouts on shared storage.
 
         Returns:
             Dict with command results.  For apply/destroy, includes a
@@ -274,6 +290,11 @@ class TerraformRunner(BaseRunner):
         cmd = [self.tool_path, command]
         if auto_approve and command in {"apply", "destroy"}:
             cmd.append("-auto-approve")
+
+        # Limit concurrent operations when requested (e.g. -parallelism=1
+        # to serialize Proxmox VM clones that contend on NFS storage locks).
+        if parallelism is not None and command in {"apply", "destroy", "plan"}:
+            cmd.append(f"-parallelism={parallelism}")
 
         # Add -target flags for resource filtering
         if target_resources:

--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -38,6 +38,9 @@ class ProxmoxProvider(
         """Initialize Proxmox provider."""
         super().__init__("proxmox", config_dir, output_dir)
         self.fail_on_missing_snippets = False
+        # Serialize terraform operations to avoid CFS lock timeouts when
+        # cloning VMs onto shared (NFS/CIFS) storage in a Proxmox cluster.
+        self.terraform_parallelism = 1
         # Cache of resources from the most recent generate_terraform call.
         # Used by get_terraform_env_vars to resolve resource-level
         # ``terraform_secrets`` references into TF_VAR_* env vars.

--- a/tests/integration/test_orchestrator_workflows.py
+++ b/tests/integration/test_orchestrator_workflows.py
@@ -28,6 +28,7 @@ def mock_providers(tmp_path):
     proxmox.get_resource_types = Mock(return_value=["vm", "network", "template"])
     proxmox.get_dependencies = Mock(return_value={})  # No dependencies defined
     proxmox.get_terraform_env_vars = Mock(return_value={})
+    proxmox.terraform_parallelism = None
 
     return {"proxmox": proxmox}
 

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -556,7 +556,8 @@ def test_destroy_orchestrator_skips_generate_when_provider_lacks_method(console)
     runner_registry.list_runners.return_value = ["terraform"]
 
     # Provider deliberately lacks generate_terraform
-    provider = MagicMock(spec=["set_environment", "ensure_directories"])
+    provider = MagicMock(spec=["set_environment", "ensure_directories", "terraform_parallelism"])
+    provider.terraform_parallelism = None
     providers = cast("dict[str, ProviderBase]", {"proxmox": provider})
 
     resources = [_resource("vm1")]

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -66,6 +66,11 @@ class TestProviderBase:
         deps = provider.get_dependencies()
         assert deps == {}
 
+    def test_terraform_parallelism_defaults_to_none(self, temp_dir):
+        """Test terraform_parallelism defaults to None (terraform default of 10)."""
+        provider = StubProviderImplementation("test", temp_dir / "cfg", temp_dir / "out")
+        assert provider.terraform_parallelism is None
+
     def test_resource_config_creation(self):
         """Test ResourceConfig dataclass."""
         resource = ResourceConfig(

--- a/tests/unit/test_provider_proxmox.py
+++ b/tests/unit/test_provider_proxmox.py
@@ -34,6 +34,13 @@ class TestProxmoxProvider:
         assert "vm" in types
         assert "template" in types
 
+    def test_terraform_parallelism_defaults_to_one(self, temp_dir):
+        """Proxmox serializes terraform operations to avoid CFS lock timeouts."""
+        config_dir = temp_dir / "config"
+        config_dir.mkdir()
+        provider = ProxmoxProvider(config_dir=config_dir, output_dir=temp_dir / "output")
+        assert provider.terraform_parallelism == 1
+
     def test_get_dependencies(self, temp_dir):
         """Test dependency resolution."""
         config_dir = temp_dir / "config"

--- a/tests/unit/test_runner_terraform.py
+++ b/tests/unit/test_runner_terraform.py
@@ -214,6 +214,70 @@ def test_apply_adds_auto_approve(runner: TerraformRunner, provider: MagicMock) -
         assert mock_popen.call_args[1]["cwd"] == provider.terraform_dir
 
 
+def test_apply_passes_parallelism_flag(runner: TerraformRunner, provider: MagicMock) -> None:
+    """Apply passes -parallelism=N when requested."""
+    mock_process = MagicMock()
+    mock_process.stdout = iter([])
+    mock_process.stderr = MagicMock()
+    mock_process.stderr.__iter__ = MagicMock(return_value=iter([]))
+    mock_process.returncode = 0
+    mock_process.wait.return_value = 0
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+        patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        runner.apply(provider, auto_approve=True, parallelism=1)
+
+        args = mock_popen.call_args[0][0]
+        assert "-parallelism=1" in args
+        assert "-auto-approve" in args
+
+
+def test_apply_omits_parallelism_when_none(runner: TerraformRunner, provider: MagicMock) -> None:
+    """Apply does not add -parallelism when parallelism is None."""
+    mock_process = MagicMock()
+    mock_process.stdout = iter([])
+    mock_process.stderr = MagicMock()
+    mock_process.stderr.__iter__ = MagicMock(return_value=iter([]))
+    mock_process.returncode = 0
+    mock_process.wait.return_value = 0
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+        patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        runner.apply(provider, auto_approve=True)
+
+        args = mock_popen.call_args[0][0]
+        assert not any(a.startswith("-parallelism") for a in args)
+
+
+def test_destroy_passes_parallelism_flag(runner: TerraformRunner, provider: MagicMock) -> None:
+    """Destroy passes -parallelism=N when requested."""
+    mock_process = MagicMock()
+    mock_process.stdout = iter([])
+    mock_process.stderr = MagicMock()
+    mock_process.stderr.__iter__ = MagicMock(return_value=iter([]))
+    mock_process.returncode = 0
+    mock_process.wait.return_value = 0
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/terraform"),
+        patch("subprocess.run") as mock_run,
+        patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+    ):
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+        runner.destroy(provider, auto_approve=True, parallelism=2)
+
+        args = mock_popen.call_args[0][0]
+        assert "-parallelism=2" in args
+
+
 def test_validate_config_success(runner: TerraformRunner, provider: MagicMock) -> None:
     """Validate config succeeds when terraform validate exits 0."""
     (provider.terraform_dir / "main.tf").write_text("# test")


### PR DESCRIPTION
## Description

The terraform runner had no way to limit concurrent operations. Terraform defaults to 10 parallel operations, which causes CFS lock timeouts when cloning multiple VMs onto shared NFS storage in a Proxmox cluster. This adds a `terraform_parallelism` attribute to `ProviderBase` that flows through the runner to the `-parallelism=N` terraform CLI flag. ProxmoxProvider sets it to 1 by default to serialize operations and avoid lock contention.

## Related Issue

Addresses #528

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `terraform_parallelism` attribute to `ProviderBase` (defaults to `None`, meaning terraform's default of 10)
- Accept `parallelism` kwarg in `TerraformRunner._run_terraform()`, `apply()`, and `destroy()` methods
- Append `-parallelism=N` to terraform commands when a value is provided
- Pass `terraform_parallelism` from provider through `DeploymentExecutor.apply()` and `OrchestratorWorkflows.destroy()`
- Set `terraform_parallelism=1` on `ProxmoxProvider` to serialize operations by default

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

New test coverage:
- `test_provider.py`: verify `ProviderBase.terraform_parallelism` defaults to `None`
- `test_provider_proxmox.py`: verify `ProxmoxProvider.terraform_parallelism` defaults to `1`
- `test_runner_terraform.py`: verify `-parallelism=N` is passed on apply and destroy, and omitted when not set

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
