### PR TITLE
feat: add infra list command to show packages in an environment

### DIFF
--- a/src/infrafoundry/cli/commands/infra/__init__.py
+++ b/src/infrafoundry/cli/commands/infra/__init__.py
@@ -6,6 +6,7 @@ from .apply import apply
 from .destroy import destroy
 from .drift import drift
 from .history import history
+from .list_packages import list_packages
 from .plan import plan
 from .reset import reset
 from .rollback import rollback
@@ -32,6 +33,7 @@ infra.add_command(security)
 infra.add_command(status)
 infra.add_command(test)
 infra.add_command(history)
+infra.add_command(list_packages)
 infra.add_command(unlock)
 
 

--- a/src/infrafoundry/cli/commands/infra/list_packages.py
+++ b/src/infrafoundry/cli/commands/infra/list_packages.py
@@ -1,0 +1,98 @@
+"""List configured packages in an environment."""
+
+from typing import Any
+
+import click
+
+from infrafoundry.core.config import ConfigManager
+from infrafoundry.core.config.package_loader import PackageLoader
+from infrafoundry.core.exceptions import (
+    ConfigurationError,
+    EnvironmentNotFoundError,
+    InfraFoundryError,
+)
+
+from ...output import output_data
+from ...utils import console, raise_cli_error
+
+
+@click.command("list")
+@click.option("--env", "-e", required=True, help="Environment name (e.g., dev, prod)")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (default: text)",
+)
+@click.pass_context
+def list_packages(ctx: click.Context, env: str, output_format: str) -> None:
+    """List configured packages in an environment."""
+    try:
+        config_repo = ctx.obj.get("config_dir")
+        if config_repo:
+            config_manager = ConfigManager(base_dir=config_repo / "envs")
+        else:
+            config_manager = ConfigManager()
+
+        # Discover provider-scoped packages
+        discovered_providers = config_manager.provider_centric.discover_providers(env)
+        packages: list[dict[str, Any]] = []
+
+        for provider_name in sorted(discovered_providers):
+            for package_dir in config_manager._package_loader.discover_packages(env, provider_name):
+                manifest = config_manager._package_loader._parse_manifest(
+                    package_dir / PackageLoader.MANIFEST_FILENAME
+                )
+                packages.append(
+                    {
+                        "provider": provider_name,
+                        "name": manifest.name,
+                        "description": manifest.description or "",
+                        "blueprint": manifest.blueprint or "",
+                    }
+                )
+
+        # Discover env-root packages
+        for package_dir in config_manager._package_loader.discover_env_root_packages(env):
+            manifest = config_manager._package_loader._parse_manifest(
+                package_dir / PackageLoader.MANIFEST_FILENAME
+            )
+            packages.append(
+                {
+                    "provider": manifest.provider or "",
+                    "name": manifest.name,
+                    "description": manifest.description or "",
+                    "blueprint": manifest.blueprint or "",
+                }
+            )
+
+        if not packages:
+            if output_format == "json":
+                output_data({"environment": env, "packages": []}, output_format)
+            else:
+                console.warning(f"No packages found in environment '{env}'.")
+            return
+
+        if output_format == "json":
+            output_data({"environment": env, "packages": packages}, output_format)
+        else:
+            console.header(f"Packages in {env}:")
+            for pkg in packages:
+                provider = pkg["provider"]
+                name = pkg["name"]
+                description = pkg["description"]
+                label = f"{provider}/{name}" if provider else name
+                if description:
+                    console.list_item(f"{label} — {description}")
+                else:
+                    console.list_item(label)
+
+    except click.ClickException:
+        raise
+    except (EnvironmentNotFoundError, ConfigurationError) as exc:
+        raise_cli_error("Failed to list packages", exc)
+    except InfraFoundryError as exc:
+        raise_cli_error("Failed to list packages", exc)
+    except Exception as exc:
+        raise_cli_error("Failed to list packages", exc)

--- a/tests/unit/test_cli_list_packages.py
+++ b/tests/unit/test_cli_list_packages.py
@@ -1,0 +1,258 @@
+"""Unit tests for the 'infra list' CLI command."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from infrafoundry.cli.main import main
+from infrafoundry.core.config import ConfigManager
+from infrafoundry.core.config.models import PackageManifest
+from infrafoundry.core.exceptions import EnvironmentNotFoundError
+
+
+@pytest.fixture
+def cli_runner():
+    """Fixture for invoking CLI commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_config_manager():
+    """Mock ConfigManager for testing."""
+    mock = Mock(spec=ConfigManager)
+    mock.provider_centric = Mock()
+    mock._package_loader = Mock()
+    return mock
+
+
+def _make_manifest(
+    name: str,
+    description: str | None = None,
+    provider: str | None = None,
+    blueprint: str | None = None,
+) -> PackageManifest:
+    """Create a PackageManifest for testing."""
+    return PackageManifest(
+        name=name,
+        description=description,
+        provider=provider,
+        blueprint=blueprint,
+    )
+
+
+def test_list_packages_text(cli_runner, mock_config_manager, tmp_path):
+    """Test listing packages in text format."""
+    mock_config_manager.provider_centric.discover_providers.return_value = {"proxmox"}
+
+    pkg_dir = tmp_path / "prod" / "proxmox" / "my-cluster"
+    pkg_dir.mkdir(parents=True)
+    mock_config_manager._package_loader.discover_packages.return_value = [pkg_dir]
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = []
+    mock_config_manager._package_loader._parse_manifest.return_value = _make_manifest(
+        name="my-cluster", description="Test cluster"
+    )
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "prod"])
+
+    assert result.exit_code == 0
+    assert "Packages in prod:" in result.output
+    assert "proxmox/my-cluster" in result.output
+    assert "Test cluster" in result.output
+
+
+def test_list_packages_json(cli_runner, mock_config_manager, tmp_path):
+    """Test listing packages in JSON format."""
+    mock_config_manager.provider_centric.discover_providers.return_value = {"proxmox"}
+
+    pkg_dir = tmp_path / "prod" / "proxmox" / "my-cluster"
+    pkg_dir.mkdir(parents=True)
+    mock_config_manager._package_loader.discover_packages.return_value = [pkg_dir]
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = []
+    mock_config_manager._package_loader._parse_manifest.return_value = _make_manifest(
+        name="my-cluster", description="Test cluster", blueprint="base-vm"
+    )
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "prod", "--format", "json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["environment"] == "prod"
+    assert len(data["packages"]) == 1
+    pkg = data["packages"][0]
+    assert pkg["provider"] == "proxmox"
+    assert pkg["name"] == "my-cluster"
+    assert pkg["description"] == "Test cluster"
+    assert pkg["blueprint"] == "base-vm"
+
+
+def test_list_packages_empty(cli_runner, mock_config_manager):
+    """Test listing packages when none exist."""
+    mock_config_manager.provider_centric.discover_providers.return_value = set()
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = []
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "prod"])
+
+    assert result.exit_code == 0
+    assert "No packages found" in result.output
+
+
+def test_list_packages_empty_json(cli_runner, mock_config_manager):
+    """Test listing packages in JSON format when none exist."""
+    mock_config_manager.provider_centric.discover_providers.return_value = set()
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = []
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "prod", "--format", "json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["environment"] == "prod"
+    assert data["packages"] == []
+
+
+def test_list_packages_invalid_env(cli_runner, mock_config_manager):
+    """Test listing packages with an invalid environment name."""
+    mock_config_manager.provider_centric.discover_providers.side_effect = EnvironmentNotFoundError(
+        "Environment 'nonexistent' not found"
+    )
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "nonexistent"])
+
+    assert result.exit_code != 0
+
+
+def test_list_packages_no_description(cli_runner, mock_config_manager, tmp_path):
+    """Test listing a package without a description."""
+    mock_config_manager.provider_centric.discover_providers.return_value = {"proxmox"}
+
+    pkg_dir = tmp_path / "prod" / "proxmox" / "bare-pkg"
+    pkg_dir.mkdir(parents=True)
+    mock_config_manager._package_loader.discover_packages.return_value = [pkg_dir]
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = []
+    mock_config_manager._package_loader._parse_manifest.return_value = _make_manifest(
+        name="bare-pkg"
+    )
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "prod"])
+
+    assert result.exit_code == 0
+    assert "proxmox/bare-pkg" in result.output
+    # Should not show a dash separator when there's no description
+    assert "bare-pkg —" not in result.output
+
+
+def test_list_packages_multiple_providers(cli_runner, mock_config_manager, tmp_path):
+    """Test listing packages across multiple providers."""
+    mock_config_manager.provider_centric.discover_providers.return_value = {
+        "proxmox",
+        "opnsense",
+    }
+
+    proxmox_pkg = tmp_path / "prod" / "proxmox" / "cluster"
+    proxmox_pkg.mkdir(parents=True)
+    opnsense_pkg = tmp_path / "prod" / "opnsense" / "firewall"
+    opnsense_pkg.mkdir(parents=True)
+
+    def discover_packages(_env_name, provider):
+        if provider == "proxmox":
+            return [proxmox_pkg]
+        if provider == "opnsense":
+            return [opnsense_pkg]
+        return []
+
+    mock_config_manager._package_loader.discover_packages.side_effect = discover_packages
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = []
+
+    manifests = {
+        str(proxmox_pkg): _make_manifest(name="cluster", description="VM cluster"),
+        str(opnsense_pkg): _make_manifest(name="firewall", description="Firewall rules"),
+    }
+
+    def parse_manifest(path):
+        # Match on the parent directory
+        parent = str(path.parent)
+        return manifests[parent]
+
+    mock_config_manager._package_loader._parse_manifest.side_effect = parse_manifest
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "prod"])
+
+    assert result.exit_code == 0
+    assert "opnsense/firewall" in result.output
+    assert "proxmox/cluster" in result.output
+
+
+def test_list_packages_env_root_packages(cli_runner, mock_config_manager, tmp_path):
+    """Test listing env-root packages (not under a provider directory)."""
+    mock_config_manager.provider_centric.discover_providers.return_value = set()
+
+    pkg_dir = tmp_path / "prod" / "shared-pkg"
+    pkg_dir.mkdir(parents=True)
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = [pkg_dir]
+    mock_config_manager._package_loader._parse_manifest.return_value = _make_manifest(
+        name="shared-pkg", description="Shared package", provider="custom"
+    )
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(main, ["infra", "list", "--env", "prod"])
+
+    assert result.exit_code == 0
+    assert "custom/shared-pkg" in result.output
+    assert "Shared package" in result.output
+
+
+def test_list_packages_with_config_dir(cli_runner, mock_config_manager, tmp_path):
+    """Test listing packages with a custom config directory."""
+    mock_config_manager.provider_centric.discover_providers.return_value = {"proxmox"}
+
+    pkg_dir = tmp_path / "envs" / "prod" / "proxmox" / "my-pkg"
+    pkg_dir.mkdir(parents=True)
+    mock_config_manager._package_loader.discover_packages.return_value = [pkg_dir]
+    mock_config_manager._package_loader.discover_env_root_packages.return_value = []
+    mock_config_manager._package_loader._parse_manifest.return_value = _make_manifest(
+        name="my-pkg", description="Custom dir pkg"
+    )
+
+    with patch(
+        "infrafoundry.cli.commands.infra.list_packages.ConfigManager",
+        return_value=mock_config_manager,
+    ):
+        result = cli_runner.invoke(
+            main,
+            ["--config-dir", str(tmp_path), "infra", "list", "--env", "prod"],
+        )
+
+    assert result.exit_code == 0
+    assert "proxmox/my-pkg" in result.output


### PR DESCRIPTION
## Description

Add `foundry infra list --env <name>` command that lists all configured packages in an environment, grouped by provider. Supports text (default) and JSON output formats.

Addresses #535

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `list_packages.py` command registered as `infra list`
- Discovers packages via existing `ConfigManager` provider/package discovery
- Text output: `provider/name — description` format
- JSON output: `{environment, packages: [{provider, name, description, blueprint}]}`
- Also discovers env-root packages (not nested under a provider)
- 9 unit tests covering text/JSON output, empty env, errors, multiple providers

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Added new tests in `tests/unit/test_cli_list_packages.py`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
