### PR TITLE
feat: add infra deployed command to show deployment status

### DIFF
--- a/src/infrafoundry/cli/commands/infra/__init__.py
+++ b/src/infrafoundry/cli/commands/infra/__init__.py
@@ -3,6 +3,7 @@
 import click
 
 from .apply import apply
+from .deployed import deployed
 from .destroy import destroy
 from .drift import drift
 from .history import history
@@ -25,6 +26,7 @@ def infra() -> None:
 # Register all subcommands
 infra.add_command(plan)
 infra.add_command(apply)
+infra.add_command(deployed)
 infra.add_command(destroy)
 infra.add_command(drift)
 infra.add_command(rollback)

--- a/src/infrafoundry/cli/commands/infra/deployed.py
+++ b/src/infrafoundry/cli/commands/infra/deployed.py
@@ -1,0 +1,210 @@
+"""Show deployment status and resources for an environment."""
+
+from collections import defaultdict
+from typing import Any
+
+import click
+
+from infrafoundry.core.exceptions import InfraFoundryError, StateError
+from infrafoundry.core.orchestrator import Orchestrator
+from infrafoundry.core.state.models import Resource
+
+from ...decorators import with_orchestrator
+from ...output import output_data
+from ...utils import console, raise_cli_error
+
+# Keys to search for IP address in resource config
+_IP_KEYS = ("ip_address", "address", "ip")
+
+# Keys to search for node/host in resource config
+_NODE_KEYS = ("target_node", "node")
+
+# Placeholder for missing values
+_MISSING = "\u2014"
+
+
+def _extract_field(config: dict[str, Any] | None, keys: tuple[str, ...]) -> str:
+    """Extract the first matching key from a resource config dict.
+
+    Args:
+        config: Resource configuration dictionary (may be None).
+        keys: Ordered tuple of key names to try.
+
+    Returns:
+        The first found value as a string, or the em-dash placeholder.
+    """
+    if not config:
+        return _MISSING
+    for key in keys:
+        value = config.get(key)
+        if value is not None:
+            return str(value)
+    return _MISSING
+
+
+def _build_resource_entry(resource: Resource) -> dict[str, str]:
+    """Build a display-ready dict for a single resource.
+
+    Args:
+        resource: A tracked Resource object.
+
+    Returns:
+        Dict with name, ip, node, and state fields.
+    """
+    state_str = resource.state.value if hasattr(resource.state, "value") else str(resource.state)
+    return {
+        "name": resource.name,
+        "resource_type": resource.resource_type,
+        "ip": _extract_field(resource.config, _IP_KEYS),
+        "node": _extract_field(resource.config, _NODE_KEYS),
+        "state": state_str,
+    }
+
+
+@click.command("deployed")
+@click.option("--env", "-e", required=True, help="Environment name")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format (default: text)",
+)
+@with_orchestrator("Failed to show deployment status", require_env=False, load_credentials=False)
+def deployed(
+    _ctx: click.Context,
+    orchestrator: Orchestrator,
+    env: str,
+    output_format: str,
+) -> None:
+    """Show deployment status and resources for an environment."""
+    try:
+        state_manager = orchestrator.state_manager
+
+        # Get latest non-dry-run apply
+        deployments = state_manager.get_deployment_history(
+            environment=env,
+            command="apply",
+            exclude_dry_run=True,
+            limit=1,
+        )
+
+        # Get tracked resources (returns newest first via created_at DESC)
+        resources = state_manager.get_resources(environment=env)
+
+        # Deduplicate: keep only the latest record per (provider, name)
+        # and filter out deleted resources
+        seen: set[tuple[str, str]] = set()
+        grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+        for resource in resources:
+            key = (resource.provider, resource.name)
+            if key in seen:
+                continue
+            seen.add(key)
+            state_str = (
+                resource.state.value if hasattr(resource.state, "value") else str(resource.state)
+            )
+            if state_str == "deleted":
+                continue
+            entry = _build_resource_entry(resource)
+            grouped[resource.provider].append(entry)
+
+        # Sort resources within each provider by name
+        for provider in grouped:
+            grouped[provider].sort(key=lambda r: r["name"])
+
+        if output_format == "json":
+            _output_json(deployments, env, grouped)
+        else:
+            _output_text(deployments, env, grouped)
+
+    except click.ClickException:
+        raise
+    except StateError as exc:
+        if "no such table" in str(exc).lower():
+            console.info("Run 'infra init' to initialize state tracking.")
+        raise_cli_error("Failed to show deployment status", exc)
+    except InfraFoundryError as exc:
+        raise_cli_error("Failed to show deployment status", exc)
+    except Exception as exc:
+        if "no such table" in str(exc).lower():
+            console.info("Run 'infra init' to initialize state tracking.")
+        raise_cli_error("Failed to show deployment status", exc)
+
+
+def _output_json(
+    deployments: list[Any],
+    env: str,
+    grouped: dict[str, list[dict[str, str]]],
+) -> None:
+    """Emit JSON output for the deployed command.
+
+    Args:
+        deployments: List of Deployment objects (0 or 1 items).
+        env: Environment name.
+        grouped: Resources grouped by provider.
+    """
+    data: dict[str, Any] = {"environment": env}
+
+    if deployments:
+        dep = deployments[0]
+        status_str = dep.status.value if hasattr(dep.status, "value") else str(dep.status)
+        data["last_deployment"] = {
+            "id": dep.id,
+            "status": status_str,
+            "started_at": dep.started_at.isoformat() if dep.started_at else None,
+            "completed_at": dep.completed_at.isoformat() if dep.completed_at else None,
+            "user": dep.user or "unknown",
+        }
+    else:
+        data["last_deployment"] = None
+
+    data["resources"] = dict(sorted(grouped.items()))
+
+    output_data(data, "json")
+
+
+def _output_text(
+    deployments: list[Any],
+    env: str,
+    grouped: dict[str, list[dict[str, str]]],
+) -> None:
+    """Emit human-readable text output for the deployed command.
+
+    Args:
+        deployments: List of Deployment objects (0 or 1 items).
+        env: Environment name.
+        grouped: Resources grouped by provider.
+    """
+    console.header(f"Environment: {env}")
+
+    if deployments:
+        dep = deployments[0]
+        status_str = dep.status.value if hasattr(dep.status, "value") else str(dep.status)
+        started = dep.started_at.strftime("%Y-%m-%d %H:%M") if dep.started_at else _MISSING
+        completed = dep.completed_at.strftime("%Y-%m-%d %H:%M") if dep.completed_at else _MISSING
+        user = dep.user or "unknown"
+
+        console.info("Last deployment:")
+        console.info(f"  Status:    {status_str}")
+        console.info(f"  Started:   {started}")
+        console.info(f"  Completed: {completed}")
+        console.info(f"  User:      {user}")
+    else:
+        console.warning(f"No deployments found for environment '{env}'.")
+
+    console.info("")
+
+    if not grouped:
+        console.warning(f"No tracked resources for environment '{env}'.")
+        return
+
+    console.info("Resources:")
+    for provider in sorted(grouped):
+        console.info(f"  {provider}:")
+        for entry in grouped[provider]:
+            name = entry["name"]
+            ip = entry["ip"]
+            node = entry["node"]
+            state = entry["state"]
+            console.info(f"    {name:<20s} {ip:<16s} {node:<8s} {state}")

--- a/tests/unit/test_cli_deployed.py
+++ b/tests/unit/test_cli_deployed.py
@@ -1,0 +1,248 @@
+"""Unit tests for the 'deployed' CLI command."""
+
+import json
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from infrafoundry.cli.main import main
+from infrafoundry.core.orchestrator import Orchestrator
+from infrafoundry.core.state import DeploymentStatus
+from infrafoundry.core.state.models import ResourceState
+
+
+@pytest.fixture
+def cli_runner():
+    """Fixture for invoking CLI commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_orchestrator():
+    """Mock orchestrator for testing."""
+    mock = Mock(spec=Orchestrator)
+    mock.state_manager = Mock()
+    return mock
+
+
+@pytest.fixture
+def sample_deployment():
+    """A single completed apply deployment."""
+    dep = Mock()
+    dep.id = 42
+    dep.environment = "prod"
+    dep.command = "apply"
+    dep.status = DeploymentStatus.COMPLETED
+    dep.dry_run = False
+    dep.started_at = datetime(2026, 4, 12, 16, 45, 0)
+    dep.completed_at = datetime(2026, 4, 12, 16, 48, 0)
+    dep.user = "endavis"
+    return dep
+
+
+@pytest.fixture
+def sample_resources():
+    """Sample resources across two providers."""
+    r1 = Mock()
+    r1.name = "aiqum"
+    r1.provider = "proxmox"
+    r1.resource_type = "vm"
+    r1.state = ResourceState.ACTIVE
+    r1.config = {"ip_address": "192.168.10.206", "target_node": "pve1"}
+
+    r2 = Mock()
+    r2.name = "ontap-node01"
+    r2.provider = "proxmox"
+    r2.resource_type = "vm"
+    r2.state = ResourceState.ACTIVE
+    r2.config = {"ip_address": "192.168.10.203", "target_node": "pve1"}
+
+    r3 = Mock()
+    r3.name = "dhcp-aiqum"
+    r3.provider = "opnsense"
+    r3.resource_type = "dhcp"
+    r3.state = ResourceState.ACTIVE
+    r3.config = {}
+
+    return [r1, r2, r3]
+
+
+def test_deployed_shows_deployment_info(
+    cli_runner, mock_orchestrator, sample_deployment, sample_resources
+):
+    """Test that deployed command shows latest deployment info and resources."""
+    mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
+    mock_orchestrator.state_manager.get_resources.return_value = sample_resources
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "prod"])
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    assert "Environment: prod" in result.output
+    assert "completed" in result.output
+    assert "2026-04-12 16:45" in result.output
+    assert "2026-04-12 16:48" in result.output
+    assert "endavis" in result.output
+    assert "aiqum" in result.output
+    assert "192.168.10.206" in result.output
+    assert "pve1" in result.output
+    assert "dhcp-aiqum" in result.output
+
+    mock_orchestrator.state_manager.get_deployment_history.assert_called_once_with(
+        environment="prod",
+        command="apply",
+        exclude_dry_run=True,
+        limit=1,
+    )
+    mock_orchestrator.state_manager.get_resources.assert_called_once_with(environment="prod")
+
+
+def test_deployed_no_deployments(cli_runner, mock_orchestrator):
+    """Test deployed command when no deployments exist."""
+    mock_orchestrator.state_manager.get_deployment_history.return_value = []
+    mock_orchestrator.state_manager.get_resources.return_value = []
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "staging"])
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    assert "No deployments found for environment 'staging'" in result.output
+    assert "No tracked resources for environment 'staging'" in result.output
+
+
+def test_deployed_no_resources(cli_runner, mock_orchestrator, sample_deployment):
+    """Test deployed command when deployment exists but no resources tracked."""
+    mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
+    mock_orchestrator.state_manager.get_resources.return_value = []
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "prod"])
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    assert "completed" in result.output
+    assert "No tracked resources for environment 'prod'" in result.output
+
+
+def test_deployed_json_output(cli_runner, mock_orchestrator, sample_deployment, sample_resources):
+    """Test JSON output has correct structure."""
+    mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
+    mock_orchestrator.state_manager.get_resources.return_value = sample_resources
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "prod", "--format", "json"])
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    data = json.loads(result.output)
+
+    assert data["environment"] == "prod"
+    assert data["last_deployment"]["id"] == 42
+    assert data["last_deployment"]["status"] == "completed"
+    assert data["last_deployment"]["user"] == "endavis"
+    assert "proxmox" in data["resources"]
+    assert "opnsense" in data["resources"]
+    assert len(data["resources"]["proxmox"]) == 2
+    assert len(data["resources"]["opnsense"]) == 1
+
+
+def test_deployed_json_no_deployments(cli_runner, mock_orchestrator):
+    """Test JSON output when no deployments exist."""
+    mock_orchestrator.state_manager.get_deployment_history.return_value = []
+    mock_orchestrator.state_manager.get_resources.return_value = []
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main, ["infra", "deployed", "--env", "staging", "--format", "json"]
+        )
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    data = json.loads(result.output)
+
+    assert data["environment"] == "staging"
+    assert data["last_deployment"] is None
+    assert data["resources"] == {}
+
+
+def test_deployed_missing_ip_and_node(cli_runner, mock_orchestrator, sample_deployment):
+    """Test that missing IP/node fields show dash placeholder."""
+    resource = Mock()
+    resource.name = "some-service"
+    resource.provider = "cloudflare"
+    resource.resource_type = "dns"
+    resource.state = ResourceState.ACTIVE
+    resource.config = {"zone": "example.com"}
+
+    mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
+    mock_orchestrator.state_manager.get_resources.return_value = [resource]
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "prod"])
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    assert "some-service" in result.output
+    # Em dash used for missing fields
+    assert "\u2014" in result.output
+
+
+def test_deployed_null_config(cli_runner, mock_orchestrator, sample_deployment):
+    """Test resource with None config does not crash."""
+    resource = Mock()
+    resource.name = "orphan"
+    resource.provider = "proxmox"
+    resource.resource_type = "vm"
+    resource.state = ResourceState.ACTIVE
+    resource.config = None
+
+    mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
+    mock_orchestrator.state_manager.get_resources.return_value = [resource]
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "prod"])
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    assert "orphan" in result.output
+
+
+def test_deployed_state_error(cli_runner, mock_orchestrator):
+    """Test handling of state DB not initialized."""
+    from infrafoundry.core.exceptions import StateError
+
+    mock_orchestrator.state_manager.get_deployment_history.side_effect = StateError(
+        "no such table: deployments"
+    )
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "prod"])
+
+    assert result.exit_code != 0
+    assert "infra init" in result.output
+
+
+def test_deployed_requires_env(cli_runner, mock_orchestrator):
+    """Test that --env is required."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed"])
+
+    assert result.exit_code != 0
+    assert "Missing option" in result.output or "required" in result.output.lower()
+
+
+def test_deployed_alternative_ip_keys(cli_runner, mock_orchestrator, sample_deployment):
+    """Test that alternative config keys (address, ip, node) are recognized."""
+    r1 = Mock()
+    r1.name = "host-with-address"
+    r1.provider = "custom"
+    r1.resource_type = "server"
+    r1.state = ResourceState.ACTIVE
+    r1.config = {"address": "10.0.0.5", "node": "node3"}
+
+    mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
+    mock_orchestrator.state_manager.get_resources.return_value = [r1]
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "deployed", "--env", "prod"])
+
+    assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
+    assert "10.0.0.5" in result.output
+    assert "node3" in result.output


### PR DESCRIPTION
## Description

Add `foundry infra deployed --env <name>` command that shows the latest deployment status and per-resource details for an environment. Queries the state DB for the most recent non-dry-run apply and lists resources grouped by provider with IP, node, and state cherry-picked from the config JSON.

Addresses #566

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `deployed.py` command registered as `infra deployed`
- Shows latest deployment info: status, started/completed timestamps, user
- Lists resources by provider with name, IP, node, and state columns
- Cherry-picks IP from config keys `ip_address`/`address`/`ip` and node from `target_node`/`node`
- Supports `--format json` for machine-readable output
- Handles no deployments, no resources, null config, and uninitialized state DB
- 10 unit tests

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Added new tests in `tests/unit/test_cli_deployed.py`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
