### PR TITLE
fix: add hostname, optional jumphost, and install URL to aiqum blueprint

### DIFF
--- a/blueprints/aiqum/blueprint.yaml
+++ b/blueprints/aiqum/blueprint.yaml
@@ -14,7 +14,12 @@ defaults:
   vlan_tag: 10
   mac_address: ""             # Empty: Proxmox auto-assigns
 
+  # --- SSH access ---
+  jumphost: ""                # Empty: direct SSH. Set to e.g. "ansible@jump.example.com"
+  ssh_user: ansible
+
   # --- AIQUM ---
+  aiqum_url_base: ""            # URL base for AIQUM install files (e.g. http://web.example.com/aiqum)
   aiqum_admin_user: umadmin
 
   # --- SMTP ---

--- a/blueprints/aiqum/scripts/aiqum-install-remote.sh
+++ b/blueprints/aiqum/scripts/aiqum-install-remote.sh
@@ -17,19 +17,19 @@ sudo yum install -y wget unzip
 # --- Step 2: Configure EPEL repository ---
 echo ""
 echo "=== Step 2: Configuring EPEL repository ==="
-wget -q https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -O epel-release-latest-9.noarch.rpm
+wget -4 -q https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -O epel-release-latest-9.noarch.rpm
 sudo yum install -y ./epel-release-latest-9.noarch.rpm
 
 # --- Step 3: Configure MySQL 8.4 Community repository ---
 echo ""
 echo "=== Step 3: Configuring MySQL 8.4 Community repository ==="
-wget -q http://repo.mysql.com/yum/mysql-8.4-community/el/9/x86_64/mysql84-community-release-el9-1.noarch.rpm -O mysql84-community-release-el9-1.noarch.rpm
+wget -4 -q http://repo.mysql.com/yum/mysql-8.4-community/el/9/x86_64/mysql84-community-release-el9-1.noarch.rpm -O mysql84-community-release-el9-1.noarch.rpm
 sudo yum install -y ./mysql84-community-release-el9-1.noarch.rpm
 
 # --- Step 4: Install 7-Zip ---
 echo ""
 echo "=== Step 4: Installing 7-Zip ==="
-curl -sO "${AIQUM_URL_BASE}/install7zip.sh"
+curl -4 -sO "${AIQUM_URL_BASE}/install7zip.sh"
 chmod +x install7zip.sh
 sudo bash install7zip.sh
 
@@ -48,12 +48,12 @@ sudo firewall-cmd --reload
 # --- Step 6: Download AIQUM files ---
 echo ""
 echo "=== Step 6: Downloading AIQUM files ==="
-curl -sO "${AIQUM_URL_BASE}/pre_install_check.sh"
+curl -4 -sO "${AIQUM_URL_BASE}/pre_install_check.sh"
 chmod +x pre_install_check.sh
 
 if [ ! -f netapp-um-9.18-el9.x86_64.rpm ]; then
     echo "Downloading netapp-um RPM (~1.9GB, please wait)..."
-    curl -sO "${AIQUM_URL_BASE}/netapp-um-9.18-el9.x86_64.rpm"
+    curl -4 -sO "${AIQUM_URL_BASE}/netapp-um-9.18-el9.x86_64.rpm"
     echo "Download complete ($(ls -lh netapp-um-9.18-el9.x86_64.rpm | awk '{print $5}'))"
 else
     echo "RPM already downloaded ($(ls -lh netapp-um-9.18-el9.x86_64.rpm | awk '{print $5}'))"

--- a/blueprints/aiqum/scripts/aiqum-post-terraform.sh
+++ b/blueprints/aiqum/scripts/aiqum-post-terraform.sh
@@ -40,19 +40,35 @@ for k, val in v.items():
 ")"
 fi
 
-JUMPHOST="${jumphost:-ansible@ansible.example.com}"
+JUMPHOST="${jumphost:-}"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+SSH_USER="${ssh_user:-ansible}"
+
+# Build remote command helpers based on whether a jumphost is configured
+if [ -n "${JUMPHOST}" ]; then
+    remote_cmd() { ${SSH} ${JUMPHOST} "${SSH} ${SSH_USER}@${1} '${2}'"; }
+    remote_cmd_long() { ${SSH} -o ServerAliveInterval=30 ${JUMPHOST} "${SSH} -o ServerAliveInterval=30 ${SSH_USER}@${1} '${2}'"; }
+    remote_upload() { scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$1" "${JUMPHOST}:/tmp/_aiqum_upload" && ${SSH} ${JUMPHOST} "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/_aiqum_upload ${SSH_USER}@${2}:${3}"; }
+else
+    remote_cmd() { ${SSH} ${SSH_USER}@${1} "${2}"; }
+    remote_cmd_long() { ${SSH} -o ServerAliveInterval=30 ${SSH_USER}@${1} "${2}"; }
+    remote_upload() { scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$1" "${SSH_USER}@${2}:${3}"; }
+fi
 
 echo "=== AIQUM Post-Terraform Setup ==="
 echo "VM: ${vm_name} (${ip_address})"
-echo "Jumphost: ${JUMPHOST}"
+if [ -n "${JUMPHOST}" ]; then
+    echo "Jumphost: ${JUMPHOST}"
+else
+    echo "Jumphost: (direct SSH)"
+fi
 
 # --- Phase 1: Wait for VM to be reachable ---
 echo ""
 echo "--- Phase 1: Waiting for VM to be reachable ---"
 MAX_WAIT=300
 ELAPSED=0
-while ! ${SSH} ${JUMPHOST} "${SSH} ansible@${ip_address} 'echo ready'" &>/dev/null; do
+while ! remote_cmd "${ip_address}" "echo ready" &>/dev/null; do
     if [ $ELAPSED -ge $MAX_WAIT ]; then
         echo "ERROR: VM not reachable after ${MAX_WAIT}s"
         exit 1
@@ -73,20 +89,13 @@ if [ ! -f "${REMOTE_SCRIPT}" ]; then
     exit 1
 fi
 
-# Step 1: Upload install script to jumphost
-echo "  Uploading install script to jumphost..."
-scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    "${REMOTE_SCRIPT}" "${JUMPHOST}:/tmp/aiqum-install-remote.sh"
+# Step 1: Upload install script to VM
+echo "  Uploading install script to VM..."
+remote_upload "${REMOTE_SCRIPT}" "${ip_address}" "/tmp/aiqum-install-remote.sh"
 
-# Step 2: Copy from jumphost to VM
-echo "  Copying install script to VM..."
-${SSH} ${JUMPHOST} "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    /tmp/aiqum-install-remote.sh ansible@${ip_address}:/tmp/aiqum-install-remote.sh"
-
-# Step 3: Run the install script on the VM (via jumphost)
+# Step 2: Run the install script on the VM
 echo "  Running install script on VM (downloading 1.9GB RPM + installing)..."
-${SSH} -o ServerAliveInterval=30 ${JUMPHOST} \
-    "${SSH} -o ServerAliveInterval=30 ansible@${ip_address} 'chmod +x /tmp/aiqum-install-remote.sh && bash /tmp/aiqum-install-remote.sh'"
+remote_cmd_long "${ip_address}" "chmod +x /tmp/aiqum-install-remote.sh && AIQUM_URL_BASE='${aiqum_url_base}' bash /tmp/aiqum-install-remote.sh"
 
 echo "  AIQUM RPM installed successfully"
 
@@ -116,12 +125,12 @@ echo "--- Phase 4: Regenerating certificates ---"
 
 # Regenerate client certificate (used for ONTAP mutual auth / EMS)
 echo "  Regenerating client certificate..."
-${SSH} ${JUMPHOST} "${SSH} ansible@${ip_address} 'sudo /opt/netapp/ocum/scripts/clientKeyManager.sh regenerate_client_cert jboss'"
+remote_cmd "${ip_address}" "sudo /opt/netapp/ocum/scripts/clientKeyManager.sh regenerate_client_cert jboss"
 echo "  Client certificate regenerated"
 
 # Restart AIQUM services to pick up new certs
 echo "  Restarting AIQUM services..."
-${SSH} ${JUMPHOST} "${SSH} ansible@${ip_address} 'sudo systemctl restart ocie ocieau'"
+remote_cmd "${ip_address}" "sudo systemctl restart ocie ocieau"
 
 # Wait for web UI to come back
 echo "  Waiting for AIQUM web UI to restart..."

--- a/blueprints/aiqum/vm.yaml
+++ b/blueprints/aiqum/vm.yaml
@@ -21,5 +21,8 @@ vms:
       - users/ansible
       - network/dhcp
       - packages/qemu-agent
+      - system/hostname
+    cloud_init_vars:
+      HOSTNAME: "{{ vm_name }}"
     tags: [ontap, aiqum]
     onboot: true

--- a/tests/unit/test_aiqum_blueprint.py
+++ b/tests/unit/test_aiqum_blueprint.py
@@ -117,6 +117,7 @@ def test_aiqum_example_vm_config_uses_merged_values(loader: PackageLoader) -> No
         "users/ansible",
         "network/dhcp",
         "packages/qemu-agent",
+        "system/hostname",
     ]
 
 


### PR DESCRIPTION
## Description

Fixes several issues in the aiqum blueprint discovered during end-to-end testing:

1. Added `system/hostname` cloud-init snippet and `cloud_init_vars.HOSTNAME` so the VM gets the correct hostname
2. Made jumphost optional — SSH helpers support both direct and jumphost-tunneled access
3. Added `aiqum_url_base` variable so the install script URL is configurable (was hardcoded placeholder)
4. Forced IPv4 on curl/wget in install script to avoid broken IPv6 routing to internal servers

## Related Issue

Addresses #540

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `blueprints/aiqum/vm.yaml` — added hostname snippet and cloud_init_vars
- `blueprints/aiqum/blueprint.yaml` — added jumphost, ssh_user, aiqum_url_base defaults
- `blueprints/aiqum/scripts/aiqum-post-terraform.sh` — refactored SSH to use helpers (direct or jumphost), pass AIQUM_URL_BASE
- `blueprints/aiqum/scripts/aiqum-install-remote.sh` — added -4 flag to curl/wget
- `tests/unit/test_aiqum_blueprint.py` — updated snippet list assertion

## Testing

- [x] All existing tests pass
- [x] Manually tested end-to-end: full AIQUM deploy with jumphost succeeds

## Checklist

- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings