### PR TITLE
feat: add default alert policy to aiqum setup wizard

### DIFF
--- a/blueprints/aiqum/README.md
+++ b/blueprints/aiqum/README.md
@@ -118,6 +118,7 @@ infra apply --package aiqum
                  +-- Step 5: Add ONTAP cluster
                  +-- Step 6: Mark setup complete
                  +-- Step 7: Create default alert policy (if aiqum_alert_email set)
+                 +-- Step 8: Send test alert email (if alert created)
 ```
 
 ## Firewall Ports

--- a/blueprints/aiqum/README.md
+++ b/blueprints/aiqum/README.md
@@ -59,6 +59,7 @@ infra apply --env <env> --package aiqum
 | `smtp_password` | SMTP auth password | (secret) |
 | `ontap_cluster_ip` | ONTAP cluster management IP | `192.168.1.220` |
 | `ontap_admin_password` | ONTAP admin password | (secret) |
+| `aiqum_alert_email` | Email address for alert notifications (empty = skip) | `alerts@example.com` |
 
 ### Optional (blueprint defaults)
 
@@ -116,6 +117,7 @@ infra apply --package aiqum
                  +-- Step 4: Enable API Gateway
                  +-- Step 5: Add ONTAP cluster
                  +-- Step 6: Mark setup complete
+                 +-- Step 7: Create default alert policy (if aiqum_alert_email set)
 ```
 
 ## Firewall Ports

--- a/blueprints/aiqum/blueprint.yaml
+++ b/blueprints/aiqum/blueprint.yaml
@@ -26,6 +26,9 @@ defaults:
   # --- SMTP ---
   smtp_port: 587
 
+  # --- Alerting ---
+  aiqum_alert_email: ""           # Empty: skip alerting. Set to receive storage alerts.
+
   # --- ONTAP integration ---
   ontap_admin_user: admin
 

--- a/blueprints/aiqum/scripts/aiqum-initial-setup.py
+++ b/blueprints/aiqum/scripts/aiqum-initial-setup.py
@@ -11,6 +11,7 @@ Steps:
   4. Enable API Gateway
   5. Add ONTAP cluster
   6. Mark setup complete
+  7. Create default alert policy (if aiqum_alert_email set)
 """
 
 import sys
@@ -24,6 +25,73 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 HAL_JSON = "application/vnd.netapp.v1.hal+json"
 DEFAULT_PASSWORD = "admin"
+
+DEFAULT_ALERT_SEVERITIES = ["critical", "error", "warning"]
+
+DEFAULT_ALERT_EVENT_TYPES = [
+    "Cluster Monitoring Failed",
+    "Some Unassigned Disks",
+    "Cluster Lacks Spare Disks",
+    "Some Failed Disks",
+    "Cluster Not Reachable",
+    "Protection Job Failed",
+    "Space In Audit Volume Almost Full",
+    "MetroCluster Spare Disks Left Behind",
+    "Flash Disks - Spare Blocks Almost Consumed",
+    "Flash Disks - No Spare Blocks",
+    "Some Unsupported Disks",
+    "MetroCluster Automatic Unplanned Switchover Disabled",
+    "Critical EMS received",
+    "Warning EMS received",
+    "Error EMS received",
+    "Informational EMS received",
+    "Notice EMS received",
+    "Debug EMS received",
+    "Emergency EMS received",
+    "Alert EMS received",
+    "Cluster IOPS Critical Threshold Breached",
+    "Cluster IOPS Warning Threshold Breached",
+    "Cluster MB/s Critical Threshold Breached",
+    "Cluster MB/s Warning Threshold Breached",
+    "Cluster FabricPool License Capacity Limits Exceeded",
+    "Object Maintenance Window Started",
+    "Cluster Cloud Tier Planning",
+    "FabricPool Space Nearly Full",
+    "NVMe-oF Grace Period Started",
+    "NVMe-oF Grace Period Active",
+    "NVMe-oF Grace Period Expired",
+    "Cluster Load Imbalance Threshold Breached",
+    "NTP server count is low",
+    "FIPS Mode Disabled",
+    "Telnet Protocol Enabled",
+    "Default local admin user enabled",
+    "Log Forwarding Not Encrypted",
+    "Login Banner Disabled",
+    "SSH is using insecure ciphers",
+    "Cluster Peer Communication Not Encrypted",
+    "AutoSupport HTTPS transport disabled",
+    "Cluster Capacity Imbalance Threshold Breached",
+    "Cluster Login Banner Changed",
+    "Cluster Log Forwarding Destinations Changed",
+    "Cluster NTP Server Names Changed",
+    "Remote Shell is Enabled on the cluster",
+    "Cluster uses a self-signed certificate",
+    "Passwords of some ONTAP user accounts use the less secure MD5 hash function",
+    "Cluster Certificate Expired",
+    "Cluster Certificate About to Expire",
+    "Mutual TLS Certificate Expired",
+    "Mutual TLS Certificate About to Expire",
+    "Controller Susceptible To Bug 509721",
+    "Controller Susceptible To Bug 677849",
+    "Cluster HA Configuration Is Not Set",
+    "ONTAP Version Mismatch",
+    "Controller Has Only One Cluster LIF",
+    "Unsupported HA Interconnect Cables",
+    "Cluster Health Is Intact",
+    "Advisory ID: NTAP-20170331-0002",
+    "Advisory ID: NTAP-20160722-0001",
+    "CN1610 FastPath OS Is In Limited Support",
+]
 
 
 def load_config() -> dict:
@@ -60,6 +128,49 @@ def save_option(base_url: str, name: str, value: str | int | bool, auth: tuple) 
         return True
     # Avoid logging response body — may contain sensitive data
     print(f"    Failed to set {name}: {r.status_code}")
+    return False
+
+
+def create_alert(base_url: str, name: str, email: str, auth: tuple) -> bool:
+    """Create a default alert policy via the management-server API.
+
+    Args:
+        base_url: AIQUM base URL (e.g. https://192.168.1.50).
+        name: Display name for the alert policy.
+        email: Recipient email address for notifications.
+        auth: Tuple of (username, password) for Basic auth.
+
+    Returns:
+        True on success or if the alert already exists (409), False otherwise.
+    """
+    payload = {
+        "name": name,
+        "enabled": True,
+        "action": {
+            "notification": {
+                "emails": [email],
+                "send_snmp_trap": False,
+            }
+        },
+        "resource": [{"type": "cluster", "include_all": True}],
+        "event": {
+            "severities": DEFAULT_ALERT_SEVERITIES,
+            "types": DEFAULT_ALERT_EVENT_TYPES,
+        },
+    }
+    r = requests.post(
+        f"{base_url}/api/management-server/alerts",
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        auth=auth,
+        verify=False,
+    )
+    if r.status_code in (200, 201):
+        return True
+    if r.status_code == 409:
+        print("    Alert already exists (OK)")
+        return True
+    print(f"    Failed to create alert: {r.status_code}")
     return False
 
 
@@ -185,6 +296,18 @@ def main() -> int:
     else:
         print("  Setup complete: FAILED")
         return 1
+
+    # Step 7: Create default alert policy
+    alert_email = config.get("aiqum_alert_email", "")
+    if alert_email:
+        alert_name = f"Alerts to {alert_email}"
+        print("\nStep 7: Creating default alert policy...")
+        if create_alert(base_url, alert_name, alert_email, auth):
+            print(f"  Alert: OK ({alert_name})")
+        else:
+            print("  Alert: FAILED (non-fatal)")
+    else:
+        print("\nStep 7: Skipping alert setup (aiqum_alert_email not set)")
 
     print(f"\n=== AIQUM Initial Setup Complete ===")
     print(f"  URL: {base_url}/")

--- a/blueprints/aiqum/scripts/aiqum-initial-setup.py
+++ b/blueprints/aiqum/scripts/aiqum-initial-setup.py
@@ -12,10 +12,13 @@ Steps:
   5. Add ONTAP cluster
   6. Mark setup complete
   7. Create default alert policy (if aiqum_alert_email set)
+  8. Send test alert email (if alert created)
 """
 
+import smtplib
 import sys
 import urllib3
+from email.mime.text import MIMEText
 from pathlib import Path
 
 import requests
@@ -174,6 +177,39 @@ def create_alert(base_url: str, name: str, email: str, auth: tuple) -> bool:
     return False
 
 
+def send_test_email(config: dict, recipient: str) -> bool:
+    """Send a test email via SMTP to verify the alert delivery path.
+
+    Uses the same SMTP settings configured in Step 1 to send a short
+    verification message to the alert recipient.
+
+    Args:
+        config: Package variables dict with smtp_server, smtp_port,
+            smtp_user, smtp_password, and aiqum_admin_email.
+        recipient: Email address to send the test to.
+
+    Returns:
+        True if the email was sent successfully, False otherwise.
+    """
+    msg = MIMEText(
+        "This is a test email from the AIQUM initial setup wizard.\n\n"
+        "If you received this message, alert email delivery is working.\n"
+    )
+    msg["Subject"] = f"[AIQUM] Test alert email from {config.get('ip_address', 'unknown')}"
+    msg["From"] = config["aiqum_admin_email"]
+    msg["To"] = recipient
+
+    try:
+        with smtplib.SMTP(config["smtp_server"], int(config["smtp_port"]), timeout=30) as srv:
+            srv.starttls()
+            srv.login(config["smtp_user"], config["smtp_password"])
+            srv.send_message(msg)
+        return True
+    except Exception as exc:
+        print(f"    SMTP error: {exc}")
+        return False
+
+
 def main() -> int:
     config = load_config()
     base_url = f"https://{config['ip_address']}"
@@ -304,6 +340,12 @@ def main() -> int:
         print("\nStep 7: Creating default alert policy...")
         if create_alert(base_url, alert_name, alert_email, auth):
             print(f"  Alert: OK ({alert_name})")
+            # Step 8: Send test email
+            print("\nStep 8: Sending test alert email...")
+            if send_test_email(config, alert_email):
+                print(f"  Test email: OK (sent to {alert_email})")
+            else:
+                print("  Test email: FAILED (non-fatal)")
         else:
             print("  Alert: FAILED (non-fatal)")
     else:

--- a/tests/unit/test_aiqum_initial_setup.py
+++ b/tests/unit/test_aiqum_initial_setup.py
@@ -1,0 +1,290 @@
+"""Tests for the AIQUM initial setup script's alert creation logic.
+
+The script ``blueprints/aiqum/scripts/aiqum-initial-setup.py`` is a standalone
+Python file (not a package module), so we import it via ``importlib`` using
+its filesystem path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the standalone script as a module
+# ---------------------------------------------------------------------------
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "blueprints"
+    / "aiqum"
+    / "scripts"
+    / "aiqum-initial-setup.py"
+)
+
+spec = importlib.util.spec_from_file_location("aiqum_initial_setup", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+aiqum_setup = importlib.util.module_from_spec(spec)
+sys.modules["aiqum_initial_setup"] = aiqum_setup
+spec.loader.exec_module(aiqum_setup)
+
+# Re-export for convenience
+create_alert = aiqum_setup.create_alert
+DEFAULT_ALERT_SEVERITIES = aiqum_setup.DEFAULT_ALERT_SEVERITIES
+DEFAULT_ALERT_EVENT_TYPES = aiqum_setup.DEFAULT_ALERT_EVENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+BASE_URL = "https://192.168.1.50"
+AUTH = ("umadmin", "secret")
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_alert function
+# ---------------------------------------------------------------------------
+class TestCreateAlert:
+    """Tests for the ``create_alert`` helper."""
+
+    def test_returns_true_on_201(self) -> None:
+        """Successful creation (201) returns True."""
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+
+        with patch("aiqum_initial_setup.requests.post", return_value=mock_response) as mock_post:
+            result = create_alert(BASE_URL, "My Alert", "user@example.com", AUTH)
+
+        assert result is True
+        mock_post.assert_called_once()
+
+    def test_returns_true_on_200(self) -> None:
+        """Some API versions return 200; should also succeed."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("aiqum_initial_setup.requests.post", return_value=mock_response):
+            assert create_alert(BASE_URL, "My Alert", "user@example.com", AUTH) is True
+
+    def test_returns_true_on_409_already_exists(self, capsys: pytest.CaptureFixture) -> None:
+        """409 means the alert already exists -- treated as success."""
+        mock_response = MagicMock()
+        mock_response.status_code = 409
+
+        with patch("aiqum_initial_setup.requests.post", return_value=mock_response):
+            result = create_alert(BASE_URL, "My Alert", "user@example.com", AUTH)
+
+        assert result is True
+        assert "already exists" in capsys.readouterr().out
+
+    def test_returns_false_on_error(self, capsys: pytest.CaptureFixture) -> None:
+        """Non-success status codes return False and print a message."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch("aiqum_initial_setup.requests.post", return_value=mock_response):
+            result = create_alert(BASE_URL, "My Alert", "user@example.com", AUTH)
+
+        assert result is False
+        assert "Failed to create alert: 500" in capsys.readouterr().out
+
+    def test_payload_structure(self) -> None:
+        """The POST payload matches the expected AIQUM alert API structure."""
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+
+        with patch("aiqum_initial_setup.requests.post", return_value=mock_response) as mock_post:
+            create_alert(BASE_URL, "Alerts to me@test.com", "me@test.com", AUTH)
+
+        _, kwargs = mock_post.call_args
+        payload = kwargs["json"]
+
+        assert payload["name"] == "Alerts to me@test.com"
+        assert payload["enabled"] is True
+        assert payload["action"]["notification"]["emails"] == ["me@test.com"]
+        assert payload["action"]["notification"]["send_snmp_trap"] is False
+        assert payload["resource"] == [{"type": "cluster", "include_all": True}]
+        assert payload["event"]["severities"] == DEFAULT_ALERT_SEVERITIES
+        assert payload["event"]["types"] == DEFAULT_ALERT_EVENT_TYPES
+
+    def test_posts_to_correct_url(self) -> None:
+        """The request targets the management-server alerts endpoint."""
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+
+        with patch("aiqum_initial_setup.requests.post", return_value=mock_response) as mock_post:
+            create_alert(BASE_URL, "My Alert", "user@example.com", AUTH)
+
+        call_args = mock_post.call_args
+        assert call_args[0][0] == f"{BASE_URL}/api/management-server/alerts"
+        assert call_args[1]["auth"] == AUTH
+        assert call_args[1]["verify"] is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: main() integration for Step 7
+# ---------------------------------------------------------------------------
+def _make_config(alert_email: str = "") -> dict:
+    """Build a minimal config dict for main()."""
+    return {
+        "ip_address": "192.168.1.50",
+        "aiqum_admin_password": "newpass",
+        "aiqum_admin_user": "umadmin",
+        "aiqum_admin_email": "admin@example.com",
+        "smtp_server": "smtp.example.com",
+        "smtp_port": 587,
+        "smtp_user": "aiqum",
+        "smtp_password": "smtppass",
+        "ontap_cluster_ip": "192.168.1.220",
+        "ontap_admin_user": "admin",
+        "ontap_admin_password": "ontappass",
+        "aiqum_alert_email": alert_email,
+    }
+
+
+def _mock_requests_get_ok(status_code: int = 200) -> MagicMock:
+    """Return a mock response for successful GET requests."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    return resp
+
+
+def _mock_requests_post_ok(status_code: int = 201) -> MagicMock:
+    """Return a mock response for successful POST requests."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {}
+    resp.text = ""
+    return resp
+
+
+class TestMainAlertStep:
+    """Tests for Step 7 (alert creation) within ``main()``."""
+
+    @patch("aiqum_initial_setup.create_alert", return_value=True)
+    @patch("aiqum_initial_setup.load_config")
+    @patch("aiqum_initial_setup.requests.post")
+    @patch("aiqum_initial_setup.requests.get")
+    @patch("aiqum_initial_setup.requests.put")
+    def test_calls_create_alert_when_email_set(
+        self,
+        mock_put: MagicMock,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        mock_load_config: MagicMock,
+        mock_create_alert: MagicMock,
+    ) -> None:
+        """Step 7 calls create_alert when aiqum_alert_email is configured."""
+        mock_load_config.return_value = _make_config("alerts@test.com")
+        mock_get.return_value = _mock_requests_get_ok()
+        mock_post.return_value = _mock_requests_post_ok()
+        mock_put.return_value = _mock_requests_post_ok(200)
+
+        result = aiqum_setup.main()
+
+        assert result == 0
+        mock_create_alert.assert_called_once_with(
+            BASE_URL,
+            "Alerts to alerts@test.com",
+            "alerts@test.com",
+            ("umadmin", "newpass"),
+        )
+
+    @patch("aiqum_initial_setup.create_alert")
+    @patch("aiqum_initial_setup.load_config")
+    @patch("aiqum_initial_setup.requests.post")
+    @patch("aiqum_initial_setup.requests.get")
+    @patch("aiqum_initial_setup.requests.put")
+    def test_skips_alert_when_email_empty(
+        self,
+        mock_put: MagicMock,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        mock_load_config: MagicMock,
+        mock_create_alert: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Step 7 skips alert creation when aiqum_alert_email is empty."""
+        mock_load_config.return_value = _make_config("")
+        mock_get.return_value = _mock_requests_get_ok()
+        mock_post.return_value = _mock_requests_post_ok()
+        mock_put.return_value = _mock_requests_post_ok(200)
+
+        result = aiqum_setup.main()
+
+        assert result == 0
+        mock_create_alert.assert_not_called()
+        assert "Skipping alert setup" in capsys.readouterr().out
+
+    @patch("aiqum_initial_setup.create_alert")
+    @patch("aiqum_initial_setup.load_config")
+    @patch("aiqum_initial_setup.requests.post")
+    @patch("aiqum_initial_setup.requests.get")
+    @patch("aiqum_initial_setup.requests.put")
+    def test_skips_alert_when_email_missing(
+        self,
+        mock_put: MagicMock,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        mock_load_config: MagicMock,
+        mock_create_alert: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Step 7 skips alert creation when aiqum_alert_email key is absent."""
+        config = _make_config()
+        del config["aiqum_alert_email"]
+        mock_load_config.return_value = config
+        mock_get.return_value = _mock_requests_get_ok()
+        mock_post.return_value = _mock_requests_post_ok()
+        mock_put.return_value = _mock_requests_post_ok(200)
+
+        result = aiqum_setup.main()
+
+        assert result == 0
+        mock_create_alert.assert_not_called()
+        assert "Skipping alert setup" in capsys.readouterr().out
+
+    @patch("aiqum_initial_setup.create_alert", return_value=False)
+    @patch("aiqum_initial_setup.load_config")
+    @patch("aiqum_initial_setup.requests.post")
+    @patch("aiqum_initial_setup.requests.get")
+    @patch("aiqum_initial_setup.requests.put")
+    def test_returns_zero_when_alert_fails(
+        self,
+        mock_put: MagicMock,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        mock_load_config: MagicMock,
+        mock_create_alert: MagicMock,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """main() returns 0 even when alert creation fails (non-fatal)."""
+        mock_load_config.return_value = _make_config("alerts@test.com")
+        mock_get.return_value = _mock_requests_get_ok()
+        mock_post.return_value = _mock_requests_post_ok()
+        mock_put.return_value = _mock_requests_post_ok(200)
+
+        result = aiqum_setup.main()
+
+        assert result == 0
+        mock_create_alert.assert_called_once()
+        assert "FAILED (non-fatal)" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Tests: module-level constants
+# ---------------------------------------------------------------------------
+class TestAlertConstants:
+    """Verify the alert constants are well-formed."""
+
+    def test_severities_are_strings(self) -> None:
+        assert all(isinstance(s, str) for s in DEFAULT_ALERT_SEVERITIES)
+        assert len(DEFAULT_ALERT_SEVERITIES) == 3
+
+    def test_event_types_are_strings(self) -> None:
+        assert all(isinstance(t, str) for t in DEFAULT_ALERT_EVENT_TYPES)
+
+    def test_event_types_count(self) -> None:
+        """The curated list should have 62 event types (from prod)."""
+        assert len(DEFAULT_ALERT_EVENT_TYPES) == 62

--- a/tests/unit/test_aiqum_initial_setup.py
+++ b/tests/unit/test_aiqum_initial_setup.py
@@ -6,6 +6,7 @@ its filesystem path.
 """
 
 import importlib.util
+import smtplib
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -31,6 +32,7 @@ spec.loader.exec_module(aiqum_setup)
 
 # Re-export for convenience
 create_alert = aiqum_setup.create_alert
+send_test_email = aiqum_setup.send_test_email
 DEFAULT_ALERT_SEVERITIES = aiqum_setup.DEFAULT_ALERT_SEVERITIES
 DEFAULT_ALERT_EVENT_TYPES = aiqum_setup.DEFAULT_ALERT_EVENT_TYPES
 
@@ -159,9 +161,55 @@ def _mock_requests_post_ok(status_code: int = 201) -> MagicMock:
     return resp
 
 
+# ---------------------------------------------------------------------------
+# Tests: send_test_email function
+# ---------------------------------------------------------------------------
+class TestSendTestEmail:
+    """Tests for the ``send_test_email`` helper."""
+
+    def test_returns_true_on_success(self) -> None:
+        """Successful send returns True."""
+        config = _make_config("alerts@test.com")
+        with patch("aiqum_initial_setup.smtplib.SMTP") as mock_smtp:
+            mock_srv = MagicMock()
+            mock_smtp.return_value.__enter__ = MagicMock(return_value=mock_srv)
+            mock_smtp.return_value.__exit__ = MagicMock(return_value=False)
+            result = send_test_email(config, "alerts@test.com")
+
+        assert result is True
+        mock_srv.starttls.assert_called_once()
+        mock_srv.login.assert_called_once_with("aiqum", "smtppass")
+        mock_srv.send_message.assert_called_once()
+
+    def test_returns_false_on_smtp_error(self, capsys: pytest.CaptureFixture) -> None:
+        """SMTP failure returns False and prints error."""
+        config = _make_config("alerts@test.com")
+        with patch("aiqum_initial_setup.smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value.__enter__ = MagicMock(
+                side_effect=smtplib.SMTPException("connection refused")
+            )
+            mock_smtp.return_value.__exit__ = MagicMock(return_value=False)
+            result = send_test_email(config, "alerts@test.com")
+
+        assert result is False
+        assert "SMTP error" in capsys.readouterr().out
+
+    def test_uses_correct_smtp_settings(self) -> None:
+        """SMTP connection uses server and port from config."""
+        config = _make_config("alerts@test.com")
+        with patch("aiqum_initial_setup.smtplib.SMTP") as mock_smtp:
+            mock_srv = MagicMock()
+            mock_smtp.return_value.__enter__ = MagicMock(return_value=mock_srv)
+            mock_smtp.return_value.__exit__ = MagicMock(return_value=False)
+            send_test_email(config, "alerts@test.com")
+
+        mock_smtp.assert_called_once_with("smtp.example.com", 587, timeout=30)
+
+
 class TestMainAlertStep:
     """Tests for Step 7 (alert creation) within ``main()``."""
 
+    @patch("aiqum_initial_setup.send_test_email", return_value=True)
     @patch("aiqum_initial_setup.create_alert", return_value=True)
     @patch("aiqum_initial_setup.load_config")
     @patch("aiqum_initial_setup.requests.post")
@@ -174,6 +222,7 @@ class TestMainAlertStep:
         mock_post: MagicMock,
         mock_load_config: MagicMock,
         mock_create_alert: MagicMock,
+        mock_send_test: MagicMock,
     ) -> None:
         """Step 7 calls create_alert when aiqum_alert_email is configured."""
         mock_load_config.return_value = _make_config("alerts@test.com")
@@ -190,6 +239,7 @@ class TestMainAlertStep:
             "alerts@test.com",
             ("umadmin", "newpass"),
         )
+        mock_send_test.assert_called_once()
 
     @patch("aiqum_initial_setup.create_alert")
     @patch("aiqum_initial_setup.load_config")
@@ -245,6 +295,7 @@ class TestMainAlertStep:
         mock_create_alert.assert_not_called()
         assert "Skipping alert setup" in capsys.readouterr().out
 
+    @patch("aiqum_initial_setup.send_test_email")
     @patch("aiqum_initial_setup.create_alert", return_value=False)
     @patch("aiqum_initial_setup.load_config")
     @patch("aiqum_initial_setup.requests.post")
@@ -257,6 +308,7 @@ class TestMainAlertStep:
         mock_post: MagicMock,
         mock_load_config: MagicMock,
         mock_create_alert: MagicMock,
+        mock_send_test: MagicMock,
         capsys: pytest.CaptureFixture,
     ) -> None:
         """main() returns 0 even when alert creation fails (non-fatal)."""
@@ -269,6 +321,7 @@ class TestMainAlertStep:
 
         assert result == 0
         mock_create_alert.assert_called_once()
+        mock_send_test.assert_not_called()
         assert "FAILED (non-fatal)" in capsys.readouterr().out
 
 


### PR DESCRIPTION
## Description

Add an optional default alert policy to the AIQUM initial setup wizard. When the new `aiqum_alert_email` blueprint variable is set, Step 7 creates a broad alert policy covering critical cluster, disk, security, and EMS event types. When unset, alerting is silently skipped.

Addresses #555

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `aiqum_alert_email` variable to `blueprint.yaml` (default empty string)
- Add `create_alert()` function and default severity/event-type lists to `aiqum-initial-setup.py`
- Add Step 7 to `main()` that creates the alert policy via the management-server API
- Update `README.md` with the new variable
- Add comprehensive unit tests for the alert creation logic

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (`tests/unit/test_aiqum_initial_setup.py`)
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
