### PR TITLE
fix: support cloning aiqum VM from template on a different node

### DIFF
--- a/blueprints/aiqum/blueprint.yaml
+++ b/blueprints/aiqum/blueprint.yaml
@@ -5,6 +5,7 @@ version: "1.0.0"
 defaults:
   # --- VM hardware ---
   template_vmid: 901          # Standard rocky9-template vmid
+  template_node: pve1         # Proxmox node hosting the template
   cores: 4
   memory: 12288               # AIQUM minimum recommendation (12 GiB)
   disk_size: 150              # AIQUM minimum (~100 GB+)

--- a/blueprints/aiqum/vm.yaml
+++ b/blueprints/aiqum/vm.yaml
@@ -4,7 +4,9 @@ vms:
   - name: "{{ vm_name }}"
     vmid: {{ vmid }}
     target_node: "{{ target_node }}"
-    clone: {{ template_vmid }}
+    clone:
+      vm_id: {{ template_vmid }}
+      node_name: "{{ template_node }}"
     cores: {{ cores }}
     memory: {{ memory }}
     agent: true

--- a/tests/unit/test_aiqum_blueprint.py
+++ b/tests/unit/test_aiqum_blueprint.py
@@ -97,7 +97,7 @@ def test_aiqum_example_vm_config_uses_merged_values(loader: PackageLoader) -> No
     assert config["disk"]["storage"] == "local-lvm"
 
     # Blueprint defaults
-    assert config["clone"] == 901
+    assert config["clone"] == {"vm_id": 901, "node_name": "pve1"}
     assert config["cores"] == 4
     assert config["memory"] == 12288
     assert config["disk"]["size"] == 150


### PR DESCRIPTION
## Description

The aiqum blueprint's `vm.yaml` used the scalar shorthand `clone: {{ template_vmid }}`, which the framework normalizes to `{"vm_id": <scalar>}` with no `node_name`. The generated terraform then produces a `clone` block with only `vm_id`, and the Proxmox provider defaults the clone source node to `target_node`. This silently breaks when the rocky9 template and the target VM live on different Proxmox nodes.

Discovered when moving aiqum-test from pve2 to pve3 to dodge host memory pressure: rocky9-template (vmid 901) only lives on pve1, and the deploy couldn't find the template on pve3.

The framework already supports the dict form — normalization at `providers/proxmox/__init__.py:298-301` and conditional `node_name` emission at `templates/proxmox/vms.tf.j2:86-88`. The aiqum blueprint just wasn't using it. Pure blueprint fix.

## Related Issue

Addresses #550

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `blueprints/aiqum/vm.yaml`: clone switched from scalar to dict form with `vm_id` and `node_name`.
- `blueprints/aiqum/blueprint.yaml`: added `template_node: pve1` default (current location of rocky9-template in this homelab). Packages can override if their template lives elsewhere.
- `tests/unit/test_aiqum_blueprint.py`: updated clone assertion to expect the dict form.

## Testing

- [x] All existing tests pass
- [x] Updated the one test that hardcoded the old scalar clone value
- [x] Manually validated end-to-end with aiqum-test on pve3 cloning from template 901 on pve1

`doit check` passes locally.

## Checklist

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the test that depends on the changed value
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
