### PR TITLE
feat: add infra move-package command to migrate packages between environments

### DIFF
--- a/src/infrafoundry/cli/commands/infra/__init__.py
+++ b/src/infrafoundry/cli/commands/infra/__init__.py
@@ -8,6 +8,7 @@ from .destroy import destroy
 from .drift import drift
 from .history import history
 from .list_packages import list_packages
+from .move_package import move_package
 from .plan import plan
 from .reset import reset
 from .rollback import rollback
@@ -36,6 +37,7 @@ infra.add_command(status)
 infra.add_command(test)
 infra.add_command(history)
 infra.add_command(list_packages)
+infra.add_command(move_package)
 infra.add_command(unlock)
 
 

--- a/src/infrafoundry/cli/commands/infra/move_package.py
+++ b/src/infrafoundry/cli/commands/infra/move_package.py
@@ -1,0 +1,92 @@
+"""Move a package between environments."""
+
+import os
+from pathlib import Path
+
+import click
+
+from infrafoundry.core.exceptions import (
+    ConfigurationError,
+    EnvironmentNotFoundError,
+    InfraFoundryError,
+    PackageNotFoundError,
+)
+from infrafoundry.core.package_mover import PackageMover
+
+from ...utils import console, raise_cli_error
+
+
+@click.command("move-package")
+@click.option("--env", "-e", required=True, help="Source environment name")
+@click.option("--package", "-p", required=True, help="Package name to move")
+@click.option("--to-env", required=True, help="Target environment name")
+@click.option("--create-env", is_flag=True, help="Create target environment if it doesn't exist")
+@click.option("--dry-run", is_flag=True, help="Show what would be done without executing")
+@click.pass_context
+def move_package(
+    ctx: click.Context,
+    env: str,
+    package: str,
+    to_env: str,
+    create_env: bool,
+    dry_run: bool,
+) -> None:
+    """Move a package from one environment to another.
+
+    Safely relocates the package config directory, copies terraform state
+    to the target, removes the moved resources from source state, and
+    updates the InfraFoundry state database.
+    """
+    try:
+        config_dir = ctx.obj.get("config_dir")
+        if not config_dir:
+            raise ConfigurationError(
+                "No config directory configured. Use --config-dir or set INFRAFOUNDRY_CONFIG_REPO."
+            )
+
+        # config_dir from context points to the repo root (or repo/envs in some paths).
+        # PackageMover expects the repo root containing envs/.
+        # If config_dir already ends with /envs, go up one level.
+        repo_root = config_dir.parent if config_dir.name == "envs" else config_dir
+
+        generated_dir = Path(os.getenv("INFRAFOUNDRY_OUTPUT_DIR", "generated"))
+
+        mover = PackageMover(config_dir=repo_root, generated_dir=generated_dir)
+
+        if dry_run:
+            console.header(f"Dry run: move package '{package}' from '{env}' to '{to_env}'")
+
+        result = mover.execute(
+            source_env=env,
+            package_name=package,
+            target_env=to_env,
+            create_env=create_env,
+            dry_run=dry_run,
+        )
+
+        if dry_run:
+            console.info("")
+            console.info("Planned actions:")
+            for action in result["actions"]:
+                console.list_item(action)
+            console.info("")
+            console.warning("No changes made (dry run)")
+        else:
+            console.success(
+                f"Moved package '{package}' from '{env}' to '{to_env}' "
+                f"(provider: {result['provider']})"
+            )
+            rm_count = result.get("state_rm_count", 0)
+            if rm_count:
+                console.info(f"  Removed {rm_count} resource(s) from source terraform state")
+            if result.get("state_db_updated"):
+                console.info("  Updated InfraFoundry state DB")
+
+    except click.ClickException:
+        raise
+    except (PackageNotFoundError, EnvironmentNotFoundError, ConfigurationError) as exc:
+        raise_cli_error("Failed to move package", exc)
+    except InfraFoundryError as exc:
+        raise_cli_error("Failed to move package", exc)
+    except Exception as exc:
+        raise_cli_error("Failed to move package", exc)

--- a/src/infrafoundry/core/package_mover.py
+++ b/src/infrafoundry/core/package_mover.py
@@ -1,0 +1,560 @@
+"""Move infrastructure packages between environments.
+
+Handles relocating a package's configuration directory, copying terraform
+state, removing moved resources from the source state, and updating the
+InfraFoundry state database.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+from infrafoundry.core.config.models import PackageManifest
+from infrafoundry.core.config.package_loader import PackageLoader
+from infrafoundry.core.exceptions import (
+    ConfigurationError,
+    EnvironmentNotFoundError,
+    PackageNotFoundError,
+)
+from infrafoundry.core.runners.terraform_runner import TerraformRunner
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILENAME = PackageLoader.MANIFEST_FILENAME
+
+
+class PackageMover:
+    """Moves a package between environments safely.
+
+    Orchestrates the full move: config directory relocation, terraform
+    state copy + selective removal, and state DB updates.
+    """
+
+    def __init__(
+        self,
+        config_dir: Path,
+        generated_dir: Path,
+        terraform_runner: TerraformRunner | None = None,
+    ) -> None:
+        """Initialize package mover.
+
+        Args:
+            config_dir: Path to config repo root (contains envs/)
+            generated_dir: Path to generated/ directory
+            terraform_runner: Optional terraform runner instance.
+                Creates a default one if not provided.
+        """
+        self.config_dir = config_dir
+        self.generated_dir = generated_dir
+        self._terraform_runner = terraform_runner or TerraformRunner()
+
+    @property
+    def envs_dir(self) -> Path:
+        """Return the envs/ directory path."""
+        return self.config_dir / "envs"
+
+    def find_package(self, env_name: str, package_name: str) -> tuple[Path, str]:
+        """Find a package in an environment.
+
+        Searches provider subdirectories first, then the env root.
+
+        Args:
+            env_name: Environment name
+            package_name: Package name to find
+
+        Returns:
+            Tuple of (package_path, provider_name)
+
+        Raises:
+            PackageNotFoundError: If the package is not found
+            EnvironmentNotFoundError: If the environment directory does not exist
+        """
+        env_dir = self.envs_dir / env_name
+        if not env_dir.exists():
+            raise EnvironmentNotFoundError(f"Environment '{env_name}' not found at {env_dir}")
+
+        # Search provider subdirectories
+        for item in sorted(env_dir.iterdir()):
+            if not item.is_dir():
+                continue
+            if item.name in PackageLoader.EXCLUDED_DIRS | PackageLoader.ENV_ROOT_EXCLUDED_DIRS:
+                continue
+            # Check if this is a provider directory containing packages
+            for sub in sorted(item.iterdir()):
+                if not sub.is_dir():
+                    continue
+                manifest_path = sub / MANIFEST_FILENAME
+                if manifest_path.exists():
+                    manifest = self._parse_manifest(manifest_path)
+                    if manifest.name == package_name:
+                        return sub, item.name
+
+        # Search env root packages
+        for item in sorted(env_dir.iterdir()):
+            if not item.is_dir():
+                continue
+            if item.name in PackageLoader.EXCLUDED_DIRS | PackageLoader.ENV_ROOT_EXCLUDED_DIRS:
+                continue
+            manifest_path = item / MANIFEST_FILENAME
+            if manifest_path.exists():
+                manifest = self._parse_manifest(manifest_path)
+                if manifest.name == package_name:
+                    provider = manifest.provider or ""
+                    if not provider:
+                        raise PackageNotFoundError(
+                            f"Package '{package_name}' in env root has no provider field "
+                            f"in its manifest. Cannot determine provider for state operations."
+                        )
+                    return item, provider
+
+        raise PackageNotFoundError(
+            f"Package '{package_name}' not found in environment '{env_name}'"
+        )
+
+    def get_terraform_addresses(
+        self, env_name: str, provider_name: str, package_path: Path
+    ) -> dict[str, list[str]]:
+        """Get terraform state addresses for resources in a package.
+
+        Uses the full PackageLoader rendering pipeline to get actual
+        resource names (including those from Jinja2 loops and blueprints),
+        then matches against terraform state across all providers.
+
+        Args:
+            env_name: Environment name
+            provider_name: Provider name (primary provider for the package)
+            package_path: Path to the package directory
+
+        Returns:
+            Dict mapping provider names to lists of terraform addresses.
+            Includes the primary provider and any cross-provider resources.
+        """
+        resource_names = self._get_rendered_resource_names(env_name, provider_name, package_path)
+        if not resource_names:
+            return {}
+
+        # Build set of terraform name variants for matching
+        tf_names: set[str] = set()
+        for name in resource_names:
+            tf_names.add(name.replace("-", "_"))
+
+        # Check all provider state directories (handles cross-provider resources)
+        terraform_base = self.generated_dir / env_name / "terraform"
+        if not terraform_base.exists():
+            return {}
+
+        result: dict[str, list[str]] = {}
+        for provider_dir in sorted(terraform_base.iterdir()):
+            if not provider_dir.is_dir():
+                continue
+            state_file = provider_dir / "terraform.tfstate"
+            if not state_file.exists():
+                continue
+
+            all_addresses = self._terraform_runner.state_list(provider_dir)
+            if not all_addresses:
+                continue
+
+            matched: list[str] = []
+            for address in all_addresses:
+                parts = address.rsplit(".", 1)
+                if len(parts) != 2:
+                    continue
+                tf_name = parts[1]
+                # Match exact name or name as suffix (e.g., cloud_init_user_data_aiqum)
+                for expected in tf_names:
+                    if tf_name == expected or tf_name.endswith(f"_{expected}"):
+                        matched.append(address)
+                        break
+
+            if matched:
+                result[provider_dir.name] = matched
+
+        return result
+
+    def _get_rendered_resource_names(
+        self, env_name: str, provider_name: str, package_path: Path
+    ) -> list[str]:
+        """Load a package through the full rendering pipeline to get resource names.
+
+        Falls back to manifest name + key variables if rendering fails
+        (e.g., missing secrets for Jinja2 StrictUndefined).
+
+        Args:
+            env_name: Environment name
+            provider_name: Provider name
+            package_path: Path to the package directory
+
+        Returns:
+            List of resource names
+        """
+        try:
+            resolver = BlueprintResolver(self.envs_dir)
+            loader = PackageLoader(
+                base_dir=self.envs_dir,
+                blueprint_resolver=resolver,
+            )
+            resources, _, _ = loader.load_package(package_path, provider_name, env_name)
+            names = [r.name for r in resources]
+            if names:
+                return names
+        except Exception as exc:
+            logger.debug("Full package rendering failed, using fallback: %s", exc)
+
+        # Fallback: use package name + key variables
+        manifest = self._parse_manifest(package_path / MANIFEST_FILENAME)
+        names = [manifest.name]
+        for key in ("vm_name", "server_name", "control_name", "template_name"):
+            value = manifest.variables.get(key)
+            if value and isinstance(value, str) and value not in names:
+                names.append(value)
+        return names
+
+    def execute(
+        self,
+        source_env: str,
+        package_name: str,
+        target_env: str,
+        create_env: bool = False,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Execute the full package move.
+
+        Args:
+            source_env: Source environment name
+            package_name: Package name to move
+            target_env: Target environment name
+            create_env: Create target environment if it doesn't exist
+            dry_run: Show what would be done without executing
+
+        Returns:
+            Dict with summary of actions taken
+
+        Raises:
+            PackageNotFoundError: If the source package is not found
+            EnvironmentNotFoundError: If the target env does not exist
+                and create_env is False
+            ConfigurationError: If the target already contains the package
+        """
+        actions: list[str] = []
+
+        # 1. Find source package
+        source_path, provider_name = self.find_package(source_env, package_name)
+        actions.append(
+            f"Found package '{package_name}' at {source_path} (provider: {provider_name})"
+        )
+
+        # 2. Validate target environment
+        target_env_dir = self.envs_dir / target_env
+        if not target_env_dir.exists():
+            if create_env:
+                actions.append(f"Create target environment directory: {target_env_dir}")
+                if not dry_run:
+                    target_env_dir.mkdir(parents=True, exist_ok=True)
+            else:
+                raise EnvironmentNotFoundError(
+                    f"Target environment '{target_env}' not found. Use --create-env to create it."
+                )
+
+        # 3. Determine target package path (flat, no provider subdir)
+        target_package_dir = target_env_dir / source_path.name
+        if target_package_dir.exists():
+            raise ConfigurationError(
+                f"Target directory already exists: {target_package_dir}. "
+                f"Remove it first or choose a different target."
+            )
+        actions.append(f"Move config: {source_path} -> {target_package_dir}")
+
+        # 4. Check manifest for provider field
+        manifest = self._parse_manifest(source_path / MANIFEST_FILENAME)
+        needs_provider_field = manifest.provider is None
+        if needs_provider_field:
+            actions.append(f"Add 'provider: {provider_name}' to manifest")
+
+        # 5. Terraform state operations
+        # Get addresses across ALL providers (handles cross-provider resources)
+        addresses_by_provider = self.get_terraform_addresses(source_env, provider_name, source_path)
+
+        # Plan state copy for each provider that has matching resources
+        providers_to_copy: list[str] = []
+        for prov in sorted(addresses_by_provider):
+            source_tf_dir = self.generated_dir / source_env / "terraform" / prov
+            target_tf_dir = self.generated_dir / target_env / "terraform" / prov
+            source_state_file = source_tf_dir / "terraform.tfstate"
+            target_state_file = target_tf_dir / "terraform.tfstate"
+
+            if source_state_file.exists() and not target_state_file.exists():
+                providers_to_copy.append(prov)
+                actions.append(f"Copy state file: {source_state_file} -> {target_state_file}")
+                source_backup = source_tf_dir / "terraform.tfstate.backup"
+                if source_backup.exists():
+                    actions.append(
+                        f"Copy state backup: {source_backup} -> "
+                        f"{target_tf_dir / 'terraform.tfstate.backup'}"
+                    )
+            elif source_state_file.exists():
+                actions.append(f"Skip state copy for {prov}: target already has terraform.tfstate")
+
+        # Also copy primary provider state even if no addresses matched
+        primary_source = self.generated_dir / source_env / "terraform" / provider_name
+        primary_target = self.generated_dir / target_env / "terraform" / provider_name
+        if (
+            primary_source.exists()
+            and (primary_source / "terraform.tfstate").exists()
+            and not (primary_target / "terraform.tfstate").exists()
+            and provider_name not in providers_to_copy
+        ):
+            providers_to_copy.append(provider_name)
+            actions.append(
+                f"Copy state file: {primary_source / 'terraform.tfstate'} -> "
+                f"{primary_target / 'terraform.tfstate'}"
+            )
+
+        total_addresses = sum(len(addrs) for addrs in addresses_by_provider.values())
+        if addresses_by_provider:
+            for prov, addrs in sorted(addresses_by_provider.items()):
+                for addr in addrs:
+                    actions.append(f"terraform state rm (source {prov}): {addr}")
+        else:
+            has_any_state = any(
+                (self.generated_dir / source_env / "terraform" / p / "terraform.tfstate").exists()
+                for p in [provider_name]
+            )
+            if has_any_state:
+                actions.append("No matching terraform state addresses found for package resources")
+            else:
+                actions.append("No source terraform state file found (config-only move)")
+
+        # 6. State DB update
+        actions.append(f"Update state DB: move resources from '{source_env}' to '{target_env}'")
+
+        # 7. Remove source directory
+        actions.append(f"Remove source directory: {source_path}")
+
+        if dry_run:
+            return {
+                "dry_run": True,
+                "actions": actions,
+                "source_path": str(source_path),
+                "target_path": str(target_package_dir),
+                "provider": provider_name,
+                "state_addresses": addresses_by_provider,
+            }
+
+        # --- Execute ---
+
+        # Move config directory
+        shutil.copytree(source_path, target_package_dir)
+
+        # Add provider field to manifest if needed
+        if needs_provider_field:
+            self._add_provider_to_manifest(target_package_dir / MANIFEST_FILENAME, provider_name)
+
+        # Copy terraform state for each provider
+        for prov in providers_to_copy:
+            src_tf = self.generated_dir / source_env / "terraform" / prov
+            tgt_tf = self.generated_dir / target_env / "terraform" / prov
+            tgt_tf.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_tf / "terraform.tfstate", tgt_tf / "terraform.tfstate")
+
+            backup = src_tf / "terraform.tfstate.backup"
+            if backup.exists():
+                shutil.copy2(backup, tgt_tf / "terraform.tfstate.backup")
+
+            # Copy .terraform directory for provider plugins
+            src_dot_tf = src_tf / ".terraform"
+            tgt_dot_tf = tgt_tf / ".terraform"
+            if src_dot_tf.exists() and not tgt_dot_tf.exists():
+                shutil.copytree(src_dot_tf, tgt_dot_tf)
+
+        # Remove resources from source terraform state (all providers)
+        rm_results: list[dict[str, Any]] = []
+        for prov, addrs in sorted(addresses_by_provider.items()):
+            src_tf = self.generated_dir / source_env / "terraform" / prov
+            for addr in addrs:
+                success = self._terraform_runner.state_rm(src_tf, addr)
+                rm_results.append({"provider": prov, "address": addr, "success": success})
+
+        # Update state DB
+        db_updated = self._update_state_db(source_env, target_env, provider_name, package_name)
+
+        # Remove source config directory
+        shutil.rmtree(source_path)
+
+        return {
+            "dry_run": False,
+            "actions": actions,
+            "source_path": str(source_path),
+            "target_path": str(target_package_dir),
+            "provider": provider_name,
+            "state_addresses": addresses_by_provider,
+            "state_rm_results": rm_results,
+            "state_rm_count": total_addresses,
+            "state_db_updated": db_updated,
+        }
+
+    def _parse_manifest(self, manifest_path: Path) -> PackageManifest:
+        """Parse an infrafoundry.yml manifest file.
+
+        Args:
+            manifest_path: Path to the manifest file
+
+        Returns:
+            PackageManifest instance
+
+        Raises:
+            ConfigurationError: If the manifest cannot be parsed
+        """
+        if not manifest_path.exists():
+            raise ConfigurationError(f"Manifest not found: {manifest_path}")
+
+        try:
+            text = manifest_path.read_text()
+        except OSError as e:
+            raise ConfigurationError(f"Failed to read manifest {manifest_path}: {e}") from e
+
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as e:
+            raise ConfigurationError(f"Invalid YAML in {manifest_path}: {e}") from e
+
+        if not data or not isinstance(data, dict):
+            raise ConfigurationError(f"Manifest must be a YAML mapping: {manifest_path}")
+
+        # Filter out keys not in PackageManifest to avoid validation errors
+        # (e.g. inventory raw text from extraction)
+        valid_fields = set(PackageManifest.model_fields.keys())
+        filtered = {k: v for k, v in data.items() if k in valid_fields}
+        return PackageManifest(**filtered)
+
+    def _extract_resource_names(self, package_path: Path, manifest: PackageManifest) -> list[str]:
+        """Extract resource names from a package's resource files.
+
+        Reads each resource file listed in the manifest and extracts
+        the ``name`` field from resource definitions.
+
+        Args:
+            package_path: Path to the package directory
+            manifest: Parsed package manifest
+
+        Returns:
+            List of resource names
+        """
+        names: list[str] = []
+        for resource_file in manifest.resources:
+            resource_path = package_path / resource_file
+            if not resource_path.exists():
+                continue
+            try:
+                data = yaml.safe_load(resource_path.read_text())
+            except (OSError, yaml.YAMLError):
+                continue
+            if not isinstance(data, dict):
+                continue
+
+            # Resource-centric format
+            if "resources" in data and isinstance(data["resources"], list):
+                for item in data["resources"]:
+                    if isinstance(item, dict) and "name" in item:
+                        names.append(item["name"])
+                continue
+
+            # Provider-centric format: look for list values containing dicts with "name"
+            for value in data.values():
+                if isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict) and "name" in item:
+                            names.append(item["name"])
+
+        return names
+
+    def _add_provider_to_manifest(self, manifest_path: Path, provider_name: str) -> None:
+        """Add a provider field to a manifest file.
+
+        Inserts ``provider: <name>`` after the ``name:`` line to preserve
+        readability.
+
+        Args:
+            manifest_path: Path to the manifest file
+            provider_name: Provider name to add
+        """
+        lines = manifest_path.read_text().splitlines(keepends=True)
+        new_lines: list[str] = []
+        inserted = False
+
+        for line in lines:
+            new_lines.append(line)
+            if not inserted and line.strip().startswith("name:"):
+                # Insert provider line after name line
+                indent = len(line) - len(line.lstrip())
+                provider_line = f"{' ' * indent}provider: {provider_name}\n"
+                new_lines.append(provider_line)
+                inserted = True
+
+        if not inserted:
+            # Fallback: prepend provider line
+            new_lines.insert(0, f"provider: {provider_name}\n")
+
+        manifest_path.write_text("".join(new_lines))
+
+    def _update_state_db(
+        self,
+        source_env: str,
+        target_env: str,
+        provider_name: str,
+        package_name: str,
+    ) -> bool:
+        """Update resource records in the InfraFoundry state DB.
+
+        Moves resources belonging to the package from source to target
+        environment. Silently skips if the state DB is not available.
+
+        Args:
+            source_env: Source environment name
+            target_env: Target environment name
+            provider_name: Provider name
+            package_name: Package name (used for logging)
+
+        Returns:
+            True if resources were updated, False if skipped
+        """
+        try:
+            from infrafoundry.core.state.state_manager import StateManager
+
+            state_mgr = StateManager()
+            state_mgr.initialize()
+
+            resources = state_mgr.get_resources(environment=source_env, provider=provider_name)
+
+            updated_count = 0
+            for resource in resources:
+                # Update environment field directly via session
+                with state_mgr.SessionLocal() as session:
+                    from infrafoundry.core.state.models import Resource
+
+                    db_resource = session.query(Resource).filter_by(id=resource.id).first()
+                    if db_resource:
+                        db_resource.environment = target_env
+                        session.commit()
+                        updated_count += 1
+
+            if updated_count > 0:
+                logger.info(
+                    "Updated %d resource(s) in state DB from '%s' to '%s' for package '%s'",
+                    updated_count,
+                    source_env,
+                    target_env,
+                    package_name,
+                )
+                return True
+            return False
+
+        except Exception as e:
+            logger.debug("State DB update skipped: %s", e)
+            return False

--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -671,6 +671,63 @@ class TerraformRunner(BaseRunner):
                     break
         return still_present
 
+    def state_list(self, working_dir: Path) -> list[str]:
+        """List all resource addresses in terraform state.
+
+        Runs ``terraform state list`` in the given directory and returns
+        the resource addresses. Returns an empty list if no state file
+        exists or the command fails.
+
+        Args:
+            working_dir: Terraform working directory containing state
+
+        Returns:
+            List of terraform resource addresses
+        """
+        state_file = working_dir / "terraform.tfstate"
+        if not state_file.exists():
+            return []
+
+        try:
+            result = subprocess.run(  # nosec B603
+                [self.tool_path, "state", "list"],
+                cwd=working_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            addresses = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            return addresses
+        except subprocess.CalledProcessError as e:
+            logger.warning("terraform state list failed in %s: %s", working_dir, e.stderr)
+            return []
+
+    def state_rm(self, working_dir: Path, address: str) -> bool:
+        """Remove a resource from terraform state without destroying it.
+
+        Runs ``terraform state rm <address>`` in the given directory.
+
+        Args:
+            working_dir: Terraform working directory containing state
+            address: Terraform resource address to remove
+
+        Returns:
+            True if the resource was successfully removed
+        """
+        try:
+            subprocess.run(  # nosec B603
+                [self.tool_path, "state", "rm", address],
+                cwd=working_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            logger.info("Removed %s from terraform state in %s", address, working_dir)
+            return True
+        except subprocess.CalledProcessError as e:
+            logger.warning("terraform state rm %s failed in %s: %s", address, working_dir, e.stderr)
+            return False
+
     def get_resource_ids(self, provider: ProviderBase) -> dict[str, str]:
         """Extract Terraform resource IDs from state.
 

--- a/tests/unit/test_cli_move_package.py
+++ b/tests/unit/test_cli_move_package.py
@@ -1,0 +1,137 @@
+"""Unit tests for the 'infra move-package' CLI command."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from infrafoundry.cli.main import main
+from infrafoundry.core.exceptions import PackageNotFoundError
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Fixture for invoking CLI commands."""
+    return CliRunner()
+
+
+def test_required_options(cli_runner: CliRunner) -> None:
+    """Required options are enforced."""
+    result = cli_runner.invoke(main, ["infra", "move-package"])
+    assert result.exit_code != 0
+    assert "Missing option" in result.output or "required" in result.output.lower()
+
+
+def test_requires_config_dir(cli_runner: CliRunner) -> None:
+    """Command errors when no config directory is configured."""
+    result = cli_runner.invoke(
+        main,
+        ["infra", "move-package", "--env", "prod", "--package", "foo", "--to-env", "staging"],
+    )
+    assert result.exit_code != 0
+    assert "config" in result.output.lower() or "Error" in result.output
+
+
+def test_dry_run_shows_actions(cli_runner: CliRunner, tmp_path) -> None:
+    """--dry-run shows planned actions via mocked PackageMover."""
+    mock_result = {
+        "dry_run": True,
+        "actions": [
+            "Found package 'my-cluster' at /some/path (provider: proxmox)",
+            "Move config: /source -> /target",
+        ],
+        "source_path": "/source",
+        "target_path": "/target",
+        "provider": "proxmox",
+        "state_addresses": [],
+    }
+
+    with patch("infrafoundry.cli.commands.infra.move_package.PackageMover") as mock_mover_cls:
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = mock_result
+        mock_mover_cls.return_value = mock_instance
+
+        result = cli_runner.invoke(
+            main,
+            [
+                "-c",
+                str(tmp_path),
+                "infra",
+                "move-package",
+                "--env",
+                "prod",
+                "--package",
+                "my-cluster",
+                "--to-env",
+                "staging",
+                "--dry-run",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "dry run" in result.output.lower()
+
+
+def test_success_with_mocked_mover(cli_runner: CliRunner, tmp_path) -> None:
+    """Successful move with mocked PackageMover."""
+    mock_result = {
+        "dry_run": False,
+        "actions": [],
+        "source_path": "/source",
+        "target_path": "/target",
+        "provider": "proxmox",
+        "state_addresses": ["proxmox_virtual_environment_vm.web_01"],
+        "state_rm_results": [{"address": "proxmox_virtual_environment_vm.web_01", "success": True}],
+        "state_db_updated": True,
+    }
+
+    with patch("infrafoundry.cli.commands.infra.move_package.PackageMover") as mock_mover_cls:
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = mock_result
+        mock_mover_cls.return_value = mock_instance
+
+        result = cli_runner.invoke(
+            main,
+            [
+                "-c",
+                str(tmp_path),
+                "infra",
+                "move-package",
+                "--env",
+                "prod",
+                "--package",
+                "my-cluster",
+                "--to-env",
+                "staging",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "proxmox" in result.output.lower()
+
+
+def test_package_not_found_error(cli_runner: CliRunner, tmp_path) -> None:
+    """PackageNotFoundError is reported as CLI error."""
+    with patch("infrafoundry.cli.commands.infra.move_package.PackageMover") as mock_mover_cls:
+        mock_instance = MagicMock()
+        mock_instance.execute.side_effect = PackageNotFoundError("Package 'foo' not found")
+        mock_mover_cls.return_value = mock_instance
+
+        result = cli_runner.invoke(
+            main,
+            [
+                "-c",
+                str(tmp_path),
+                "infra",
+                "move-package",
+                "--env",
+                "prod",
+                "--package",
+                "foo",
+                "--to-env",
+                "staging",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower() or "Error" in result.output

--- a/tests/unit/test_package_mover.py
+++ b/tests/unit/test_package_mover.py
@@ -1,0 +1,500 @@
+"""Unit tests for PackageMover."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from infrafoundry.core.exceptions import (
+    ConfigurationError,
+    EnvironmentNotFoundError,
+    PackageNotFoundError,
+)
+from infrafoundry.core.package_mover import PackageMover
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    """Create a config directory structure."""
+    envs = tmp_path / "envs"
+    envs.mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def generated_dir(tmp_path: Path) -> Path:
+    """Create a generated directory."""
+    gen = tmp_path / "generated"
+    gen.mkdir()
+    return gen
+
+
+@pytest.fixture
+def mock_terraform_runner() -> MagicMock:
+    """Create a mock terraform runner."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mover(config_dir: Path, generated_dir: Path, mock_terraform_runner: MagicMock) -> PackageMover:
+    """Create a PackageMover instance."""
+    return PackageMover(
+        config_dir=config_dir,
+        generated_dir=generated_dir,
+        terraform_runner=mock_terraform_runner,
+    )
+
+
+def _create_package(
+    envs_dir: Path,
+    env_name: str,
+    package_name: str,
+    provider: str | None = None,
+    provider_subdir: str | None = None,
+    resources: list[str] | None = None,
+) -> Path:
+    """Create a package directory with manifest.
+
+    Args:
+        envs_dir: Path to envs/ directory
+        env_name: Environment name
+        package_name: Package name
+        provider: Provider to set in manifest (None to omit)
+        provider_subdir: Provider subdirectory name (None for env root)
+        resources: List of resource filenames to list in manifest
+
+    Returns:
+        Path to the created package directory
+    """
+    if provider_subdir:
+        pkg_dir = envs_dir / env_name / provider_subdir / package_name
+    else:
+        pkg_dir = envs_dir / env_name / package_name
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest: dict = {"name": package_name}
+    if provider:
+        manifest["provider"] = provider
+    if resources:
+        manifest["resources"] = resources
+
+    (pkg_dir / "infrafoundry.yml").write_text(yaml.dump(manifest))
+    return pkg_dir
+
+
+def _create_resource_file(pkg_dir: Path, filename: str, resources: list[dict]) -> None:
+    """Create a resource YAML file with provider-centric format."""
+    stem = Path(filename).stem
+    data = {stem: resources}
+    (pkg_dir / filename).write_text(yaml.dump(data))
+
+
+class TestFindPackage:
+    """Tests for PackageMover.find_package."""
+
+    def test_find_in_provider_subdir(self, mover: PackageMover, config_dir: Path) -> None:
+        """find_package locates a package nested under a provider directory."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        path, provider = mover.find_package("prod", "my-cluster")
+        assert path.name == "my-cluster"
+        assert provider == "proxmox"
+
+    def test_find_at_env_root(self, mover: PackageMover, config_dir: Path) -> None:
+        """find_package locates a package at the environment root."""
+        _create_package(config_dir / "envs", "prod", "my-pkg", provider="opnsense")
+        path, provider = mover.find_package("prod", "my-pkg")
+        assert path.name == "my-pkg"
+        assert provider == "opnsense"
+
+    def test_env_root_missing_provider_raises(self, mover: PackageMover, config_dir: Path) -> None:
+        """find_package raises when env root package has no provider in manifest."""
+        _create_package(config_dir / "envs", "prod", "orphan")
+        with pytest.raises(PackageNotFoundError, match="no provider field"):
+            mover.find_package("prod", "orphan")
+
+    def test_missing_package_raises(self, mover: PackageMover, config_dir: Path) -> None:
+        """find_package raises PackageNotFoundError for non-existent package."""
+        (config_dir / "envs" / "prod").mkdir(parents=True)
+        with pytest.raises(PackageNotFoundError, match="not found"):
+            mover.find_package("prod", "nonexistent")
+
+    def test_missing_env_raises(self, mover: PackageMover) -> None:
+        """find_package raises EnvironmentNotFoundError for missing env."""
+        with pytest.raises(EnvironmentNotFoundError):
+            mover.find_package("missing-env", "pkg")
+
+
+class TestGetTerraformAddresses:
+    """Tests for PackageMover.get_terraform_addresses."""
+
+    def test_matches_resource_names(
+        self,
+        mover: PackageMover,
+        config_dir: Path,
+        generated_dir: Path,
+        mock_terraform_runner: MagicMock,
+    ) -> None:
+        """get_terraform_addresses matches resource names to state addresses."""
+        pkg = _create_package(
+            config_dir / "envs",
+            "prod",
+            "my-cluster",
+            provider_subdir="proxmox",
+            resources=["vm.yaml"],
+        )
+        _create_resource_file(pkg, "vm.yaml", [{"name": "web-01"}, {"name": "db-01"}])
+
+        tf_dir = generated_dir / "prod" / "terraform" / "proxmox"
+        tf_dir.mkdir(parents=True)
+        (tf_dir / "terraform.tfstate").write_text("{}")
+
+        mock_terraform_runner.state_list.return_value = [
+            "proxmox_virtual_environment_vm.web_01",
+            "proxmox_virtual_environment_vm.db_01",
+            "proxmox_virtual_environment_vm.other_node",
+        ]
+
+        addresses = mover.get_terraform_addresses("prod", "proxmox", pkg)
+        assert "proxmox" in addresses
+        assert "proxmox_virtual_environment_vm.web_01" in addresses["proxmox"]
+        assert "proxmox_virtual_environment_vm.db_01" in addresses["proxmox"]
+        assert "proxmox_virtual_environment_vm.other_node" not in addresses["proxmox"]
+
+    def test_matches_prefixed_names(
+        self,
+        mover: PackageMover,
+        config_dir: Path,
+        generated_dir: Path,
+        mock_terraform_runner: MagicMock,
+    ) -> None:
+        """get_terraform_addresses handles prefixed terraform names."""
+        pkg = _create_package(
+            config_dir / "envs", "prod", "aiqum", provider_subdir="proxmox", resources=["vm.yaml"]
+        )
+        _create_resource_file(pkg, "vm.yaml", [{"name": "aiqum"}])
+
+        tf_dir = generated_dir / "prod" / "terraform" / "proxmox"
+        tf_dir.mkdir(parents=True)
+        (tf_dir / "terraform.tfstate").write_text("{}")
+
+        mock_terraform_runner.state_list.return_value = [
+            "proxmox_virtual_environment_vm.ova_vm_aiqum",
+        ]
+
+        addresses = mover.get_terraform_addresses("prod", "proxmox", pkg)
+        assert "proxmox" in addresses
+        assert "proxmox_virtual_environment_vm.ova_vm_aiqum" in addresses["proxmox"]
+
+    def test_no_state_file_returns_empty(self, mover: PackageMover, config_dir: Path) -> None:
+        """get_terraform_addresses returns empty list when no state file exists."""
+        pkg = _create_package(
+            config_dir / "envs",
+            "prod",
+            "my-cluster",
+            provider_subdir="proxmox",
+            resources=["vm.yaml"],
+        )
+        _create_resource_file(pkg, "vm.yaml", [{"name": "web-01"}])
+
+        addresses = mover.get_terraform_addresses("prod", "proxmox", pkg)
+        assert addresses == {}
+
+
+class TestExecute:
+    """Tests for PackageMover.execute."""
+
+    def test_dry_run_returns_actions(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() with dry_run returns planned actions without modifying filesystem."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+        mock_terraform_runner.state_list.return_value = []
+
+        result = mover.execute("prod", "my-cluster", "staging", dry_run=True)
+
+        assert result["dry_run"] is True
+        assert len(result["actions"]) > 0
+        # Source should still exist
+        assert (config_dir / "envs" / "prod" / "proxmox" / "my-cluster").exists()
+        # Target should not exist
+        assert not (config_dir / "envs" / "staging" / "my-cluster").exists()
+
+    def test_moves_config_dir(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() moves the config directory to the target environment."""
+        pkg = _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+        mock_terraform_runner.state_list.return_value = []
+
+        result = mover.execute("prod", "my-cluster", "staging")
+
+        assert result["dry_run"] is False
+        assert not pkg.exists()
+        assert (config_dir / "envs" / "staging" / "my-cluster" / "infrafoundry.yml").exists()
+
+    def test_adds_provider_field(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() adds provider field to manifest when missing."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+        mock_terraform_runner.state_list.return_value = []
+
+        mover.execute("prod", "my-cluster", "staging")
+
+        manifest_text = (
+            config_dir / "envs" / "staging" / "my-cluster" / "infrafoundry.yml"
+        ).read_text()
+        assert "provider: proxmox" in manifest_text
+
+    def test_skips_provider_field_when_present(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() does not duplicate provider field when already present."""
+        _create_package(
+            config_dir / "envs", "prod", "my-cluster", provider="proxmox", provider_subdir="proxmox"
+        )
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+        mock_terraform_runner.state_list.return_value = []
+
+        mover.execute("prod", "my-cluster", "staging")
+
+        manifest_text = (
+            config_dir / "envs" / "staging" / "my-cluster" / "infrafoundry.yml"
+        ).read_text()
+        assert manifest_text.count("provider:") == 1
+
+    def test_copies_state_file(
+        self,
+        mover: PackageMover,
+        config_dir: Path,
+        generated_dir: Path,
+        mock_terraform_runner: MagicMock,
+    ) -> None:
+        """execute() copies state file when target has none."""
+        pkg = _create_package(
+            config_dir / "envs",
+            "prod",
+            "my-cluster",
+            provider_subdir="proxmox",
+            resources=["vm.yaml"],
+        )
+        _create_resource_file(pkg, "vm.yaml", [{"name": "web-01"}])
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+
+        source_tf = generated_dir / "prod" / "terraform" / "proxmox"
+        source_tf.mkdir(parents=True)
+        (source_tf / "terraform.tfstate").write_text('{"version": 4}')
+        (source_tf / "terraform.tfstate.backup").write_text('{"version": 3}')
+
+        mock_terraform_runner.state_list.return_value = ["proxmox_virtual_environment_vm.web_01"]
+        mock_terraform_runner.state_rm.return_value = True
+
+        mover.execute("prod", "my-cluster", "staging")
+
+        target_tf = generated_dir / "staging" / "terraform" / "proxmox"
+        assert (target_tf / "terraform.tfstate").exists()
+        assert (target_tf / "terraform.tfstate.backup").exists()
+
+    def test_skips_state_copy_when_target_has_state(
+        self,
+        mover: PackageMover,
+        config_dir: Path,
+        generated_dir: Path,
+        mock_terraform_runner: MagicMock,
+    ) -> None:
+        """execute() skips state copy when target already has terraform.tfstate."""
+        pkg = _create_package(
+            config_dir / "envs",
+            "prod",
+            "my-cluster",
+            provider_subdir="proxmox",
+            resources=["vm.yaml"],
+        )
+        _create_resource_file(pkg, "vm.yaml", [{"name": "web-01"}])
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+
+        source_tf = generated_dir / "prod" / "terraform" / "proxmox"
+        source_tf.mkdir(parents=True)
+        (source_tf / "terraform.tfstate").write_text('{"version": 4}')
+
+        target_tf = generated_dir / "staging" / "terraform" / "proxmox"
+        target_tf.mkdir(parents=True)
+        (target_tf / "terraform.tfstate").write_text('{"version": 99}')
+
+        mock_terraform_runner.state_list.return_value = ["proxmox_virtual_environment_vm.web_01"]
+        mock_terraform_runner.state_rm.return_value = True
+
+        mover.execute("prod", "my-cluster", "staging")
+
+        # Target state should be unchanged
+        assert (target_tf / "terraform.tfstate").read_text() == '{"version": 99}'
+
+    def test_calls_state_rm_for_resources(
+        self,
+        mover: PackageMover,
+        config_dir: Path,
+        generated_dir: Path,
+        mock_terraform_runner: MagicMock,
+    ) -> None:
+        """execute() calls terraform state rm for each matched resource address."""
+        pkg = _create_package(
+            config_dir / "envs",
+            "prod",
+            "my-cluster",
+            provider_subdir="proxmox",
+            resources=["vm.yaml"],
+        )
+        _create_resource_file(pkg, "vm.yaml", [{"name": "web-01"}, {"name": "db-01"}])
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+
+        source_tf = generated_dir / "prod" / "terraform" / "proxmox"
+        source_tf.mkdir(parents=True)
+        (source_tf / "terraform.tfstate").write_text("{}")
+
+        mock_terraform_runner.state_list.return_value = [
+            "proxmox_virtual_environment_vm.web_01",
+            "proxmox_virtual_environment_vm.db_01",
+        ]
+        mock_terraform_runner.state_rm.return_value = True
+
+        mover.execute("prod", "my-cluster", "staging")
+
+        assert mock_terraform_runner.state_rm.call_count == 2
+        calls = [c.args for c in mock_terraform_runner.state_rm.call_args_list]
+        addresses = [c[1] for c in calls]
+        assert "proxmox_virtual_environment_vm.web_01" in addresses
+        assert "proxmox_virtual_environment_vm.db_01" in addresses
+
+    def test_removes_source_directory(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() removes the source config directory after move."""
+        pkg = _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+        mock_terraform_runner.state_list.return_value = []
+
+        mover.execute("prod", "my-cluster", "staging")
+
+        assert not pkg.exists()
+
+    def test_create_env_creates_target(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() with create_env creates the target environment directory."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        mock_terraform_runner.state_list.return_value = []
+
+        mover.execute("prod", "my-cluster", "new-env", create_env=True)
+
+        assert (config_dir / "envs" / "new-env").exists()
+        assert (config_dir / "envs" / "new-env" / "my-cluster" / "infrafoundry.yml").exists()
+
+    def test_missing_target_without_create_env_raises(
+        self, mover: PackageMover, config_dir: Path
+    ) -> None:
+        """execute() raises when target env doesn't exist and create_env is False."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+
+        with pytest.raises(EnvironmentNotFoundError, match="Use --create-env"):
+            mover.execute("prod", "my-cluster", "nonexistent")
+
+    def test_target_already_exists_raises(self, mover: PackageMover, config_dir: Path) -> None:
+        """execute() raises when target package directory already exists."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        # Create conflicting target
+        target = config_dir / "envs" / "staging" / "my-cluster"
+        target.mkdir(parents=True)
+
+        with pytest.raises(ConfigurationError, match="already exists"):
+            mover.execute("prod", "my-cluster", "staging")
+
+    def test_no_state_file_config_only_move(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() handles packages with no terraform state (config-only move)."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+        mock_terraform_runner.state_list.return_value = []
+
+        result = mover.execute("prod", "my-cluster", "staging")
+
+        assert result["state_addresses"] == {}
+        assert result["state_rm_results"] == []
+        assert (config_dir / "envs" / "staging" / "my-cluster" / "infrafoundry.yml").exists()
+
+    def test_state_db_update_called(
+        self, mover: PackageMover, config_dir: Path, mock_terraform_runner: MagicMock
+    ) -> None:
+        """execute() attempts to update the state DB."""
+        _create_package(config_dir / "envs", "prod", "my-cluster", provider_subdir="proxmox")
+        (config_dir / "envs" / "staging").mkdir(parents=True)
+        mock_terraform_runner.state_list.return_value = []
+
+        with patch.object(mover, "_update_state_db", return_value=True) as mock_db:
+            mover.execute("prod", "my-cluster", "staging")
+            mock_db.assert_called_once_with("prod", "staging", "proxmox", "my-cluster")
+
+
+class TestAddProviderToManifest:
+    """Tests for the _add_provider_to_manifest helper."""
+
+    def test_inserts_after_name(self, tmp_path: Path) -> None:
+        """Provider field is inserted after the name line."""
+        manifest = tmp_path / "infrafoundry.yml"
+        manifest.write_text("name: my-cluster\nvariables:\n  foo: bar\n")
+
+        mover = PackageMover(config_dir=tmp_path, generated_dir=tmp_path)
+        mover._add_provider_to_manifest(manifest, "proxmox")
+
+        lines = manifest.read_text().splitlines()
+        assert lines[0] == "name: my-cluster"
+        assert lines[1] == "provider: proxmox"
+        assert lines[2] == "variables:"
+
+
+class TestExtractResourceNames:
+    """Tests for resource name extraction from YAML files."""
+
+    def test_provider_centric_format(self, tmp_path: Path, config_dir: Path) -> None:
+        """Extracts names from provider-centric resource format."""
+        pkg = _create_package(
+            config_dir / "envs",
+            "prod",
+            "test-pkg",
+            provider_subdir="proxmox",
+            resources=["vm.yaml"],
+        )
+        _create_resource_file(pkg, "vm.yaml", [{"name": "web-01"}, {"name": "db-01"}])
+
+        mover = PackageMover(config_dir=config_dir, generated_dir=tmp_path)
+        manifest = mover._parse_manifest(pkg / "infrafoundry.yml")
+        names = mover._extract_resource_names(pkg, manifest)
+        assert "web-01" in names
+        assert "db-01" in names
+
+    def test_resource_centric_format(self, tmp_path: Path, config_dir: Path) -> None:
+        """Extracts names from resource-centric format."""
+        pkg = _create_package(
+            config_dir / "envs",
+            "prod",
+            "test-pkg",
+            provider_subdir="proxmox",
+            resources=["resources.yaml"],
+        )
+        data = {
+            "resources": [
+                {"name": "web-01", "type": "vm", "provider": "proxmox"},
+                {"name": "db-01", "type": "vm", "provider": "proxmox"},
+            ]
+        }
+        (pkg / "resources.yaml").write_text(yaml.dump(data))
+
+        mover = PackageMover(config_dir=config_dir, generated_dir=tmp_path)
+        manifest = mover._parse_manifest(pkg / "infrafoundry.yml")
+        names = mover._extract_resource_names(pkg, manifest)
+        assert "web-01" in names
+        assert "db-01" in names


### PR DESCRIPTION
## Description

Add `foundry infra move-package --env <source> --package <name> --to-env <target>` command that safely migrates packages between environments, handling config directories, terraform state, and the InfraFoundry state DB.

Addresses #576

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`package_mover.py`** — Core `PackageMover` class: finds packages, renders resource names via full PackageLoader pipeline (handles Jinja2 loops and blueprints), maps to terraform addresses across all providers (handles cross-provider resources), copies state files, runs `terraform state rm` on source, updates state DB
- **`move_package.py`** — CLI command with `--env`, `--package`, `--to-env`, `--create-env`, `--dry-run` options
- **`terraform_runner.py`** — Added `state_list()` and `state_rm()` methods
- **29 tests** covering core logic, CLI integration, and edge cases

### Key design decisions

- **Copy state + state rm**: Copies the provider's entire state file to target, then removes moved resources from source state. Avoids needing `terraform import`.
- **Full rendering for resource names**: Uses `PackageLoader.load_package()` to get actual rendered resource names, handling Jinja2 loops (k3s agents), blueprint templates, and variable substitution. Falls back to package name + key variables if rendering fails.
- **Cross-provider scanning**: Checks all provider state directories, not just the package's primary provider (catches kubernetes resources created by a proxmox package, etc.)

## Testing

- [x] All tests pass (`doit check`)
- [x] 24 unit tests in `test_package_mover.py`
- [x] 5 CLI tests in `test_cli_move_package.py`
- [x] Manually tested `--dry-run` and actual moves against live config repo

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
