### PR TITLE
feat: support configurable tags in Proxmox blueprints

### DIFF
--- a/blueprints/aiqum/README.md
+++ b/blueprints/aiqum/README.md
@@ -75,6 +75,7 @@ infra apply --env <env> --package aiqum
 | `aiqum_admin_user` | `umadmin` | AIQUM admin username |
 | `smtp_port` | `587` | SMTP port |
 | `ontap_admin_user` | `admin` | ONTAP admin username |
+| `extra_tags` | `[]` | Additional Proxmox tags to append |
 
 ## Prerequisites
 
@@ -144,8 +145,8 @@ After a successful deploy:
 
 - VM hardware (`cores`, `memory`, `disk_size`) is set to AIQUM minimum
   recommendations and is rarely overridden.
-- The `tags: [ontap, aiqum]` and `cloud_init_snippets` are recipe-level
-  metadata baked into the blueprint.
+- The default tags (`ontap`, `aiqum`) and `cloud_init_snippets` are recipe-level
+  metadata baked into the blueprint. Additional tags can be appended via `extra_tags`.
 - Events live at the top of `blueprint.yaml` (not embedded in `vm.yaml`)
   because the shorthand `vms:` format does not extract per-resource events.
 - See `blueprints/ontap-cluster/` for the canonical structure reference for

--- a/blueprints/aiqum/blueprint.yaml
+++ b/blueprints/aiqum/blueprint.yaml
@@ -32,6 +32,9 @@ defaults:
   # --- ONTAP integration ---
   ontap_admin_user: admin
 
+  # Extra Proxmox tags appended to the blueprint's default tags
+  extra_tags: []
+
 resources:
   - vm.yaml
   - dhcp.yaml

--- a/blueprints/aiqum/vm.yaml
+++ b/blueprints/aiqum/vm.yaml
@@ -26,5 +26,5 @@ vms:
       - system/hostname
     cloud_init_vars:
       HOSTNAME: "{{ vm_name }}"
-    tags: [ontap, aiqum]
+    tags: {{ ["ontap", "aiqum"] + extra_tags }}
     onboot: true

--- a/blueprints/ontap-cluster/blueprint.yaml
+++ b/blueprints/ontap-cluster/blueprint.yaml
@@ -72,6 +72,9 @@ defaults:
   # Override in package infrafoundry.yml if you need specific MACs.
   dhcp_subnet: opt1-infrastructure
 
+  # Extra Proxmox tags appended to the blueprint's default tags
+  extra_tags: []
+
 resources:
   - vm.yaml
   - dhcp.yaml

--- a/blueprints/ontap-cluster/vm.yaml
+++ b/blueprints/ontap-cluster/vm.yaml
@@ -12,7 +12,7 @@ vms:
     serial: true
     boot_order: [ide0]
     onboot: false
-    tags: [ontap, ontap-lab]
+    tags: {{ ["ontap", "ontap-lab"] + extra_tags }}
     network:
       - bridge: {{ bridge }}
         model: e1000        # e0a — cluster interconnect
@@ -47,7 +47,7 @@ vms:
     serial: true
     boot_order: [ide0]
     onboot: false
-    tags: [ontap, ontap-lab]
+    tags: {{ ["ontap", "ontap-lab"] + extra_tags }}
     network:
       - bridge: {{ bridge }}
         model: e1000        # e0a — cluster interconnect

--- a/blueprints/proxmox-k3s-cluster/README.md
+++ b/blueprints/proxmox-k3s-cluster/README.md
@@ -95,6 +95,7 @@ infra apply --env <env> --package k3s-cluster
 | `jumphost` | `""` (direct SSH) | SSH jumphost for VM access during install. When empty, the post-deploy script SSHes directly from the InfraFoundry host to each node. Set to e.g. `ansible@jump.example.com` to tunnel through a bastion. |
 | `k3s_server_args` | `--disable traefik --disable servicelb` | Extra flags for the k3s server installer |
 | `kubeconfig_dir` | `~/.kube` | Directory for the fetched kubeconfig (file is named `<cluster_name>.yaml`) |
+| `extra_tags` | `[]` | Additional Proxmox tags to append |
 
 ### Agent dict schema
 
@@ -145,8 +146,8 @@ infra apply --package k3s-cluster
 
 - VM hardware (`cores`, `memory`, `disk_size`) is set to sensible homelab
   defaults and is rarely overridden.
-- The `tags: [k3s, k3s-server]` / `[k3s, k3s-agent]` and `cloud_init_snippets`
-  are recipe-level metadata baked into the blueprint.
+- The default tags (`k3s`, `k3s-server` / `k3s-agent`) and `cloud_init_snippets`
+  are recipe-level metadata baked into the blueprint. Additional tags can be appended via `extra_tags`.
 - Events live at the top of `blueprint.yaml` (not embedded in `vm.yaml`)
   because the shorthand `vms:` format does not extract per-resource events.
 - The `requires:` field of the on_create handler lists only the server VM.

--- a/blueprints/proxmox-k3s-cluster/blueprint.yaml
+++ b/blueprints/proxmox-k3s-cluster/blueprint.yaml
@@ -31,6 +31,9 @@ defaults:
   # --- Local kubeconfig destination directory (expanded by the post-deploy script) ---
   kubeconfig_dir: "~/.kube"
 
+  # Extra Proxmox tags appended to the blueprint's default tags
+  extra_tags: []
+
 resources:
   - vm.yaml
   - dhcp.yaml

--- a/blueprints/proxmox-k3s-cluster/vm.yaml
+++ b/blueprints/proxmox-k3s-cluster/vm.yaml
@@ -27,7 +27,7 @@ vms:
       - packages/qemu-agent
     cloud_init_vars:
       HOSTNAME: "{{ server_name }}"
-    tags: [k3s, k3s-server]
+    tags: {{ ["k3s", "k3s-server"] + extra_tags }}
     onboot: true
 
   # --- Agent nodes (one entry per item in agents:) ---
@@ -55,6 +55,6 @@ vms:
       - packages/qemu-agent
     cloud_init_vars:
       HOSTNAME: "{{ agent.name }}"
-    tags: [k3s, k3s-agent]
+    tags: {{ ["k3s", "k3s-agent"] + extra_tags }}
     onboot: true
 {% endfor %}

--- a/blueprints/rocky9-template/README.md
+++ b/blueprints/rocky9-template/README.md
@@ -53,6 +53,7 @@ infra apply --env <env> --package rocky9-template
 | `ciuser` | `rocky` | Default cloud-init user |
 | `image_url` | Rocky 9 latest qcow2 URL | Source image to download |
 | `image_filename` | `Rocky-9-GenericCloud-Base.latest.x86_64.qcow2` | Local filename on Proxmox storage |
+| `extra_tags` | `[]` | Additional Proxmox tags to append |
 
 ## What It Does
 

--- a/blueprints/rocky9-template/blueprint.yaml
+++ b/blueprints/rocky9-template/blueprint.yaml
@@ -15,5 +15,8 @@ defaults:
   # --- Per-instance overrides (typical) ---
   template_name: rocky9-template
 
+  # Extra Proxmox tags appended to the blueprint's default tags
+  extra_tags: []
+
 resources:
   - template.yaml

--- a/blueprints/rocky9-template/template.yaml
+++ b/blueprints/rocky9-template/template.yaml
@@ -16,5 +16,5 @@ templates:
     download_image:
       url: "{{ image_url }}"
       filename: "{{ image_filename }}"
-    tags: ["template", "rocky9"]
+    tags: {{ ["template", "rocky9"] + extra_tags }}
     description: "Rocky Linux 9 cloud image template"

--- a/blueprints/ubuntu-template/blueprint.yaml
+++ b/blueprints/ubuntu-template/blueprint.yaml
@@ -15,5 +15,8 @@ defaults:
   # --- Per-instance overrides (typical) ---
   template_name: ubuntu-template
 
+  # Extra Proxmox tags appended to the blueprint's default tags
+  extra_tags: []
+
 resources:
   - template.yaml

--- a/blueprints/ubuntu-template/template.yaml
+++ b/blueprints/ubuntu-template/template.yaml
@@ -16,5 +16,5 @@ templates:
     download_image:
       url: "{{ image_url }}"
       filename: "{{ image_filename }}"
-    tags: ["template", "ubuntu"]
+    tags: {{ ["template", "ubuntu"] + extra_tags }}
     description: "Ubuntu 24.04 LTS cloud image template"

--- a/tests/unit/test_blueprint_extra_tags.py
+++ b/tests/unit/test_blueprint_extra_tags.py
@@ -1,0 +1,160 @@
+"""Unit tests for blueprint extra_tags support.
+
+Verifies that Jinja2 tag expressions in blueprint resource templates correctly
+merge hardcoded tags with the extra_tags variable.
+"""
+
+from pathlib import Path
+
+import jinja2
+import pytest
+import yaml
+
+# Root of the blueprints directory
+BLUEPRINTS_DIR = Path(__file__).resolve().parents[2] / "blueprints"
+
+# Tag expressions used in each blueprint, mapped to their resource files.
+# Each entry: (blueprint, resource_file, base_tags_list)
+BLUEPRINT_TAG_CASES = [
+    ("aiqum", "vm.yaml", ["ontap", "aiqum"]),
+    ("proxmox-k3s-cluster", "vm.yaml", ["k3s", "k3s-server"]),
+    ("proxmox-k3s-cluster", "vm.yaml", ["k3s", "k3s-agent"]),
+    ("ontap-cluster", "vm.yaml", ["ontap", "ontap-lab"]),
+    ("rocky9-template", "template.yaml", ["template", "rocky9"]),
+    ("ubuntu-template", "template.yaml", ["template", "ubuntu"]),
+]
+
+
+def _render_tag_expression(base_tags: list[str], extra_tags: list[str]) -> list[str]:
+    """Render a Jinja2 tag concatenation expression and parse the result as YAML.
+
+    Simulates the rendering pipeline used by PackageLoader._render_resource_file.
+
+    Args:
+        base_tags: The hardcoded tag list (e.g. ["ontap", "aiqum"]).
+        extra_tags: The user-supplied extra tags list.
+
+    Returns:
+        The merged list of tags after Jinja2 rendering and YAML parsing.
+    """
+    template_str = "tags: {{ base + extra }}"
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template = env.from_string(template_str)
+    rendered = template.render(base=base_tags, extra=extra_tags)
+    data = yaml.safe_load(rendered)
+    return data["tags"]
+
+
+@pytest.mark.unit
+class TestExtraTagsExpression:
+    """Test that Jinja2 list concatenation produces correct tag lists."""
+
+    def test_empty_extra_tags_preserves_base(self):
+        """Default extra_tags=[] produces only the base tags."""
+        result = _render_tag_expression(["ontap", "aiqum"], [])
+        assert result == ["ontap", "aiqum"]
+
+    def test_single_extra_tag_appended(self):
+        """A single extra tag is appended after the base tags."""
+        result = _render_tag_expression(["ontap", "aiqum"], ["test"])
+        assert result == ["ontap", "aiqum", "test"]
+
+    def test_multiple_extra_tags_appended(self):
+        """Multiple extra tags are appended in order."""
+        result = _render_tag_expression(["ontap", "aiqum"], ["test", "dev"])
+        assert result == ["ontap", "aiqum", "test", "dev"]
+
+    @pytest.mark.parametrize(
+        "base_tags",
+        [
+            ["ontap", "aiqum"],
+            ["k3s", "k3s-server"],
+            ["k3s", "k3s-agent"],
+            ["ontap", "ontap-lab"],
+            ["template", "rocky9"],
+            ["template", "ubuntu"],
+        ],
+        ids=[
+            "aiqum",
+            "k3s-server",
+            "k3s-agent",
+            "ontap-cluster",
+            "rocky9-template",
+            "ubuntu-template",
+        ],
+    )
+    def test_all_blueprints_empty_extra(self, base_tags):
+        """Each blueprint's base tags are preserved when extra_tags is empty."""
+        result = _render_tag_expression(base_tags, [])
+        assert result == base_tags
+
+    @pytest.mark.parametrize(
+        "base_tags",
+        [
+            ["ontap", "aiqum"],
+            ["k3s", "k3s-server"],
+            ["k3s", "k3s-agent"],
+            ["ontap", "ontap-lab"],
+            ["template", "rocky9"],
+            ["template", "ubuntu"],
+        ],
+        ids=[
+            "aiqum",
+            "k3s-server",
+            "k3s-agent",
+            "ontap-cluster",
+            "rocky9-template",
+            "ubuntu-template",
+        ],
+    )
+    def test_all_blueprints_with_extra(self, base_tags):
+        """Each blueprint's base tags are extended when extra_tags is non-empty."""
+        result = _render_tag_expression(base_tags, ["custom", "env-test"])
+        assert result == [*base_tags, "custom", "env-test"]
+
+
+@pytest.mark.unit
+class TestBlueprintDefaultsIncludeExtraTags:
+    """Verify that each blueprint.yaml declares extra_tags in its defaults."""
+
+    @pytest.mark.parametrize(
+        "blueprint",
+        [
+            "aiqum",
+            "proxmox-k3s-cluster",
+            "ontap-cluster",
+            "rocky9-template",
+            "ubuntu-template",
+        ],
+    )
+    def test_extra_tags_in_defaults(self, blueprint):
+        """Blueprint defaults must include extra_tags with an empty list default."""
+        blueprint_path = BLUEPRINTS_DIR / blueprint / "blueprint.yaml"
+        data = yaml.safe_load(blueprint_path.read_text())
+        assert "extra_tags" in data["defaults"], (
+            f"{blueprint}/blueprint.yaml missing extra_tags in defaults"
+        )
+        assert data["defaults"]["extra_tags"] == []
+
+
+@pytest.mark.unit
+class TestResourceTemplatesUseExtraTags:
+    """Verify that resource templates reference extra_tags in their tag expressions."""
+
+    @pytest.mark.parametrize(
+        "blueprint,resource_file",
+        [
+            ("aiqum", "vm.yaml"),
+            ("proxmox-k3s-cluster", "vm.yaml"),
+            ("ontap-cluster", "vm.yaml"),
+            ("rocky9-template", "template.yaml"),
+            ("ubuntu-template", "template.yaml"),
+        ],
+    )
+    def test_template_contains_extra_tags(self, blueprint, resource_file):
+        """Resource template must contain '+ extra_tags' in a tags expression."""
+        resource_path = BLUEPRINTS_DIR / blueprint / resource_file
+        content = resource_path.read_text()
+        assert "+ extra_tags" in content, (
+            f"{blueprint}/{resource_file} does not reference extra_tags in tags expression"
+        )


### PR DESCRIPTION
## Description

Add an `extra_tags` default (empty list) to every blueprint and convert hardcoded
`tags:` values in resource templates to Jinja2 list-concatenation expressions
(`{{ base_tags + extra_tags }}`). Users can now append custom Proxmox tags to any
blueprint instance without forking or patching the blueprint itself.

Addresses #538

## Related Issue

Addresses #538

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `extra_tags: []` default to all 5 blueprint.yaml files (aiqum, ontap-cluster, proxmox-k3s-cluster, rocky9-template, ubuntu-template)
- Converted static `tags:` lists in 5 resource templates (vm.yaml / template.yaml) to Jinja2 expressions that concatenate the base tags with `extra_tags`
- Updated 3 blueprint READMEs to document the new `extra_tags` parameter
- Added comprehensive unit tests covering Jinja2 tag rendering, blueprint defaults validation, and resource template content checks

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Added new tests in `tests/unit/test_blueprint_extra_tags.py`
  - Jinja2 list-concatenation rendering (empty, single, multiple extra tags)
  - Parametrized across all blueprint tag sets
  - Blueprint defaults include `extra_tags: []`
  - Resource templates reference `extra_tags`
- [ ] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
