### PR TITLE
refactor: add timestamps and jumphost-reexec helper to aiqum scripts

### DIFF
--- a/blueprints/_lib/reexec-on-jumphost.sh
+++ b/blueprints/_lib/reexec-on-jumphost.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Shared helper: re-execute the calling script on the jumphost if one is
+# configured in the package variables. Sourced by blueprint post-terraform
+# scripts that need to run one hop from the VM (e.g. to reach API endpoints
+# on a VLAN that isn't directly routable from the operator's workstation).
+#
+# Usage (at the top of any blueprint script):
+#
+#   #!/bin/bash
+#   set -euo pipefail
+#   SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+#   source "${SCRIPT_DIR}/../../_lib/reexec-on-jumphost.sh"
+#
+#   # ... rest of the blueprint's script, unchanged ...
+#
+# Behavior:
+#   - If no jumphost is configured, returns immediately. Script continues
+#     running on the operator's host.
+#   - If a jumphost is configured and we are NOT already on it:
+#       * rsyncs the calling script's directory to the jumphost
+#       * re-executes the same script there via ssh
+#       * pipes INFRAFOUNDRY_PACKAGE_VARS through stdin (secrets never appear
+#         on the command line or in ps output)
+#       * exits with the remote exit code
+#   - Strips "jumphost" from the forwarded INFRAFOUNDRY_PACKAGE_VARS so the
+#     downstream copy of the script parses the JSON and sees no jumphost,
+#     and its existing remote_cmd helpers (which branch on ${jumphost:-}) do
+#     direct SSH to the target VM rather than nested jumphost-to-jumphost.
+#   - INFRAFOUNDRY_ON_JUMPHOST=1 is set on re-exec as a recursion guard.
+#
+# Prerequisites on the jumphost:
+#   - bash, rsync, python3 (standard on any ansible control node)
+#   - Whatever the downstream script itself needs (e.g. python3 requests)
+
+if [ -n "${INFRAFOUNDRY_VAR_jumphost:-}" ] && [ -z "${INFRAFOUNDRY_ON_JUMPHOST:-}" ]; then
+    _JH="${INFRAFOUNDRY_VAR_jumphost}"
+    _CALLER="$(realpath "$0")"
+    _CALLER_DIR="$(dirname "${_CALLER}")"
+    _CALLER_NAME="$(basename "${_CALLER}")"
+    _REMOTE_DIR="/tmp/infrafoundry-$$"
+
+    _REMOTE_VARS=$(python3 -c '
+import json, os, sys
+v = json.loads(os.environ.get("INFRAFOUNDRY_PACKAGE_VARS", "{}"))
+v.pop("jumphost", None)
+sys.stdout.write(json.dumps(v))
+')
+
+    echo "[$(date +%H:%M:%S)] reexec: shipping ${_CALLER_DIR} to ${_JH} and running ${_CALLER_NAME}"
+    ssh -o StrictHostKeyChecking=no "${_JH}" "mkdir -p ${_REMOTE_DIR}" || exit 1
+    rsync -a -e "ssh -o StrictHostKeyChecking=no" "${_CALLER_DIR}/" "${_JH}:${_REMOTE_DIR}/" || exit 1
+    printf '%s' "${_REMOTE_VARS}" | ssh -o StrictHostKeyChecking=no "${_JH}" \
+        "INFRAFOUNDRY_ON_JUMPHOST=1 INFRAFOUNDRY_PACKAGE_VARS=\"\$(cat)\" bash ${_REMOTE_DIR}/${_CALLER_NAME}"
+    _rc=$?
+    ssh -o StrictHostKeyChecking=no "${_JH}" "rm -rf ${_REMOTE_DIR}" 2>/dev/null || true
+    exit ${_rc}
+fi

--- a/blueprints/aiqum/scripts/aiqum-install-remote.sh
+++ b/blueprints/aiqum/scripts/aiqum-install-remote.sh
@@ -5,37 +5,39 @@
 # then installs the AIQUM RPM.
 set -euo pipefail
 
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+
 AIQUM_URL_BASE="${AIQUM_URL_BASE:-http://your-web-server/applications/aiqum}"
 
 mkdir -p /tmp/aiqum-install
 cd /tmp/aiqum-install
 
 # --- Step 1: Install basic tools ---
-echo "=== Step 1: Installing basic tools ==="
+log "=== Step 1: Installing basic tools ==="
 sudo yum install -y wget unzip
 
 # --- Step 2: Configure EPEL repository ---
 echo ""
-echo "=== Step 2: Configuring EPEL repository ==="
+log "=== Step 2: Configuring EPEL repository ==="
 wget -4 -q https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -O epel-release-latest-9.noarch.rpm
 sudo yum install -y ./epel-release-latest-9.noarch.rpm
 
 # --- Step 3: Configure MySQL 8.4 Community repository ---
 echo ""
-echo "=== Step 3: Configuring MySQL 8.4 Community repository ==="
+log "=== Step 3: Configuring MySQL 8.4 Community repository ==="
 wget -4 -q http://repo.mysql.com/yum/mysql-8.4-community/el/9/x86_64/mysql84-community-release-el9-1.noarch.rpm -O mysql84-community-release-el9-1.noarch.rpm
 sudo yum install -y ./mysql84-community-release-el9-1.noarch.rpm
 
 # --- Step 4: Install 7-Zip ---
 echo ""
-echo "=== Step 4: Installing 7-Zip ==="
+log "=== Step 4: Installing 7-Zip ==="
 curl -4 -sO "${AIQUM_URL_BASE}/install7zip.sh"
 chmod +x install7zip.sh
 sudo bash install7zip.sh
 
 # --- Step 5: Install firewalld and open AIQUM ports ---
 echo ""
-echo "=== Step 5: Configuring firewall ==="
+log "=== Step 5: Configuring firewall ==="
 sudo yum install -y firewalld
 sudo systemctl enable firewalld
 sudo systemctl start firewalld
@@ -47,7 +49,7 @@ sudo firewall-cmd --reload
 
 # --- Step 6: Download AIQUM files ---
 echo ""
-echo "=== Step 6: Downloading AIQUM files ==="
+log "=== Step 6: Downloading AIQUM files ==="
 curl -4 -sO "${AIQUM_URL_BASE}/pre_install_check.sh"
 chmod +x pre_install_check.sh
 
@@ -61,12 +63,12 @@ fi
 
 # --- Step 7: Verify prerequisites ---
 echo ""
-echo "=== Step 7: Verifying prerequisites ==="
+log "=== Step 7: Verifying prerequisites ==="
 sudo bash pre_install_check.sh || true
 
 # --- Step 8: Install AIQUM RPM ---
 echo ""
-echo "=== Step 8: Installing AIQUM RPM ==="
+log "=== Step 8: Installing AIQUM RPM ==="
 echo "This may take several minutes..."
 sudo yum install -y ./netapp-um-9.18-el9.x86_64.rpm
 

--- a/blueprints/aiqum/scripts/aiqum-post-terraform.sh
+++ b/blueprints/aiqum/scripts/aiqum-post-terraform.sh
@@ -18,8 +18,19 @@
 # - SSH jumphost reachable (set jumphost in infrafoundry.yml)
 set -euo pipefail
 
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Re-execute on the jumphost if one is configured. No-op otherwise.
+# See blueprints/_lib/reexec-on-jumphost.sh for behavior details.
+# The file-exists check is intentional: when the reexec'd copy of this
+# script runs on the jumphost, _lib/ has not been rsynced alongside, so
+# the helper is absent and the source is skipped. That's the base case
+# that breaks the reexec loop.
+_REEXEC_HELPER="${SCRIPT_DIR}/../../_lib/reexec-on-jumphost.sh"
+[ -f "${_REEXEC_HELPER}" ] && source "${_REEXEC_HELPER}"
 
 # Read variables from INFRAFOUNDRY_PACKAGE_VARS or fall back to infrafoundry.yml
 if [ -n "${INFRAFOUNDRY_PACKAGE_VARS:-}" ]; then
@@ -55,7 +66,7 @@ else
     remote_upload() { scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$1" "${SSH_USER}@${2}:${3}"; }
 fi
 
-echo "=== AIQUM Post-Terraform Setup ==="
+log "=== AIQUM Post-Terraform Setup ==="
 echo "VM: ${vm_name} (${ip_address})"
 if [ -n "${JUMPHOST}" ]; then
     echo "Jumphost: ${JUMPHOST}"
@@ -65,7 +76,7 @@ fi
 
 # --- Phase 1: Wait for VM to be reachable ---
 echo ""
-echo "--- Phase 1: Waiting for VM to be reachable ---"
+log "--- Phase 1: Waiting for VM to be reachable ---"
 MAX_WAIT=300
 ELAPSED=0
 while ! remote_cmd "${ip_address}" "echo ready" &>/dev/null; do
@@ -81,7 +92,7 @@ echo "  VM is reachable via SSH"
 
 # --- Phase 2: Upload and run install script ---
 echo ""
-echo "--- Phase 2: Installing AIQUM RPM ---"
+log "--- Phase 2: Installing AIQUM RPM ---"
 
 REMOTE_SCRIPT="${SCRIPT_DIR}/aiqum-install-remote.sh"
 if [ ! -f "${REMOTE_SCRIPT}" ]; then
@@ -101,7 +112,7 @@ echo "  AIQUM RPM installed successfully"
 
 # --- Phase 3: Wait for AIQUM web UI ---
 echo ""
-echo "--- Phase 3: Waiting for AIQUM web UI ---"
+log "--- Phase 3: Waiting for AIQUM web UI ---"
 MAX_WAIT=600
 ELAPSED=0
 while ! curl -sk -o /dev/null -w "%{http_code}" "https://${ip_address}/" 2>/dev/null | grep -q "200\|302\|401"; do
@@ -121,7 +132,7 @@ echo "  AIQUM web UI is available"
 # failure. Regenerate both the HTTPS cert and the client cert (used for mutual
 # auth with ONTAP) so they include the FQDN.
 echo ""
-echo "--- Phase 4: Regenerating certificates ---"
+log "--- Phase 4: Regenerating certificates ---"
 
 # Regenerate client certificate (used for ONTAP mutual auth / EMS)
 echo "  Regenerating client certificate..."
@@ -148,10 +159,10 @@ echo "  AIQUM web UI is back"
 
 # --- Phase 5: Run initial setup wizard (FEW) ---
 echo ""
-echo "--- Phase 5: Running initial setup wizard ---"
+log "--- Phase 5: Running initial setup wizard ---"
 python3 "${SCRIPT_DIR}/aiqum-initial-setup.py"
 
 echo ""
-echo "=== AIQUM Setup Complete ==="
+log "=== AIQUM Setup Complete ==="
 echo "  URL: https://${ip_address}/"
 echo "  User: ${aiqum_admin_user}"


### PR DESCRIPTION
## Description

Two related robustness improvements to the aiqum post-terraform scripts, driven by failures encountered deploying aiqum-test on a newly-added VLAN.

**1. Per-phase/step timestamps via a `log()` helper.**

Both `aiqum-install-remote.sh` and `aiqum-post-terraform.sh` now prefix every phase banner and step banner with `[HH:MM:SS]`. Pure observability: when the handler log spans 20-40 minutes, it's now obvious where time was spent per phase. No behavior change.

**2. New `blueprints/_lib/reexec-on-jumphost.sh` shared helper.**

Any blueprint script can source it at the top. If `INFRAFOUNDRY_VAR_jumphost` is set, the helper rsyncs the calling script's directory to the jumphost, strips `jumphost` from the forwarded `INFRAFOUNDRY_PACKAGE_VARS`, pipes the modified JSON via stdin to `ssh` (keeps secrets out of `ps` output), and re-executes the same script on the jumphost with `INFRAFOUNDRY_ON_JUMPHOST=1` set as a recursion guard.

`aiqum-post-terraform.sh` now sources this helper. When a jumphost is configured, the entire post-terraform script runs on the jumphost. Phases 1-4 degrade cleanly to direct SSH via the existing `remote_cmd` helpers' no-jumphost branch, and Phase 5's Python first-experience wizard (`aiqum-initial-setup.py`, which uses `requests.*` to hit the VM's REST API) reaches the VM directly from the jumphost without needing the operator host to have routing to the target VLAN.

## Related Issue

Addresses #548. Interim fix for the same underlying gap tracked in #544 (framework-native version).

## Type of Change

- [x] Code refactoring
- [x] Bug fix (deployment now works from operator hosts that don't have direct reachability to the target VLAN)

## Changes Made

- `blueprints/_lib/reexec-on-jumphost.sh`: new shared helper (~60 lines incl. extensive documentation).
- `blueprints/aiqum/scripts/aiqum-install-remote.sh`: added `log()` helper, converted `Step N:` banners.
- `blueprints/aiqum/scripts/aiqum-post-terraform.sh`: added `log()` helper, converted `Phase N:` and start/end banners, added conditional `source` of the reexec helper (with file-exists guard so the re-exec'd copy on the jumphost doesn't recurse).

## Testing

- [x] All existing tests pass
- [x] Manually validated end-to-end aiqum-test deploy with the reexec helper in place — all 5 phases complete successfully, including the first-experience wizard which previously failed due to operator-host routing gaps.

`doit check` passes locally.

## Follow-ups

- Once #544 lands (framework-native jumphost reexec in `ScriptHandler`), both `blueprints/_lib/reexec-on-jumphost.sh` and the `source` line in `aiqum-post-terraform.sh` can be removed.

## Checklist

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Helper includes inline documentation covering usage and behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
