### PR TITLE
fix: scope on_create event handlers to the created resource

### DIFF
--- a/src/infrafoundry/core/deployment_executor.py
+++ b/src/infrafoundry/core/deployment_executor.py
@@ -558,6 +558,7 @@ class DeploymentExecutor:
                     created_event,
                     target_resources=[resource.name],
                     package_filter=package_filter,
+                    resource_scoped=True,
                 )
 
         # Fire resource lifecycle events based on IaC outcomes
@@ -700,6 +701,7 @@ class DeploymentExecutor:
                     "address": outcome.address,
                     "action": outcome.action,
                 },
+                resource_scoped=True,
                 provider=provider_name,
                 resource=outcome.resource_name,
                 target_resources=[qualified_owner, outcome.resource_name],

--- a/src/infrafoundry/core/events/bus.py
+++ b/src/infrafoundry/core/events/bus.py
@@ -218,12 +218,18 @@ class UnifiedEventBus(BaseManager):
         self,
         context: EventContext,
         abort_on_failure: bool = True,
+        resource_scoped: bool = False,
     ) -> list[EventResult]:
         """Emit an event to all registered handlers.
 
         Args:
             context: Event context with all relevant information
             abort_on_failure: If True, raise EventAbortedError on handler abort
+            resource_scoped: If True, only fire handlers that have
+                ``_resource_owner`` set (i.e., resource-level handlers).
+                Package-level handlers (without ``_resource_owner``) are
+                skipped. This prevents package-level ``on_create`` handlers
+                from firing on per-resource events.
 
         Returns:
             List of results from all handlers
@@ -239,6 +245,12 @@ class UnifiedEventBus(BaseManager):
 
         # Execute registered handlers
         for handler in self._handlers[event_type]:
+            if resource_scoped and not handler.is_resource_scoped:
+                self._log_debug(
+                    f"Skipping handler {handler.name}: "
+                    f"resource_scoped emit but handler has no _resource_owner"
+                )
+                continue
             if not handler.matches_package(context.package_filter):
                 self._log_debug(
                     f"Skipping handler {handler.name}: "
@@ -273,6 +285,8 @@ class UnifiedEventBus(BaseManager):
         event_type: EventType,
         environment: str,
         data: Mapping[str, Any] | None = None,
+        *,
+        resource_scoped: bool = False,
         **kwargs: Any,
     ) -> list[EventResult]:
         """Convenience method to create context and emit.
@@ -283,6 +297,8 @@ class UnifiedEventBus(BaseManager):
             event_type: Type of event
             environment: Environment name
             data: Event-specific data (dict or TypedDict)
+            resource_scoped: If True, only fire resource-level handlers
+                (those with ``_resource_owner`` set).
             **kwargs: Additional context fields (provider, resource, etc.)
 
         Returns:
@@ -294,7 +310,7 @@ class UnifiedEventBus(BaseManager):
             data=dict(data) if data else {},
             **kwargs,
         )
-        return self.emit(context)
+        return self.emit(context, resource_scoped=resource_scoped)
 
     def _execute_handler(
         self,

--- a/src/infrafoundry/core/events/handlers/base.py
+++ b/src/infrafoundry/core/events/handlers/base.py
@@ -28,6 +28,16 @@ class BaseHandler(ABC):
         """Handler name for logging and identification."""
         return str(self._name)
 
+    @property
+    def is_resource_scoped(self) -> bool:
+        """Whether this handler is scoped to a specific resource.
+
+        Returns:
+            True when ``_resource_owner`` is set, meaning the handler was
+            registered for a specific resource (e.g., on_create on a VM).
+        """
+        return self._resource_owner is not None
+
     @abstractmethod
     def execute(self, context: EventContext) -> EventResult:
         """Execute the handler for an event.

--- a/tests/unit/test_package_event_filtering.py
+++ b/tests/unit/test_package_event_filtering.py
@@ -252,6 +252,174 @@ class TestResourceOwnerScoping:
         assert handler.matches_resources(["db-server"]) is False
 
 
+# --- BaseHandler.is_resource_scoped property (#539) ---
+
+
+class TestIsResourceScoped:
+    """Tests for BaseHandler.is_resource_scoped property."""
+
+    def test_handler_with_resource_owner_is_scoped(self) -> None:
+        """Handler with _resource_owner is resource-scoped."""
+        handler = _make_handler_with_owner(resource_owner="web-server")
+        assert handler.is_resource_scoped is True
+
+    def test_handler_without_resource_owner_is_not_scoped(self) -> None:
+        """Handler without _resource_owner is not resource-scoped."""
+        handler = _make_handler_with_owner(resource_owner=None)
+        assert handler.is_resource_scoped is False
+
+    def test_package_level_handler_is_not_scoped(self) -> None:
+        """Package-level handler (with _package but no _resource_owner) is not scoped."""
+        handler = _make_handler(package="k3s-cluster")
+        assert handler.is_resource_scoped is False
+
+
+# --- resource_scoped emit (#539) ---
+
+
+class TestResourceScopedEmit:
+    """Tests for resource_scoped parameter in UnifiedEventBus.emit()."""
+
+    def test_resource_scoped_skips_package_level_handler(self) -> None:
+        """emit() with resource_scoped=True skips handlers without _resource_owner."""
+        bus = UnifiedEventBus()
+        # Package-level handler with requires (the bug scenario)
+        bus.register_handler(
+            EventType.RESOURCE_CREATED,
+            {
+                "type": "python",
+                "module": "dummy",
+                "function": "handler",
+                "name": "pkg-handler",
+                "requires": ["aiqum"],
+            },
+        )
+
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="prod",
+            target_resources=["aiqum"],
+        )
+        results = bus.emit(ctx, abort_on_failure=False, resource_scoped=True)
+        assert len(results) == 0
+
+    def test_resource_scoped_fires_resource_level_handler(self) -> None:
+        """emit() with resource_scoped=True fires handlers with _resource_owner."""
+        bus = UnifiedEventBus()
+        bus.register_handler(
+            EventType.RESOURCE_CREATED,
+            {
+                "type": "python",
+                "module": "dummy",
+                "function": "handler",
+                "name": "res-handler",
+                "_resource_owner": "aiqum",
+            },
+        )
+
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="prod",
+            target_resources=["aiqum"],
+        )
+        results = bus.emit(ctx, abort_on_failure=False, resource_scoped=True)
+        assert len(results) == 1
+
+    def test_non_resource_scoped_fires_all(self) -> None:
+        """emit() without resource_scoped fires both package and resource handlers."""
+        bus = UnifiedEventBus()
+        bus.register_handler(
+            EventType.RESOURCE_CREATED,
+            {
+                "type": "python",
+                "module": "dummy",
+                "function": "handler",
+                "name": "pkg-handler",
+                "requires": ["aiqum"],
+            },
+        )
+        bus.register_handler(
+            EventType.RESOURCE_CREATED,
+            {
+                "type": "python",
+                "module": "dummy",
+                "function": "handler",
+                "name": "res-handler",
+                "_resource_owner": "aiqum",
+            },
+        )
+
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="prod",
+            target_resources=["aiqum"],
+        )
+        results = bus.emit(ctx, abort_on_failure=False, resource_scoped=False)
+        assert len(results) == 2
+
+    def test_emit_event_passes_resource_scoped(self) -> None:
+        """emit_event() convenience method passes resource_scoped to emit()."""
+        bus = UnifiedEventBus()
+        bus.register_handler(
+            EventType.RESOURCE_CREATED,
+            {
+                "type": "python",
+                "module": "dummy",
+                "function": "handler",
+                "name": "pkg-handler",
+                "requires": ["aiqum"],
+            },
+        )
+
+        results = bus.emit_event(
+            EventType.RESOURCE_CREATED,
+            "prod",
+            {"action": "create"},
+            resource_scoped=True,
+            target_resources=["aiqum"],
+        )
+        assert len(results) == 0
+
+    def test_resource_scoped_mixed_handlers(self) -> None:
+        """resource_scoped=True: only resource-level handler fires, not package-level.
+
+        This is the exact scenario from issue #539: a package-level on_create
+        handler with requires: ["aiqum"] should NOT fire when a DHCP
+        reservation named "aiqum" triggers a per-resource RESOURCE_CREATED event.
+        """
+        bus = UnifiedEventBus()
+        # Package-level handler (no _resource_owner) — should be skipped
+        bus.register_handler(
+            EventType.RESOURCE_CREATED,
+            {
+                "type": "python",
+                "module": "dummy",
+                "function": "handler",
+                "name": "pkg-on-create",
+                "requires": ["aiqum"],
+            },
+        )
+        # Resource-level handler (has _resource_owner) — should fire
+        bus.register_handler(
+            EventType.RESOURCE_CREATED,
+            {
+                "type": "python",
+                "module": "dummy",
+                "function": "handler",
+                "name": "res-on-create",
+                "_resource_owner": "aiqum",
+            },
+        )
+
+        ctx = EventContext(
+            event_type=EventType.RESOURCE_CREATED,
+            environment="prod",
+            target_resources=["opnsense:aiqum", "aiqum"],
+        )
+        results = bus.emit(ctx, abort_on_failure=False, resource_scoped=True)
+        assert len(results) == 1
+
+
 class TestEventBusResourceOwnerFiltering:
     """Integration tests for _resource_owner filtering in UnifiedEventBus.emit()."""
 

--- a/tests/unit/test_resource_lifecycle_events.py
+++ b/tests/unit/test_resource_lifecycle_events.py
@@ -649,6 +649,62 @@ class TestTypeAwareEventFiring:
         assert executor.event_manager.emit_event.call_count == 1
 
 
+# --- Per-resource events pass resource_scoped=True (#539) ---
+
+
+class TestPerResourceEventResourceScoped:
+    """Test that _fire_resource_lifecycle_events passes resource_scoped=True.
+
+    This ensures package-level handlers (without _resource_owner) are NOT
+    triggered by per-resource events, only by the aggregate event in apply_serial.
+    """
+
+    def _make_executor(self) -> Any:
+        """Create a DeploymentExecutor with mocked dependencies."""
+        from infrafoundry.core.deployment_executor import DeploymentExecutor
+
+        executor = DeploymentExecutor(
+            runner_registry=MagicMock(),
+            state_manager=MagicMock(),
+            event_manager=MagicMock(),
+            providers={},
+        )
+        return executor
+
+    def _make_provider(self, tf_type_map: dict[str, list[str]]) -> MagicMock:
+        """Create a mock provider with the given terraform type mapping."""
+        provider = MagicMock()
+        provider.get_terraform_resource_types.return_value = tf_type_map
+        return provider
+
+    def test_per_resource_event_sets_resource_scoped(self) -> None:
+        """emit_event in _fire_resource_lifecycle_events passes resource_scoped=True."""
+        executor = self._make_executor()
+        provider = self._make_provider(
+            {"vm": ["proxmox_virtual_environment_vm"]},
+        )
+        resource = ResourceConfig(
+            name="aiqum",
+            type="vm",
+            provider="proxmox",
+            config={"name": "aiqum"},
+            events={"on_create": [{"type": "script", "script": "setup.sh"}]},
+        )
+        outcome = ResourceOutcome(
+            address="proxmox_virtual_environment_vm.aiqum",
+            action="create",
+            resource_name="aiqum",
+        )
+
+        executor._fire_resource_lifecycle_events(
+            "prod", "proxmox", provider, [resource], [outcome], None
+        )
+
+        assert executor.event_manager.emit_event.called
+        call_kwargs = executor.event_manager.emit_event.call_args
+        assert call_kwargs.kwargs.get("resource_scoped") is True
+
+
 # --- Aggregate event deduplication ---
 
 


### PR DESCRIPTION
## Description

Fixes resource scoping for `on_create` event handlers. Previously, a handler attached to one package could fire against resources created as part of a different package in the same terraform apply, because the `resource_scoped` flag wasn't being set on all `emit_event` call sites in `DeploymentExecutor`.

## Related Issue

Addresses #539

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Set `resource_scoped=True` on the two `emit_event` call sites in `DeploymentExecutor.apply_serial` that fire `RESOURCE_CREATED`.
- Added helper support in `core/events/bus.py` and `core/events/handlers/base.py` so the scoping flag is consistently respected when filtering handler matches.
- Added unit tests covering the package-filter path (`test_package_event_filtering.py`) and the per-resource lifecycle path (`test_resource_lifecycle_events.py`).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type, tests, security, spelling).

Validated end-to-end by deploying aiqum-test during debugging: the `aiqum-setup` handler now fires exactly once against the aiqum VM resource, not three times against unrelated resources in the same apply.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
