### PR TITLE
fix: translate separate api_token_id/secret keys in proxmox tfvars mapping

### DIFF
--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -30,6 +30,8 @@ class ProxmoxProvider(
     _PROXMOX_TFVARS_MAPPING: ClassVar[dict[str, str]] = {
         "api_url": "proxmox_api_url",
         "api_token": "proxmox_api_token",  # nosec B105
+        "api_token_id": "proxmox_api_token_id",  # nosec B105
+        "api_token_secret": "proxmox_api_token_secret",  # nosec B105
         "node": "proxmox_node",
         "storage": "proxmox_storage",
     }


### PR DESCRIPTION
## Description

`ProxmoxProvider._PROXMOX_TFVARS_MAPPING` translated `api_token` (the combined `tokenid=secret` form) but not the separate `api_token_id` / `api_token_secret` form. Every other code path in the Proxmox provider already accepts both forms — `validator.py`, `api_client.py`, `exporter.py`, and the parallel `_CREDENTIAL_ENV_MAPPING` for the env-var credential path. Only the settings-path tfvars translation had the gap.

**Symptom**: an environment whose credentials are configured only in `settings.yaml` under the `proxmox:` nested section with the separate token_id/token_secret form silently produced `null` for `TF_VAR_proxmox_api_token_id` and `TF_VAR_proxmox_api_token_secret`. The `provider.tf.j2` expression that combines them evaluates to `null`, and Proxmox API auth fails at terraform apply time with no useful error.

**Why it wasn't noticed**: environments that have `envs/<env>/proxmox.yaml` (the SOPS-encrypted credential file that `ProxmoxCredentialLoader` reads into env vars) get credentials via the env-var path, which already handles both forms through `_CREDENTIAL_ENV_MAPPING`. The gap only surfaces for environments that rely entirely on `settings.yaml` for Proxmox credentials. Discovered on a homelab test env set up today with that config shape.

## Related Issue

Addresses #552

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/infrafoundry/providers/proxmox/__init__.py`: added `api_token_id` and `api_token_secret` entries to `_PROXMOX_TFVARS_MAPPING` so the settings path produces the same `TF_VAR_*` output as the env-var path.

## Testing

- [x] All existing tests pass
- [x] Manually validated end-to-end deploy on an environment using only `settings.yaml` for credentials (prior to the fix this environment couldn't authenticate to Proxmox)

`doit check` passes locally.

## Follow-up (separate PR)

This is the minimum fix to unblock settings-only environments. A separate refactor can later retire the env-var credential path for Proxmox (and potentially OPNsense) entirely, since the settings path now fully replaces it for this project's usage pattern. That's a larger change and out of scope here.

## Checklist

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
