### PR TITLE
docs: document CLI command hierarchy and domain model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,21 +139,56 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 ## CLI & Operations
 
 Key commands (`foundry` via `uv run foundry ...`):
+
+**Top-level:**
 - `doctor` – check system dependencies (Terraform, OpenTofu, Ansible, SOPS, Age)
+- `completion <bash|zsh|fish|uninstall>` – manage shell completion
+
+**Config group (`config`):**
 - `config doctor [--deep]` – check config repo health (structure, state, SOPS, consistency, blueprints)
-- `config envs` – list configured environments
-- `config export --env <name> --output <dir> [--provider proxmox]` – export provider config to YAML
-- `config schema export` – export JSON schemas for IDE autocomplete
+- `config envs` – list configured environments with sync status
+- `config diff --env-a <a> --env-b <b>` – compare two environments
+- `config show --env <name>` – show resolved configuration
+- `config init <name>` – initialize a new environment
+- `config new create <blueprint> <dir>` – create infrastructure from blueprints
+- `config migrate --env <name> --provider <p> --component <c>` – migrate existing infra to config
+- `config export --env <name> --output <dir>` – export provider config to YAML
+- `config schema <export|list|show>` – JSON schemas for IDE autocomplete
+
+**Infra group (`infra`):**
 - `infra doctor --env <name>` – validate infrastructure against provider APIs
 - `infra plan --env <name>` – generate files only (use `--dry-run` when applicable)
 - `infra apply --env <name>` – generate and execute Terraform/Ansible
 - `infra destroy --env <name>` – tear down infrastructure
-- `infra drift --env <name>` – detect drift
-- `infra history --env <name>` – inspect past deployments
-- `infra analyze dependencies --env <name>` – show dependency graph
-- `infra analyze impact --env <name> --resource <name>` – analyze change impact
-- `state audit list` – view audit trail
-- `secrets <init|encrypt|decrypt>` – manage SOPS secrets
+- `infra drift <detect|remediate|history>` – detect and remediate drift
+- `infra deployed --env <name>` – show deployment status and resources
+- `infra history [--env <name>]` – inspect past deployments
+- `infra list --env <name>` – list configured packages in an environment
+- `infra move-package --env <src> --package <pkg> --to-env <dst>` – move package between environments
+- `infra analyze <dependencies|impact|graph>` – dependency analysis and visualization
+- `infra rollback <list|to>` – rollback to previous deployment state
+- `infra security --env <name>` – scan for security issues (Checkov)
+- `infra test --env <name>` – run infrastructure tests
+- `infra status --env <name>` – show infrastructure status
+- `infra reset --env <name> --provider <p> --component <c>` – reset provider component
+- `infra unlock [--env <name> | --list]` – manage deployment locks
+
+**State group (`state`):**
+- `state init` – initialize state database
+- `state list --env <name>` – list resources in an environment
+- `state resources` – list tracked infrastructure resources
+- `state backup` – backup state database
+- `state backend <validate|migrate>` – manage Terraform backend configuration
+- `state audit <list|export|verify>` – view and export audit trail
+
+**Secrets group (`secrets`):**
+- `secrets init` – initialize age encryption key
+- `secrets encrypt <file>` – encrypt a file with SOPS
+- `secrets decrypt <file>` – decrypt and display a SOPS-encrypted file
+- `secrets rotate --env <name>` – rotate encryption keys
+
+**Policy group (`policy`):**
+- `policy list` – list available infrastructure policies
 
 Generated artifacts should be reviewed (and optionally validated with native Terraform/Ansible tools) from the `generated/` directory hierarchy.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,7 +12,7 @@ This document consolidates planned features, enhancements, and tools for InfraFo
 - [ ] **Cost estimation** [Complexity: 6/10]: Integrate Infracost; budget-aware policies. ([Issue](https://github.com/endavis/infrafoundry/issues/32))
 
 ### Security
-- [x] **Secrets rotation** [Complexity: 9/10]: `infra secrets rotate` to re-encrypt/update secrets. ([Issue](https://github.com/endavis/infrafoundry/issues/33))
+- [x] **Secrets rotation** [Complexity: 9/10]: `foundry secrets rotate` to re-encrypt/update secrets. ([Issue](https://github.com/endavis/infrafoundry/issues/33))
 - [x] **External vault integration** [Complexity: 7/10]: Expand `SecretProvider` implementations for Vault/AWS and others. ([Issue](https://github.com/endavis/infrafoundry/issues/34))
 
 ---

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -19,14 +19,14 @@ InfraFoundry’s architecture combines pluggable providers, template-driven code
 
 1. Generate + apply to see the flow in action:
    ```bash
-   infra validate --env dev --check-api --check-refs
-   infra plan --env dev
-   infra apply --env dev
+   foundry infra doctor --env dev
+   foundry infra plan --env dev
+   foundry infra apply --env dev
    ```
 2. Inspect state and history:
    ```bash
-   infra history --env dev
-   infra status --env dev
+   foundry infra history --env dev
+   foundry infra status --env dev
    ```
 
 ## Architecture Details
@@ -40,8 +40,8 @@ InfraFoundry’s architecture combines pluggable providers, template-driven code
 
 ## Validation and Checks
 
-- Use `infra validate --env <env> --check-api --check-refs` to ensure configs, providers, and references are resolvable.
-- Check state usage by running `infra history`/`infra status`; verify DB connectivity if using PostgreSQL.
+- Use `foundry infra doctor --env <env>` to ensure configs, providers, and references are resolvable.
+- Check state usage by running `foundry infra history`/`foundry infra status`; verify DB connectivity if using PostgreSQL.
 - Review generated outputs before apply to confirm graph/order is correct.
 
 ## Examples
@@ -71,7 +71,7 @@ InfraFoundry’s architecture combines pluggable providers, template-driven code
 
 - **Symptom:** State/history missing. **Fix:** Confirm SQLite file exists or PostgreSQL DSN is reachable; check permissions.
 - **Symptom:** Events not firing. **Fix:** Ensure subscribers are registered and event types match; enable debug logging.
-- **Symptom:** Ordering issues. **Fix:** Review dependency graph output (`infra graph`) and provider reference definitions; validate configs with `--check-refs`.
+- **Symptom:** Ordering issues. **Fix:** Review dependency graph output (`foundry infra analyze graph`) and provider reference definitions; validate configs with `--check-refs`.
 
 ---
 

--- a/docs/architecture/graphing.md
+++ b/docs/architecture/graphing.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-`infra graph` builds a dependency graph of resources to show creation/destruction order. Output is Mermaid (or DOT) so you can visualize relationships and debug dependencies.
+`foundry infra analyze graph` builds a dependency graph of resources to show creation/destruction order. Output is Mermaid (or DOT) so you can visualize relationships and debug dependencies.
 
 ## Audience and Prerequisites
 
 - **Audience:** Operators and reviewers inspecting dependencies before apply/destroy.
-- **Prereqs:** Config repo available; `uv run infra` installed; a target environment with resources.
+- **Prereqs:** Config repo available; `foundry` installed; a target environment with resources.
 
 ## When to Use This
 
@@ -18,21 +18,21 @@
 ## Quick Start
 
 ```bash
-infra graph --env dev --format mermaid > graph.mmd
+foundry infra analyze graph --env dev --format mermaid > graph.mmd
 ```
 
 Render with Mermaid Live Editor or embed in Markdown. Use DOT for alternative tooling (`--format dot`).
 
 ## Configuration Details
 
-- **Command:** `infra graph --env <env> [--format mermaid|dot]`.
+- **Command:** `foundry infra analyze graph --env <env> [--format mermaid|dot]`.
 - **Nodes:** Provider-scoped resources (e.g., `proxmox:vm-01`, `opnsense:firewall-rule-100`).
 - **Edges:** `A --> B` means A depends on B (B created before A; A destroyed before B).
 - **Sources of dependencies:** Provider rules, cross-resource references, and future explicit `depends_on`.
 
 ## Validation and Checks
 
-- Run `infra validate --env <env> --check-refs` to ensure referenced resources exist before graphing.
+- Run `foundry infra doctor --env <env>` to ensure referenced resources exist before graphing.
 - Review generated graph to confirm expected ordering; missing edges can signal missing references.
 
 ## Examples
@@ -49,7 +49,7 @@ Render with Mermaid Live Editor or embed in Markdown. Use DOT for alternative to
   ```
 - **Generate DOT:**
   ```bash
-  infra graph --env prod --format dot > graph.dot
+  foundry infra analyze graph --env prod --format dot > graph.dot
   ```
 
 ## Related Documentation
@@ -61,7 +61,7 @@ Render with Mermaid Live Editor or embed in Markdown. Use DOT for alternative to
 
 ## Troubleshooting
 
-- **Symptom:** Missing nodes or edges. **Fix:** Ensure resources declare correct references; rerun `infra validate --check-refs`.
+- **Symptom:** Missing nodes or edges. **Fix:** Ensure resources declare correct references; rerun `foundry infra doctor --env <env>`.
 - **Symptom:** Unexpected ordering. **Fix:** Check provider rules and references; verify resource names match between configs.
 - **Symptom:** Graph output unreadable. **Fix:** Switch format (`--format dot`) and render with DOT tools; simplify by filtering resources before generation (future enhancement).
 

--- a/docs/architecture/orchestrator-architecture.md
+++ b/docs/architecture/orchestrator-architecture.md
@@ -19,9 +19,9 @@ The Orchestrator is a thin coordinator that wires providers, runners, policy che
 
 1. Run a workflow to see orchestration in action:
    ```bash
-   infra plan --env dev
-   infra apply --env dev
-   infra destroy --env dev
+   foundry infra plan --env dev
+   foundry infra apply --env dev
+   foundry infra destroy --env dev
    ```
 2. Inspect generated artifacts and events to verify order and outputs.
 
@@ -245,8 +245,8 @@ sequenceDiagram
 
 ## Validation and Checks
 
-- Use `infra validate --env <env> --check-api --check-refs` before workflows.
-- Check state updates with `infra history`/`infra status`.
+- Use `foundry infra doctor --env <env>` before workflows.
+- Check state updates with `foundry infra history`/`foundry infra status`.
 - Review event emissions (notifications/logs) to ensure hooks fire.
 
 ## Examples

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -19,15 +19,15 @@ InfraFoundry separates code generation from execution: YAML configs are rendered
 
 1. Generate only:
    ```bash
-   infra plan --env dev
+   foundry infra plan --env dev
    ```
 2. Generate + execute:
    ```bash
-   infra apply --env dev
+   foundry infra apply --env dev
    ```
 3. Destroy:
    ```bash
-   infra destroy --env dev
+   foundry infra destroy --env dev
    ```
 
 ## Architecture Details
@@ -65,14 +65,14 @@ InfraFoundry separates code generation from execution: YAML configs are rendered
 
 ## Validation and Checks
 
-- `infra validate --env <env> --check-api --check-refs` before plan/apply.
+- `foundry infra doctor --env <env>` before plan/apply.
 - Inspect generated Terraform/Ansible under `generated/{env}/...` to verify outputs before execution.
 
 ## Examples
 
-- **Review without applying:** `infra plan --env dev --dry-run` (validate only).
-- **Full run:** `infra apply --env prod` (generate + terraform + ansible + state tracking).
-- **Remove:** `infra destroy --env prod` (tears down resources via Terraform/Ansible).
+- **Review without applying:** `foundry infra plan --env dev --dry-run` (validate only).
+- **Full run:** `foundry infra apply --env prod` (generate + terraform + ansible + state tracking).
+- **Remove:** `foundry infra destroy --env prod` (tears down resources via Terraform/Ansible).
 
 ## Related Documentation
 
@@ -84,8 +84,8 @@ InfraFoundry separates code generation from execution: YAML configs are rendered
 
 ## Troubleshooting
 
-- **Symptom:** Generated files missing. **Fix:** Run `infra plan --env <env>` and ensure configs are present; check `generated/{env}`.
-- **Symptom:** Execution fails after generation. **Fix:** Inspect generated Terraform/Ansible, rerun `infra validate --check-api --check-refs`, and address provider-specific errors.
+- **Symptom:** Generated files missing. **Fix:** Run `foundry infra plan --env <env>` and ensure configs are present; check `generated/{env}`.
+- **Symptom:** Execution fails after generation. **Fix:** Inspect generated Terraform/Ansible, rerun `foundry infra doctor --env <env>`, and address provider-specific errors.
 - **Symptom:** Policies or events not triggered. **Fix:** Confirm event subscriptions and policy files are present; run with validation/policy checks to surface issues.
 
 ---

--- a/docs/architecture/plans/refactor.md
+++ b/docs/architecture/plans/refactor.md
@@ -390,7 +390,7 @@
 
 5. **Config Tools**
    - Add `infra init env --from <existing>` scaffolding
-   - Add `infra diff --env dev prod` comparison
+   - Add `foundry config diff --env-a dev --env-b prod` comparison
    - Standardize on single variable syntax
 
 6. **Shell Completion**

--- a/docs/architecture/secrets-architecture.md
+++ b/docs/architecture/secrets-architecture.md
@@ -86,22 +86,22 @@ On failure, automatically rolls back to the backup.
 
 ```bash
 # Generate new key and rotate all secrets for dev environment
-infra secrets rotate --env dev --generate-new-key
+foundry secrets rotate --env dev --generate-new-key
 
 # Rotate with an existing new key file
-infra secrets rotate --env prod --new-key-file /path/to/new_age.key
+foundry secrets rotate --env prod --new-key-file /path/to/new_age.key
 
 # Rotate specific files only
-infra secrets rotate --env dev --generate-new-key --files proxmox.yaml --files opnsense.yaml
+foundry secrets rotate --env dev --generate-new-key --files proxmox.yaml --files opnsense.yaml
 
 # Dry run to preview rotation
-infra secrets rotate --env dev --generate-new-key --dry-run
+foundry secrets rotate --env dev --generate-new-key --dry-run
 
 # Skip verification (not recommended)
-infra secrets rotate --env dev --generate-new-key --no-verify
+foundry secrets rotate --env dev --generate-new-key --no-verify
 
 # Don't keep backup after rotation (not recommended)
-infra secrets rotate --env dev --generate-new-key --no-backup
+foundry secrets rotate --env dev --generate-new-key --no-backup
 ```
 
 ### Post-Rotation Steps

--- a/docs/architecture/state-management.md
+++ b/docs/architecture/state-management.md
@@ -19,8 +19,8 @@ InfraFoundry manages three artifacts: Terraform state, the InfraFoundry state da
 
 1. Use default local state for dev:
    ```bash
-   infra plan --env dev
-   infra apply --env dev
+   foundry infra plan --env dev
+   foundry infra apply --env dev
    ```
    Terraform state is in `generated/{env}/terraform/{provider}/.terraform/terraform.tfstate`; InfraFoundry state is `~/.infrafoundry/state.db`.
 2. Configure remote backends (example S3 + DynamoDB locking):
@@ -95,12 +95,12 @@ InfraFoundry tracks deployments and resources through well-defined state transit
 
 ```bash
 # View deployment status and history
-infra history --env prod
-infra status --env dev
+foundry infra history --env prod
+foundry infra status --env dev
 
 # View resource states from database
-infra resources --env prod --state ACTIVE
-infra resources --env prod --state ERROR
+foundry state resources --env prod --state ACTIVE
+foundry state resources --env prod --state ERROR
 ```
 
 ## Backend Configuration
@@ -228,7 +228,7 @@ InfraFoundry automatically detects backend configuration changes and triggers re
 
 1. **Change Detection:** Compares `backend.tf` with `.terraform/terraform.tfstate`
 2. **Automatic Reconfiguration:** Runs `terraform init -reconfigure` when backend type changes
-3. **Manual Migration:** Use `infra backend migrate --env <env>` to migrate state between backends
+3. **Manual Migration:** Use `foundry state backend migrate --env <env>` to migrate state between backends
 
 ### State Locking
 
@@ -250,7 +250,7 @@ correctness; one does not replace the other.
 **Verifying Locking:**
 ```bash
 # Backend validation shows locking status
-infra backend validate --env prod
+foundry state backend validate --env prod
 
 # Check generated backend.tf
 cat generated/prod/terraform/proxmox/backend.tf
@@ -339,7 +339,7 @@ for the full rationale and trade-offs.
   foundry config envs
 
   # Detailed consistency check (exits 1 on divergence)
-  foundry config check --deep
+  foundry config doctor --deep
   ```
   `FS-ONLY` means an environment directory exists on disk but has no state DB records. `DB-ONLY` means the state DB tracks an environment whose config directory is missing.
 - Inspect Terraform state:
@@ -350,11 +350,11 @@ for the full rationale and trade-offs.
   ```
 - Inspect InfraFoundry state/history:
   ```bash
-  infra history
-  infra history --env prod
-  infra status --env dev
+  foundry infra history
+  foundry infra history --env prod
+  foundry infra status --env dev
   ```
-- Verify backend configuration by ensuring state files/DB entries update after `infra plan/apply`.
+- Verify backend configuration by ensuring state files/DB entries update after `foundry infra plan`/`foundry infra apply`.
 
 ## Examples
 
@@ -399,23 +399,23 @@ for the full rationale and trade-offs.
       dynamodb_table: terraform-locks
       encrypt: true
   ```
-  Then run `infra plan --env prod` to generate backend.tf.
+  Then run `foundry infra plan --env prod` to generate backend.tf.
 
 - **Migrate from local to S3 backend:**
   ```bash
   # 1. Add backend config to settings.yaml (as shown above)
   # 2. Run plan to generate backend.tf
-  infra plan --env prod
+  foundry infra plan --env prod
 
   # 3. Terraform will prompt to migrate state
   # Or use manual migration command
-  infra backend migrate --env prod --from local --to s3
+  foundry state backend migrate --env prod --from local --to s3
   ```
 
 - **Validate backend configuration:**
   ```bash
   # Check backend configuration and locking support
-  infra backend validate --env prod
+  foundry state backend validate --env prod
 
   # View generated backend.tf
   cat generated/prod/terraform/proxmox/backend.tf
@@ -425,7 +425,7 @@ for the full rationale and trade-offs.
   ```bash
   # Override default ~/.infrafoundry location
   export INFRAFOUNDRY_STATE_HOME=/mnt/shared/infrafoundry-state
-  infra init
+  foundry state init
   # State will be created at /mnt/shared/infrafoundry-state/state.db
 
   # Useful for shared network storage or custom backup locations
@@ -442,16 +442,16 @@ for the full rationale and trade-offs.
 
 - **Symptom:** State collisions or locks. **Fix:** Use remote backend with locking (S3 + DynamoDB) and avoid sharing local state directories.
 - **Symptom:** Missing history entries. **Fix:** Confirm InfraFoundry state backend is reachable (SQLite file present or PostgreSQL DSN correct); check `INFRAFOUNDRY_STATE_HOME` if using custom location.
-- **Symptom:** Drift between YAML and deployed infra. **Fix:** Re-run `infra plan --env <env>` and inspect generated configs and Terraform state; import existing resources if needed.
+- **Symptom:** Drift between YAML and deployed infra. **Fix:** Re-run `foundry infra plan --env <env>` and inspect generated configs and Terraform state; import existing resources if needed.
 - **Symptom:** Permission errors on state paths. **Fix:** Check filesystem permissions for `generated/` and state database location (default `~/.infrafoundry/state.db` or custom via `INFRAFOUNDRY_STATE_HOME`); ensure CI containers persist writable paths.
-- **Symptom:** State database not found after setting custom location. **Fix:** Ensure `INFRAFOUNDRY_STATE_HOME` is set in environment and directory exists with write permissions; run `infra init` to create state database in custom location.
-- **Symptom:** Resources stuck in ERROR state. **Fix:** Review deployment logs to identify cause; manually fix underlying issue (network, credentials, provider API); re-run `infra apply` to resume from ERROR state.
+- **Symptom:** State database not found after setting custom location. **Fix:** Ensure `INFRAFOUNDRY_STATE_HOME` is set in environment and directory exists with write permissions; run `foundry state init` to create state database in custom location.
+- **Symptom:** Resources stuck in ERROR state. **Fix:** Review deployment logs to identify cause; manually fix underlying issue (network, credentials, provider API); re-run `foundry infra apply` to resume from ERROR state.
 - **Symptom:** Deployment status shows IN_PROGRESS but no activity. **Fix:** Check if process was killed or terminated; deployment may need manual intervention to move to FAILED or COMPLETED state in database.
-- **Symptom:** Backend configuration invalid error. **Fix:** Run `infra backend validate --env <env>` to check configuration; ensure all required fields for backend type are present in `settings.yaml`.
+- **Symptom:** Backend configuration invalid error. **Fix:** Run `foundry state backend validate --env <env>` to check configuration; ensure all required fields for backend type are present in `settings.yaml`.
 - **Symptom:** Terraform fails to initialize with backend error. **Fix:** Verify credentials for backend (AWS credentials for S3, GCP credentials for GCS, etc.); check network connectivity to backend service; ensure backend resources exist (S3 bucket, DynamoDB table, etc.).
 - **Symptom:** State locking timeout. **Fix:** Check if another process holds the lock; verify DynamoDB table exists for S3 backend; ensure locking is supported for backend type; manually break lock if process crashed: `cd generated/{env}/terraform/{provider} && terraform force-unlock <lock-id>`.
-- **Symptom:** Backend reconfiguration loop. **Fix:** Check if backend configuration in `settings.yaml` matches generated `backend.tf`; remove `.terraform/` directory and re-run `infra plan --env <env>`; verify no conflicting backend configurations.
-- **Symptom:** State migration fails between backends. **Fix:** Use `infra backend migrate --env <env> --from <old> --to <new>` with `--auto-approve` for non-interactive migration; ensure both old and new backends are accessible; backup state before migration.
+- **Symptom:** Backend reconfiguration loop. **Fix:** Check if backend configuration in `settings.yaml` matches generated `backend.tf`; remove `.terraform/` directory and re-run `foundry infra plan --env <env>`; verify no conflicting backend configurations.
+- **Symptom:** State migration fails between backends. **Fix:** Use `foundry state backend migrate --env <env> --from <old> --to <new>` with `--auto-approve` for non-interactive migration; ensure both old and new backends are accessible; backup state before migration.
 
 ---
 

--- a/docs/configuration/blueprints.md
+++ b/docs/configuration/blueprints.md
@@ -7,7 +7,7 @@ Blueprints are template projects that scaffold new InfraFoundry configuration re
 ## Audience and Prerequisites
 
 - **Audience:** Operators and platform teams standardizing configuration patterns.
-- **Prereqs:** InfraFoundry installed (`uv run infra`), access to built-in or custom blueprints, and a target directory to create into.
+- **Prereqs:** InfraFoundry installed (`foundry`), access to built-in or custom blueprints, and a target directory to create into.
 
 ## When to Use This
 
@@ -18,13 +18,12 @@ Blueprints are template projects that scaffold new InfraFoundry configuration re
 ## Quick Start
 
 ```bash
-infra new list
-infra new create basic-vm ./my-new-vm
+foundry config new create basic-vm ./my-new-vm
 ```
 
 ## Configuration Details
 
-- **Command:** `infra new create <blueprint-name> <target-directory>`.
+- **Command:** `foundry config new create <blueprint-name> <target-directory>`.
 - **Built-in location:** `src/infrafoundry/blueprints/`.
 - **Blueprint contents:** `blueprint.yaml` metadata + template files (copied as-is). Future versions may add Jinja2 templating.
 - **Metadata (`blueprint.yaml`):**
@@ -40,14 +39,13 @@ infra new create basic-vm ./my-new-vm
 
 ## Validation and Checks
 
-- List available blueprints to confirm discovery: `infra new list`.
-- After creation, run `infra validate --env <env>` within the generated repo to ensure configs are sound.
+- After creation, run `foundry infra doctor --env <env>` within the generated repo to ensure configs are sound.
 
 ## Examples
 
 - **Instantiate a VM blueprint:**
   ```bash
-  infra new create basic-vm ./my-new-vm
+  foundry config new create basic-vm ./my-new-vm
   ```
 - **Example structure:**
   ```
@@ -65,7 +63,7 @@ infra new create basic-vm ./my-new-vm
 
 ## Troubleshooting
 
-- **Symptom:** Blueprint not found. **Fix:** Check name from `infra new list`; verify custom blueprints are placed in the expected directory.
+- **Symptom:** Blueprint not found. **Fix:** Verify the blueprint name matches a directory under `src/infrafoundry/blueprints/`; verify custom blueprints are placed in the expected directory.
 - **Symptom:** Generated files missing. **Fix:** Ensure `blueprint.yaml` lists files if selective inclusion is used; otherwise include all files in the blueprint directory.
 
 ---

--- a/docs/configuration/lifecycle-hooks.md
+++ b/docs/configuration/lifecycle-hooks.md
@@ -245,7 +245,7 @@ Test your hooks with a dry run:
 
 ```bash
 # See what hooks would be executed
-infra plan --env prod --dry-run
+foundry infra plan --env prod --dry-run
 ```
 
 Check script permissions:

--- a/docs/configuration/notifications.md
+++ b/docs/configuration/notifications.md
@@ -32,8 +32,8 @@ InfraFoundry can emit deployment, drift, and policy events to Slack, Discord, or
    ```
 2. Run InfraFoundry; events matching the config will be sent:
    ```bash
-   infra apply --env dev
-   infra drift --env prod
+   foundry infra apply --env dev
+   foundry infra drift --env prod
    ```
 
 ## Configuration Details
@@ -68,7 +68,7 @@ InfraFoundry can emit deployment, drift, and policy events to Slack, Discord, or
 
 - Validate config structure:
   ```bash
-  infra validate --env dev
+  foundry infra doctor --env dev
   ```
 - Send a test event by running a dry plan/apply; check target channel for delivery.
 - For Slack/Discord, verify webhook URL is active and workspace permissions allow incoming webhooks.

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -7,7 +7,7 @@ InfraFoundry environments are defined entirely in YAML: `settings.yaml` for envi
 ## Audience and Prerequisites
 
 - **Audience:** Config repo maintainers and operators creating or updating environments.
-- **Prereqs:** Config repo path (`--config-dir` or `INFRAFOUNDRY_CONFIG_REPO`), `sops`/`age` for secrets, `uv run infra` installed, and provider credentials.
+- **Prereqs:** Config repo path (`--config-dir` or `INFRAFOUNDRY_CONFIG_REPO`), `sops`/`age` for secrets, `foundry` installed, and provider credentials.
 
 ## When to Use This
 
@@ -24,8 +24,8 @@ InfraFoundry environments are defined entirely in YAML: `settings.yaml` for envi
 3. Encrypt secrets in `settings.yaml` with SOPS/age.
 4. Validate and plan:
    ```bash
-   infra validate --env dev --check-api --check-refs
-   infra plan --env dev
+   foundry infra doctor --env dev
+   foundry infra plan --env dev
    ```
 
 ## Configuration Details
@@ -43,7 +43,7 @@ InfraFoundry environments are defined entirely in YAML: `settings.yaml` for envi
 
 ## Validation and Checks
 
-- Run `infra validate --env <env>` for structure and type checks; add `--check-api --check-refs` to verify connectivity and referenced resources.
+- Run `foundry infra doctor --env <env>` for structure and type checks; add `--check-api --check-refs` to verify connectivity and referenced resources.
 - Confirm provider discovery by checking per-provider sections in validation output.
 - Inspect generated tfvars under `generated/{env}/terraform/{provider}/` to confirm SSH overrides and credentials.
 
@@ -100,9 +100,9 @@ InfraFoundry environments are defined entirely in YAML: `settings.yaml` for envi
   ```
 - **Secrets workflow:**
   ```bash
-  infra secrets init
-  infra secrets encrypt envs/dev/settings.yaml
-  infra secrets decrypt envs/dev/settings.yaml
+  foundry secrets init
+  foundry secrets encrypt envs/dev/settings.yaml
+  foundry secrets decrypt envs/dev/settings.yaml
   ```
 
 ## Related Documentation
@@ -116,7 +116,7 @@ InfraFoundry environments are defined entirely in YAML: `settings.yaml` for envi
 ## Troubleshooting
 
 - **Symptom:** Providers not detected. **Fix:** Ensure resource files include `provider` keys and live under `resources/` or provider directories.
-- **Symptom:** SSH operations fail in Proxmox. **Fix:** Verify `ssh`/`provider_ssh` entries and key paths; rerun `infra validate --check-api`.
+- **Symptom:** SSH operations fail in Proxmox. **Fix:** Verify `ssh`/`provider_ssh` entries and key paths; rerun `foundry infra doctor --env <env>`.
 - **Symptom:** Secrets not decrypted. **Fix:** Confirm SOPS/age keys are available and `settings.yaml` is encrypted with the expected rules.
 
 ---

--- a/docs/configuration/per-environment-credentials.md
+++ b/docs/configuration/per-environment-credentials.md
@@ -7,7 +7,7 @@ InfraFoundry automatically loads credentials for the environment you target with
 ## Audience and Prerequisites
 
 - **Audience:** Config repo maintainers and operators deploying to multiple environments.
-- **Prereqs:** Config repo with `envs/{env}`, `sops` + `age` installed, per-environment age keys (git-ignored), and `uv run infra` available.
+- **Prereqs:** Config repo with `envs/{env}`, `sops` + `age` installed, per-environment age keys (git-ignored), and `foundry` available.
 
 ## When to Use This
 
@@ -40,13 +40,13 @@ InfraFoundry automatically loads credentials for the environment you target with
    ```
 4. Run commands; InfraFoundry picks credentials for the specified env:
    ```bash
-   infra plan --env dev
-   infra apply --env prod
+   foundry infra plan --env dev
+   foundry infra apply --env prod
    ```
 
 ## Configuration Details
 
-- **Automatic loading:** `infra ... --env <env>` decrypts `envs/{env}/settings.yaml`, extracts `provider_settings`, and maps credentials to `TF_VAR_*` environment variables via each provider's `_CREDENTIAL_ENV_MAPPING`. For example, `PROXMOX_API_URL` is mapped to `TF_VAR_proxmox_api_url`. No `.tfvars` files are written to disk.
+- **Automatic loading:** `foundry infra ... --env <env>` decrypts `envs/{env}/settings.yaml`, extracts `provider_settings`, and maps credentials to `TF_VAR_*` environment variables via each provider's `_CREDENTIAL_ENV_MAPPING`. For example, `PROXMOX_API_URL` is mapped to `TF_VAR_proxmox_api_url`. No `.tfvars` files are written to disk.
 - **Recommended structure:**
   ```
   config-repo/
@@ -72,7 +72,7 @@ InfraFoundry automatically loads credentials for the environment you target with
 
 - Ensure keys are ignored: `git status --ignored | grep age.key` should show ignored paths only.
 - Confirm encryption works: `sops --decrypt envs/dev/settings.yaml >/dev/null`.
-- Run `infra validate --env <env> --check-api` to confirm credentials work against provider endpoints.
+- Run `foundry infra doctor --env <env>` to confirm credentials work against provider endpoints.
 
 ## Examples
 
@@ -94,7 +94,7 @@ InfraFoundry automatically loads credentials for the environment you target with
   ```bash
   SOPS_AGE_KEY_FILE=envs/prod/age.key infra plan --env prod
   ```
-- **Credential rotation:** Update `settings.yaml`, re-encrypt with SOPS, and rerun `infra validate --check-api`.
+- **Credential rotation:** Update `settings.yaml`, re-encrypt with SOPS, and rerun `foundry infra doctor --env <env>`.
 
 ## Related Documentation
 

--- a/docs/configuration/policy-configuration.md
+++ b/docs/configuration/policy-configuration.md
@@ -36,8 +36,8 @@ InfraFoundry’s policy engine enforces rules before deployment. Policies can bl
    ```
 2. Check policies:
    ```bash
-   infra policies check --env dev
-   infra policies check --env prod --enforce
+   foundry infra plan --env dev --enforce-policies
+   foundry infra plan --env prod --enforce-policies
    ```
 
 ## Configuration Details
@@ -63,8 +63,8 @@ InfraFoundry’s policy engine enforces rules before deployment. Policies can bl
 
 ## Validation and Checks
 
-- Run `infra policies check --env <env>` to report violations.
-- Use `--enforce` to exit non-zero on `error`-level violations.
+- Run `foundry policy list` to list available policies.
+- Run `foundry infra plan --env <env> --enforce-policies` to enforce policies during planning (blocks on violations).
 - Combine with CI to block merges when policies fail.
 
 ## Examples

--- a/docs/configuration/separate-config-repo.md
+++ b/docs/configuration/separate-config-repo.md
@@ -29,8 +29,8 @@ Keep InfraFoundry framework code and infrastructure configs in distinct reposito
    ```
 3. Run commands:
    ```bash
-   infra validate --env dev --check-api --check-refs
-   infra plan --env dev
+   foundry infra doctor --env dev
+   foundry infra plan --env dev
    ```
 
 ## Configuration Details
@@ -56,11 +56,11 @@ Keep InfraFoundry framework code and infrastructure configs in distinct reposito
 
 - Confirm the config path resolution by running:
   ```bash
-  infra envs --config-dir /path/to/config
+  foundry config envs --config-dir /path/to/config
   ```
 - Validate before plan/apply:
   ```bash
-  infra validate --env dev --check-api --check-refs
+  foundry infra doctor --env dev
   ```
 - Ensure secrets are encrypted and keys are git-ignored.
 
@@ -75,7 +75,7 @@ Keep InfraFoundry framework code and infrastructure configs in distinct reposito
   ```bash
   INFRAFOUNDRY_CONFIG_REPO=../my-infra-config infra plan --env prod
   # or
-  infra --config-dir ../my-infra-config apply --env prod
+  foundry --config-dir ../my-infra-config apply --env prod
   ```
 - **Per-env SOPS rules (config repo `.sops.yaml`):**
   ```yaml

--- a/docs/configuration/settings-file-structure.md
+++ b/docs/configuration/settings-file-structure.md
@@ -24,8 +24,8 @@ Each environment uses a single SOPS-encrypted `settings.yaml` to define metadata
    ```
 3. Validate and plan:
    ```bash
-   infra validate --env dev --check-api
-   infra plan --env dev
+   foundry infra doctor --env dev
+   foundry infra plan --env dev
    ```
 
 ## Configuration Details
@@ -104,7 +104,7 @@ Each environment uses a single SOPS-encrypted `settings.yaml` to define metadata
 
 ## Validation and Checks
 
-- Run `infra validate --env <env> --check-api` to confirm structure and credentials.
+- Run `foundry infra doctor --env <env>` to confirm structure and credentials.
 - Inspect generated `.tf` files to verify provider configuration and variables:
   ```bash
   cat generated/dev/terraform/proxmox/variables.tf
@@ -223,11 +223,11 @@ Each environment uses a single SOPS-encrypted `settings.yaml` to define metadata
 
 ## Troubleshooting
 
-- **Symptom:** Missing credential values at Terraform runtime. **Fix:** Ensure fields exist in `settings.yaml` under `provider_settings` and rerun `infra plan`. Credentials are mapped to `TF_VAR_*` env vars via each provider's `_CREDENTIAL_ENV_MAPPING`.
+- **Symptom:** Missing credential values at Terraform runtime. **Fix:** Ensure fields exist in `settings.yaml` under `provider_settings` and rerun `foundry infra plan`. Credentials are mapped to `TF_VAR_*` env vars via each provider's `_CREDENTIAL_ENV_MAPPING`.
 - **Symptom:** SSH fails during Proxmox operations. **Fix:** Verify `ssh`/`provider_ssh` entries and key paths; re-validate with `--check-api`.
 - **Symptom:** Secrets exposed in git. **Fix:** Encrypt `settings.yaml` with SOPS/age and confirm ignore rules include keys.
 - **Symptom:** Provider not loading despite having resources defined. **Fix:** Check `providers` list in `settings.yaml`; if specified, only listed providers will be enabled.
-- **Symptom:** Backend configuration validation fails. **Fix:** Run `infra backend validate --env <env>` for detailed error messages; ensure all required fields for the backend type are present (e.g., `bucket` and `region` for S3).
+- **Symptom:** Backend configuration validation fails. **Fix:** Run `foundry state backend validate --env <env>` for detailed error messages; ensure all required fields for the backend type are present (e.g., `bucket` and `region` for S3).
 - **Symptom:** Terraform init fails with backend error. **Fix:** Verify backend resources exist (S3 bucket, DynamoDB table, GCS bucket, etc.); check credentials/permissions for accessing backend; confirm network connectivity to backend service.
 - **Symptom:** No backend.tf generated. **Fix:** Ensure `backend` field exists in `settings.yaml`; local backend type does not generate backend.tf (this is expected behavior); verify backend type is not `local`.
 

--- a/docs/configuration/yaml-only-config.md
+++ b/docs/configuration/yaml-only-config.md
@@ -7,7 +7,7 @@ InfraFoundry uses **pure YAML** for all environment, resource, and credential co
 ## Audience and Prerequisites
 
 - **Audience:** Config repo maintainers and operators defining environments/resources.
-- **Prereqs:** Config repo available, `sops`/`age` for secrets, `uv run infra` installed, and provider credentials ready.
+- **Prereqs:** Config repo available, `sops`/`age` for secrets, `foundry` installed, and provider credentials ready.
 
 ## When to Use This
 
@@ -22,8 +22,8 @@ InfraFoundry uses **pure YAML** for all environment, resource, and credential co
 3. Encrypt secrets with SOPS/age as needed.
 4. Generate and validate:
    ```bash
-   infra validate --env dev
-   infra plan --env dev
+   foundry infra doctor --env dev
+   foundry infra plan --env dev
    ```
 
 ## Configuration Details
@@ -35,7 +35,7 @@ InfraFoundry uses **pure YAML** for all environment, resource, and credential co
 
 ## Validation and Checks
 
-- Run `infra validate --env <env> --check-api --check-refs` to confirm YAML structure, provider discovery, connectivity, and referenced templates/networks/aliases.
+- Run `foundry infra doctor --env <env>` to confirm YAML structure, provider discovery, connectivity, and referenced templates/networks/aliases.
 - Inspect generated Terraform inputs under `generated/{env}/terraform/{provider}/terraform.tfvars` to confirm values and SSH overrides.
 
 ## Examples
@@ -99,9 +99,9 @@ InfraFoundry uses **pure YAML** for all environment, resource, and credential co
 
 ## Troubleshooting
 
-- **Symptom:** Generated `terraform.tfvars` missing values. **Fix:** Ensure fields exist in `settings.yaml`; rerun `infra plan`.
+- **Symptom:** Generated `terraform.tfvars` missing values. **Fix:** Ensure fields exist in `settings.yaml`; rerun `foundry infra plan`.
 - **Symptom:** Providers not discovered. **Fix:** Confirm resource files include `provider` keys and are placed under `resources/` or provider directories.
-- **Symptom:** SSH fails during Proxmox operations. **Fix:** Verify `ssh` or `provider_ssh` entries and that keys are accessible; re-run `infra validate --check-api`.
+- **Symptom:** SSH fails during Proxmox operations. **Fix:** Verify `ssh` or `provider_ssh` entries and that keys are accessible; re-run `foundry infra doctor --env <env>`.
 
 ---
 

--- a/docs/development/ci-cd-deployment.md
+++ b/docs/development/ci-cd-deployment.md
@@ -116,7 +116,7 @@ export SOPS_AGE_KEY=$(cat envs/dev/age.key | base64 -w 0)
 ./ci/setup-ci.sh dev
 
 # Deploy infrastructure
-infra apply --env dev --auto-approve
+foundry infra apply --env dev --auto-approve
 ```
 
 ---

--- a/docs/development/implementing-providers.md
+++ b/docs/development/implementing-providers.md
@@ -34,7 +34,7 @@ Provider plugins implement `ProviderBase`, render Terraform/Ansible via Jinja2, 
 
 - Validate required fields per resource type; surface clear errors.
 - Ensure templates produce deterministic output; keep secrets out of generated files.
-- Run `infra validate --env <env> --check-api --check-refs` for new providers; add provider-specific validators as needed.
+- Run `foundry infra doctor --env <env>` for new providers; add provider-specific validators as needed.
 
 ## Environment Configuration
 
@@ -109,7 +109,7 @@ def validate_connectivity(self, env_config, report):
         report.add_error(f"{self.name}: Connection failed - {e}")
 ```
 
-**Usage:** Called by `infra validate --env <env> --check-api`
+**Usage:** Called by `foundry infra doctor --env <env>`
 
 ---
 
@@ -162,7 +162,7 @@ def validate_references(self, resources, env_config, report):
                 )
 ```
 
-**Usage:** Called by `infra validate --env <env> --check-refs`
+**Usage:** Called by `foundry infra doctor --env <env>`
 
 ---
 

--- a/docs/examples/GITLAB_CI_EXAMPLE.md
+++ b/docs/examples/GITLAB_CI_EXAMPLE.md
@@ -27,7 +27,7 @@ This example shows a GitLab CI pipeline configuration for running InfraFoundry l
 
 ## Validation and Checks
 
-- Ensure `infra validate --env <env>` runs before apply.
+- Ensure `foundry infra doctor --env <env>` runs before apply.
 - Include coverage/lint jobs similar to GitHub Actions if desired.
 
 ## Examples
@@ -41,12 +41,12 @@ This example shows a GitLab CI pipeline configuration for running InfraFoundry l
   validate:
     stage: validate
     script:
-      - uv run infra validate --env dev --check-api --check-refs
+      - uv run foundry infra doctor --env dev
 
   apply:
     stage: apply
     script:
-      - uv run infra apply --env dev --auto-approve
+      - uv run foundry infra apply --env dev --auto-approve
     when: manual
   ```
 

--- a/docs/examples/custom-runner-example.md
+++ b/docs/examples/custom-runner-example.md
@@ -745,21 +745,21 @@ runner.apply(provider, stack_name="my-custom-stack")
 ### Plan Changes
 
 ```bash
-infra plan --env prod
+foundry infra plan --env prod
 # Creates CloudFormation change sets for each provider
 ```
 
 ### Apply Changes
 
 ```bash
-infra apply --env prod --auto-approve
+foundry infra apply --env prod --auto-approve
 # Deploys CloudFormation stacks
 ```
 
 ### Destroy Infrastructure
 
 ```bash
-infra destroy --env dev --auto-approve
+foundry infra destroy --env dev --auto-approve
 # Deletes CloudFormation stacks
 ```
 

--- a/docs/examples/oci-k3s-cluster.md
+++ b/docs/examples/oci-k3s-cluster.md
@@ -147,7 +147,7 @@ Edit `envs/oci-k3s/oci/instances.yaml`:
 ### 3. Encrypt Settings
 
 ```bash
-infra secrets init --env oci-k3s
+foundry secrets init --env oci-k3s
 sops --encrypt --in-place envs/oci-k3s/settings.yaml
 ```
 
@@ -155,10 +155,10 @@ sops --encrypt --in-place envs/oci-k3s/settings.yaml
 
 ```bash
 # Generate and review Terraform
-infra plan --env oci-k3s
+foundry infra plan --env oci-k3s
 
 # Create infrastructure and install K3s
-infra apply --env oci-k3s
+foundry infra apply --env oci-k3s
 ```
 
 ### 5. Access Your Cluster
@@ -181,10 +181,10 @@ kubectl get pods -A
 TAILSCALE_API_KEY=tskey-api-xxx ./scripts/cleanup-tailscale.sh
 
 # 2. Destroy infrastructure
-infra destroy --env oci-k3s
+foundry infra destroy --env oci-k3s
 
 # 3. (Optional) Recreate
-infra apply --env oci-k3s
+foundry infra apply --env oci-k3s
 ```
 
 Get your API key from: https://login.tailscale.com/admin/settings/keys
@@ -280,7 +280,7 @@ ssh ubuntu@<node> 'sudo iptables -L INPUT -n | grep 8472'
 
 **Fix:** Re-run Ansible to apply iptables rules:
 ```bash
-infra apply --env oci-k3s --ansible-only
+foundry infra apply --env oci-k3s --ansible-only
 ```
 
 ### kubectl logs/exec Returns 502 Bad Gateway

--- a/docs/getting-started/setup-guide.md
+++ b/docs/getting-started/setup-guide.md
@@ -31,7 +31,8 @@ This guide helps you stand up InfraFoundry with Proxmox and OPNsense, covering b
    ```
 4. Validate connectivity and structure:
    ```bash
-   infra validate --env dev --check-api --check-refs
+   foundry config doctor --deep
+   foundry infra doctor --env dev
    ```
 
 ## Configuration Details
@@ -57,23 +58,23 @@ This guide helps you stand up InfraFoundry with Proxmox and OPNsense, covering b
 
 ## Validation and Checks
 
-- Run `infra validate --env <env>` after populating settings and resources.
-- Add `--check-api --check-refs` before first apply to catch connectivity and reference issues.
+- Run `foundry config doctor` after populating settings and resources.
+- Run `foundry infra doctor --env <env>` before first apply to catch connectivity and reference issues.
 - Review generated outputs in `generated/{env}/terraform` and `generated/{env}/ansible` when planning.
 
 ## Examples
 
 - **Plan after setup:**
   ```bash
-  infra plan --env dev
+  foundry infra plan --env dev
   ```
 - **Apply a newly configured environment:**
   ```bash
-  infra apply --env dev
+  foundry infra apply --env dev
   ```
 - **Destroy if you need to reset:**
   ```bash
-  infra destroy --env dev
+  foundry infra destroy --env dev
   ```
 
 ## Related Documentation
@@ -87,7 +88,7 @@ This guide helps you stand up InfraFoundry with Proxmox and OPNsense, covering b
 ## Troubleshooting
 
 - **Symptom:** Missing dependencies. **Fix:** Re-run `./scripts/setup-dependencies.sh`; confirm `uv` is on `PATH`.
-- **Symptom:** Cannot reach Proxmox/OPNsense. **Fix:** Verify API URLs, tokens/keys, and network access; rerun `infra validate --check-api`.
+- **Symptom:** Cannot reach Proxmox/OPNsense. **Fix:** Verify API URLs, tokens/keys, and network access; rerun `foundry infra doctor --env <env>`.
 - **Symptom:** Configs not found. **Fix:** Ensure `INFRAFOUNDRY_CONFIG_REPO` or `--config-dir` points to your repo and `envs/{env}` exists.
 
 ---

--- a/docs/guides/age-key-management.md
+++ b/docs/guides/age-key-management.md
@@ -33,8 +33,8 @@ Age keys secure SOPS-encrypted secrets in InfraFoundry. This guide outlines how 
    ```
 4. Run InfraFoundry commands; the correct key is picked up by `--env`:
    ```bash
-   infra plan --env dev
-   infra apply --env prod
+   foundry infra plan --env dev
+   foundry infra apply --env prod
    ```
 
 ## Configuration Details
@@ -51,7 +51,7 @@ Age keys secure SOPS-encrypted secrets in InfraFoundry. This guide outlines how 
   ```bash
   sops --decrypt envs/dev/proxmox.yaml >/dev/null
   ```
-- Verify InfraFoundry picks the right key by running `infra plan --env <env>` and checking for missing key errors.
+- Verify InfraFoundry picks the right key by running `foundry infra plan --env <env>` and checking for missing key errors.
 
 ## Examples
 
@@ -71,7 +71,7 @@ Age keys secure SOPS-encrypted secrets in InfraFoundry. This guide outlines how 
   │       └── *.yaml
   └── .sops.yaml
   ```
-- **Automatic key selection:** `infra plan --env dev` uses `envs/dev/age.key`; `infra apply --env prod` uses `envs/prod/age.key`.
+- **Automatic key selection:** `foundry infra plan --env dev` uses `envs/dev/age.key`; `foundry infra apply --env prod` uses `envs/prod/age.key`.
 - **Distribution options:** Vault, AWS Secrets Manager, Azure Key Vault, 1Password/Bitwarden (preferred for audit and rotation).
 
 ## Related Documentation

--- a/docs/guides/ci-cd-with-separate-config-repo.md
+++ b/docs/guides/ci-cd-with-separate-config-repo.md
@@ -115,28 +115,28 @@ jobs:
 
       - name: Validate configuration
         run: |
-          infra envs
+          foundry config envs
           echo "Deploying to: ${{ github.event.inputs.environment || 'dev' }}"
 
       - name: Plan infrastructure
         if: github.event.inputs.action != 'apply' && github.event.inputs.action != 'destroy'
         run: |
-          infra plan --env ${{ github.event.inputs.environment || 'dev' }}
+          foundry infra plan --env ${{ github.event.inputs.environment || 'dev' }}
 
       - name: Apply infrastructure
         if: github.event.inputs.action == 'apply'
         run: |
-          infra apply --env ${{ github.event.inputs.environment || 'dev' }} --auto-approve
+          foundry infra apply --env ${{ github.event.inputs.environment || 'dev' }} --auto-approve
 
       - name: Destroy infrastructure
         if: github.event.inputs.action == 'destroy'
         run: |
-          infra destroy --env ${{ github.event.inputs.environment || 'dev' }} --auto-approve
+          foundry infra destroy --env ${{ github.event.inputs.environment || 'dev' }} --auto-approve
 
       - name: Show status
         if: always()
         run: |
-          infra status --env ${{ github.event.inputs.environment || 'dev' }} || true
+          foundry infra status --env ${{ github.event.inputs.environment || 'dev' }} || true
 
       - name: Upload generated files
         if: always()
@@ -209,7 +209,7 @@ validate:
   stage: validate
   <<: *setup
   script:
-    - infra envs
+    - foundry config envs
     - echo "Configuration validated"
   only:
     - merge_requests

--- a/docs/guides/dhcp-vm-integration.md
+++ b/docs/guides/dhcp-vm-integration.md
@@ -50,7 +50,7 @@ InfraFoundry can align OPNsense DHCP static mappings with Proxmox VMs so VMs use
    ```
 3. Apply:
    ```bash
-   infra apply --env homelab
+   foundry infra apply --env homelab
    ```
 
 ## Configuration Details
@@ -62,7 +62,7 @@ InfraFoundry can align OPNsense DHCP static mappings with Proxmox VMs so VMs use
 
 ## Validation and Checks
 
-- Run `infra validate --env <env> --check-api --check-refs` to confirm OPNsense aliases/interfaces and Proxmox templates/bridges exist.
+- Run `foundry infra doctor --env <env>` to confirm OPNsense aliases/interfaces and Proxmox templates/bridges exist.
 - Verify MAC format is colon-separated and unique per VM.
 - After apply, confirm DHCP leases in OPNsense and VM IP assignment in Proxmox.
 
@@ -70,12 +70,12 @@ InfraFoundry can align OPNsense DHCP static mappings with Proxmox VMs so VMs use
 
 - **Apply with validation:**
   ```bash
-  infra validate --env homelab --check-api --check-refs
-  infra apply --env homelab
+  foundry infra doctor --env homelab
+  foundry infra apply --env homelab
   ```
 - **Destroy if you need to recreate mappings/VMs:**
   ```bash
-  infra destroy --env homelab
+  foundry infra destroy --env homelab
   ```
 
 ## Related Documentation

--- a/docs/guides/drift-detection.md
+++ b/docs/guides/drift-detection.md
@@ -37,29 +37,29 @@ InfraFoundry drift detection supports runners that implement the `DriftDetectabl
 
 ```bash
 # Detect drift in all providers for an environment
-infra drift detect --env dev
+foundry infra drift detect --env dev
 
 # Detect drift for a specific provider
-infra drift detect --env dev --provider proxmox
+foundry infra drift detect --env dev --provider proxmox
 
 # Verbose output showing detailed changes
-infra drift detect --env dev --verbose
+foundry infra drift detect --env dev --verbose
 
 # Output results as JSON
-infra drift detect --env dev --format json
+foundry infra drift detect --env dev --format json
 ```
 
 ### View Drift Information
 
 ```bash
 # Show drift summary for environment
-infra drift status --env dev
+foundry infra drift status --env dev
 
 # Show drift for specific provider
-infra drift status --env dev --provider opnsense
+foundry infra drift status --env dev --provider opnsense
 
 # Show historical drift detection results
-infra drift history --env dev --limit 10
+foundry infra drift history --env dev --limit 10
 ```
 
 ## Understanding Drift Results
@@ -152,18 +152,18 @@ Always check for drift before applying changes:
 
 ```bash
 # Check for drift
-infra drift detect --env prod
+foundry infra drift detect --env prod
 
 # If no drift, apply changes
-infra apply --env prod
+foundry infra apply --env prod
 
 # If drift exists, review and decide:
 # Option 1: Accept drift and apply anyway
-infra apply --env prod --accept-drift
+foundry infra apply --env prod --accept-drift
 
 # Option 2: Remediate drift first
-infra drift remediate --env prod --auto-approve
-infra apply --env prod
+foundry infra drift remediate --env prod --auto-approve
+foundry infra apply --env prod
 ```
 
 ### CI/CD Integration
@@ -208,7 +208,7 @@ drift-check:
 **Cause:** Provider has never been applied or state file is missing
 
 **Solutions:**
-1. Run `infra apply --env <env>` first to create state
+1. Run `foundry infra apply --env <env>` first to create state
 2. Verify state file exists in `generated/{env}/{runner}/{provider}/`
 3. Check state backend configuration if using remote state
 
@@ -239,11 +239,11 @@ drift-check:
 **Solutions:**
 ```bash
 # Force state refresh before drift detection
-infra drift detect --env dev --refresh
+foundry infra drift detect --env dev --refresh
 
 # Or manually refresh state first
-infra state refresh --env dev
-infra drift detect --env dev
+foundry state list --env dev
+foundry infra drift detect --env dev
 ```
 
 ## Best Practices
@@ -299,13 +299,13 @@ Drift detection is the first step in drift remediation:
 
 ```bash
 # Step 1: Detect drift
-infra drift detect --env dev
+foundry infra drift detect --env dev
 
 # Step 2: Review drift
-infra drift status --env dev
+foundry infra drift status --env dev
 
 # Step 3: Remediate if within thresholds
-infra drift remediate --env dev --auto-approve
+foundry infra drift remediate --env dev --auto-approve
 ```
 
 See [Drift Remediation Guide](drift-remediation.md) for automated remediation.

--- a/docs/guides/drift-remediation.md
+++ b/docs/guides/drift-remediation.md
@@ -66,23 +66,23 @@ drift_remediation:
 
 ```bash
 # Detect drift without remediation
-infra drift detect --env dev
+foundry infra drift detect --env dev
 ```
 
 ### Remediate Drift
 
 ```bash
 # Dry-run: detect and show what would be remediated
-infra drift remediate --env dev --dry-run
+foundry infra drift remediate --env dev --dry-run
 
 # Auto-remediate if within configured thresholds
-infra drift remediate --env dev --auto-approve
+foundry infra drift remediate --env dev --auto-approve
 
 # Override max changes threshold for this run
-infra drift remediate --env dev --auto-approve --max-changes 10
+foundry infra drift remediate --env dev --auto-approve --max-changes 10
 
 # Set custom thresholds for different operations
-infra drift remediate --env dev --auto-approve \
+foundry infra drift remediate --env dev --auto-approve \
   --max-add 5 \
   --max-change 3 \
   --max-destroy 0
@@ -92,13 +92,13 @@ infra drift remediate --env dev --auto-approve \
 
 ```bash
 # Show last 10 remediation entries
-infra drift history
+foundry infra drift history
 
 # Show last 20 entries for dev environment
-infra drift history --env dev --limit 20
+foundry infra drift history --env dev --limit 20
 
 # Show all recent remediation attempts
-infra drift history --limit 50
+foundry infra drift history --limit 50
 ```
 
 ## Safety Features
@@ -141,7 +141,7 @@ All remediation actions are tracked in `.drift_history/` with:
 Always test with `--dry-run` first:
 ```bash
 # See what would be remediated without applying
-infra drift remediate --env dev --dry-run --auto-approve
+foundry infra drift remediate --env dev --dry-run --auto-approve
 ```
 
 ### Event Notifications
@@ -199,26 +199,26 @@ Use cron or systemd timers to run periodic checks:
 
 1. Run drift detection:
    ```bash
-   infra drift detect --env prod
+   foundry infra drift detect --env prod
    ```
 
 2. If drift found, simulate remediation:
    ```bash
-   infra drift remediate --env prod --dry-run --auto-approve
+   foundry infra drift remediate --env prod --dry-run --auto-approve
    ```
 
 3. Review the decision and apply if safe:
    ```bash
    # If within thresholds, apply
-   infra drift remediate --env prod --auto-approve
+   foundry infra drift remediate --env prod --auto-approve
 
    # Or manually apply
-   infra apply --env prod
+   foundry infra apply --env prod
    ```
 
 4. Check history:
    ```bash
-   infra drift history --env prod --limit 5
+   foundry infra drift history --env prod --limit 5
    ```
 
 ## Troubleshooting
@@ -244,11 +244,11 @@ Use cron or systemd timers to run periodic checks:
 1. Review the drift to ensure it's expected
 2. Increase thresholds if appropriate:
    ```bash
-   infra drift remediate --env dev --auto-approve --max-changes 15
+   foundry infra drift remediate --env dev --auto-approve --max-changes 15
    ```
 3. Or manually apply:
    ```bash
-   infra apply --env dev
+   foundry infra apply --env dev
    ```
 
 ### Issue: Won't remediate destroy operations
@@ -262,14 +262,14 @@ Use cron or systemd timers to run periodic checks:
 2. Review the resources being destroyed
 3. Manually apply if safe:
    ```bash
-   infra apply --env dev
+   foundry infra apply --env dev
    ```
 4. Only increase `max_to_destroy` if you're certain it's safe
 
 ### Issue: No history files created
 
 **Symptoms:**
-- `infra drift history` shows no entries
+- `foundry infra drift history` shows no entries
 - No files in `.drift_history/`
 
 **Solutions:**
@@ -323,7 +323,7 @@ Use different thresholds for different environments:
 Regularly review remediation history:
 ```bash
 # Weekly review
-infra drift history --limit 50 > weekly_drift_report.txt
+foundry infra drift history --limit 50 > weekly_drift_report.txt
 ```
 
 ### 5. Combine with Notifications
@@ -359,7 +359,7 @@ Always keep `max_to_destroy: 0` unless you have a very specific use case.
 
 Regularly audit what's being auto-applied:
 ```bash
-infra drift history --env prod --limit 100
+foundry infra drift history --env prod --limit 100
 ```
 
 ### 3. Use Dry-Run in Production
@@ -378,7 +378,7 @@ drift_remediation:
 Use resource filters if you only want to auto-remediate specific resources:
 ```bash
 # Only remediate specific resource types (future enhancement)
-infra drift remediate --env dev --auto-approve --resources vm-*
+foundry infra drift remediate --env dev --auto-approve --resources vm-*
 ```
 
 ## Related Documentation

--- a/docs/guides/isc-to-kea-migration.md
+++ b/docs/guides/isc-to-kea-migration.md
@@ -7,7 +7,7 @@ InfraFoundry provides an automated migration from legacy ISC DHCP configs to Kea
 ## Audience and Prerequisites
 
 - **Audience:** Operators migrating OPNsense DHCP from ISC to Kea.
-- **Prereqs:** OPNsense access, `infra migrate` available, and target config repo to receive generated YAML.
+- **Prereqs:** OPNsense access, `foundry config migrate` available, and target config repo to receive generated YAML.
 
 ## When to Use This
 
@@ -19,13 +19,13 @@ InfraFoundry provides an automated migration from legacy ISC DHCP configs to Kea
 
 ```bash
 # Migrate all interfaces
-infra migrate --env prod --provider opnsense --component isc-to-kea
+foundry config migrate --env prod --provider opnsense --component isc-to-kea
 
 # Migrate selected interfaces
-infra migrate --env prod --provider opnsense --component isc-to-kea -i lan -i opt1
+foundry config migrate --env prod --provider opnsense --component isc-to-kea -i lan -i opt1
 
 # Dry-run preview
-infra migrate --env prod --provider opnsense --component isc-to-kea --dry-run
+foundry config migrate --env prod --provider opnsense --component isc-to-kea --dry-run
 ```
 
 ## Configuration Details
@@ -40,14 +40,14 @@ infra migrate --env prod --provider opnsense --component isc-to-kea --dry-run
 ## Validation and Checks
 
 - Review generated YAML before apply; ensure networks, gateways, and reservations align with desired state.
-- Run `infra validate --env <env> --check-refs` after adding migrated resources.
+- Run `foundry infra doctor --env <env>` after adding migrated resources.
 - Keep backups of original ISC configs (`/var/dhcpd/etc/dhcpd.conf`, `/var/dhcpd/etc/dhcpdv6.conf`).
 
 ## Examples
 
 - **Custom output path:**
   ```bash
-  infra migrate --env prod --provider opnsense --component isc-to-kea -o custom/path/dhcp-config.yaml
+  foundry config migrate --env prod --provider opnsense --component isc-to-kea -o custom/path/dhcp-config.yaml
   ```
 - **Generated resource snippet:**
   ```yaml
@@ -78,7 +78,7 @@ infra migrate --env prod --provider opnsense --component isc-to-kea --dry-run
 
 - **Symptom:** Missing interface migration. **Fix:** Specify interfaces with `-i`; confirm interface names match OPNsense.
 - **Symptom:** Incorrect reservations. **Fix:** Verify MAC/IP in generated YAML against source config; adjust before apply.
-- **Symptom:** Apply errors post-migration. **Fix:** Validate references/networks and rerun `infra validate --check-refs`; ensure Kea services are reachable.
+- **Symptom:** Apply errors post-migration. **Fix:** Validate references/networks and rerun `foundry infra doctor --env <env>`; ensure Kea services are reachable.
 
 ---
 

--- a/docs/guides/ssh-authentication.md
+++ b/docs/guides/ssh-authentication.md
@@ -28,8 +28,8 @@ InfraFoundry uses SSH for Proxmox tasks that lack API support (image extraction,
    ```
 2. Run with validation:
    ```bash
-   infra validate --env dev --check-api
-   infra apply --env dev
+   foundry infra doctor --env dev
+   foundry infra apply --env dev
    ```
 3. CI: write the key to disk and set `TF_VAR_proxmox_ssh_key_path`.
 
@@ -47,7 +47,7 @@ InfraFoundry uses SSH for Proxmox tasks that lack API support (image extraction,
 ## Validation and Checks
 
 - Test connectivity manually: `ssh -v root@pve1 "hostname"`.
-- Run `infra validate --env <env> --check-api` to confirm SSH-based operations can proceed.
+- Run `foundry infra doctor --env <env>` to confirm SSH-based operations can proceed.
 - Ensure keys are readable (`chmod 600`) and loaded into ssh-agent when used.
 
 ## Examples

--- a/docs/meta/documentation-template.md
+++ b/docs/meta/documentation-template.md
@@ -35,7 +35,7 @@ Short, action-oriented name (e.g., “Validation and Pre-Flight Checks”).
 
 ## Validation and Checks
 
-- How to validate configs or runs (e.g., `infra validate --env <env> --check-api --check-refs`).
+- How to validate configs or runs (e.g., `foundry infra doctor --env <env>`).
 - Typical outputs and what pass/fail looks like.
 
 ## Examples

--- a/docs/providers/esxi.md
+++ b/docs/providers/esxi.md
@@ -273,7 +273,7 @@ The ESXi provider validates:
 - **OVF deployments**: Required fields (`host`, `ovf_source`, `disk_store`, `network_map`), non-empty network mappings, and `mac_map` key/format validation
 
 ```bash
-infra validate --env prod
+foundry infra doctor --env prod
 ```
 
 ## Config Export
@@ -293,21 +293,21 @@ The exporter connects to ESXi hosts and runs `esxcli` and `vim-cmd` commands to 
 
 ```bash
 # Generate Terraform files
-infra plan --env prod
+foundry infra plan --env prod
 
 # Validate configuration and host connectivity
-infra validate --env prod
+foundry infra doctor --env prod
 
 # Apply infrastructure
-infra apply --env prod
+foundry infra apply --env prod
 
 # Destroy infrastructure
-infra destroy --env prod
+foundry infra destroy --env prod
 ```
 
 ## Generated Files
 
-After `infra plan`, the generated directory contains:
+After `foundry infra plan`, the generated directory contains:
 
 ```
 generated/prod/terraform/esxi/

--- a/docs/providers/oci.md
+++ b/docs/providers/oci.md
@@ -198,28 +198,28 @@ The OCI provider validates:
 - **References**: Subnet-to-VCN and instance-to-subnet cross-references
 
 ```bash
-infra validate --env prod
+foundry infra doctor --env prod
 ```
 
 ## Usage
 
 ```bash
 # Generate Terraform files
-infra plan --env prod
+foundry infra plan --env prod
 
 # Validate configuration and API connectivity
-infra validate --env prod
+foundry infra doctor --env prod
 
 # Apply infrastructure
-infra apply --env prod
+foundry infra apply --env prod
 
 # Destroy infrastructure
-infra destroy --env prod
+foundry infra destroy --env prod
 ```
 
 ## Generated Files
 
-After `infra plan`, the generated directory contains:
+After `foundry infra plan`, the generated directory contains:
 
 ```
 generated/prod/terraform/oci/

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -61,13 +61,13 @@ InfraFoundry uses structured error codes to help you quickly identify and resolv
   Validation failed: Invalid YAML in proxmox/vm.yaml
 
   Suggestions:
-    - Run 'foundry config validate --env <env>' to see validation errors
+    - Run 'foundry config doctor --deep' to check configuration health
     - Check YAML syntax (indentation, colons, quotes)
     - Ensure required fields are present
 ```
 
 **Solutions:**
-1. Validate your configuration: `foundry config validate --env <env>`
+1. Validate your configuration: `foundry config doctor --deep`
 2. Check YAML indentation (use spaces, not tabs)
 3. Verify required fields are present
 
@@ -227,10 +227,9 @@ InfraFoundry uses structured error codes to help you quickly identify and resolv
 **Cause:** The state database is inconsistent with actual resources.
 
 **Solutions:**
-1. Run `foundry config check --deep` to identify environment-level divergence
-2. Run `foundry infra drift --env <env>` to detect resource-level drift
-3. Consider `foundry state reset` (use with caution)
-4. Check for concurrent modifications
+1. Run `foundry config doctor --deep` to identify environment-level divergence
+2. Run `foundry infra drift detect --env <env>` to detect resource-level drift
+3. Check for concurrent modifications
 
 ---
 
@@ -240,7 +239,7 @@ InfraFoundry uses structured error codes to help you quickly identify and resolv
 
 **Solutions:**
 1. Check the error message for both the original failure and rollback errors
-2. Run `foundry config check --deep` to assess environment consistency
+2. Run `foundry config doctor --deep` to assess environment consistency
 3. Manually verify package state in both source and destination environments
 4. Use `foundry infra deployed --env <env>` to check resource tracking
 
@@ -327,7 +326,7 @@ InfraFoundry uses structured error codes to help you quickly identify and resolv
 **Solutions:**
 1. Review validation errors in the output
 2. Check resource configuration against schema
-3. Run `foundry config validate` for detailed validation
+3. Run `foundry config doctor --deep` for detailed validation
 
 ---
 
@@ -349,7 +348,7 @@ InfraFoundry uses structured error codes to help you quickly identify and resolv
 **Solutions:**
 1. Check referenced resources exist
 2. Verify resource names match exactly (case-sensitive)
-3. Review dependency graph with `foundry analyze dependencies`
+3. Review dependency graph with `foundry infra analyze dependencies --env <env>`
 
 ---
 
@@ -371,7 +370,7 @@ InfraFoundry uses structured error codes to help you quickly identify and resolv
 **Cause:** Resources have circular dependencies that cannot be resolved.
 
 **Solutions:**
-1. Run `foundry analyze graph --env <env>` to visualize dependencies
+1. Run `foundry infra analyze graph --env <env> --format mermaid` to visualize dependencies
 2. Break circular dependency by restructuring resources
 3. Use explicit dependency ordering if needed
 
@@ -556,7 +555,7 @@ foundry --debug infra plan --env dev
 Some commands support `--verbose` for additional output:
 
 ```bash
-foundry config validate --env dev --verbose
+foundry infra doctor --env dev --verbose
 ```
 
 ### Checking Logs

--- a/docs/runners/ansible.md
+++ b/docs/runners/ansible.md
@@ -32,7 +32,7 @@ The Ansible runner configures provisioned resources by generating inventory and 
    ```
 2. Run:
    ```bash
-   infra apply --env dev
+   foundry infra apply --env dev
    ```
    Ansible inventory/playbook is generated and executed after provisioning.
 
@@ -45,7 +45,7 @@ The Ansible runner configures provisioned resources by generating inventory and 
 
 ## Validation and Checks
 
-- Validate configs: `infra validate --env <env> --check-api --check-refs`.
+- Validate configs: `foundry infra doctor --env <env>`.
 - Ensure SSH connectivity for hosts produced by Terraform.
 - Use Ansible syntax/lint checks locally if needed.
 

--- a/docs/runners/opentofu.md
+++ b/docs/runners/opentofu.md
@@ -34,8 +34,8 @@ The OpenTofu runner is a drop-in alternative to the Terraform runner. OpenTofu i
 
 3. Run as usual:
    ```bash
-   infra plan --env dev
-   infra apply --env dev
+   foundry infra plan --env dev
+   foundry infra apply --env dev
    ```
 
 ## Configuration Details

--- a/docs/runners/overview.md
+++ b/docs/runners/overview.md
@@ -45,7 +45,7 @@ runner_priorities:
 
 - Confirm priorities with `runner_priorities` in `settings.yaml`.
 - Inspect generated runner outputs for order and content.
-- Validate resources before run: `infra validate --env <env> --check-refs`.
+- Validate resources before run: `foundry infra doctor --env <env>`.
 
 ## Examples
 

--- a/docs/runners/pulumi.md
+++ b/docs/runners/pulumi.md
@@ -23,8 +23,8 @@ The Pulumi runner provisions infrastructure from YAML by generating Pulumi progr
 export INFRA_ENABLE_EXPERIMENTAL=1
 
 # Run standard workflows
-infra plan --env dev
-infra apply --env dev
+foundry infra plan --env dev
+foundry infra apply --env dev
 ```
 
 ## Configuration Details
@@ -51,7 +51,7 @@ This makes it functionally equivalent to TerraformRunner in terms of capabilitie
 
 - Validate configs before running:
   ```bash
-  infra validate --env dev --check-api --check-refs
+  foundry infra doctor --env dev
   ```
 - Inspect generated files for debugging:
   ```bash

--- a/docs/runners/pyinfra.md
+++ b/docs/runners/pyinfra.md
@@ -34,7 +34,7 @@ The PyInfra runner executes Python-based deploys for post-provision configuratio
    ```
 2. Apply:
    ```bash
-   infra apply --env dev
+   foundry infra apply --env dev
    ```
    Inventory and deploy scripts are generated under `generated/{env}/pyinfra/{provider}/` and executed.
 
@@ -47,9 +47,9 @@ The PyInfra runner executes Python-based deploys for post-provision configuratio
 
 ## Validation and Checks
 
-- Validate configs: `infra validate --env <env> --check-api --check-refs`.
+- Validate configs: `foundry infra doctor --env <env>`.
 - Ensure SSH connectivity and credentials from `settings.yaml`/`provider_ssh`.
-- Optionally dry-run via `infra plan --env <env>` to see generation without execution.
+- Optionally dry-run via `foundry infra plan --env <env>` to see generation without execution.
 
 ## Examples
 

--- a/docs/runners/terraform.md
+++ b/docs/runners/terraform.md
@@ -18,8 +18,8 @@ The Terraform runner provisions infrastructure from YAML by rendering `.tf` file
 ## Quick Start
 
 ```bash
-infra plan --env dev
-infra apply --env dev
+foundry infra plan --env dev
+foundry infra apply --env dev
 ```
 
 ## Configuration Details
@@ -33,7 +33,7 @@ infra apply --env dev
 
 - Validate configs and references before running:
   ```bash
-  infra validate --env dev --check-api --check-refs
+  foundry infra doctor --env dev
   ```
 - Inspect generated files for debugging:
   ```bash
@@ -70,7 +70,7 @@ infra apply --env dev
 
 ## Troubleshooting
 
-- **Symptom:** Terraform errors on apply. **Fix:** Inspect generated `.tf` files; rerun `infra validate --check-api --check-refs`. Check that provider credentials in `settings.yaml` are correct — they are passed as `TF_VAR_*` env vars.
+- **Symptom:** Terraform errors on apply. **Fix:** Inspect generated `.tf` files; rerun `foundry infra doctor --env <env>`. Check that provider credentials in `settings.yaml` are correct — they are passed as `TF_VAR_*` env vars.
 - **Symptom:** State conflicts. **Fix:** Configure remote backend with locking (e.g., S3 + DynamoDB) and avoid sharing local state dirs.
 - **Symptom:** Missing credentials. **Fix:** Ensure `settings.yaml` contains provider credentials and is decrypted. Credentials are mapped to `TF_VAR_*` env vars automatically via each provider's `_CREDENTIAL_ENV_MAPPING`.
 

--- a/docs/tools/config-diff.md
+++ b/docs/tools/config-diff.md
@@ -6,7 +6,7 @@ The Config Diff tool allows you to compare infrastructure configurations between
 ## Usage
 
 ```bash
-infra diff --env prod --compare-with dev
+foundry config diff --env-a prod --env-b dev
 ```
 
 ## Features

--- a/docs/tools/dependency-analysis.md
+++ b/docs/tools/dependency-analysis.md
@@ -6,7 +6,7 @@ The Dependency Analysis tool visualizes and analyzes dependencies between infras
 ## Usage
 
 ```bash
-infra dependencies --env dev
+foundry infra analyze dependencies --env dev
 ```
 
 ## Features

--- a/docs/tools/proxmox-exporter.md
+++ b/docs/tools/proxmox-exporter.md
@@ -6,7 +6,7 @@ The Proxmox Config Exporter allows you to extract existing Proxmox cluster confi
 ## Usage
 
 ```bash
-infra export-proxmox --api-url https://proxmox.example.com --token-id ... --token-secret ... --output-dir ./envs/imported
+foundry config export --env prod --output ./envs/imported --provider proxmox
 ```
 
 ## Features

--- a/docs/usage/cli-reference.md
+++ b/docs/usage/cli-reference.md
@@ -2,243 +2,709 @@
 
 ## Overview
 
-`infra` drives environment discovery, generation, validation, apply/destroy flows, and policy/secrets management. Use this reference to run common workflows and explore command options.
+The InfraFoundry CLI (`foundry`) organizes infrastructure management into a three-tier command hierarchy. Each command group owns a distinct domain, keeping concerns separated and making it clear where to look for a given operation.
+
+## Command Domain Model
+
+InfraFoundry commands are organized into five domain groups plus two top-level utilities:
+
+| Domain | Command Group | Responsibility |
+|--------|--------------|----------------|
+| **System** | `foundry doctor` | Binary dependency checks (Terraform, Ansible, SOPS, Age) |
+| **Shell** | `foundry completion` | Shell autocompletion setup |
+| **Configuration** | `foundry config` | Config repo management: environments, schemas, diffs, health checks, blueprints, exports, migrations |
+| **Infrastructure** | `foundry infra` | Day-2 operations: plan, apply, destroy, drift, rollback, security, testing, analysis |
+| **State** | `foundry state` | State database management: init, backup, resources, backend migration, audit trail |
+| **Secrets** | `foundry secrets` | SOPS/age secret lifecycle: init, encrypt, decrypt, rotate |
+| **Policy** | `foundry policy` | Policy listing and enforcement |
+
+**The three-tier doctor pattern** illustrates the hierarchy:
+
+- `foundry doctor` -- checks system-level binary dependencies
+- `foundry config doctor` -- checks config repo structure and health
+- `foundry infra doctor --env <env>` -- validates against live provider APIs
 
 ## Audience and Prerequisites
 
 - **Audience:** Operators and CI systems running InfraFoundry workflows.
-- **Prereqs:** Config repo available (`--config-dir` or `INFRAFOUNDRY_CONFIG_REPO`), `uv run infra` installed, and provider credentials/secrets configured.
+- **Prerequisites:** Config repo available (`--config-dir` or `INFRAFOUNDRY_CONFIG_REPO`), `foundry` installed via `uv`, and provider credentials/secrets configured.
 
-## When to Use This
+## Quick Reference
 
-- Running plan/apply/destroy for environments or specific resources.
-- Inspecting environments, state, history, or drift.
-- Managing secrets, policies, blueprints, and helpers.
+**"I want to..."**
 
-## Quick Start
+| Goal | Command |
+|------|---------|
+| Check if tools are installed | `foundry doctor` |
+| Check config repo health | `foundry config doctor [--deep]` |
+| Validate against provider APIs | `foundry infra doctor --env <env>` |
+| List environments | `foundry config envs` |
+| Compare two environments | `foundry config diff --env-a dev --env-b prod` |
+| Show resolved config | `foundry config show --env <env>` |
+| Create a new environment | `foundry config init <name>` |
+| Create from a blueprint | `foundry config new create <blueprint> <dir>` |
+| Export provider config to YAML | `foundry config export --env <env> --output <dir>` |
+| Generate JSON schemas for IDE | `foundry config schema export` |
+| Migrate existing infra to config | `foundry config migrate --env <env> --provider opnsense --component <comp>` |
+| Plan changes | `foundry infra plan --env <env>` |
+| Apply changes | `foundry infra apply --env <env>` |
+| Destroy infrastructure | `foundry infra destroy --env <env>` |
+| Detect drift | `foundry infra drift detect --env <env>` |
+| Auto-remediate drift | `foundry infra drift remediate --env <env> --auto-approve` |
+| View drift history | `foundry infra drift history` |
+| Show deployment status | `foundry infra deployed --env <env>` |
+| View deployment history | `foundry infra history --env <env>` |
+| List packages in an environment | `foundry infra list --env <env>` |
+| Move a package between envs | `foundry infra move-package --env <src> --package <pkg> --to-env <dst>` |
+| Analyze dependencies | `foundry infra analyze dependencies --env <env>` |
+| Analyze change impact | `foundry infra analyze impact --env <env> --resource <name>` |
+| Visualize dependency graph | `foundry infra analyze graph --env <env> --format mermaid` |
+| Rollback to previous deployment | `foundry infra rollback to <deployment-id>` |
+| List rollback points | `foundry infra rollback list --env <env>` |
+| Run security scan | `foundry infra security --env <env>` |
+| Run infrastructure tests | `foundry infra test --env <env>` |
+| Show infrastructure status | `foundry infra status --env <env>` |
+| Reset a provider component | `foundry infra reset --env <env> --provider opnsense --component <comp>` |
+| Manage deployment locks | `foundry infra unlock --list` |
+| Initialize state database | `foundry state init` |
+| List resources in state | `foundry state list --env <env>` |
+| List tracked resources | `foundry state resources` |
+| Backup state database | `foundry state backup` |
+| Validate backend config | `foundry state backend validate --env <env>` |
+| Migrate backend | `foundry state backend migrate --env <env>` |
+| View audit trail | `foundry state audit list` |
+| Export audit entries | `foundry state audit export --output <file>` |
+| Verify audit integrity | `foundry state audit verify <entry-id>` |
+| Initialize secrets | `foundry secrets init` |
+| Encrypt a file | `foundry secrets encrypt <file>` |
+| Decrypt a file | `foundry secrets decrypt <file>` |
+| Rotate encryption keys | `foundry secrets rotate --env <env> --generate-new-key` |
+| List policies | `foundry policy list` |
+| Install shell completion | `foundry completion bash` |
+
+## Global Options
+
+```
+foundry [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --version                              Show version and exit
+  --debug                                Enable debug mode (full tracebacks)
+  -c, --config-dir DIRECTORY             Path to config repo (overrides INFRAFOUNDRY_CONFIG_REPO)
+  --strict-mode / --no-strict-mode       Fail on missing secrets/snippets
+  --fail-on-missing-secrets / --allow-missing-secrets
+  --fail-on-missing-snippets / --allow-missing-snippets
+```
+
+**Environment variables:** `INFRAFOUNDRY_CONFIG_REPO`, `INFRAFOUNDRY_STRICT_MODE`, `INFRAFOUNDRY_FAIL_ON_MISSING_SECRETS`, `INFRAFOUNDRY_FAIL_ON_MISSING_SNIPPETS`.
+
+## Top-Level Commands
+
+### `foundry doctor`
+
+Check system dependencies (Terraform, OpenTofu, Ansible, SOPS, Age).
 
 ```bash
-# Check system dependencies
-foundry doctor
-
-# Check config repo health
-foundry config doctor
-
-# Validate against provider APIs
-foundry infra doctor --env dev
-
-# List environments
-infra envs
-
-# Plan + apply
-infra plan --env dev
-infra apply --env dev
-infra destroy --env dev --auto-approve
+foundry doctor                  # text output
+foundry doctor --format json    # JSON for scripting
 ```
+
+**Options:** `--format [text|json]`
+
+### `foundry completion`
+
+Install or remove shell completion.
+
+```bash
+foundry completion bash         # install for bash
+foundry completion zsh          # install for zsh
+foundry completion fish         # install for fish
+foundry completion uninstall    # remove completion
+```
+
+---
+
+## Config Group (`foundry config`)
+
+Configuration repo management: environments, schemas, diffs, health, blueprints, exports, and migrations.
+
+### `config doctor`
+
+Check configuration repository health: repo structure, environments, state backend, SOPS keys, state/filesystem consistency, blueprint validation.
+
+```bash
+foundry config doctor                 # basic health check
+foundry config doctor --deep          # include per-environment resource counts
+foundry config doctor --format json   # JSON output for CI
+```
+
+**Options:** `--format [text|json]`, `--deep`
+
+### `config envs`
+
+List available environments with sync status (OK, FS-ONLY, DB-ONLY).
+
+```bash
+foundry config envs
+foundry config envs --format json
+```
+
+**Options:** `--format [text|json]`
+
+### `config diff`
+
+Compare configurations between two environments.
+
+```bash
+foundry config diff --env-a dev --env-b prod
+foundry config diff --env-a dev --env-b prod --provider proxmox
+foundry config diff --env-a dev --env-b prod --verbose
+```
+
+**Options:** `--env-a TEXT` (required), `--env-b TEXT` (required), `-p/--provider TEXT`, `-v/--verbose`
+
+### `config show`
+
+Show resolved configuration for an environment after variable substitution.
+
+```bash
+foundry config show --env dev
+foundry config show --env dev --provider proxmox
+foundry config show --env dev --resource my-vm
+foundry config show --env dev --format yaml
+foundry config show --env dev --settings-only
+```
+
+**Options:** `-e/--env TEXT` (required), `-p/--provider TEXT`, `-t/--resource-type TEXT`, `-r/--resource TEXT`, `--format [table|yaml|json]`, `--settings-only`
+
+### `config init`
+
+Initialize a new environment. Optionally scaffold from an existing environment.
+
+```bash
+foundry config init staging
+foundry config init staging --from dev
+foundry config init prod --from staging -d "Production environment"
+```
+
+**Options:** `--from TEXT`, `-d/--description TEXT`, `-f/--force`
+
+### `config new`
+
+Create infrastructure from blueprints.
+
+```bash
+foundry config new create basic-vm ./my-new-vm
+```
+
+**Subcommands:** `create <blueprint-name> <target-dir>`
+
+### `config migrate`
+
+Migrate existing infrastructure to InfraFoundry configuration by reading from provider APIs.
+
+```bash
+foundry config migrate --env prod --provider opnsense --component kea/dhcp
+foundry config migrate --env prod --provider opnsense --component isc-to-kea
+foundry config migrate --env prod --provider opnsense --component isc-to-kea -i lan -i wan
+foundry config migrate --env prod --provider opnsense --component isc-to-kea --dry-run
+```
+
+**Options:** `-e/--env TEXT` (required), `-p/--provider [opnsense]` (required), `-c/--component [kea/dhcp|isc-to-kea]` (required), `-i/--interfaces TEXT` (repeatable), `-o/--output TEXT`, `--dry-run`
+
+### `config export`
+
+Export provider configuration to InfraFoundry YAML.
+
+```bash
+foundry config export --env prod --output ./exported --provider proxmox
+foundry config export --env prod --output ./exported --provider proxmox --node pve01 --resource-type vm
+```
+
+**Options:** `-e/--env TEXT` (required), `-o/--output DIRECTORY` (required), `-p/--provider [proxmox]`, `--node TEXT`, `--resource-type [vm|network|storage]`
+
+### `config schema`
+
+Export JSON schemas for IDE autocomplete.
+
+```bash
+foundry config schema export                    # export to .schemas/
+foundry config schema export --output ./schemas # export to custom dir
+foundry config schema list                      # list available schemas
+foundry config schema show settings             # show a schema
+foundry config schema show resources --format yaml
+```
+
+**Subcommands:** `export [--output PATH]`, `list`, `show <name> [--format json|yaml]`
+
+Available schemas: `settings`, `resources`, `backend`, `hooks`, `resource`.
+
+---
+
+## Infra Group (`foundry infra`)
+
+Day-2 infrastructure operations: plan, apply, destroy, drift, rollback, security, testing, and analysis.
+
+### `infra doctor`
+
+Validate infrastructure against provider APIs (connectivity, nodes, storage, networks, templates, resource IDs, MAC conflicts).
+
+```bash
+foundry infra doctor --env dev
+foundry infra doctor --env dev --resource vm-01 --resource vm-02
+foundry infra doctor --env dev --verbose
+```
+
+**Options:** `-e/--env TEXT` (required), `-r/--resource TEXT` (repeatable), `-v/--verbose`
+
+### `infra plan`
+
+Generate Terraform/Ansible files for an environment.
+
+```bash
+foundry infra plan --env dev
+foundry infra plan --env dev --dry-run
+foundry infra plan --env dev --resource vm-01 --resource vm-02
+foundry infra plan --env dev --package ontap-cluster
+foundry infra plan --env dev --enforce-policies
+```
+
+**Options:** `-e/--env TEXT` (required), `--dry-run`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `--enforce-policies`
+
+Note: `--resource` and `--package` are mutually exclusive.
+
+### `infra apply`
+
+Deploy infrastructure changes.
+
+```bash
+foundry infra apply --env dev
+foundry infra apply --env dev --auto-approve
+foundry infra apply --env dev --package ontap-cluster --auto-approve
+foundry infra apply --env dev --parallel --max-workers 8
+foundry infra apply --env dev --lock-timeout 300 --lock-ttl 1800
+```
+
+**Options:** `-e/--env TEXT` (required), `--auto-approve`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `--parallel`, `--max-workers INTEGER` (default: 4), `--lock-timeout INTEGER` (default: 0), `--lock-ttl INTEGER` (default: 600)
+
+**Lock options:** `--lock-timeout` sets how long to wait for an existing lock before failing. `--lock-ttl` sets how long the lock is valid before considered stale (auto-extended every `ttl / 3` while running).
+
+### `infra destroy`
+
+Tear down infrastructure.
+
+```bash
+foundry infra destroy --env dev --auto-approve
+foundry infra destroy --env dev --package ontap-cluster
+foundry infra destroy --env dev --resource vm-01
+```
+
+**Options:** `-e/--env TEXT` (required), `--auto-approve`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `--lock-timeout INTEGER`, `--lock-ttl INTEGER`
+
+### `infra drift`
+
+Detect and remediate infrastructure drift. This is a command group with three subcommands.
+
+```bash
+# Detect drift
+foundry infra drift detect --env dev
+
+# Auto-remediate within configured thresholds
+foundry infra drift remediate --env dev --auto-approve
+foundry infra drift remediate --env dev --dry-run
+foundry infra drift remediate --env dev --auto-approve --max-changes 10
+foundry infra drift remediate --env dev --auto-approve --max-add 5 --max-change 3 --max-destroy 0
+
+# View remediation history
+foundry infra drift history
+foundry infra drift history --env dev --limit 20
+```
+
+**Subcommands:**
+
+- `detect` -- `-e/--env TEXT` (required)
+- `remediate` -- `-e/--env TEXT` (required), `--auto-approve`, `--dry-run`, `--max-changes INTEGER`, `--max-add INTEGER`, `--max-change INTEGER`, `--max-destroy INTEGER`
+- `history` -- `-e/--env TEXT`, `-n/--limit INTEGER` (default: 10)
+
+### `infra deployed`
+
+Show deployment status and resources for an environment.
+
+```bash
+foundry infra deployed --env prod
+foundry infra deployed --env prod --format json
+```
+
+**Options:** `-e/--env TEXT` (required), `--format [text|json]`
+
+### `infra history`
+
+Show deployment history with optional filters.
+
+```bash
+foundry infra history --env prod
+foundry infra history --env prod --command apply --status completed
+foundry infra history --limit 20
+foundry infra history --exclude-dry-runs --format json
+```
+
+**Options:** `-e/--env TEXT`, `-c/--command [plan|apply|destroy]`, `-s/--status [completed|failed|in_progress|planned]`, `-n/--limit INTEGER`, `--exclude-dry-runs`, `--format [text|json]`
+
+### `infra list`
+
+List configured packages in an environment (from YAML configuration).
+
+```bash
+foundry infra list --env dev
+foundry infra list --env dev --format json
+```
+
+**Options:** `-e/--env TEXT` (required), `--format [text|json]`
+
+### `infra move-package`
+
+Move a package from one environment to another. Relocates the config directory, copies Terraform state, removes moved resources from source state, and updates the InfraFoundry state database.
+
+```bash
+foundry infra move-package --env dev --package my-app --to-env staging
+foundry infra move-package --env dev --package my-app --to-env staging --create-env
+foundry infra move-package --env dev --package my-app --to-env staging --dry-run
+```
+
+**Options:** `-e/--env TEXT` (required), `-p/--package TEXT` (required), `--to-env TEXT` (required), `--create-env`, `--dry-run`
+
+### `infra analyze`
+
+Analysis and visualization command group.
+
+```bash
+# Show dependency graph
+foundry infra analyze dependencies --env prod --format mermaid > deps.mmd
+foundry infra analyze dependencies --env prod --resource proxmox:vm-web-01
+
+# Analyze change impact
+foundry infra analyze impact --env prod --resource vm-database-01
+
+# Generate visual topology
+foundry infra analyze graph --env dev --format mermaid > graph.mmd
+```
+
+**Subcommands:**
+
+- `dependencies` -- `-e/--env TEXT` (required), `-r/--resource TEXT`, `--format [list|mermaid]` (default: list)
+- `impact` -- `-e/--env TEXT` (required), `-r/--resource TEXT` (required)
+- `graph` -- `-e/--env TEXT` (required), `-f/--format [mermaid]`
+
+### `infra rollback`
+
+Rollback infrastructure to a previous deployment state. This is a command group with two subcommands.
+
+```bash
+# List available rollback points
+foundry infra rollback list --env prod
+foundry infra rollback list --env prod --limit 5
+
+# Rollback to a specific deployment
+foundry infra rollback to 42
+foundry infra rollback to 42 --auto-approve
+```
+
+**Subcommands:**
+
+- `list` -- `-e/--env TEXT` (required), `-l/--limit INTEGER`
+- `to <deployment-id>` -- `--auto-approve`
+
+### `infra security`
+
+Scan infrastructure configurations for security issues using Checkov.
+
+```bash
+foundry infra security --env prod
+foundry infra security --env dev --severity medium
+foundry infra security --env staging --skip-check CKV_AWS_1 --skip-check CKV_AWS_2
+foundry infra security --env prod --output json
+```
+
+**Options:** `-e/--env TEXT` (required), `-s/--severity [critical|high|medium|low|info]` (default: high), `--skip-check TEXT` (repeatable), `-o/--output [table|json]`, `--timeout INTEGER` (default: 300)
+
+### `infra test`
+
+Run infrastructure tests against configurations.
+
+```bash
+foundry infra test --env prod
+foundry infra test --env dev --verbose
+foundry infra test --env staging --test no_duplicate_names
+foundry infra test --env prod --output json
+```
+
+**Options:** `-e/--env TEXT` (required), `-t/--test TEXT` (repeatable), `-o/--output [table|json]`, `-v/--verbose`
+
+### `infra status`
+
+Show infrastructure status for an environment.
+
+```bash
+foundry infra status --env prod
+```
+
+**Options:** `-e/--env TEXT` (required)
+
+### `infra reset`
+
+Reset (wipe) infrastructure components for a clean reapply. Currently supports OPNsense Kea components.
+
+```bash
+foundry infra reset --env prod --provider opnsense --component kea/dhcpv4
+foundry infra reset --env prod --provider opnsense --component kea/dhcp --auto-approve
+```
+
+**Options:** `-e/--env TEXT` (required), `-p/--provider [opnsense]` (required), `-c/--component [kea/dhcpv4|kea/dhcpv6|kea/dhcp]` (required), `--auto-approve`
+
+### `infra unlock`
+
+Release or inspect deployment locks.
+
+```bash
+foundry infra unlock --list                    # list all locks
+foundry infra unlock --env prod                # release expired lock
+foundry infra unlock --env prod --force --yes  # force-release active lock
+```
+
+**Options:** `-e/--env TEXT` (required unless `--list`), `--force`, `--yes`, `--list`
+
+Set `INFRAFOUNDRY_SKIP_LOCK=1` to bypass locking entirely (emergency use only).
+
+---
+
+## State Group (`foundry state`)
+
+State database management: initialization, backup, resource tracking, backend migration, and audit trail.
+
+### `state init`
+
+Initialize the InfraFoundry state database (SQLite by default).
+
+```bash
+foundry state init
+```
+
+### `state list`
+
+List all resources in an environment from the state database.
+
+```bash
+foundry state list --env prod
+foundry state list --env prod --provider proxmox --type vms
+foundry state list --env prod --format json
+```
+
+**Options:** `-e/--env TEXT` (required), `-p/--provider TEXT`, `-t/--type TEXT`, `--format [text|json]`
+
+### `state resources`
+
+List tracked infrastructure resources from the state database.
+
+```bash
+foundry state resources
+foundry state resources --env prod --state ACTIVE
+foundry state resources --provider proxmox --type vm
+```
+
+**Options:** `-e/--env TEXT`, `-p/--provider TEXT`, `-t/--type TEXT`, `-s/--state [PLANNED|CREATING|ACTIVE|DELETING|DELETED|FAILED]`
+
+### `state backup`
+
+Create a timestamped backup of the state database. Optionally includes the `generated/` directory.
+
+```bash
+foundry state backup
+foundry state backup --output-dir ./backups
+foundry state backup --output-dir ./backups --include-generated
+```
+
+**Options:** `-o/--output-dir DIRECTORY`, `-g/--include-generated`
+
+### `state backend`
+
+Manage Terraform backend configuration.
+
+```bash
+# Validate backend configuration
+foundry state backend validate --env prod
+
+# Migrate state between backends
+foundry state backend migrate --env prod
+foundry state backend migrate --env prod --from local --to s3
+foundry state backend migrate --env prod --auto-approve
+```
+
+**Subcommands:**
+
+- `validate` -- `-e/--env TEXT` (required)
+- `migrate` -- `-e/--env TEXT` (required), `--from [local|s3|gcs|azurerm|postgres|remote]`, `--to [local|s3|gcs|azurerm|postgres|remote]`, `--auto-approve`
+
+### `state audit`
+
+View and export audit trail for compliance.
+
+```bash
+# List audit entries
+foundry state audit list --env prod
+foundry state audit list --user admin --since 2024-01-01
+foundry state audit list --action apply_completed --limit 100
+
+# Export for compliance reporting
+foundry state audit export --output audit.json
+foundry state audit export --format csv --output report.csv --env prod --since 2024-01-01
+
+# Verify integrity
+foundry state audit verify 123
+```
+
+**Subcommands:**
+
+- `list` -- `-e/--env TEXT`, `-u/--user TEXT`, `-a/--action TEXT`, `--since TEXT`, `--until TEXT`, `-n/--limit INTEGER` (default: 50), `--format [text|json]`
+- `export` -- `-o/--output FILE` (required), `-f/--format [json|csv]`, `-e/--env TEXT`, `-u/--user TEXT`, `-a/--action TEXT`, `--since TEXT`, `--until TEXT`
+- `verify <entry-id>`
+
+---
+
+## Secrets Group (`foundry secrets`)
+
+SOPS/age secret lifecycle management.
+
+### `secrets init`
+
+Initialize secrets with a new age key.
+
+```bash
+foundry secrets init
+foundry secrets init --key-file /path/to/age.key
+```
+
+**Options:** `--key-file TEXT`
+
+### `secrets encrypt`
+
+Encrypt a file with SOPS.
+
+```bash
+foundry secrets encrypt envs/dev/secrets.yaml
+```
+
+### `secrets decrypt`
+
+Decrypt and display a SOPS-encrypted file.
+
+```bash
+foundry secrets decrypt envs/dev/secrets.yaml
+```
+
+### `secrets rotate`
+
+Rotate secrets with a new age encryption key. Re-encrypts all secrets with a new key, with automatic rollback on failure.
+
+```bash
+foundry secrets rotate --env dev --generate-new-key
+foundry secrets rotate --env prod --new-key-file /path/to/new_age.key
+foundry secrets rotate --env dev --generate-new-key --files proxmox.yaml --files opnsense.yaml
+foundry secrets rotate --env dev --generate-new-key --dry-run
+```
+
+**Options:** `-e/--env TEXT` (required), `--new-key-file PATH`, `--generate-new-key`, `--files TEXT` (repeatable), `--no-verify`, `--no-backup`, `--dry-run`
+
+---
+
+## Policy Group (`foundry policy`)
+
+### `policy list`
+
+List available infrastructure policies.
+
+```bash
+foundry policy list
+foundry policy list --env prod
+```
+
+**Options:** `-e/--env TEXT`
+
+---
 
 ## Configuration Details
 
-- **Global options:**
-  - `--config-dir/-c PATH` (overrides `INFRAFOUNDRY_CONFIG_REPO`)
-  - `--strict-mode/--no-strict-mode`
-  - `--fail-on-missing-secrets | --allow-missing-secrets`
-  - `--fail-on-missing-snippets | --allow-missing-snippets`
-  - Environment equivalents: `INFRAFOUNDRY_STRICT_MODE`, `INFRAFOUNDRY_FAIL_ON_MISSING_SECRETS`, `INFRAFOUNDRY_FAIL_ON_MISSING_SNIPPETS`.
 - **State:** InfraFoundry DB at `~/.infrafoundry/state.db` (unless overridden); Terraform state under `generated/{env}/terraform/{provider}`.
 - **Generated artifacts:** `generated/{env}/{terraform|ansible}/{provider}`; always reproducible from YAML.
 
-## Commands and Examples
+## Full Command Tree
 
-- **Health Checks (doctor commands)**
-  - `foundry doctor [--format text|json]` — check system dependencies (Terraform, OpenTofu, Ansible, SOPS, Age).
-  - `foundry config doctor [--format text|json] [--deep]` — check config repo health: config repo structure, environments, state backend, SOPS keys, state/filesystem consistency, blueprint validation.
-  - `foundry infra doctor --env <env> [--resource <name>]... [--verbose]` — validate infrastructure against provider APIs (connectivity, nodes, storage, networks, templates, etc.).
-- **Initialization**
-  - `infra init` — create state DB (SQLite by default).
-- **Blueprints**
-  - `infra new list` — list blueprints.
-  - `infra new create <blueprint> <path>` — scaffold from blueprint.
-- **Environment introspection**
-  - `infra envs` — list environments with sync status (OK/FS-ONLY/DB-ONLY) showing consistency between filesystem and state database.
-  - `infra list --env <env> [--provider ... --type ...]` — list resources from YAML.
-  - `infra resources [--env ... --provider ... --type ... --state ...]` — list tracked resources from state DB.
-  - `infra status --env <env>` — show deployment status.
-  - `infra history [--env <env>]` — view deployment history.
-  - `infra diff --env-a <env1> --env-b <env2> [--provider ...] [--verbose]` — compare configurations between two environments.
-- **Plan/Apply/Destroy**
-  - `infra plan --env <env> [--resource ...] [--package <name>] [--dry-run]`
-  - `infra apply --env <env> [--resource ...] [--package <name>] [--auto-approve] [--lock-timeout <seconds>] [--lock-ttl <seconds>]`
-  - `infra destroy --env <env> [--resource ...] [--package <name>] [--auto-approve] [--lock-timeout <seconds>] [--lock-ttl <seconds>]`
-  - `infra reset --env <env> --provider <provider> --component <component> [--auto-approve]` — completely remove component configuration from provider for clean reapply.
-  - **Lock options on apply/destroy:**
-    - `--lock-timeout <seconds>` — how long to wait for an existing lock before failing. Default `0` (fail fast).
-    - `--lock-ttl <seconds>` — how long the acquired lock is valid before it is considered stale. The lock is auto-extended every `ttl / 3` seconds while the process runs, so this only governs stale-lock recovery after a crash. Default `600` (10 minutes).
-- **Locking**
-  - `infra unlock --env <env>` — release an expired lock for the environment (refuses to release active locks).
-  - `infra unlock --env <env> --force [--yes]` — force-release an active lock; prompts for confirmation unless `--yes` is supplied.
-  - `infra unlock --list` — list all current deployment locks across environments.
-  - Set `INFRAFOUNDRY_SKIP_LOCK=1` to bypass locking entirely (emergency use only — emits a loud warning).
-- **Rollback and Recovery**
-  - `infra rollback-points --env <env> [--limit <n>]` — list available rollback points for an environment.
-  - `infra rollback --deployment-id <id> [--auto-approve]` — rollback infrastructure to a previous deployment state.
-- **State Management**
-  - `infra state backup [--output-dir <dir>] [--include-generated]` — create timestamped backup of state database and optionally the generated/ directory.
-- **Validation and Drift**
-  - `infra doctor --env <env> [--resource <name>]... [--verbose]` — pre-flight validation against provider APIs.
-  - `infra drift --env <env>`
-- **Policies**
-  - `infra policies check --env <env> [--enforce]`
-- **Secrets**
-  - `infra secrets init|encrypt|decrypt`
-- **Dependency Analysis** (under `infra analyze`)
-  - `infra analyze dependencies --env <env> [--resource <provider:name>] [--format list|mermaid]` — show dependency graph or analyze specific resource dependencies.
-  - `infra analyze impact --env <env> --resource <name>` — analyze the impact of changes to a resource and show what depends on it.
-  - `infra analyze graph --env <env> --format mermaid|dot` — generate visual topology graph.
-- **Configuration Export**
-  - `config export --env <env> --output <dir> [--provider proxmox] [--node ...] [--resource-type ...]` — export provider configuration to InfraFoundry YAML.
-- **Schema Management** (under `config schema`)
-  - `config schema export [--output <dir>]` — export all JSON schemas for IDE autocomplete.
-  - `config schema list` — list available schemas.
-  - `config schema show <name> [--format json|yaml]` — show a specific schema.
-- **Audit Trail** (under `state audit`)
-  - `state audit list [--env ... --user ... --action ... --limit ... --since ...]` — list audit entries.
-  - `state audit export --output <file> [--format json|csv] [--env ... --since ...]` — export audit entries.
-  - `state audit verify <ENTRY_ID>` — verify integrity of an audit entry.
-
-## Validation and Checks
-
-- Prefer `infra doctor --env <env>` before `plan`/`apply` to catch configuration errors early.
-- Use `--strict-mode` to treat missing secrets/snippets as errors.
-- Inspect generated files under `generated/` if behavior is unexpected.
-
-## Examples
-
-- **Target specific resources:**
-  ```bash
-  infra plan --env dev --resource vm-01 --resource vm-02
-  infra apply --env dev --resource vm-01 --auto-approve
-  ```
-- **Target an entire package:**
-  ```bash
-  infra plan --env dev --package ontap-cluster
-  infra apply --env dev -p ontap-cluster --auto-approve
-  infra destroy --env dev -p ontap-cluster
-  ```
-  Note: `--package` (`-p`) and `--resource` (`-r`) are mutually exclusive.
-- **Rollback to previous deployment:**
-  ```bash
-  # View deployment history to find deployment ID
-  infra history --env prod
-
-  # Rollback to deployment ID 42
-  infra rollback --deployment-id 42
-
-  # Rollback without confirmation prompt (use with caution)
-  infra rollback --deployment-id 42 --auto-approve
-  ```
-- **Backup state and generated files:**
-  ```bash
-  # Backup state database only
-  infra state backup --output-dir ./backups
-
-  # Backup state database and generated/ directory
-  infra state backup --output-dir ./backups --include-generated
-
-  # Creates timestamped files:
-  # - infrafoundry_state_20250127_143022.db
-  # - infrafoundry_generated_20250127_143022.tar.gz (if --include-generated)
-  ```
-- **Compare environments:**
-  ```bash
-  # Compare dev and prod configurations
-  infra diff --env-a dev --env-b prod
-
-  # Compare specific provider configurations
-  infra diff --env-a dev --env-b prod --provider proxmox
-
-  # Show detailed differences for changed resources
-  infra diff --env-a dev --env-b prod --verbose
-  ```
-- **Analyze dependencies and impact:**
-  ```bash
-  # Show full dependency graph for environment
-  infra analyze dependencies --env prod --format mermaid > deps.mmd
-
-  # Analyze dependencies for specific resource
-  infra analyze dependencies --env prod --resource proxmox:vm-web-01
-
-  # Analyze impact of changing a resource
-  infra analyze impact --env prod --resource vm-database-01
-  # Shows: What resources depend on vm-database-01 and risk level
-  ```
-- **Reset component configuration:**
-  ```bash
-  # Reset Kea DHCPv4 configuration on OPNsense
-  infra reset --env prod --provider opnsense --component kea/dhcpv4
-
-  # Reset both DHCPv4 and DHCPv6 (without confirmation)
-  infra reset --env prod --provider opnsense --component kea/dhcp --auto-approve
-  ```
-- **Export provider configuration:**
-  ```bash
-  # Export all Proxmox resources to YAML
-  config export --env prod --output ./exported --provider proxmox
-
-  # Export only VMs from specific node
-  config export --env prod --output ./exported --provider proxmox --node pve01 --resource-type vm
-
-  # Export network configurations
-  config export --env prod --output ./exported --provider proxmox --resource-type network
-  ```
-- **List rollback points:**
-  ```bash
-  # List all available rollback points
-  infra rollback-points --env prod
-
-  # List only last 5 rollback points
-  infra rollback-points --env prod --limit 5
-  ```
-- **Check configuration health:**
-  ```bash
-  # Full config repo health check
-  config doctor
-
-  # Detailed check with resource counts per environment
-  config doctor --deep
-
-  # JSON output for scripting or CI pipelines
-  config doctor --format json
-  ```
-- **Policy enforcement in CI:**
-  ```bash
-  infra policies check --env prod --enforce
-  ```
-- **Drift detection:**
-  ```bash
-  infra drift --env prod
-  ```
-- **Manage deployment locks:**
-  ```bash
-  # Wait up to 5 minutes for an active lock before failing
-  infra apply --env prod --lock-timeout 300
-
-  # Use a longer TTL as a safety net (the lock is auto-extended while the
-  # process runs; this only matters for recovering from a crashed holder).
-  infra apply --env prod --lock-ttl 1800
-
-  # Inspect current locks
-  infra unlock --list
-
-  # Release an expired lock
-  infra unlock --env prod
-
-  # Force-release an active lock (use with caution)
-  infra unlock --env prod --force --yes
-  ```
-- **Graph dependencies:**
-  ```bash
-  infra analyze graph --env dev --format mermaid > graph.mmd
-  ```
+```
+foundry
++-- doctor [--format text|json]
++-- completion
+|   +-- bash
+|   +-- zsh
+|   +-- fish
+|   +-- uninstall
++-- config
+|   +-- doctor [--format text|json] [--deep]
+|   +-- envs [--format text|json]
+|   +-- diff --env-a <env1> --env-b <env2> [-p provider] [-v]
+|   +-- show -e <env> [-p provider] [-t type] [-r resource] [--format] [--settings-only]
+|   +-- init <name> [--from <env>] [-d desc] [-f]
+|   +-- new
+|   |   +-- create <blueprint> <target-dir>
+|   +-- migrate -e <env> -p <provider> -c <component> [-i interfaces] [--dry-run]
+|   +-- export -e <env> -o <dir> [-p provider] [--node] [--resource-type]
+|   +-- schema
+|       +-- export [-o path]
+|       +-- list
+|       +-- show <name> [--format json|yaml]
++-- infra
+|   +-- doctor -e <env> [-r resource] [-v]
+|   +-- plan -e <env> [--dry-run] [-r resource] [-p package] [--enforce-policies]
+|   +-- apply -e <env> [--auto-approve] [-r resource] [-p package] [--parallel] [--max-workers] [--lock-timeout] [--lock-ttl]
+|   +-- destroy -e <env> [--auto-approve] [-r resource] [-p package] [--lock-timeout] [--lock-ttl]
+|   +-- drift
+|   |   +-- detect -e <env>
+|   |   +-- remediate -e <env> [--auto-approve] [--dry-run] [--max-changes] [--max-add] [--max-change] [--max-destroy]
+|   |   +-- history [-e env] [-n limit]
+|   +-- deployed -e <env> [--format text|json]
+|   +-- history [-e env] [-c command] [-s status] [-n limit] [--exclude-dry-runs] [--format text|json]
+|   +-- list -e <env> [--format text|json]
+|   +-- move-package -e <env> -p <package> --to-env <env> [--create-env] [--dry-run]
+|   +-- analyze
+|   |   +-- dependencies -e <env> [-r resource] [--format list|mermaid]
+|   |   +-- impact -e <env> -r <resource>
+|   |   +-- graph -e <env> [-f mermaid]
+|   +-- rollback
+|   |   +-- list -e <env> [-l limit]
+|   |   +-- to <deployment-id> [--auto-approve]
+|   +-- security -e <env> [-s severity] [--skip-check] [-o table|json] [--timeout]
+|   +-- test -e <env> [-t test] [-o table|json] [-v]
+|   +-- status -e <env>
+|   +-- reset -e <env> -p <provider> -c <component> [--auto-approve]
+|   +-- unlock [-e env] [--force] [--yes] [--list]
++-- state
+|   +-- init
+|   +-- list -e <env> [-p provider] [-t type] [--format text|json]
+|   +-- resources [-e env] [-p provider] [-t type] [-s state]
+|   +-- backup [-o dir] [-g]
+|   +-- backend
+|   |   +-- validate -e <env>
+|   |   +-- migrate -e <env> [--from backend] [--to backend] [--auto-approve]
+|   +-- audit
+|       +-- list [-e env] [-u user] [-a action] [--since] [--until] [-n limit] [--format text|json]
+|       +-- export -o <file> [-f json|csv] [-e env] [-u user] [-a action] [--since] [--until]
+|       +-- verify <entry-id>
++-- secrets
+|   +-- init [--key-file]
+|   +-- encrypt <file>
+|   +-- decrypt <file>
+|   +-- rotate -e <env> [--new-key-file | --generate-new-key] [--files] [--no-verify] [--no-backup] [--dry-run]
++-- policy
+    +-- list [-e env]
+```
 
 ## Related Documentation
 
@@ -252,13 +718,13 @@ infra destroy --env dev --auto-approve
 
 - **Symptom:** Missing configs. **Fix:** Set `--config-dir` or `INFRAFOUNDRY_CONFIG_REPO`; ensure `envs/{env}` exists.
 - **Symptom:** Commands fail due to missing secrets/snippets. **Fix:** Enable `--strict-mode` to surface early, or allow missing during development; ensure SOPS keys are available.
-- **Symptom:** Unexpected resource lists. **Fix:** Use `infra list` (YAML view) vs `infra resources` (state DB view) to differentiate declared vs tracked resources.
-- **Symptom:** `infra envs` shows FS-ONLY or DB-ONLY for some environments. **Fix:** Run `config doctor --deep` for a detailed consistency report. FS-ONLY means the environment directory exists but is not tracked in the state database (run `infra plan` to populate). DB-ONLY means the state database has records for an environment whose config directory has been removed.
-- **Symptom:** Rollback fails with "deployment not found". **Fix:** Use `infra history` or `infra rollback-points --env <env>` to verify deployment ID exists and has rollback data available.
+- **Symptom:** Unexpected resource lists. **Fix:** Use `foundry infra list` (YAML-defined packages) vs `foundry state resources` (state DB tracked resources) to differentiate declared vs tracked resources.
+- **Symptom:** `config envs` shows FS-ONLY or DB-ONLY. **Fix:** Run `foundry config doctor --deep` for a detailed consistency report. FS-ONLY means the environment directory exists but is not tracked in the state database (run `foundry infra plan` to populate). DB-ONLY means the state database has records for an environment whose config directory has been removed.
+- **Symptom:** Rollback fails with "deployment not found". **Fix:** Use `foundry infra history` or `foundry infra rollback list --env <env>` to verify deployment ID exists and has rollback data available.
 - **Symptom:** State backup skips database file. **Fix:** Ensure using SQLite backend (default); PostgreSQL and other remote databases cannot be backed up via file copy.
-- **Symptom:** `diff` shows no differences but configs look different. **Fix:** Check if provider filtering is hiding changes; remove `--provider` flag to see all differences.
-- **Symptom:** `infra analyze dependencies` or `infra analyze impact` shows unexpected results. **Fix:** Ensure resources are loaded from YAML; check `get_dependencies()` implementation in provider.
-- **Symptom:** `reset` command fails or doesn't clean properly. **Fix:** Verify provider and component names are correct; currently only supports OPNsense Kea components (kea/dhcpv4, kea/dhcpv6, kea/dhcp).
+- **Symptom:** `config diff` shows no differences but configs look different. **Fix:** Check if provider filtering is hiding changes; remove `--provider` flag to see all differences.
+- **Symptom:** `infra analyze` shows unexpected results. **Fix:** Ensure resources are loaded from YAML; check `get_dependencies()` implementation in provider.
+- **Symptom:** `infra reset` fails or doesn't clean properly. **Fix:** Verify provider and component names are correct; currently only supports OPNsense Kea components (kea/dhcpv4, kea/dhcpv6, kea/dhcp).
 - **Symptom:** `config export` fails to connect. **Fix:** Verify environment credentials in `settings.yaml`; ensure provider API is accessible and credentials have read permissions.
 
 ---

--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-InfraFoundry validation catches configuration, reference, and connectivity issues **before** `infra plan` or `infra apply` to keep deployments safe and predictable.
+InfraFoundry provides a three-tier validation system to catch configuration, reference, and connectivity issues **before** `foundry infra plan` or `foundry infra apply`, keeping deployments safe and predictable.
 
 ## Audience and Prerequisites
 
 - **Audience:** Operators and CI pipelines running plan/apply workflows.
-- **Prereqs:** Config repo available, `uv run infra` installed, provider credentials and network access for targeted environments.
+- **Prerequisites:** Config repo available, `foundry` installed via `uv`, provider credentials and network access for targeted environments.
 
 ## When to Use This
 
@@ -15,41 +15,46 @@ InfraFoundry validation catches configuration, reference, and connectivity issue
 - After editing settings, resources, or secrets to ensure structural integrity.
 - In CI to block merges when validation fails.
 
+## Three-Tier Doctor System
+
+InfraFoundry validation is organized into three levels, each checking a different scope:
+
+| Level | Command | What It Checks |
+|-------|---------|----------------|
+| **System** | `foundry doctor` | Binary dependencies (Terraform, OpenTofu, Ansible, SOPS, Age) |
+| **Config** | `foundry config doctor [--deep]` | Config repo structure, environments, state backend, SOPS keys, state/filesystem consistency, blueprint validation |
+| **Infrastructure** | `foundry infra doctor --env <env>` | Provider API connectivity, nodes/hosts, storage pools, network bridges, templates, resource IDs, MAC conflicts |
+
 ## Quick Start
 
 ```bash
-infra validate --env dev
-infra validate --env prod --check-api --check-refs
+# Check system dependencies
+foundry doctor
+
+# Check config repo health
+foundry config doctor --deep
+
+# Validate against provider APIs
+foundry infra doctor --env dev
+foundry infra doctor --env dev --resource vm-01 --resource vm-02
+foundry infra doctor --env dev --verbose
 ```
 
-- `--check-api` validates provider endpoints and credentials.
-- `--check-refs` validates referenced templates, networks, aliases, namespaces, and other dependencies.
+## Additional Validation Commands
 
-## Configuration Details
+Beyond the doctor commands, InfraFoundry offers additional validation tools:
 
-- **Command:** `infra validate --env <env> [--check-api] [--check-refs]`
-- **Environment discovery:** Uses `--env` with `--config-dir` or `INFRAFOUNDRY_CONFIG_REPO`.
-- **Severity levels:** `ERROR` (blocks), `WARNING` (review), `INFO` (informational).
-- **Always checked:** YAML syntax, environment structure (`settings.yaml`, resource files), supported provider/resource types, provider registration, required fields.
-- **API checks:** Proxmox (endpoint/token/node), OPNsense (endpoint/key/secret/firewall), Kubernetes (kubeconfig/cluster/namespace).
-- **Reference checks:** Templates, networks/bridges/storage (Proxmox); aliases/VLANs/interfaces (OPNsense); namespaces/configmaps/secrets (Kubernetes).
-
-## Validation and Checks
-
-- Run baseline checks with `infra validate --env <env>`.
-- Add `--check-api` to surface credential or connectivity issues early.
-- Add `--check-refs` to ensure referenced resources exist before plan/apply.
-- Output summarizes per-provider checks and reports blocking `ERROR` entries.
+- **`foundry infra test --env <env>`** -- Run infrastructure tests against configurations (duplicate names, missing references, configuration problems).
+- **`foundry infra security --env <env>`** -- Scan generated Terraform/Ansible for security issues using Checkov.
+- **`foundry infra analyze dependencies --env <env>`** -- Verify dependency graph is acyclic and references resolve.
 
 ## Examples
 
-- **Basic validation:**
+- **Pre-deployment validation:**
   ```bash
-  infra validate --env dev
-  ```
-- **Pre-deployment validation with external checks:**
-  ```bash
-  infra validate --env prod --check-api --check-refs
+  foundry config doctor --deep
+  foundry infra doctor --env prod
+  foundry infra test --env prod
   ```
 - **CI usage (GitHub Actions excerpt):**
   ```yaml
@@ -58,18 +63,9 @@ infra validate --env prod --check-api --check-refs
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
-        - run: infra validate --env prod --check-api --check-refs
-  ```
-- **Provider extension (custom connectivity check):**
-  ```python
-  class MyProvider(ProviderBase):
-      def validate_connectivity(self, env_config: dict[str, Any], report: ValidationReport) -> None:
-          api_url = env_config["provider_settings"]["myprovider"]["api_url"]
-          response = requests.get(f"{api_url}/health")
-          passed = response.status_code == 200
-          level = ValidationLevel.INFO if passed else ValidationLevel.ERROR
-          message = "Connected" if passed else f"API returned {response.status_code}"
-          report.add_check("myprovider_connectivity", passed=passed, message=message, level=level)
+        - run: foundry config doctor --deep
+        - run: foundry infra doctor --env prod
+        - run: foundry infra test --env prod
   ```
 
 ## Related Documentation
@@ -81,13 +77,13 @@ infra validate --env prod --check-api --check-refs
 
 ## Troubleshooting
 
-- **Symptom:** Missing templates/networks. **Fix:** Create the resource in the provider or update the reference; rerun with `--check-refs`.
-- **Symptom:** API check failures. **Fix:** Verify endpoints, tokens, kubeconfig, and network reachability; test with provider CLIs.
+- **Symptom:** Missing templates/networks in doctor output. **Fix:** Create the resource in the provider or update the configuration reference; rerun `foundry infra doctor --env <env>`.
+- **Symptom:** Doctor reports API failures. **Fix:** Verify endpoints, tokens, kubeconfig, and network reachability; test with provider CLIs.
 - **Symptom:** Unknown resource/provider. **Fix:** Confirm resource type spelling and provider availability in the current framework version.
 
 ---
 
-Last updated: 2025-12-23 14:12 GMT
+Last updated: 2026-04-13 GMT
 
 
 ---


### PR DESCRIPTION
## Description

Rewrites CLI documentation to match the current command structure after #599 (three-tier doctor) and #600 (CLI reorganization). The existing docs referenced many non-existent commands and missed many real ones.

Addresses #601

## Type of Change

- [x] Documentation update

## Changes Made

- **`docs/usage/cli-reference.md`** — Full rewrite with command domain model, quick reference decision tree, and accurate per-group sections
- **`AGENTS.md`** — CLI & Operations section rewritten with complete command list
- **`docs/usage/validation.md`** — Updated for three-tier doctor system
- **40+ other docs files** — Fixed stale command references

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
