### PR TITLE
chore: raise script and ansible handler timeout cap to 14400

### DIFF
--- a/blueprints/aiqum/blueprint.yaml
+++ b/blueprints/aiqum/blueprint.yaml
@@ -38,7 +38,7 @@ events:
       name: aiqum-setup
       script: scripts/aiqum-post-terraform.sh
       description: "Install AIQUM, complete first-experience wizard, add ONTAP cluster"
-      timeout: 1800
+      timeout: 5400
       continue_on_error: false
       requires:
         - "{{ vm_name }}"

--- a/src/infrafoundry/core/events/handlers/ansible.py
+++ b/src/infrafoundry/core/events/handlers/ansible.py
@@ -82,8 +82,8 @@ class AnsibleHandler(BaseHandler):
             errors.append("Ansible handler requires 'playbook' field")
 
         timeout = self.config.get("timeout", 300)
-        if not isinstance(timeout, int) or timeout < 1 or timeout > 3600:
-            errors.append("Timeout must be an integer between 1 and 3600")
+        if not isinstance(timeout, int) or timeout < 1 or timeout > 14400:
+            errors.append("Timeout must be an integer between 1 and 14400")
 
         return errors
 

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -79,8 +79,8 @@ class ScriptHandler(BaseHandler):
             errors.append("Script handler requires 'script' field")
 
         timeout = self.config.get("timeout", 300)
-        if not isinstance(timeout, int) or timeout < 1 or timeout > 3600:
-            errors.append("Timeout must be an integer between 1 and 3600")
+        if not isinstance(timeout, int) or timeout < 1 or timeout > 14400:
+            errors.append("Timeout must be an integer between 1 and 14400")
 
         return errors
 

--- a/tests/unit/test_aiqum_blueprint.py
+++ b/tests/unit/test_aiqum_blueprint.py
@@ -151,7 +151,7 @@ def test_aiqum_blueprint_inherits_events(loader: PackageLoader) -> None:
     assert handler["type"] == "script"
     assert handler["name"] == "aiqum-setup"
     assert handler["script"].endswith("scripts/aiqum-post-terraform.sh")
-    assert handler["timeout"] == 1800
+    assert handler["timeout"] == 5400
     assert handler["continue_on_error"] is False
     # Templated requires field rendered with per-instance vm_name
     assert handler["requires"] == ["aiqum"]


### PR DESCRIPTION
## Description

Raises the maximum allowed event-handler timeout in `ScriptHandler` and `AnsibleHandler` from 3600 seconds (60 minutes) to 14400 seconds (4 hours), and bumps the aiqum blueprint's handler timeout from 1800 to 5400 seconds as the immediate user of the raised cap.

The 3600-second cap was too tight for legitimate long-running post-terraform installers. Concrete example: the aiqum blueprint installs NetApp Active IQ Unified Manager, which involves a ~1.9 GB RPM download, 225 package installs, ~40 MySQL restart cycles inside the netapp-um postinstall scriptlet, cert regeneration, and the first-experience-wizard API setup. On reasonable hardware this comfortably exceeds 30 minutes and pushed past 60 minutes under memory / storage / network pressure.

4 hours is a ceiling that still catches runaway/infinite-loop bugs but no longer restricts real workloads. The floor stays at 1 second.

## Related Issue

Addresses #546

## Type of Change

- [x] Code refactoring
- [x] Bug fix (unblocks aiqum-test from hitting the cap)

## Changes Made

- `src/infrafoundry/core/events/handlers/script.py`: upper bound 3600 → 14400.
- `src/infrafoundry/core/events/handlers/ansible.py`: upper bound 3600 → 14400.
- `blueprints/aiqum/blueprint.yaml`: `aiqum-setup` handler timeout 1800 → 5400.
- `tests/unit/test_aiqum_blueprint.py`: update assertion to match.

## Testing

- [x] All existing tests pass
- [x] Updated the one test that hardcoded the old 1800 value
- [x] Manually verified aiqum-test deploys end-to-end on pve3 without hitting the cap

`doit check` passes locally (format, lint, type, tests, security, spelling).

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the test that depends on the changed value
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
