### PR TITLE
feat: add multi-provider blueprint support

### DIFF
--- a/docs/decisions/0003-multi-provider-blueprint-support.md
+++ b/docs/decisions/0003-multi-provider-blueprint-support.md
@@ -1,0 +1,57 @@
+# ADR-0003: Multi-provider blueprint support
+
+## Status
+
+Accepted
+
+## Context
+
+Blueprints currently hardcode provider-specific resource schemas. The `proxmox-k3s-cluster` and `oci-k3s-cluster` blueprints duplicate the same intent (k3s cluster with server and agent nodes) in completely different syntax. Adding ESXi or AWS support would mean more duplication.
+
+The orchestrator is already provider-agnostic, routing by `provider` field and calling abstract methods. The gap is at the resource configuration level: no shared schema exists between providers.
+
+Two approaches were considered:
+
+1. **Base schema abstraction layer** -- define abstract compute/network/storage fields and translate to provider-native syntax at generation time.
+2. **Provider-conditional resource file selection** -- keep provider-native resource templates but let a single blueprint declare which resource files to use per provider.
+
+Related issue: [#507](https://github.com/endavis/infrafoundry/issues/507)
+
+## Decision
+
+Use provider-conditional resource file selection rather than a new schema abstraction layer.
+
+A blueprint's `blueprint.yaml` gains an optional `providers:` section that maps provider names to resource file lists and optional provider-specific defaults:
+
+```yaml
+providers:
+  proxmox:
+    resources:
+      - providers/proxmox/vm.yaml
+    defaults:
+      target_node: pve1
+  oci:
+    resources:
+      - providers/oci/instance.yaml
+```
+
+The PackageLoader selects the correct resource set based on the package's `provider` value. The defaults merge order is: `blueprint.defaults < providers[x].defaults < package.variables`.
+
+Blueprints without a `providers:` section continue to work unchanged.
+
+See [Package Loader](../architecture/package-loader.md) for implementation details (to be created in Phase 2).
+
+## Consequences
+
+**Easier:**
+- A single blueprint can serve multiple providers, deduplicating shared defaults, scripts, events, and inventory
+- Zero migration cost for existing single-provider blueprints
+- Provider expertise stays in provider-native templates with no lossy translation
+- Shared variables (e.g., `server_cores`) naturally feed into both `cores: {{ server_cores }}` (Proxmox) and `ocpus: {{ server_cores }}` (OCI) via Jinja2
+
+**Harder:**
+- No schema validation across providers -- no guarantee that Proxmox and OCI templates consume the same variables
+- No automatic field mapping -- blueprint authors still write provider-specific templates
+- Still need N resource file sets for N providers (but shared defaults, scripts, and events are deduplicated)
+
+These are acceptable tradeoffs. The real duplication today is in the non-resource parts (scripts, ansible, defaults, events) which this design fully deduplicates.

--- a/src/infrafoundry/core/config/blueprint_resolver.py
+++ b/src/infrafoundry/core/config/blueprint_resolver.py
@@ -94,6 +94,7 @@ class BlueprintResolver:
             "inventory": data.get("inventory"),
             "inventory_raw": inventory_raw,
             "blueprint_dir": blueprint_dir,
+            "providers": data.get("providers"),
         }
 
         logger.debug(

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -193,9 +193,37 @@ class PackageLoader:
 
             # Merge defaults: blueprint defaults < package variables
             merged_vars: dict[str, Any] = {**blueprint["defaults"], **manifest.variables}
+
+            # Provider-conditional resource and defaults selection
+            bp_providers = blueprint.get("providers")
+            effective_provider = manifest.provider or provider
+            if bp_providers:
+                if not effective_provider:
+                    raise InvalidConfigurationError(
+                        f"Blueprint '{manifest.blueprint}' declares provider-specific "
+                        f"resources but package '{manifest.name}' has no provider"
+                    )
+                if effective_provider not in bp_providers:
+                    available = ", ".join(sorted(bp_providers))
+                    raise InvalidConfigurationError(
+                        f"Blueprint '{manifest.blueprint}' has no resources for "
+                        f"provider '{effective_provider}' "
+                        f"(available providers: {available})"
+                    )
+                provider_block = bp_providers[effective_provider]
+                # Merge provider-specific defaults between blueprint defaults
+                # and package variables:
+                # blueprint.defaults < providers[x].defaults < package.variables
+                provider_defaults = provider_block.get("defaults", {})
+                merged_vars = {**blueprint["defaults"], **provider_defaults, **manifest.variables}
+                # Use provider-specific resources when package doesn't declare its own
+                if not manifest.resources and provider_block.get("resources"):
+                    manifest.resources = list(provider_block["resources"])
+
             manifest.variables = merged_vars
 
             # Inherit resources from blueprint if package doesn't declare its own
+            # (only when no provider-conditional selection occurred above)
             if not manifest.resources and blueprint["resources"]:
                 manifest.resources = list(blueprint["resources"])
 

--- a/tests/unit/test_package_loader_multi_provider.py
+++ b/tests/unit/test_package_loader_multi_provider.py
@@ -1,0 +1,483 @@
+"""Unit tests for multi-provider blueprint support in PackageLoader."""
+
+import pytest
+import yaml
+
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+from infrafoundry.core.config.package_loader import PackageLoader
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+
+def _create_package(base_dir, env_name, provider, package_name, manifest, resource_files=None):
+    """Helper to create a package directory structure.
+
+    Args:
+        base_dir: Base envs directory
+        env_name: Environment name
+        provider: Provider name
+        package_name: Package subdirectory name
+        manifest: Dict for infrafoundry.yml content
+        resource_files: Optional dict of filename -> content
+    """
+    package_dir = base_dir / env_name / provider / package_name
+    package_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = package_dir / "infrafoundry.yml"
+    with open(manifest_path, "w") as f:
+        yaml.dump(manifest, f)
+
+    if resource_files:
+        for filename, content in resource_files.items():
+            resource_path = package_dir / filename
+            resource_path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, str):
+                resource_path.write_text(content)
+            else:
+                with open(resource_path, "w") as f:
+                    yaml.dump(content, f)
+
+    return package_dir
+
+
+def _create_blueprint(base_dir, name, manifest_data, extra_files=None):
+    """Helper to create a blueprint directory under config_repo/blueprints/.
+
+    Args:
+        base_dir: The envs/ directory (base_dir.parent / "blueprints" is used)
+        name: Blueprint name
+        manifest_data: Dict for blueprint.yaml
+        extra_files: Optional dict of relative_path -> content
+    """
+    blueprint_dir = base_dir.parent / "blueprints" / name
+    blueprint_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = blueprint_dir / "blueprint.yaml"
+    with open(manifest_path, "w") as f:
+        yaml.dump(manifest_data, f)
+
+    if extra_files:
+        for rel_path, content in extra_files.items():
+            file_path = blueprint_dir / rel_path
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, str):
+                file_path.write_text(content)
+            else:
+                with open(file_path, "w") as f:
+                    yaml.dump(content, f)
+
+    return blueprint_dir
+
+
+@pytest.mark.unit
+class TestMultiProviderBlueprint:
+    """Tests for provider-conditional resource selection in blueprints."""
+
+    def test_selects_correct_resources_for_provider(self, temp_dir):
+        """Blueprint with providers section selects correct resource files."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "multi-bp",
+            {
+                "name": "multi-bp",
+                "defaults": {"vm_name": "node"},
+                "providers": {
+                    "proxmox": {
+                        "resources": ["providers/proxmox/vm.yaml"],
+                    },
+                    "oci": {
+                        "resources": ["providers/oci/instance.yaml"],
+                    },
+                },
+            },
+            {
+                "providers/proxmox/vm.yaml": "vm:\n  - name: {{ vm_name }}-proxmox\n",
+                "providers/oci/instance.yaml": "instance:\n  - name: {{ vm_name }}-oci\n",
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "my-cluster",
+            {
+                "name": "my-cluster",
+                "blueprint": "multi-bp",
+            },
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "node-proxmox"
+        assert resources[0].provider == "proxmox"
+
+    def test_selects_oci_provider_resources(self, temp_dir):
+        """Blueprint with providers section selects OCI resources when provider is oci."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "multi-bp-oci",
+            {
+                "name": "multi-bp-oci",
+                "defaults": {"vm_name": "node"},
+                "providers": {
+                    "proxmox": {
+                        "resources": ["providers/proxmox/vm.yaml"],
+                    },
+                    "oci": {
+                        "resources": ["providers/oci/instance.yaml"],
+                    },
+                },
+            },
+            {
+                "providers/proxmox/vm.yaml": "vm:\n  - name: {{ vm_name }}-proxmox\n",
+                "providers/oci/instance.yaml": "instance:\n  - name: {{ vm_name }}-oci\n",
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "oci",
+            "my-cluster",
+            {
+                "name": "my-cluster",
+                "blueprint": "multi-bp-oci",
+            },
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "oci", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "node-oci"
+        assert resources[0].provider == "oci"
+
+    def test_backward_compat_no_providers_section(self, temp_dir):
+        """Blueprint without providers section works as before."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "classic-bp",
+            {
+                "name": "classic-bp",
+                "defaults": {"vm_name": "legacy"},
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ vm_name }}-01\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "legacy-pkg",
+            {
+                "name": "legacy-pkg",
+                "blueprint": "classic-bp",
+            },
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "legacy-01"
+
+    def test_shared_defaults_merge_order(self, temp_dir):
+        """Defaults merge: blueprint.defaults < providers[x].defaults < package.variables."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "merge-bp",
+            {
+                "name": "merge-bp",
+                "defaults": {
+                    "cores": 2,
+                    "memory": 4096,
+                    "disk": 50,
+                },
+                "providers": {
+                    "proxmox": {
+                        "resources": ["providers/proxmox/vm.yaml"],
+                        "defaults": {
+                            "memory": 8192,
+                            "target_node": "pve1",
+                        },
+                    },
+                },
+            },
+            {
+                "providers/proxmox/vm.yaml": (
+                    "vm:\n"
+                    "  - name: node-01\n"
+                    "    cores: {{ cores }}\n"
+                    "    memory: {{ memory }}\n"
+                    "    disk: {{ disk }}\n"
+                    "    target_node: {{ target_node }}\n"
+                ),
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "merge-pkg",
+            {
+                "name": "merge-pkg",
+                "blueprint": "merge-bp",
+                "variables": {"cores": 4},
+            },
+        )
+
+        _, _, variables = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        # blueprint default: cores=2, overridden by package: cores=4
+        assert variables["cores"] == 4
+        # blueprint default: memory=4096, overridden by provider defaults: memory=8192
+        assert variables["memory"] == 8192
+        # blueprint default: disk=50, not overridden
+        assert variables["disk"] == 50
+        # provider default: target_node=pve1, not in blueprint defaults
+        assert variables["target_node"] == "pve1"
+
+    def test_package_variables_override_provider_defaults(self, temp_dir):
+        """Package variables take priority over provider-specific defaults."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "override-bp",
+            {
+                "name": "override-bp",
+                "defaults": {"cores": 2},
+                "providers": {
+                    "proxmox": {
+                        "resources": ["providers/proxmox/vm.yaml"],
+                        "defaults": {"target_node": "pve1"},
+                    },
+                },
+            },
+            {
+                "providers/proxmox/vm.yaml": (
+                    "vm:\n  - name: node-01\n    target_node: {{ target_node }}\n"
+                ),
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "override-pkg",
+            {
+                "name": "override-pkg",
+                "blueprint": "override-bp",
+                "variables": {"target_node": "pve2"},
+            },
+        )
+
+        _, _, variables = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert variables["target_node"] == "pve2"
+
+    def test_missing_provider_in_providers_section_raises(self, temp_dir):
+        """Blueprint with providers section but package's provider not listed raises error."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "limited-bp",
+            {
+                "name": "limited-bp",
+                "defaults": {},
+                "providers": {
+                    "proxmox": {
+                        "resources": ["vm.yaml"],
+                    },
+                },
+            },
+            {"vm.yaml": "vm:\n  - name: test\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "esxi",
+            "my-pkg",
+            {
+                "name": "my-pkg",
+                "blueprint": "limited-bp",
+            },
+        )
+
+        with pytest.raises(InvalidConfigurationError, match="no resources for provider 'esxi'"):
+            loader.load_package(pkg_dir, "esxi", "dev")
+
+    def test_providers_section_but_no_provider_in_package_raises(self, temp_dir):
+        """Blueprint with providers section but no provider for package raises error.
+
+        This tests the edge case where both manifest.provider and the directory-
+        inferred provider argument are empty.
+        """
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "needs-provider-bp",
+            {
+                "name": "needs-provider-bp",
+                "defaults": {},
+                "providers": {
+                    "proxmox": {
+                        "resources": ["vm.yaml"],
+                    },
+                },
+            },
+            {"vm.yaml": "vm:\n  - name: test\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        # Create package under a provider dir but pass empty provider to load_package
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "misc",
+            "no-provider-pkg",
+            {
+                "name": "no-provider-pkg",
+                "blueprint": "needs-provider-bp",
+            },
+        )
+
+        with pytest.raises(InvalidConfigurationError, match="has no provider"):
+            loader.load_package(pkg_dir, "", "dev")
+
+    def test_package_own_resources_override_provider_resources(self, temp_dir):
+        """Package's own resources take priority even with providers section."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "override-res-bp",
+            {
+                "name": "override-res-bp",
+                "defaults": {"vm_name": "node"},
+                "providers": {
+                    "proxmox": {
+                        "resources": ["providers/proxmox/vm.yaml"],
+                    },
+                },
+            },
+            {
+                "providers/proxmox/vm.yaml": "vm:\n  - name: {{ vm_name }}-bp\n",
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "custom-pkg",
+            {
+                "name": "custom-pkg",
+                "blueprint": "override-res-bp",
+                "resources": ["vm.yaml"],
+            },
+            {"vm.yaml": "vm:\n  - name: {{ vm_name }}-custom\n"},
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "node-custom"
+
+    def test_provider_from_manifest_field(self, temp_dir):
+        """Provider from manifest's provider field is used for provider lookup."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "manifest-provider-bp",
+            {
+                "name": "manifest-provider-bp",
+                "defaults": {"vm_name": "node"},
+                "providers": {
+                    "oci": {
+                        "resources": ["providers/oci/instance.yaml"],
+                    },
+                },
+            },
+            {
+                "providers/oci/instance.yaml": "instance:\n  - name: {{ vm_name }}-oci\n",
+            },
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        # Package is under 'proxmox' dir but declares provider: oci in manifest
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "cross-provider-pkg",
+            {
+                "name": "cross-provider-pkg",
+                "blueprint": "manifest-provider-bp",
+                "provider": "oci",
+            },
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "node-oci"
+        assert resources[0].provider == "oci"
+
+    def test_providers_without_defaults_key(self, temp_dir):
+        """Provider block without defaults key works (no provider-specific defaults)."""
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+        _create_blueprint(
+            temp_dir,
+            "no-prov-defaults-bp",
+            {
+                "name": "no-prov-defaults-bp",
+                "defaults": {"vm_name": "node"},
+                "providers": {
+                    "proxmox": {
+                        "resources": ["vm.yaml"],
+                    },
+                },
+            },
+            {"vm.yaml": "vm:\n  - name: {{ vm_name }}-01\n"},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "simple-pkg",
+            {
+                "name": "simple-pkg",
+                "blueprint": "no-prov-defaults-bp",
+            },
+        )
+
+        resources, _, variables = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "node-01"
+        assert variables["vm_name"] == "node"


### PR DESCRIPTION
## Description

Add provider-conditional resource file selection to the blueprint system (Phase 1 of provider-agnostic blueprints). A blueprint can now declare a `providers:` section in `blueprint.yaml` that maps provider names to provider-specific resource files and optional defaults. The PackageLoader selects the correct resource set based on the consuming package's provider.

This enables a single blueprint to serve multiple providers (e.g., one `k3s-cluster` blueprint with both Proxmox and OCI resource templates) while sharing defaults, scripts, events, and documentation.

Fully backward compatible — blueprints without a `providers:` section work exactly as before.

Addresses #507

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `blueprint_resolver.py` — Pass `providers` section through to PackageLoader
- `package_loader.py` — ~28 lines of provider-conditional logic: selects `providers[x].resources` when available, merges provider-specific defaults in correct order, raises clear errors for missing providers
- ADR-0003 documenting the design decision
- 10 unit tests covering resource selection, defaults merge order, backward compat, error cases

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Added `tests/unit/test_package_loader_multi_provider.py` (10 tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
