### PR TITLE
feat: add base schema helpers for common blueprint resource patterns

### DIFF
--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -146,6 +146,36 @@ vm:
 - Resource type is derived from the filename (same as regular provider resources)
 - Both singular (`vm`) and plural (`vms`) keys are supported
 
+### Custom Filters
+
+InfraFoundry registers the following custom Jinja2 filters for use in resource
+templates. All filters are available in both package resource templates and
+blueprint validation.
+
+| Filter | Input | Output | Description |
+|:-------|:------|:-------|:------------|
+| `generate_mac` | string | `02:xx:xx:xx:xx:xx` | Deterministic locally-administered MAC from a string (SHA-256 based). |
+| `to_mib` | number (GB) | int (MiB) | Convert gigabytes to mebibytes (e.g., `8` -> `8192`). |
+| `to_gib` | number (MiB) | float (GiB) | Convert mebibytes to gibibytes (e.g., `8192` -> `8.0`). |
+| `to_gb` | number (MiB) | float (GiB) | Alias for `to_gib`. |
+| `bool_to_tf` | any | `"true"` / `"false"` | Convert a value to a Terraform boolean string. |
+| `cidr_ip` | CIDR string | string | Extract IP from CIDR notation (e.g., `"10.0.0.1/24"` -> `"10.0.0.1"`). |
+| `cidr_prefix` | CIDR string | string | Extract prefix length from CIDR notation (e.g., `"10.0.0.1/24"` -> `"24"`). |
+
+**Usage in templates:**
+
+```yaml
+vm:
+  - name: {{ cluster_name }}-node1
+    cores: {{ server_cores }}
+    memory: {{ server_memory_gb | to_mib }}
+    network:
+      - bridge: {{ mgmt_network }}
+        macaddr: {{ cluster_name ~ "-node1" | generate_mac }}
+        ip: {{ mgmt_cidr | cidr_ip }}
+    start_on_create: {{ auto_start | bool_to_tf }}
+```
+
 ## Per-Package Secrets
 
 Packages can include a `secrets.yaml` file alongside the manifest. This file holds

--- a/docs/decisions/0003-multi-provider-blueprint-support.md
+++ b/docs/decisions/0003-multi-provider-blueprint-support.md
@@ -60,3 +60,4 @@ These are acceptable tradeoffs. The real duplication today is in the non-resourc
 
 - [#507](https://github.com/endavis/infrafoundry/issues/507): Original multi-provider blueprint design
 - [#571](https://github.com/endavis/infrafoundry/issues/571): Blueprint schema validation across providers (Phase 3 — mitigates the "no schema validation across providers" consequence above)
+- [#572](https://github.com/endavis/infrafoundry/issues/572): Base schema helpers (centralized Jinja2 filter factory for blueprint templates)

--- a/src/infrafoundry/core/config/blueprint_validator.py
+++ b/src/infrafoundry/core/config/blueprint_validator.py
@@ -15,7 +15,7 @@ from typing import Any
 import jinja2
 import jinja2.meta
 
-from infrafoundry.core.config.filters import generate_mac
+from infrafoundry.core.config.filters import create_jinja2_env
 
 logger = logging.getLogger(__name__)
 
@@ -77,8 +77,7 @@ class BlueprintValidator:
     def __init__(self, resolved_blueprint: dict[str, Any]) -> None:
         self._blueprint = resolved_blueprint
         self._blueprint_dir: Path = resolved_blueprint["blueprint_dir"]
-        self._env = jinja2.Environment()  # nosec B701 - parsing only, no rendering
-        self._env.filters["generate_mac"] = generate_mac
+        self._env = create_jinja2_env()
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/infrafoundry/core/config/filters.py
+++ b/src/infrafoundry/core/config/filters.py
@@ -1,6 +1,16 @@
-"""Custom Jinja2 filters for InfraFoundry configuration rendering."""
+"""Custom Jinja2 filters for InfraFoundry configuration rendering.
+
+Provides unit-conversion and formatting filters for blueprint templates,
+plus a factory function that creates a Jinja2 environment with all filters
+pre-registered.
+"""
+
+from __future__ import annotations
 
 import hashlib
+from typing import Any
+
+import jinja2
 
 
 def generate_mac(value: str) -> str:
@@ -18,3 +28,112 @@ def generate_mac(value: str) -> str:
     """
     digest = hashlib.sha256(value.encode()).digest()
     return "02:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}".format(*digest[:5])
+
+
+def to_mib(value: int | float | str) -> int:
+    """Convert GB to MiB.
+
+    Args:
+        value: Size in GB.
+
+    Returns:
+        Size in MiB as an integer.
+    """
+    return int(float(value) * 1024)
+
+
+def to_gib(value: int | float | str) -> float:
+    """Convert MiB to GiB.
+
+    Args:
+        value: Size in MiB.
+
+    Returns:
+        Size in GiB as a float.
+    """
+    return float(value) / 1024
+
+
+def to_gb(value: int | float | str) -> float:
+    """Convert MiB to GB (alias for ``to_gib``).
+
+    Args:
+        value: Size in MiB.
+
+    Returns:
+        Size in GiB as a float.
+    """
+    return to_gib(value)
+
+
+def bool_to_tf(value: Any) -> str:
+    """Convert a value to a Terraform boolean string.
+
+    Truthy values produce ``"true"``, falsy values produce ``"false"``.
+
+    Args:
+        value: Any value that can be evaluated for truthiness.
+
+    Returns:
+        ``"true"`` or ``"false"``.
+    """
+    return "true" if value else "false"
+
+
+def cidr_ip(value: str) -> str:
+    """Extract the IP address from a CIDR notation string.
+
+    Args:
+        value: CIDR string (e.g., ``"10.0.0.1/24"``).
+
+    Returns:
+        The IP portion (e.g., ``"10.0.0.1"``).
+    """
+    return value.split("/")[0]
+
+
+def cidr_prefix(value: str) -> str:
+    """Extract the prefix length from a CIDR notation string.
+
+    Args:
+        value: CIDR string (e.g., ``"10.0.0.1/24"``).
+
+    Returns:
+        The prefix length as a string (e.g., ``"24"``).
+    """
+    return value.split("/")[1]
+
+
+# Registry of all custom filters. New filters should be added here.
+_FILTERS: dict[str, Any] = {
+    "generate_mac": generate_mac,
+    "to_mib": to_mib,
+    "to_gib": to_gib,
+    "to_gb": to_gb,
+    "bool_to_tf": bool_to_tf,
+    "cidr_ip": cidr_ip,
+    "cidr_prefix": cidr_prefix,
+}
+
+
+def create_jinja2_env(
+    undefined: type[jinja2.Undefined] | None = None,
+) -> jinja2.Environment:
+    """Create a Jinja2 environment with all InfraFoundry filters registered.
+
+    Centralizes filter registration so new filters only need to be added
+    to the ``_FILTERS`` dict above.
+
+    Args:
+        undefined: Jinja2 undefined class to use. Defaults to
+            ``jinja2.Undefined`` (permissive) when ``None``.
+
+    Returns:
+        Configured Jinja2 environment with all filters registered.
+    """
+    if undefined is None:
+        undefined = jinja2.Undefined
+
+    env = jinja2.Environment(undefined=undefined)  # nosec B701
+    env.filters.update(_FILTERS)
+    return env

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 import jinja2
 import yaml
 
-from infrafoundry.core.config.filters import generate_mac
+from infrafoundry.core.config.filters import create_jinja2_env
 from infrafoundry.core.config.inventory_generator import InventoryGenerator
 from infrafoundry.core.config.manifest_utils import extract_inventory_block
 from infrafoundry.core.config.models import PackageManifest
@@ -280,8 +280,7 @@ class PackageLoader:
 
             events_json = json.dumps(manifest.events)
             try:
-                events_env = jinja2.Environment(undefined=jinja2.Undefined)  # nosec B701 - rendering JSON, not HTML
-                events_env.filters["generate_mac"] = generate_mac
+                events_env = create_jinja2_env(undefined=jinja2.Undefined)
                 events_template = events_env.from_string(events_json)
                 rendered_events_json = events_template.render(**manifest.variables)
                 manifest.events = json.loads(rendered_events_json)
@@ -393,8 +392,7 @@ class PackageLoader:
 
         # Render Jinja2 template with StrictUndefined
         try:
-            env = jinja2.Environment(undefined=jinja2.StrictUndefined)  # nosec B701 - rendering YAML, not HTML
-            env.filters["generate_mac"] = generate_mac
+            env = create_jinja2_env(undefined=jinja2.StrictUndefined)
             template = env.from_string(content)
             rendered = template.render(**variables)
         except jinja2.UndefinedError as e:

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,0 +1,199 @@
+"""Tests for custom Jinja2 filters and environment factory."""
+
+from __future__ import annotations
+
+import jinja2
+import pytest
+
+from infrafoundry.core.config.filters import (
+    _FILTERS,
+    bool_to_tf,
+    cidr_ip,
+    cidr_prefix,
+    create_jinja2_env,
+    generate_mac,
+    to_gb,
+    to_gib,
+    to_mib,
+)
+
+
+class TestGenerateMac:
+    """Tests for the generate_mac filter."""
+
+    def test_deterministic(self) -> None:
+        """Same input always produces the same MAC."""
+        assert generate_mac("test") == generate_mac("test")
+
+    def test_starts_with_local_admin_prefix(self) -> None:
+        """MAC starts with 02 (locally administered, unicast)."""
+        mac = generate_mac("anything")
+        assert mac.startswith("02:")
+
+    def test_format(self) -> None:
+        """MAC has correct colon-separated hex format."""
+        mac = generate_mac("test")
+        parts = mac.split(":")
+        assert len(parts) == 6
+        for part in parts:
+            assert len(part) == 2
+
+    def test_different_inputs_produce_different_macs(self) -> None:
+        """Different inputs produce different MACs."""
+        assert generate_mac("host-a") != generate_mac("host-b")
+
+
+class TestToMib:
+    """Tests for the to_mib filter (GB to MiB)."""
+
+    def test_integer_gb(self) -> None:
+        assert to_mib(8) == 8192
+
+    def test_fractional_gb(self) -> None:
+        assert to_mib(0.5) == 512
+
+    def test_string_input(self) -> None:
+        assert to_mib("4") == 4096
+
+    def test_zero(self) -> None:
+        assert to_mib(0) == 0
+
+    def test_returns_int(self) -> None:
+        result = to_mib(1)
+        assert isinstance(result, int)
+
+
+class TestToGib:
+    """Tests for the to_gib filter (MiB to GiB)."""
+
+    def test_whole_gib(self) -> None:
+        assert to_gib(8192) == 8.0
+
+    def test_fractional_gib(self) -> None:
+        assert to_gib(512) == 0.5
+
+    def test_string_input(self) -> None:
+        assert to_gib("4096") == 4.0
+
+    def test_zero(self) -> None:
+        assert to_gib(0) == 0.0
+
+    def test_returns_float(self) -> None:
+        result = to_gib(1024)
+        assert isinstance(result, float)
+
+
+class TestToGb:
+    """Tests for the to_gb filter (alias for to_gib)."""
+
+    def test_is_alias_for_to_gib(self) -> None:
+        """to_gb produces the same result as to_gib."""
+        assert to_gb(8192) == to_gib(8192)
+
+    def test_basic(self) -> None:
+        assert to_gb(2048) == 2.0
+
+
+class TestBoolToTf:
+    """Tests for the bool_to_tf filter."""
+
+    def test_true(self) -> None:
+        assert bool_to_tf(True) == "true"
+
+    def test_false(self) -> None:
+        assert bool_to_tf(False) == "false"
+
+    def test_truthy_string(self) -> None:
+        assert bool_to_tf("yes") == "true"
+
+    def test_falsy_value(self) -> None:
+        assert bool_to_tf(0) == "false"
+        assert bool_to_tf("") == "false"
+        assert bool_to_tf(None) == "false"
+
+    def test_returns_string(self) -> None:
+        result = bool_to_tf(True)
+        assert isinstance(result, str)
+
+
+class TestCidrIp:
+    """Tests for the cidr_ip filter."""
+
+    def test_ipv4(self) -> None:
+        assert cidr_ip("10.0.0.1/24") == "10.0.0.1"
+
+    def test_ipv6(self) -> None:
+        assert cidr_ip("fd00::1/64") == "fd00::1"
+
+    def test_host_route(self) -> None:
+        assert cidr_ip("192.168.1.1/32") == "192.168.1.1"
+
+
+class TestCidrPrefix:
+    """Tests for the cidr_prefix filter."""
+
+    def test_ipv4(self) -> None:
+        assert cidr_prefix("10.0.0.1/24") == "24"
+
+    def test_ipv6(self) -> None:
+        assert cidr_prefix("fd00::1/64") == "64"
+
+    def test_host_route(self) -> None:
+        assert cidr_prefix("192.168.1.1/32") == "32"
+
+
+class TestCreateJinja2Env:
+    """Tests for the create_jinja2_env factory function."""
+
+    def test_has_all_filters(self) -> None:
+        """Environment has all filters from the registry."""
+        env = create_jinja2_env()
+        for name in _FILTERS:
+            assert name in env.filters, f"Missing filter: {name}"
+
+    def test_default_undefined_is_permissive(self) -> None:
+        """Default undefined mode allows missing variables."""
+        env = create_jinja2_env()
+        template = env.from_string("{{ missing_var }}")
+        result = template.render()
+        assert result == ""
+
+    def test_strict_undefined(self) -> None:
+        """StrictUndefined raises on missing variables."""
+        env = create_jinja2_env(undefined=jinja2.StrictUndefined)
+        template = env.from_string("{{ missing_var }}")
+        with pytest.raises(jinja2.UndefinedError):
+            template.render()
+
+    def test_permissive_undefined(self) -> None:
+        """Explicit Undefined is permissive."""
+        env = create_jinja2_env(undefined=jinja2.Undefined)
+        template = env.from_string("{{ missing_var }}")
+        result = template.render()
+        assert result == ""
+
+    def test_filters_work_in_templates(self) -> None:
+        """Filters are usable in rendered templates."""
+        env = create_jinja2_env()
+        template = env.from_string("{{ 8 | to_mib }}")
+        assert template.render() == "8192"
+
+    def test_generate_mac_works_in_templates(self) -> None:
+        """Pre-existing generate_mac filter works in factory env."""
+        env = create_jinja2_env()
+        template = env.from_string('{{ "test" | generate_mac }}')
+        result = template.render()
+        assert result.startswith("02:")
+
+    def test_bool_to_tf_in_template(self) -> None:
+        """bool_to_tf filter works in templates."""
+        env = create_jinja2_env()
+        template = env.from_string("{{ enabled | bool_to_tf }}")
+        assert template.render(enabled=True) == "true"
+        assert template.render(enabled=False) == "false"
+
+    def test_cidr_filters_in_template(self) -> None:
+        """CIDR filters work in templates."""
+        env = create_jinja2_env()
+        template = env.from_string("{{ addr | cidr_ip }}/{{ addr | cidr_prefix }}")
+        assert template.render(addr="10.0.0.1/24") == "10.0.0.1/24"


### PR DESCRIPTION
## Description

Centralizes Jinja2 environment creation and custom filter registration into a single
factory function (`create_jinja2_env`), replacing scattered manual setup in
`PackageLoader` and `BlueprintValidator`. Adds six new filters (`to_mib`, `to_gib`,
`to_gb`, `bool_to_tf`, `cidr_ip`, `cidr_prefix`) that blueprint authors can use in
resource templates alongside the existing `generate_mac` filter.

Addresses #572

## Related Issue

Addresses #572

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `create_jinja2_env()` factory function and `_FILTERS` registry to `filters.py`
- Added 6 new Jinja2 filters: `to_mib`, `to_gib`, `to_gb`, `bool_to_tf`, `cidr_ip`, `cidr_prefix`
- Replaced manual `jinja2.Environment` + `generate_mac` registration in `PackageLoader` (2 call sites) and `BlueprintValidator` (1 call site) with `create_jinja2_env()`
- Added 35 unit tests covering all filters and the factory function
- Documented all custom filters in the infrastructure packages guide (`docs/configuration/infrastructure-packages.md`)
- Updated ADR-0003 with issue #572 link

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (35 tests in `tests/unit/test_filters.py`)
- [x] `doit check` passes (test, lint, type-check, security, spell-check)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
