### PR TITLE
refactor: extract ubuntu-template blueprint

### DIFF
--- a/blueprints/ubuntu-template/blueprint.yaml
+++ b/blueprints/ubuntu-template/blueprint.yaml
@@ -1,0 +1,19 @@
+name: ubuntu-template
+description: "Ubuntu 24.04 LTS cloud image Proxmox VM template"
+version: "1.0.0"
+
+defaults:
+  # --- Recipe constants (rarely overridden) ---
+  image_url: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
+  image_filename: "ubuntu-24.04-server-cloudimg-amd64.qcow2"
+  ciuser: ubuntu
+  cores: 2
+  memory: 2048
+  disk_size: 32
+  bridge: vmbr0
+
+  # --- Per-instance overrides (typical) ---
+  template_name: ubuntu-template
+
+resources:
+  - template.yaml

--- a/blueprints/ubuntu-template/template.yaml
+++ b/blueprints/ubuntu-template/template.yaml
@@ -1,0 +1,20 @@
+templates:
+  - name: "{{ template_name }}"
+    vmid: {{ vmid }}
+    target_node: "{{ target_node }}"
+    cores: {{ cores }}
+    memory: {{ memory }}
+    agent: true
+    cloud_init: true
+    cloud_init_datastore: "{{ storage }}"
+    ciuser: "{{ ciuser }}"
+    disk:
+      storage: "{{ storage }}"
+      size: {{ disk_size }}
+    network:
+      bridge: "{{ bridge }}"
+    download_image:
+      url: "{{ image_url }}"
+      filename: "{{ image_filename }}"
+    tags: ["template", "ubuntu"]
+    description: "Ubuntu 24.04 LTS cloud image template"


### PR DESCRIPTION
## Description

Extracts a reusable `ubuntu-template` blueprint mirroring the existing `rocky9-template` pattern. Downloads the Ubuntu 24.04 LTS cloud image and creates a Proxmox VM template.

## Related Issue

Addresses #542

## Type of Change

- [x] Code refactoring

## Changes Made

- Created `blueprints/ubuntu-template/blueprint.yaml` with defaults (image URL, ciuser, cores, memory, disk)
- Created `blueprints/ubuntu-template/template.yaml` resource template
- Note: filename uses `.qcow2` extension instead of `.img` because the Proxmox API rejects `.img` as an invalid extension

## Testing

- [x] All existing tests pass
- [x] Manually tested: deployed ubuntu-template on prod homelab (vmid 900, pve1)

## Checklist

- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings