### PR TITLE
feat: support configurable freeform_tags in OCI blueprint

### DIFF
--- a/blueprints/oci-k3s-cluster/README.md
+++ b/blueprints/oci-k3s-cluster/README.md
@@ -110,6 +110,7 @@ The consumer environment's `settings.yaml` must supply:
 | `k3s_version` | `""` (latest) | Pinned k3s version for the installer |
 | `k3s_server_args` | `""` | Extra k3s server installer flags |
 | `k3s_oci_firewall_fix` | `true` | Apply the OCI iptables fix after k3s installation (see Design Notes) |
+| `extra_freeform_tags` | `{}` | Additional OCI freeform tags merged into each instance |
 | `kubeconfig_local_path` | `~/.kube/{{ cluster_name }}.yaml` | Local destination for the fetched kubeconfig |
 
 ### Worker dict schema

--- a/blueprints/oci-k3s-cluster/blueprint.yaml
+++ b/blueprints/oci-k3s-cluster/blueprint.yaml
@@ -51,6 +51,9 @@ defaults:
   # valid but means the node has no tags assigned.
   ts_tags: []
 
+  # Extra OCI freeform tags merged into each instance's freeform_tags
+  extra_freeform_tags: {}
+
   # OAuth credentials for the official tailscale/cloudinit/tailscale module
   # are read from the env's secrets.tailscale.{oauth_client_id, oauth_client_secret}
   # block via the framework's secrets→TF_VAR_* bridge. The blueprint declares

--- a/blueprints/oci-k3s-cluster/instance.yaml
+++ b/blueprints/oci-k3s-cluster/instance.yaml
@@ -27,6 +27,9 @@ instance:
       role: control-plane
       cluster: "{{ cluster_name }}"
       managed_by: infrafoundry
+{% for key, value in extra_freeform_tags.items() %}
+      {{ key }}: "{{ value }}"
+{% endfor %}
     tailscale:
       hostname: "{{ control_name }}"
       enable_ssh: true
@@ -53,6 +56,9 @@ instance:
       role: worker
       cluster: "{{ cluster_name }}"
       managed_by: infrafoundry
+{% for key, value in extra_freeform_tags.items() %}
+      {{ key }}: "{{ value }}"
+{% endfor %}
     tailscale:
       hostname: "{{ worker.name }}"
       enable_ssh: true

--- a/tests/unit/test_blueprint_extra_freeform_tags.py
+++ b/tests/unit/test_blueprint_extra_freeform_tags.py
@@ -1,0 +1,106 @@
+"""Unit tests for OCI blueprint extra_freeform_tags support.
+
+Verifies that Jinja2 freeform_tags blocks in the OCI k3s blueprint correctly
+merge hardcoded tags with the extra_freeform_tags variable.
+"""
+
+from pathlib import Path
+
+import jinja2
+import pytest
+import yaml
+
+# Root of the blueprints directory
+BLUEPRINTS_DIR = Path(__file__).resolve().parents[2] / "blueprints"
+
+# Minimal template that mirrors the freeform_tags block in instance.yaml
+FREEFORM_TAGS_TEMPLATE = """\
+freeform_tags:
+  role: control-plane
+  cluster: "{{ cluster_name }}"
+  managed_by: infrafoundry
+{% for key, value in extra_freeform_tags.items() %}
+  {{ key }}: "{{ value }}"
+{% endfor %}"""
+
+
+def _render_freeform_tags(
+    extra_freeform_tags: dict[str, str],
+    cluster_name: str = "test-cluster",
+) -> dict[str, str]:
+    """Render a freeform_tags template block and return the parsed dict.
+
+    Args:
+        extra_freeform_tags: Additional freeform tags to merge.
+        cluster_name: Cluster name for the template context.
+
+    Returns:
+        The freeform_tags dict after Jinja2 rendering and YAML parsing.
+    """
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template = env.from_string(FREEFORM_TAGS_TEMPLATE)
+    rendered = template.render(
+        cluster_name=cluster_name,
+        extra_freeform_tags=extra_freeform_tags,
+    )
+    data = yaml.safe_load(rendered)
+    return data["freeform_tags"]
+
+
+@pytest.mark.unit
+class TestExtraFreeformTagsExpression:
+    """Test that Jinja2 dict iteration produces correct freeform_tags."""
+
+    def test_empty_extra_freeform_tags_preserves_base(self):
+        """Default extra_freeform_tags={} produces only the hardcoded tags."""
+        result = _render_freeform_tags({})
+        assert result == {
+            "role": "control-plane",
+            "cluster": "test-cluster",
+            "managed_by": "infrafoundry",
+        }
+
+    def test_single_extra_freeform_tag_added(self):
+        """A single extra freeform tag is included in the output."""
+        result = _render_freeform_tags({"environment": "test"})
+        assert result["environment"] == "test"
+        assert result["role"] == "control-plane"
+        assert result["cluster"] == "test-cluster"
+        assert result["managed_by"] == "infrafoundry"
+
+    def test_multiple_extra_freeform_tags_added(self):
+        """Multiple extra freeform tags are all included."""
+        result = _render_freeform_tags({"environment": "test", "team": "platform"})
+        assert result["environment"] == "test"
+        assert result["team"] == "platform"
+        assert result["role"] == "control-plane"
+        assert result["cluster"] == "test-cluster"
+        assert result["managed_by"] == "infrafoundry"
+        assert len(result) == 5
+
+
+@pytest.mark.unit
+class TestBlueprintDefaultsIncludeExtraFreeformTags:
+    """Verify that oci-k3s-cluster blueprint.yaml declares extra_freeform_tags."""
+
+    def test_extra_freeform_tags_in_defaults(self):
+        """Blueprint defaults must include extra_freeform_tags with an empty dict."""
+        blueprint_path = BLUEPRINTS_DIR / "oci-k3s-cluster" / "blueprint.yaml"
+        data = yaml.safe_load(blueprint_path.read_text())
+        assert "extra_freeform_tags" in data["defaults"], (
+            "oci-k3s-cluster/blueprint.yaml missing extra_freeform_tags in defaults"
+        )
+        assert data["defaults"]["extra_freeform_tags"] == {}
+
+
+@pytest.mark.unit
+class TestResourceTemplatesUseExtraFreeformTags:
+    """Verify that instance.yaml references extra_freeform_tags."""
+
+    def test_template_contains_extra_freeform_tags(self):
+        """Resource template must contain 'extra_freeform_tags' in a loop."""
+        resource_path = BLUEPRINTS_DIR / "oci-k3s-cluster" / "instance.yaml"
+        content = resource_path.read_text()
+        assert "extra_freeform_tags" in content, (
+            "oci-k3s-cluster/instance.yaml does not reference extra_freeform_tags"
+        )


### PR DESCRIPTION
## Description

Add an `extra_freeform_tags` default (empty dict) to the OCI k3s blueprint
and merge it into each instance's `freeform_tags` block via a Jinja2 for loop.
Package consumers can now add custom OCI freeform tags without forking the blueprint.

Addresses #563

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `extra_freeform_tags: {}` default to `blueprint.yaml`
- Added Jinja2 `{% for %}` loops to both control-plane and worker `freeform_tags` blocks in `instance.yaml`
- Updated README with the new variable
- Added unit tests for Jinja2 dict rendering

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Added new tests in `tests/unit/test_blueprint_extra_freeform_tags.py`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
