### PR TITLE
feat: show last modified timestamp per resource in deployed command

### DIFF
--- a/src/infrafoundry/cli/commands/infra/deployed.py
+++ b/src/infrafoundry/cli/commands/infra/deployed.py
@@ -1,6 +1,7 @@
 """Show deployment status and resources for an environment."""
 
 from collections import defaultdict
+from datetime import datetime
 from typing import Any
 
 import click
@@ -22,6 +23,9 @@ _NODE_KEYS = ("target_node", "node")
 # Placeholder for missing values
 _MISSING = "\u2014"
 
+# Display format for timestamps
+_TIME_FMT = "%Y-%m-%d %H:%M"
+
 
 def _extract_field(config: dict[str, Any] | None, keys: tuple[str, ...]) -> str:
     """Extract the first matching key from a resource config dict.
@@ -42,6 +46,20 @@ def _extract_field(config: dict[str, Any] | None, keys: tuple[str, ...]) -> str:
     return _MISSING
 
 
+def _format_timestamp(ts: datetime | None) -> str:
+    """Format a datetime for display, returning the placeholder when absent.
+
+    Args:
+        ts: Optional datetime instance.
+
+    Returns:
+        Formatted timestamp string or the em-dash placeholder.
+    """
+    if ts is None:
+        return _MISSING
+    return ts.strftime(_TIME_FMT)
+
+
 def _build_resource_entry(resource: Resource) -> dict[str, str]:
     """Build a display-ready dict for a single resource.
 
@@ -49,7 +67,7 @@ def _build_resource_entry(resource: Resource) -> dict[str, str]:
         resource: A tracked Resource object.
 
     Returns:
-        Dict with name, ip, node, and state fields.
+        Dict with name, ip, node, state, and updated fields.
     """
     state_str = resource.state.value if hasattr(resource.state, "value") else str(resource.state)
     return {
@@ -58,6 +76,7 @@ def _build_resource_entry(resource: Resource) -> dict[str, str]:
         "ip": _extract_field(resource.config, _IP_KEYS),
         "node": _extract_field(resource.config, _NODE_KEYS),
         "state": state_str,
+        "updated": _format_timestamp(resource.updated_at),
     }
 
 
@@ -181,8 +200,8 @@ def _output_text(
     if deployments:
         dep = deployments[0]
         status_str = dep.status.value if hasattr(dep.status, "value") else str(dep.status)
-        started = dep.started_at.strftime("%Y-%m-%d %H:%M") if dep.started_at else _MISSING
-        completed = dep.completed_at.strftime("%Y-%m-%d %H:%M") if dep.completed_at else _MISSING
+        started = dep.started_at.strftime(_TIME_FMT) if dep.started_at else _MISSING
+        completed = dep.completed_at.strftime(_TIME_FMT) if dep.completed_at else _MISSING
         user = dep.user or "unknown"
 
         console.info("Last deployment:")
@@ -207,4 +226,5 @@ def _output_text(
             ip = entry["ip"]
             node = entry["node"]
             state = entry["state"]
-            console.info(f"    {name:<20s} {ip:<16s} {node:<8s} {state}")
+            updated = entry["updated"]
+            console.info(f"    {name:<20s} {ip:<16s} {node:<8s} {state:<10s} {updated}")

--- a/tests/unit/test_cli_deployed.py
+++ b/tests/unit/test_cli_deployed.py
@@ -51,6 +51,7 @@ def sample_resources():
     r1.resource_type = "vm"
     r1.state = ResourceState.ACTIVE
     r1.config = {"ip_address": "192.168.10.206", "target_node": "pve1"}
+    r1.updated_at = datetime(2026, 4, 12, 14, 30, 0)
 
     r2 = Mock()
     r2.name = "ontap-node01"
@@ -58,6 +59,7 @@ def sample_resources():
     r2.resource_type = "vm"
     r2.state = ResourceState.ACTIVE
     r2.config = {"ip_address": "192.168.10.203", "target_node": "pve1"}
+    r2.updated_at = datetime(2026, 4, 11, 9, 15, 0)
 
     r3 = Mock()
     r3.name = "dhcp-aiqum"
@@ -65,6 +67,7 @@ def sample_resources():
     r3.resource_type = "dhcp"
     r3.state = ResourceState.ACTIVE
     r3.config = {}
+    r3.updated_at = datetime(2026, 4, 12, 14, 30, 0)
 
     return [r1, r2, r3]
 
@@ -89,6 +92,8 @@ def test_deployed_shows_deployment_info(
     assert "192.168.10.206" in result.output
     assert "pve1" in result.output
     assert "dhcp-aiqum" in result.output
+    assert "2026-04-12 14:30" in result.output
+    assert "2026-04-11 09:15" in result.output
 
     mock_orchestrator.state_manager.get_deployment_history.assert_called_once_with(
         environment="prod",
@@ -144,6 +149,8 @@ def test_deployed_json_output(cli_runner, mock_orchestrator, sample_deployment, 
     assert "opnsense" in data["resources"]
     assert len(data["resources"]["proxmox"]) == 2
     assert len(data["resources"]["opnsense"]) == 1
+    assert data["resources"]["proxmox"][0]["updated"] == "2026-04-12 14:30"
+    assert data["resources"]["opnsense"][0]["updated"] == "2026-04-12 14:30"
 
 
 def test_deployed_json_no_deployments(cli_runner, mock_orchestrator):
@@ -172,6 +179,7 @@ def test_deployed_missing_ip_and_node(cli_runner, mock_orchestrator, sample_depl
     resource.resource_type = "dns"
     resource.state = ResourceState.ACTIVE
     resource.config = {"zone": "example.com"}
+    resource.updated_at = datetime(2026, 4, 10, 8, 0, 0)
 
     mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
     mock_orchestrator.state_manager.get_resources.return_value = [resource]
@@ -181,6 +189,7 @@ def test_deployed_missing_ip_and_node(cli_runner, mock_orchestrator, sample_depl
 
     assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
     assert "some-service" in result.output
+    assert "2026-04-10 08:00" in result.output
     # Em dash used for missing fields
     assert "\u2014" in result.output
 
@@ -193,6 +202,7 @@ def test_deployed_null_config(cli_runner, mock_orchestrator, sample_deployment):
     resource.resource_type = "vm"
     resource.state = ResourceState.ACTIVE
     resource.config = None
+    resource.updated_at = None
 
     mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
     mock_orchestrator.state_manager.get_resources.return_value = [resource]
@@ -202,6 +212,8 @@ def test_deployed_null_config(cli_runner, mock_orchestrator, sample_deployment):
 
     assert result.exit_code == 0, f"Exit code {result.exit_code}. Output: {result.output}"
     assert "orphan" in result.output
+    # Em dash for missing updated_at
+    assert "\u2014" in result.output
 
 
 def test_deployed_state_error(cli_runner, mock_orchestrator):
@@ -236,6 +248,7 @@ def test_deployed_alternative_ip_keys(cli_runner, mock_orchestrator, sample_depl
     r1.resource_type = "server"
     r1.state = ResourceState.ACTIVE
     r1.config = {"address": "10.0.0.5", "node": "node3"}
+    r1.updated_at = datetime(2026, 4, 13, 12, 0, 0)
 
     mock_orchestrator.state_manager.get_deployment_history.return_value = [sample_deployment]
     mock_orchestrator.state_manager.get_resources.return_value = [r1]


### PR DESCRIPTION
## Description

Surfaces the existing `updated_at` field from the Resource model in the `infra deployed` command output. Both text and JSON formats now show when each resource was last modified.

## Related Issue

Addresses #591

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `updated` column to text output (formatted as `YYYY-MM-DD HH:MM`)
- Include `updated` field in JSON output
- Add `_format_timestamp` helper for consistent timestamp rendering
- Refactor deployment timestamp formatting to use shared `_TIME_FMT` constant

## Testing

- [x] All existing tests pass
- [x] Added `updated_at` to all mock resources in test fixtures
- [x] Added assertions for timestamp display in text and JSON output
- [x] Tests cover `None` updated_at rendering as em-dash placeholder
- [x] Manually verified with `foundry infra deployed --env prod`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
