### PR TITLE
fix: expand ontap root aggregate and vol0 to prevent disk full

### DIFF
--- a/blueprints/ontap-cluster/roles/ontap-post-cluster/defaults/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-post-cluster/defaults/main.yml
@@ -24,6 +24,10 @@ ontap_licenses: []
 # Disk assignment — assign all unowned disks
 ontap_assign_disks: true
 
+# Root aggregate expansion — add spare disks to aggr0 to prevent vol0 from filling up
+ontap_root_aggregate_disk_count: 2
+ontap_root_volume_size: "3GB"
+
 # Aggregate configuration
 # Use node_index (0-based) instead of hardcoded node names.
 # Actual node names are discovered from the ONTAP REST API at runtime.

--- a/blueprints/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-post-cluster/tasks/main.yml
@@ -111,6 +111,41 @@
   ignore_errors: true
 
 # ---------------------------------------------------------------
+# Root aggregate expansion — add spare disks to aggr0
+# ---------------------------------------------------------------
+- name: Assign unowned disks for root aggregate expansion
+  netapp.ontap.na_ontap_disks:
+    <<: *ontap_conn
+    node: "{{ item }}"
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  when: ontap_root_aggregate_disk_count | int > 0
+  ignore_errors: true
+
+- name: Add disks to root aggregates
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "storage aggregate add-disks -aggregate aggr0_{{ item | regex_replace('-', '_') }} -diskcount {{ ontap_root_aggregate_disk_count }} -disksize 1"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  when: ontap_root_aggregate_disk_count | int > 0
+  ignore_errors: true
+
+- name: Expand root volume to use new aggregate space
+  netapp.ontap.na_ontap_command:
+    <<: *ontap_conn
+    command: "volume size -vserver {{ item }} -volume vol0 -new-size {{ ontap_root_volume_size }}"
+    privilege: admin
+  loop: "{{ ontap_discovered_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  when: ontap_root_aggregate_disk_count | int > 0 and ontap_root_volume_size | default('') | length > 0
+  ignore_errors: true
+
+# ---------------------------------------------------------------
 # Disk assignment
 # ---------------------------------------------------------------
 - name: Assign all unowned disks


### PR DESCRIPTION
## Description

Expand the ONTAP root aggregate (aggr0) and vol0 during post-cluster setup so the root volume does not fill up with its default 800MB allocation. The role now assigns unowned disks, adds spare disks to each node's aggr0 using `-disksize 1` for mixed-size disk compatibility, and resizes vol0 to a configurable size (default 3GB).

## Related Issue

Addresses #536

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `ontap_root_aggregate_disk_count` (default: 2) and `ontap_root_volume_size` (default: "3GB") variables to role defaults
- Added task to assign unowned disks before root aggregate expansion
- Added task to add spare disks to each node's aggr0 with `-disksize 1` for mixed-size compatibility
- Added task to expand vol0 to the configured size on each node

## Testing

- [ ] All existing tests pass (`doit check` passes)
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
