### PR TITLE
feat: add inputs section to blueprint schema for required user variables

### DIFF
--- a/blueprints/aiqum/blueprint.yaml
+++ b/blueprints/aiqum/blueprint.yaml
@@ -2,38 +2,77 @@ name: aiqum
 description: "NetApp Active IQ Unified Manager on Rocky 9 (Proxmox VM)"
 version: "1.0.0"
 
-defaults:
+inputs:
+  # --- Required per-instance inputs (no default) ---
+  - name: vm_name
+    description: "Hostname and Proxmox VM name for the AIQUM VM"
+  - name: vmid
+    description: "Proxmox VM ID"
+    type: integer
+  - name: target_node
+    description: "Proxmox node to deploy the AIQUM VM onto"
+  - name: disk_storage
+    description: "Proxmox storage pool for the AIQUM VM disk"
+  - name: ip_address
+    description: "Static IPv4 address for the AIQUM VM (DHCP reservation)"
+  - name: dhcp_subnet
+    description: "OPNsense DHCP subnet identifier used for the reservation"
+
   # --- VM hardware ---
-  template_vmid: 901          # Standard rocky9-template vmid
-  template_node: pve1         # Proxmox node hosting the template
-  cores: 4
-  memory: 12288               # AIQUM minimum recommendation (12 GiB)
-  disk_size: 150              # AIQUM minimum (~100 GB+)
+  - name: template_vmid
+    description: "Standard rocky9-template vmid"
+    default: 901
+  - name: template_node
+    description: "Proxmox node hosting the template"
+    default: pve1
+  - name: cores
+    default: 4
+  - name: memory
+    description: "AIQUM minimum recommendation (12 GiB)"
+    default: 12288
+  - name: disk_size
+    description: "AIQUM minimum (~100 GB+)"
+    default: 150
 
   # --- Network ---
-  bridge: vmbr0
-  vlan_tag: 10
-  mac_address: ""             # Empty: Proxmox auto-assigns
+  - name: bridge
+    default: vmbr0
+  - name: vlan_tag
+    default: 10
+  - name: mac_address
+    description: "Empty: Proxmox auto-assigns"
+    default: ""
 
   # --- SSH access ---
-  jumphost: ""                # Empty: direct SSH. Set to e.g. "ansible@jump.example.com"
-  ssh_user: ansible
+  - name: jumphost
+    description: 'Empty: direct SSH. Set to e.g. "ansible@jump.example.com"'
+    default: ""
+  - name: ssh_user
+    default: ansible
 
   # --- AIQUM ---
-  aiqum_url_base: ""            # URL base for AIQUM install files (e.g. http://web.example.com/aiqum)
-  aiqum_admin_user: umadmin
+  - name: aiqum_url_base
+    description: "URL base for AIQUM install files (e.g. http://web.example.com/aiqum)"
+    default: ""
+  - name: aiqum_admin_user
+    default: umadmin
 
   # --- SMTP ---
-  smtp_port: 587
+  - name: smtp_port
+    default: 587
 
   # --- Alerting ---
-  aiqum_alert_email: ""           # Empty: skip alerting. Set to receive storage alerts.
+  - name: aiqum_alert_email
+    description: "Empty: skip alerting. Set to receive storage alerts."
+    default: ""
 
   # --- ONTAP integration ---
-  ontap_admin_user: admin
+  - name: ontap_admin_user
+    default: admin
 
   # Extra Proxmox tags appended to the blueprint's default tags
-  extra_tags: []
+  - name: extra_tags
+    default: []
 
 resources:
   - vm.yaml

--- a/blueprints/k3s-cluster/blueprint.yaml
+++ b/blueprints/k3s-cluster/blueprint.yaml
@@ -2,43 +2,83 @@ name: k3s-cluster
 description: "k3s Kubernetes cluster — multi-provider (Proxmox or OCI)"
 version: "1.0.0"
 
-defaults:
-  # --- Shared cluster identity ---
-  cluster_name: k3s-cluster
-  k3s_version: ""                              # empty = latest
-  k3s_server_args: ""                          # e.g. "--disable traefik"
+inputs:
+  # --- Shared cluster identity (top-level, required for every provider) ---
+  - name: cluster_name
+    description: "Shared cluster identifier used across providers"
+    default: k3s-cluster
+  - name: k3s_version
+    description: "k3s release to install (empty = latest)"
+    default: ""
+  - name: k3s_server_args
+    description: 'Extra k3s server install flags, e.g. "--disable traefik"'
+    default: ""
 
 providers:
   # =====================================================================
   # Proxmox — Rocky 9 VMs (1 server + N agents)
   # =====================================================================
   proxmox:
-    defaults:
+    inputs:
+      # --- Required per-instance inputs ---
+      - name: server_name
+        description: "Hostname / Proxmox VM name for the k3s server"
+      - name: server_vmid
+        description: "Proxmox VM ID for the server"
+        type: integer
+      - name: server_target
+        description: "Proxmox node to deploy the server onto"
+      - name: server_ip
+        description: "Static IPv4 address for the server (DHCP reservation)"
+      - name: server_mac
+        description: "MAC address for the server's network interface"
+      - name: agents
+        description: "List of k3s agent definitions (name/vmid/target_node/mac/ip)"
+        type: list
+      - name: dhcp_subnet
+        description: "OPNsense DHCP subnet identifier used for reservations"
+
       # --- Template ---
-      template_vmid: 901          # Standard rocky9-template vmid
-      template_node: pve1         # Proxmox node hosting the template
+      - name: template_vmid
+        description: "Standard rocky9-template vmid"
+        default: 901
+      - name: template_node
+        description: "Proxmox node hosting the template"
+        default: pve1
 
       # --- VM hardware ---
-      cores: 2
-      memory: 4096                # MiB
-      disk_size: 56               # GiB
-      disk_storage: local-lvm
+      - name: cores
+        default: 2
+      - name: memory
+        description: "Memory (MiB)"
+        default: 4096
+      - name: disk_size
+        description: "Disk size (GiB)"
+        default: 56
+      - name: disk_storage
+        default: local-lvm
 
       # --- Network ---
-      bridge: vmbr0
-      vlan_tag: 10
+      - name: bridge
+        default: vmbr0
+      - name: vlan_tag
+        default: 10
 
       # --- SSH access ---
-      jumphost: ""
+      - name: jumphost
+        default: ""
 
-      # --- k3s installer flags ---
-      k3s_server_args: "--disable traefik --disable servicelb"
+      # --- k3s installer flags (proxmox override of top-level default) ---
+      - name: k3s_server_args
+        default: "--disable traefik --disable servicelb"
 
       # --- Local kubeconfig destination directory ---
-      kubeconfig_dir: "~/.kube"
+      - name: kubeconfig_dir
+        default: "~/.kube"
 
       # Extra Proxmox tags appended to the blueprint's default tags
-      extra_tags: []
+      - name: extra_tags
+        default: []
 
     resources:
       - providers/proxmox/vm.yaml
@@ -59,45 +99,72 @@ providers:
   # OCI — ARM Always-Free-Tier (1 control + N workers) with Tailscale
   # =====================================================================
   oci:
-    defaults:
-      control_name: k3s-control
+    inputs:
+      # --- Required per-instance inputs ---
+      - name: image
+        description: "OCI compute image OCID for cluster instances"
+      - name: ssh_public_key
+        description: "SSH public key material injected into instances"
+
+      - name: control_name
+        default: k3s-control
 
       # --- OCI instance sizing ---
-      instance_shape: "VM.Standard.A1.Flex"
-      control_ocpus: 2
-      control_memory_gb: 8
-      control_boot_volume_gb: 50
-      worker_boot_volume_gb: 50
+      - name: instance_shape
+        default: "VM.Standard.A1.Flex"
+      - name: control_ocpus
+        default: 2
+      - name: control_memory_gb
+        default: 8
+      - name: control_boot_volume_gb
+        default: 50
+      - name: worker_boot_volume_gb
+        default: 50
 
-      workers:
-        - name: k3s-worker-0
-          ocpus: 1
-          memory_gb: 8
-        - name: k3s-worker-1
-          ocpus: 1
-          memory_gb: 8
+      - name: workers
+        default:
+          - name: k3s-worker-0
+            ocpus: 1
+            memory_gb: 8
+          - name: k3s-worker-1
+            ocpus: 1
+            memory_gb: 8
 
       # --- Network ---
-      vcn_name: k3s-vcn
-      vcn_cidr: "10.0.0.0/16"
-      vcn_dns_label: k3svcn
-      control_subnet_name: k3s-control-subnet
-      control_subnet_cidr: "10.0.0.0/24"
-      control_subnet_dns_label: ctrl
-      worker_subnet_name: k3s-worker-subnet
-      worker_subnet_cidr: "10.0.1.0/24"
-      worker_subnet_dns_label: work
+      - name: vcn_name
+        default: k3s-vcn
+      - name: vcn_cidr
+        default: "10.0.0.0/16"
+      - name: vcn_dns_label
+        default: k3svcn
+      - name: control_subnet_name
+        default: k3s-control-subnet
+      - name: control_subnet_cidr
+        default: "10.0.0.0/24"
+      - name: control_subnet_dns_label
+        default: ctrl
+      - name: worker_subnet_name
+        default: k3s-worker-subnet
+      - name: worker_subnet_cidr
+        default: "10.0.1.0/24"
+      - name: worker_subnet_dns_label
+        default: work
 
       # --- Tailscale ---
-      tailnet: ""
-      ts_tags: []
-      extra_freeform_tags: {}
+      - name: tailnet
+        default: ""
+      - name: ts_tags
+        default: []
+      - name: extra_freeform_tags
+        default: {}
 
       # --- k3s OCI-specific ---
-      k3s_oci_firewall_fix: true
+      - name: k3s_oci_firewall_fix
+        default: true
 
       # --- Local kubeconfig destination ---
-      kubeconfig_local_path: "~/.kube/{{ cluster_name }}.yaml"
+      - name: kubeconfig_local_path
+        default: "~/.kube/{{ cluster_name }}.yaml"
 
     resources:
       - providers/oci/network.yaml

--- a/blueprints/ontap-cluster/blueprint.yaml
+++ b/blueprints/ontap-cluster/blueprint.yaml
@@ -2,78 +2,134 @@ name: ontap-cluster
 description: "NetApp ONTAP Simulator 2-node cluster on Proxmox"
 version: "1.0.0"
 
-defaults:
+inputs:
+  # --- Required per-instance inputs (no default) ---
+  - name: cluster_name
+    description: "Name of the ONTAP cluster"
+  - name: cluster_mgmt_ip
+    description: "Cluster management IP (DHCP reservation)"
+  - name: data_lif1_ip
+    description: "Data LIF 1 IP address (DHCP reservation)"
+  - name: data_lif2_ip
+    description: "Data LIF 2 IP address (DHCP reservation)"
+  - name: node01_name
+    description: "Hostname and Proxmox VM name for node 1"
+  - name: node01_vmid
+    description: "Proxmox VM ID for node 1"
+    type: integer
+  - name: node01_target
+    description: "Proxmox node to deploy node 1 onto"
+  - name: node01_mgmt_ip
+    description: "Management IP for node 1 (DHCP reservation)"
+  - name: node02_name
+    description: "Hostname and Proxmox VM name for node 2"
+  - name: node02_vmid
+    description: "Proxmox VM ID for node 2"
+    type: integer
+  - name: node02_target
+    description: "Proxmox node to deploy node 2 onto"
+  - name: node02_mgmt_ip
+    description: "Management IP for node 2 (DHCP reservation)"
+
   # --- VM Configuration ---
-  disk_storage: nas01
-  ova_source: "/mnt/pve/infra/appliances/ontap/9.18.1/vsim-netapp-DOT9.18.1-cm_nodar.ova"
+  - name: disk_storage
+    default: nas01
+  - name: ova_source
+    default: "/mnt/pve/infra/appliances/ontap/9.18.1/vsim-netapp-DOT9.18.1-cm_nodar.ova"
 
   # --- Network ---
-  bridge: vmbr0
-  mgmt_vlan: 10
+  - name: bridge
+    default: vmbr0
+  - name: mgmt_vlan
+    default: 10
 
   # --- MAC Addresses (optional — set for DHCP reservations) ---
-  node01_mgmt_mac: ""
-  node01_data_mac: ""
-  node02_mgmt_mac: ""
-  node02_data_mac: ""
+  - name: node01_mgmt_mac
+    default: ""
+  - name: node01_data_mac
+    default: ""
+  - name: node02_mgmt_mac
+    default: ""
+  - name: node02_data_mac
+    default: ""
 
   # --- Node 02 Identity (standard ONTAP simulator defaults) ---
-  node02_serial_number: "4034389-06-2"
-  node02_sysid: "4034389062"
+  - name: node02_serial_number
+    default: "4034389-06-2"
+  - name: node02_sysid
+    default: "4034389062"
 
   # --- Netmasks/Gateways ---
-  cluster_mgmt_mask: "255.255.255.0"
-  node_mgmt_mask: "255.255.255.0"
+  - name: cluster_mgmt_mask
+    default: "255.255.255.0"
+  - name: node_mgmt_mask
+    default: "255.255.255.0"
 
   # --- Licenses (standard ONTAP simulator keys) ---
-  ontap_cluster_base_license: SMKQROWJNQYQSDAAAAAAAAAAAAAA
-  ontap_licenses:
-    # Node 1 (Serial 4082368507)
-    - YVUCRRRRYVHXCFABGAAAAAAAAAAA   # CIFS
-    - WKQGSRRRYVHXCFABGAAAAAAAAAAA   # FCP
-    - SOHOURRRYVHXCFABGAAAAAAAAAAA   # FlexClone
-    - KQSRRRRRYVHXCFABGAAAAAAAAAAA   # iSCSI
-    - MBXNQRRRYVHXCFABGAAAAAAAAAAA   # NFS
-    - GUJZTRRRYVHXCFABGAAAAAAAAAAA   # SnapMirror
-    - UZLKTRRRYVHXCFABGAAAAAAAAAAA   # SnapRestore
-    - EJFDVRRRYVHXCFABGAAAAAAAAAAA   # SnapVault
-    # Node 2 (Serial 4034389062)
-    - MHEYKUNFXMSMUCEZFAAAAAAAAAAA   # CIFS
-    - KWZBMUNFXMSMUCEZFAAAAAAAAAAA   # FCP
-    - GARJOUNFXMSMUCEZFAAAAAAAAAAA   # FlexClone
-    - YBCNLUNFXMSMUCEZFAAAAAAAAAAA   # iSCSI
-    - ANGJKUNFXMSMUCEZFAAAAAAAAAAA   # NFS
-    - UFTUNUNFXMSMUCEZFAAAAAAAAAAA   # SnapMirror
-    - ILVFNUNFXMSMUCEZFAAAAAAAAAAA   # SnapRestore
-    - SUOYOUNFXMSMUCEZFAAAAAAAAAAA   # SnapVault
+  - name: ontap_cluster_base_license
+    default: SMKQROWJNQYQSDAAAAAAAAAAAAAA
+  - name: ontap_licenses
+    default:
+      # Node 1 (Serial 4082368507)
+      - YVUCRRRRYVHXCFABGAAAAAAAAAAA   # CIFS
+      - WKQGSRRRYVHXCFABGAAAAAAAAAAA   # FCP
+      - SOHOURRRYVHXCFABGAAAAAAAAAAA   # FlexClone
+      - KQSRRRRRYVHXCFABGAAAAAAAAAAA   # iSCSI
+      - MBXNQRRRYVHXCFABGAAAAAAAAAAA   # NFS
+      - GUJZTRRRYVHXCFABGAAAAAAAAAAA   # SnapMirror
+      - UZLKTRRRYVHXCFABGAAAAAAAAAAA   # SnapRestore
+      - EJFDVRRRYVHXCFABGAAAAAAAAAAA   # SnapVault
+      # Node 2 (Serial 4034389062)
+      - MHEYKUNFXMSMUCEZFAAAAAAAAAAA   # CIFS
+      - KWZBMUNFXMSMUCEZFAAAAAAAAAAA   # FCP
+      - GARJOUNFXMSMUCEZFAAAAAAAAAAA   # FlexClone
+      - YBCNLUNFXMSMUCEZFAAAAAAAAAAA   # iSCSI
+      - ANGJKUNFXMSMUCEZFAAAAAAAAAAA   # NFS
+      - UFTUNUNFXMSMUCEZFAAAAAAAAAAA   # SnapMirror
+      - ILVFNUNFXMSMUCEZFAAAAAAAAAAA   # SnapRestore
+      - SUOYOUNFXMSMUCEZFAAAAAAAAAAA   # SnapVault
 
   # --- Post-Cluster: SVM ---
-  svm_name: svm_data
-  data_lif_mask: "255.255.255.0"
+  - name: svm_name
+    default: svm_data
+  - name: data_lif_mask
+    default: "255.255.255.0"
 
   # --- CIFS Server (workgroup mode) ---
-  cifs_server_name: ""
-  cifs_workgroup: WORKGROUP
+  - name: cifs_server_name
+    default: ""
+  - name: cifs_workgroup
+    default: WORKGROUP
 
   # --- NFS Export Policy ---
-  nfs_export_policy: ""
-  nfs_client_match: ""
+  - name: nfs_export_policy
+    default: ""
+  - name: nfs_client_match
+    default: ""
 
   # --- Volumes ---
-  nfs_vol_name: ""
-  nfs_vol_aggregate: ""
-  nfs_vol_size: 1
-  cifs_vol_name: ""
-  cifs_vol_aggregate: ""
-  cifs_vol_size: 1
+  - name: nfs_vol_name
+    default: ""
+  - name: nfs_vol_aggregate
+    default: ""
+  - name: nfs_vol_size
+    default: 1
+  - name: cifs_vol_name
+    default: ""
+  - name: cifs_vol_aggregate
+    default: ""
+  - name: cifs_vol_size
+    default: 1
 
   # --- DHCP ---
   # MAC addresses use generate_mac filter for deterministic uniqueness.
   # Override in package infrafoundry.yml if you need specific MACs.
-  dhcp_subnet: opt1-infrastructure
+  - name: dhcp_subnet
+    default: opt1-infrastructure
 
   # Extra Proxmox tags appended to the blueprint's default tags
-  extra_tags: []
+  - name: extra_tags
+    default: []
 
 resources:
   - vm.yaml

--- a/blueprints/rocky9-template/blueprint.yaml
+++ b/blueprints/rocky9-template/blueprint.yaml
@@ -2,21 +2,39 @@ name: rocky9-template
 description: "Rocky Linux 9 GenericCloud Proxmox VM template"
 version: "1.0.0"
 
-defaults:
+inputs:
+  # --- Required per-instance inputs (no default) ---
+  - name: storage
+    description: "Proxmox storage pool for the template disk and cloud-init"
+  - name: target_node
+    description: "Proxmox node to create the template on"
+  - name: vmid
+    description: "Proxmox VM ID for the template"
+    type: integer
+
   # --- Recipe constants (rarely overridden) ---
-  image_url: "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2"
-  image_filename: "Rocky-9-GenericCloud-Base.latest.x86_64.qcow2"
-  ciuser: rocky
-  cores: 2
-  memory: 2048
-  disk_size: 32
-  bridge: vmbr0
+  - name: image_url
+    default: "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2"
+  - name: image_filename
+    default: "Rocky-9-GenericCloud-Base.latest.x86_64.qcow2"
+  - name: ciuser
+    default: rocky
+  - name: cores
+    default: 2
+  - name: memory
+    default: 2048
+  - name: disk_size
+    default: 32
+  - name: bridge
+    default: vmbr0
 
   # --- Per-instance overrides (typical) ---
-  template_name: rocky9-template
+  - name: template_name
+    default: rocky9-template
 
   # Extra Proxmox tags appended to the blueprint's default tags
-  extra_tags: []
+  - name: extra_tags
+    default: []
 
 resources:
   - template.yaml

--- a/blueprints/ubuntu-template/blueprint.yaml
+++ b/blueprints/ubuntu-template/blueprint.yaml
@@ -2,21 +2,39 @@ name: ubuntu-template
 description: "Ubuntu 24.04 LTS cloud image Proxmox VM template"
 version: "1.0.0"
 
-defaults:
+inputs:
+  # --- Required per-instance inputs (no default) ---
+  - name: storage
+    description: "Proxmox storage pool for the template disk and cloud-init"
+  - name: target_node
+    description: "Proxmox node to create the template on"
+  - name: vmid
+    description: "Proxmox VM ID for the template"
+    type: integer
+
   # --- Recipe constants (rarely overridden) ---
-  image_url: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
-  image_filename: "ubuntu-24.04-server-cloudimg-amd64.qcow2"
-  ciuser: ubuntu
-  cores: 2
-  memory: 2048
-  disk_size: 32
-  bridge: vmbr0
+  - name: image_url
+    default: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
+  - name: image_filename
+    default: "ubuntu-24.04-server-cloudimg-amd64.qcow2"
+  - name: ciuser
+    default: ubuntu
+  - name: cores
+    default: 2
+  - name: memory
+    default: 2048
+  - name: disk_size
+    default: 32
+  - name: bridge
+    default: vmbr0
 
   # --- Per-instance overrides (typical) ---
-  template_name: ubuntu-template
+  - name: template_name
+    default: ubuntu-template
 
   # Extra Proxmox tags appended to the blueprint's default tags
-  extra_tags: []
+  - name: extra_tags
+    default: []
 
 resources:
   - template.yaml

--- a/docs/configuration/blueprints.md
+++ b/docs/configuration/blueprints.md
@@ -24,18 +24,108 @@ foundry config new create basic-vm ./my-new-vm
 ## Configuration Details
 
 - **Command:** `foundry config new create <blueprint-name> <target-directory>`.
-- **Built-in location:** `src/infrafoundry/blueprints/`.
-- **Blueprint contents:** `blueprint.yaml` metadata + template files (copied as-is). Future versions may add Jinja2 templating.
+- **Built-in location:** `blueprints/` at the framework repo root.
+- **Blueprint contents:** `blueprint.yaml` metadata + Jinja2-templated resource files.
 - **Metadata (`blueprint.yaml`):**
   ```yaml
   name: basic-vm
   description: A simple Ubuntu VM on Proxmox
   version: 1.0.0
-  author: InfraFoundry Team
-  # Optional: files section to control included files
-  # files:
-  #   vm.yaml: "vms:\n  ..."
+  inputs:
+    - name: vm_name               # required — no default
+    - name: cores                 # optional — has default
+      default: 2
+  resources:
+    - vm.yaml
   ```
+
+## The `inputs:` Schema
+
+A blueprint declares every template variable it reads in an `inputs:` list.
+Presence of a `default:` determines whether the input is **optional** (the
+default supplies the value if the package omits it) or **required** (the
+package must supply it; otherwise template rendering fails).
+
+```yaml
+inputs:
+  # Required per-instance input — package must provide this value.
+  - name: vm_name
+    description: "Hostname and Proxmox VM name"
+
+  # Optional input — falls back to the declared default.
+  - name: cores
+    description: "Virtual CPU count"
+    type: integer
+    default: 2
+```
+
+**Entry keys** (all optional except `name`):
+
+| Key           | Purpose                                                            |
+| :------------ | :----------------------------------------------------------------- |
+| `name`        | Variable name (required, unique within the scope).                 |
+| `description` | Human-readable help text shown in tooling and `config doctor`.     |
+| `type`        | Declared type hint. Informational; not enforced by the validator.  |
+| `default`     | Default value. Presence marks the input as optional.               |
+
+Unknown keys are rejected at resolve time to catch typos early. Declaring
+both `inputs:` and the legacy `defaults:` section in the same scope is a
+hard error — `inputs:` is the single variable-declaration mechanism.
+
+### Per-Provider Inputs
+
+Multi-provider blueprints (those with a top-level `providers:` block) may
+declare inputs at two levels:
+
+- **Top-level `inputs:`** — always in scope. Values here must be supplied by
+  every package that instantiates the blueprint, regardless of provider.
+- **Per-provider `inputs:`** — only in scope when that provider's templates
+  are rendered. Use this for values that only make sense for one provider
+  (e.g. `server_vmid` is proxmox-only; `ssh_public_key` is OCI-only).
+
+```yaml
+name: k3s-cluster
+inputs:
+  - name: cluster_name
+    default: k3s-cluster       # shared, optional
+providers:
+  proxmox:
+    inputs:
+      - name: server_vmid      # proxmox-only, required
+      - name: cores
+        default: 2             # proxmox-only, optional
+    resources:
+      - providers/proxmox/vm.yaml
+  oci:
+    inputs:
+      - name: image            # oci-only, required
+      - name: ssh_public_key   # oci-only, required
+    resources:
+      - providers/oci/instance.yaml
+```
+
+### Migration (Before / After)
+
+**Before** — legacy `defaults:` only:
+
+```yaml
+defaults:
+  cores: 2
+  memory: 4096
+# vm_name is referenced by vm.yaml but never declared,
+# so `config doctor --deep` flags it as an undefined variable.
+```
+
+**After** — unified `inputs:`:
+
+```yaml
+inputs:
+  - name: vm_name              # now declared as required
+  - name: cores
+    default: 2
+  - name: memory
+    default: 4096
+```
 
 ## Validation and Checks
 
@@ -68,7 +158,7 @@ foundry config new create basic-vm ./my-new-vm
 
 ---
 
-Last updated: 2025-12-23 14:27 GMT
+Last updated: 2026-04-14
 
 
 ---

--- a/docs/decisions/0003-multi-provider-blueprint-support.md
+++ b/docs/decisions/0003-multi-provider-blueprint-support.md
@@ -61,3 +61,11 @@ These are acceptable tradeoffs. The real duplication today is in the non-resourc
 - [#507](https://github.com/endavis/infrafoundry/issues/507): Original multi-provider blueprint design
 - [#571](https://github.com/endavis/infrafoundry/issues/571): Blueprint schema validation across providers (Phase 3 — mitigates the "no schema validation across providers" consequence above)
 - [#572](https://github.com/endavis/infrafoundry/issues/572): Base schema helpers (centralized Jinja2 filter factory for blueprint templates)
+
+## Superseded schema details
+
+The `defaults:` section at both the top level and per-provider scope described
+above was replaced by `inputs:` in [ADR-0004](0004-inputs-single-blueprint-variable-section.md)
+(issue [#607](https://github.com/endavis/infrafoundry/issues/607)). The
+top-level-plus-per-provider scoping model introduced here is preserved; only
+the section name and per-entry shape changed.

--- a/docs/decisions/0004-inputs-single-blueprint-variable-section.md
+++ b/docs/decisions/0004-inputs-single-blueprint-variable-section.md
@@ -1,0 +1,111 @@
+# ADR-0004: Use `inputs:` as the single blueprint variable declaration section
+
+## Status
+
+Accepted
+
+Related issue: [#607](https://github.com/endavis/infrafoundry/issues/607)
+
+## Context
+
+`foundry config doctor --deep` reported 33 errors across the five in-repo
+blueprints because the validator treats every template variable that is not
+present in `defaults:` as undefined. In practice, most of those 33 variables
+are legitimate per-instance inputs supplied by the package (VM names, VM IDs,
+target nodes, IP addresses, DHCP subnets, etc.), not typos. The old schema
+had no way for a blueprint author to say "this variable is a required input
+the package must supply" — the only mechanism was `defaults:`, which
+conflates "optional input with a fallback value" and "variable declaration"
+into a single construct.
+
+The consequences were:
+
+1. Every blueprint produced a wall of noise under `config doctor`, drowning
+   out real mistakes (typos, missing inputs) that the check is supposed to
+   catch.
+2. Blueprint authors had no vocabulary for required-input semantics, so
+   there was no self-documenting place for package authors to look when
+   wiring up a new blueprint.
+3. Tooling that wants to surface "what must I supply?" has nothing to read.
+
+InfraFoundry is still pre-release with no external blueprint authors, so a
+clean schema change is the right moment to fix this before the surface
+solidifies.
+
+## Decision
+
+`inputs:` replaces `defaults:` as the single variable-declaration section in
+blueprint manifests.
+
+**Schema (3C — unified inputs):**
+
+- A blueprint's variables are declared in an `inputs:` list.
+- Each entry is a mapping with at least a `name`, plus optional
+  `description`, `type`, and `default`.
+- Presence of `default:` marks the input as optional; absence marks it as
+  required.
+- Declaring both `inputs:` and the legacy `defaults:` in the same scope is
+  a hard error at resolve time. No dual-schema support.
+
+**Scoping (5Y — top-level plus per-provider):**
+
+- A top-level `inputs:` list applies to every provider in a multi-provider
+  blueprint. Top-level required inputs must always be supplied.
+- Inside each entry under `providers:`, a nested `inputs:` list declares
+  inputs that are only in scope when that provider's templates render.
+  Provider-scoped required inputs are only mandatory when that provider is
+  instantiated.
+- The validator checks each provider against the union of top-level ∪
+  provider-scoped input names.
+
+**Implementation contract:**
+
+- `BlueprintResolver.resolve` parses `inputs:` into an ordered list and
+  synthesises a legacy-shape `defaults` dict (containing only inputs that
+  carry `default:`) so `package_loader.py` consumers of `blueprint["defaults"]`
+  continue working unchanged. The merge order
+  `blueprint.defaults < providers[x].defaults < package.variables`
+  is preserved exactly.
+- The resolver also populates `input_names: frozenset[str]` at the
+  top level and inside each provider block.
+- `BlueprintValidator` checks template variables against `input_names`
+  (falling back to `defaults.keys()` for legacy test fixtures that build
+  resolved dicts by hand), and reports `"Undefined variable: 'foo' (not
+  declared in inputs)"` when a reference has no matching declaration.
+
+## Consequences
+
+**Easier:**
+
+- `config doctor --deep` now gives actionable signal: a reported undefined
+  variable is always a real bug (typo or missing input declaration), not
+  noise.
+- Blueprint authors have a single, self-documenting place to describe every
+  variable their blueprint consumes, including whether it is required.
+- Package authors can see at a glance which variables they must supply by
+  reading a blueprint's `inputs:` section.
+- Future tooling (IDE autocomplete, `config schema`, interactive scaffolding)
+  has a well-defined declaration surface to read.
+
+**More difficult:**
+
+- Every existing in-repo blueprint had to be migrated by hand (five
+  manifests). For any future external blueprint authors, this is a
+  backwards-incompatible schema change they must adopt — mitigated by the
+  pre-release status.
+- Blueprint authors must remember to add new inputs to `inputs:` when
+  templates start referencing them. The validator error catches this
+  immediately, but it is still one more thing to keep in sync.
+
+**Neutral:**
+
+- No runtime behaviour change for packages: the synthesised `defaults` dict
+  preserves the existing merge contract.
+
+## Implementation
+
+- Resolver: `src/infrafoundry/core/config/blueprint_resolver.py`
+- Validator: `src/infrafoundry/core/config/blueprint_validator.py`
+- Migrated blueprints: `blueprints/{aiqum,k3s-cluster,ontap-cluster,rocky9-template,ubuntu-template}/blueprint.yaml`
+- Tests: `tests/unit/test_blueprint_resolver.py`, `tests/unit/test_blueprint_validator.py`
+- Documentation: [Configuration Blueprints Guide](../configuration/blueprints.md)

--- a/src/infrafoundry/core/config/blueprint_resolver.py
+++ b/src/infrafoundry/core/config/blueprint_resolver.py
@@ -18,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 BLUEPRINT_MANIFEST = "blueprint.yaml"
 
+# Allowed keys in an ``inputs:`` entry.
+_ALLOWED_INPUT_KEYS = frozenset({"name", "description", "type", "default"})
+
 
 class BlueprintResolver:
     """Resolves blueprint references for infrastructure packages.
@@ -83,18 +86,54 @@ class BlueprintResolver:
         data, inventory_raw = self._load_manifest(manifest_path)
         self._validate_manifest(data, manifest_path)
 
+        # Parse top-level inputs: (authoritative) and synthesize defaults dict.
+        top_inputs_raw = data.get("inputs")
+        top_defaults, top_input_names = self._parse_inputs_section(
+            top_inputs_raw,
+            data.get("defaults"),
+            manifest_path,
+            scope=f"blueprint '{blueprint_name}'",
+        )
+
+        # Parse per-provider inputs (if any).
+        providers_block: dict[str, Any] | None = data.get("providers")
+        normalised_providers: dict[str, Any] | None = None
+        if providers_block is not None:
+            if not isinstance(providers_block, dict):
+                raise InvalidConfigurationError(
+                    f"Blueprint manifest 'providers:' must be a mapping: {manifest_path}"
+                )
+            normalised_providers = {}
+            for provider_name, provider_block in providers_block.items():
+                if not isinstance(provider_block, dict):
+                    raise InvalidConfigurationError(
+                        f"Provider '{provider_name}' block must be a mapping "
+                        f"in blueprint '{blueprint_name}': {manifest_path}"
+                    )
+                provider_defaults, provider_input_names = self._parse_inputs_section(
+                    provider_block.get("inputs"),
+                    provider_block.get("defaults"),
+                    manifest_path,
+                    scope=f"blueprint '{blueprint_name}' provider '{provider_name}'",
+                )
+                new_block = dict(provider_block)
+                new_block["defaults"] = provider_defaults
+                new_block["input_names"] = provider_input_names
+                normalised_providers[provider_name] = new_block
+
         # Normalise optional fields
         result: dict[str, Any] = {
             "name": data["name"],
             "description": data.get("description"),
             "version": data.get("version"),
-            "defaults": data.get("defaults", {}),
+            "defaults": top_defaults,
+            "input_names": top_input_names,
             "resources": data.get("resources", []),
             "events": data.get("events", {}),
             "inventory": data.get("inventory"),
             "inventory_raw": inventory_raw,
             "blueprint_dir": blueprint_dir,
-            "providers": data.get("providers"),
+            "providers": normalised_providers,
         }
 
         logger.debug(
@@ -209,6 +248,99 @@ class BlueprintResolver:
 
         result: dict[str, Any] = data
         return result, inventory_raw
+
+    @staticmethod
+    def _parse_inputs_section(
+        inputs_raw: Any,
+        defaults_raw: Any,
+        manifest_path: Path,
+        scope: str,
+    ) -> tuple[dict[str, Any], frozenset[str]]:
+        """Parse an ``inputs:`` list and synthesize a ``defaults`` dict.
+
+        Enforces the "clean cutover" rule that a manifest scope (blueprint
+        root or a single provider block) cannot declare both ``inputs:`` and
+        the legacy ``defaults:`` section. When ``inputs:`` is absent and
+        ``defaults:`` is present, falls back to the legacy behaviour so
+        migrations can roll out incrementally at the sub-block level.
+
+        Args:
+            inputs_raw: Value of the ``inputs:`` key (may be ``None``).
+            defaults_raw: Value of the legacy ``defaults:`` key (may be
+                ``None``).
+            manifest_path: Path to the manifest, used in error messages.
+            scope: Human-readable scope for error messages, e.g.
+                ``"blueprint 'aiqum'"`` or
+                ``"blueprint 'k3s-cluster' provider 'proxmox'"``.
+
+        Returns:
+            Tuple of ``(defaults_dict, input_names)``. ``defaults_dict`` is
+            synthesised from input entries that carry a ``default:`` key
+            (preserving declaration order) so downstream callers that read
+            ``blueprint["defaults"]`` keep working unchanged. ``input_names``
+            is the frozenset of declared input names (required + optional).
+
+        Raises:
+            InvalidConfigurationError: If both ``inputs:`` and ``defaults:``
+                are present, if ``inputs:`` is not a list of mappings, if
+                any entry is missing ``name``, or if any entry contains
+                unknown keys.
+        """
+        if inputs_raw is not None and defaults_raw is not None:
+            raise InvalidConfigurationError(
+                f"{scope} declares both 'inputs:' and 'defaults:' in "
+                f"{manifest_path}. Use 'inputs:' only — 'defaults:' has "
+                "been removed from the blueprint schema."
+            )
+
+        if inputs_raw is None:
+            # Legacy path: no inputs declared. Use defaults dict verbatim
+            # and derive input_names from its keys so validation still
+            # works for sub-blocks that haven't been migrated.
+            legacy_defaults = defaults_raw if isinstance(defaults_raw, dict) else {}
+            return dict(legacy_defaults), frozenset(legacy_defaults.keys())
+
+        if not isinstance(inputs_raw, list):
+            raise InvalidConfigurationError(
+                f"{scope} has a non-list 'inputs:' value in {manifest_path}; "
+                "expected a list of input entries."
+            )
+
+        defaults: dict[str, Any] = {}
+        names: list[str] = []
+        for idx, entry in enumerate(inputs_raw):
+            if not isinstance(entry, dict):
+                raise InvalidConfigurationError(
+                    f"{scope} has a non-mapping input entry at index {idx} "
+                    f"in {manifest_path}; each input must be a mapping with "
+                    "at least a 'name' key."
+                )
+            if "name" not in entry:
+                raise InvalidConfigurationError(
+                    f"{scope} has an input entry missing 'name' at index {idx} in {manifest_path}."
+                )
+            name = entry["name"]
+            if not isinstance(name, str) or not name:
+                raise InvalidConfigurationError(
+                    f"{scope} has a non-string or empty 'name' at input "
+                    f"index {idx} in {manifest_path}."
+                )
+            unknown = set(entry.keys()) - _ALLOWED_INPUT_KEYS
+            if unknown:
+                raise InvalidConfigurationError(
+                    f"{scope} input '{name}' has unknown keys "
+                    f"{sorted(unknown)} in {manifest_path}; allowed keys are "
+                    f"{sorted(_ALLOWED_INPUT_KEYS)}."
+                )
+            if name in names:
+                raise InvalidConfigurationError(
+                    f"{scope} declares input '{name}' more than once in {manifest_path}."
+                )
+            names.append(name)
+            if "default" in entry:
+                defaults[name] = entry["default"]
+
+        return defaults, frozenset(names)
 
     @staticmethod
     def _validate_manifest(data: dict[str, Any], manifest_path: Path) -> None:

--- a/src/infrafoundry/core/config/blueprint_validator.py
+++ b/src/infrafoundry/core/config/blueprint_validator.py
@@ -102,10 +102,9 @@ class BlueprintValidator:
     def _validate_single_provider(self) -> BlueprintValidationResult:
         """Validate a single-provider (flat) blueprint."""
         resources: list[str] = self._blueprint.get("resources", [])
-        global_defaults = self._blueprint.get("defaults", {})
 
         template_vars = self._collect_provider_vars(resources, self._blueprint_dir)
-        defaults_keys = frozenset(global_defaults.keys())
+        defaults_keys = self._resolve_input_names(self._blueprint)
 
         errors = self._find_undefined_vars(template_vars, defaults_keys)
 
@@ -130,7 +129,7 @@ class BlueprintValidator:
         self, providers_block: dict[str, Any]
     ) -> BlueprintValidationResult:
         """Validate a multi-provider blueprint."""
-        global_defaults = self._blueprint.get("defaults", {})
+        global_input_names = self._resolve_input_names(self._blueprint)
         provider_results: list[ProviderValidationResult] = []
 
         # Collect vars per provider first for asymmetry detection
@@ -138,10 +137,10 @@ class BlueprintValidator:
 
         for provider_name, provider_block in providers_block.items():
             resources: list[str] = provider_block.get("resources", [])
-            provider_defaults = provider_block.get("defaults", {})
+            provider_input_names = self._resolve_input_names(provider_block)
 
             template_vars = self._collect_provider_vars(resources, self._blueprint_dir)
-            all_defaults = frozenset(global_defaults.keys()) | frozenset(provider_defaults.keys())
+            all_defaults = global_input_names | provider_input_names
 
             errors = self._find_undefined_vars(template_vars, all_defaults)
             provider_var_map[provider_name] = template_vars
@@ -156,7 +155,7 @@ class BlueprintValidator:
             )
 
         # Detect asymmetric variable usage across providers
-        self._detect_asymmetric_vars(provider_results, provider_var_map, global_defaults)
+        self._detect_asymmetric_vars(provider_results, provider_var_map, global_input_names)
 
         return BlueprintValidationResult(
             blueprint_name=self._blueprint["name"],
@@ -222,19 +221,38 @@ class BlueprintValidator:
             Sorted list of error messages for undefined variables.
         """
         undefined = template_vars - defaults_keys
-        return sorted(
-            f"Undefined variable: '{var}' (not in any defaults layer)" for var in undefined
-        )
+        return sorted(f"Undefined variable: '{var}' (not declared in inputs)" for var in undefined)
+
+    @staticmethod
+    def _resolve_input_names(block: dict[str, Any]) -> frozenset[str]:
+        """Return the declared input names for a resolved block.
+
+        Prefers the resolver-populated ``input_names`` frozenset; falls back
+        to ``defaults.keys()`` for legacy / test fixtures that build blocks
+        without going through the resolver.
+
+        Args:
+            block: Either the full resolved blueprint dict or a single
+                provider block within ``providers``.
+
+        Returns:
+            Frozenset of variable names considered declared for this block.
+        """
+        names = block.get("input_names")
+        if isinstance(names, frozenset):
+            return names
+        defaults = block.get("defaults") or {}
+        return frozenset(defaults.keys())
 
     @staticmethod
     def _detect_asymmetric_vars(
         provider_results: list[ProviderValidationResult],
         provider_var_map: dict[str, frozenset[str]],
-        global_defaults: dict[str, Any],
+        global_input_names: frozenset[str],
     ) -> None:
         """Detect variables used by some providers but not all.
 
-        Only considers variables that come from global defaults (shared across
+        Only considers variables that come from global inputs (shared across
         providers). Provider-specific variables are expected to differ.
 
         Modifies provider results in place by appending warnings.
@@ -242,12 +260,12 @@ class BlueprintValidator:
         Args:
             provider_results: Per-provider results to append warnings to.
             provider_var_map: Mapping of provider name to template variables.
-            global_defaults: The blueprint's top-level defaults dict.
+            global_input_names: The blueprint's top-level declared input names.
         """
         if len(provider_var_map) < 2:
             return
 
-        global_keys = frozenset(global_defaults.keys())
+        global_keys = global_input_names
         all_provider_names = list(provider_var_map.keys())
 
         # For each global default, check if it's used asymmetrically

--- a/tests/unit/test_blueprint_extra_freeform_tags.py
+++ b/tests/unit/test_blueprint_extra_freeform_tags.py
@@ -84,15 +84,16 @@ class TestBlueprintDefaultsIncludeExtraFreeformTags:
     """Verify that oci-k3s-cluster blueprint.yaml declares extra_freeform_tags."""
 
     def test_extra_freeform_tags_in_defaults(self):
-        """Blueprint defaults must include extra_freeform_tags with an empty dict."""
+        """Blueprint inputs must declare extra_freeform_tags with an empty dict default."""
         blueprint_path = BLUEPRINTS_DIR / "k3s-cluster" / "blueprint.yaml"
         data = yaml.safe_load(blueprint_path.read_text())
-        # Multi-provider blueprint: extra_freeform_tags is under providers.oci.defaults
-        defaults = data["providers"]["oci"]["defaults"]
-        assert "extra_freeform_tags" in defaults, (
-            "k3s-cluster/blueprint.yaml missing extra_freeform_tags in oci defaults"
+        # Multi-provider blueprint: extra_freeform_tags is under providers.oci.inputs
+        inputs = data["providers"]["oci"]["inputs"]
+        by_name = {entry["name"]: entry for entry in inputs if "name" in entry}
+        assert "extra_freeform_tags" in by_name, (
+            "k3s-cluster/blueprint.yaml missing extra_freeform_tags input declaration"
         )
-        assert defaults["extra_freeform_tags"] == {}
+        assert by_name["extra_freeform_tags"].get("default") == {}
 
 
 @pytest.mark.unit

--- a/tests/unit/test_blueprint_extra_tags.py
+++ b/tests/unit/test_blueprint_extra_tags.py
@@ -128,18 +128,19 @@ class TestBlueprintDefaultsIncludeExtraTags:
         ],
     )
     def test_extra_tags_in_defaults(self, blueprint):
-        """Blueprint defaults must include extra_tags with an empty list default."""
+        """Blueprint inputs must declare extra_tags with an empty list default."""
         blueprint_path = BLUEPRINTS_DIR / blueprint / "blueprint.yaml"
         data = yaml.safe_load(blueprint_path.read_text())
-        # Multi-provider blueprints store extra_tags under providers.<name>.defaults
+        # Multi-provider blueprints store extra_tags under providers.<name>.inputs
         if "providers" in data and "proxmox" in data.get("providers", {}):
-            defaults = data["providers"]["proxmox"].get("defaults", {})
+            inputs = data["providers"]["proxmox"].get("inputs", [])
         else:
-            defaults = data.get("defaults", {})
-        assert "extra_tags" in defaults, (
-            f"{blueprint}/blueprint.yaml missing extra_tags in defaults"
+            inputs = data.get("inputs", [])
+        by_name = {entry["name"]: entry for entry in inputs if "name" in entry}
+        assert "extra_tags" in by_name, (
+            f"{blueprint}/blueprint.yaml missing extra_tags input declaration"
         )
-        assert defaults["extra_tags"] == []
+        assert by_name["extra_tags"].get("default") == []
 
 
 @pytest.mark.unit

--- a/tests/unit/test_blueprint_resolver.py
+++ b/tests/unit/test_blueprint_resolver.py
@@ -160,6 +160,159 @@ class TestBlueprintResolverResolve:
 
 
 @pytest.mark.unit
+class TestBlueprintResolverInputs:
+    """Tests for the ``inputs:`` schema parsing in ``resolve``."""
+
+    def test_inputs_with_defaults_synthesises_defaults_dict(self, temp_dir):
+        """Inputs carrying ``default:`` populate the synthesised ``defaults``."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {
+            "name": "bp",
+            "inputs": [
+                {"name": "required_var", "description": "no default"},
+                {"name": "cores", "default": 4},
+                {"name": "bridge", "default": "vmbr0"},
+            ],
+        }
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        result = resolver.resolve("bp")
+
+        # Synthesised defaults only contain entries that had ``default:``.
+        assert result["defaults"] == {"cores": 4, "bridge": "vmbr0"}
+        # ``input_names`` contains every declared input (required + optional).
+        assert result["input_names"] == frozenset({"required_var", "cores", "bridge"})
+
+    def test_inputs_in_provider_block(self, temp_dir):
+        """Per-provider ``inputs:`` are parsed and exposed."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {
+            "name": "bp",
+            "inputs": [{"name": "cluster_name", "default": "demo"}],
+            "providers": {
+                "proxmox": {
+                    "inputs": [
+                        {"name": "server_name"},
+                        {"name": "cores", "default": 2},
+                    ],
+                    "resources": ["providers/proxmox/vm.yaml"],
+                },
+            },
+        }
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        result = resolver.resolve("bp")
+
+        assert result["input_names"] == frozenset({"cluster_name"})
+        proxmox = result["providers"]["proxmox"]
+        assert proxmox["defaults"] == {"cores": 2}
+        assert proxmox["input_names"] == frozenset({"server_name", "cores"})
+
+    def test_both_inputs_and_defaults_raises(self, temp_dir):
+        """Declaring both sections at the top level is a hard error."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {
+            "name": "bp",
+            "defaults": {"cores": 2},
+            "inputs": [{"name": "cores", "default": 4}],
+        }
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        with pytest.raises(InvalidConfigurationError, match="both 'inputs:' and 'defaults:'"):
+            resolver.resolve("bp")
+
+    def test_both_inputs_and_defaults_in_provider_raises(self, temp_dir):
+        """Declaring both sections inside a provider block is a hard error."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {
+            "name": "bp",
+            "providers": {
+                "proxmox": {
+                    "defaults": {"cores": 2},
+                    "inputs": [{"name": "cores", "default": 4}],
+                    "resources": [],
+                },
+            },
+        }
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        with pytest.raises(InvalidConfigurationError, match="provider 'proxmox'"):
+            resolver.resolve("bp")
+
+    def test_input_entry_missing_name_raises(self, temp_dir):
+        """An input entry without a ``name`` key is rejected."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {
+            "name": "bp",
+            "inputs": [{"description": "missing name"}],
+        }
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        with pytest.raises(InvalidConfigurationError, match="missing 'name'"):
+            resolver.resolve("bp")
+
+    def test_input_entry_unknown_key_raises(self, temp_dir):
+        """Unknown keys in an input entry are rejected."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {
+            "name": "bp",
+            "inputs": [{"name": "foo", "defualt": 1}],  # codespell:ignore defualt
+        }
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        with pytest.raises(InvalidConfigurationError, match="unknown keys"):
+            resolver.resolve("bp")
+
+    def test_input_section_must_be_list(self, temp_dir):
+        """``inputs:`` must be a list of entries."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {"name": "bp", "inputs": {"cores": 2}}
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        with pytest.raises(InvalidConfigurationError, match="non-list 'inputs:'"):
+            resolver.resolve("bp")
+
+    def test_duplicate_input_name_raises(self, temp_dir):
+        """Declaring the same input twice is rejected."""
+        envs_dir = temp_dir / "envs"
+        envs_dir.mkdir()
+        resolver = _make_resolver(envs_dir)
+
+        manifest = {
+            "name": "bp",
+            "inputs": [
+                {"name": "cores", "default": 2},
+                {"name": "cores", "default": 4},
+            ],
+        }
+        _create_blueprint(envs_dir, "bp", manifest)
+
+        with pytest.raises(InvalidConfigurationError, match="more than once"):
+            resolver.resolve("bp")
+
+
+@pytest.mark.unit
 class TestBlueprintResolverExists:
     """Tests for BlueprintResolver.exists."""
 

--- a/tests/unit/test_blueprint_validator.py
+++ b/tests/unit/test_blueprint_validator.py
@@ -231,6 +231,66 @@ class TestMultiProviderValidation:
 
 
 # ------------------------------------------------------------------
+# inputs:-schema tests
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInputsSchemaValidation:
+    """Tests covering the new ``input_names``-based validation path."""
+
+    def test_required_input_without_default_is_accepted(self, tmp_path):
+        """A declared input without a ``default:`` is not flagged as undefined."""
+        _write_template(tmp_path, "vm.yaml", "name: {{ vm_name }}\ncores: {{ cores }}")
+        resolved = _make_resolved(
+            tmp_path,
+            defaults={"cores": 2},  # only defaults-backed
+            resources=["vm.yaml"],
+        )
+        # The resolver normally populates ``input_names``; simulate that here.
+        resolved["input_names"] = frozenset({"vm_name", "cores"})
+        result = BlueprintValidator(resolved).validate()
+        assert not result.has_errors
+
+    def test_truly_undefined_variable_is_still_flagged(self, tmp_path):
+        """Typos / vars not declared as inputs must still error."""
+        _write_template(tmp_path, "vm.yaml", "name: {{ vm_nmae }}")
+        resolved = _make_resolved(tmp_path, defaults={}, resources=["vm.yaml"])
+        resolved["input_names"] = frozenset({"vm_name"})
+        result = BlueprintValidator(resolved).validate()
+        assert result.has_errors
+        # New error message wording.
+        assert any("not declared in inputs" in e for e in result.providers[0].errors)
+
+    def test_provider_scoped_input_not_visible_to_sibling(self, tmp_path):
+        """A variable declared only for provider A is undefined for provider B."""
+        _write_template(tmp_path, "providers/a/vm.yaml", "name: {{ only_in_a }}")
+        _write_template(tmp_path, "providers/b/vm.yaml", "name: {{ only_in_a }}")
+        resolved = _make_resolved(
+            tmp_path,
+            defaults={},
+            providers={
+                "a": {
+                    "defaults": {},
+                    "input_names": frozenset({"only_in_a"}),
+                    "resources": ["providers/a/vm.yaml"],
+                },
+                "b": {
+                    "defaults": {},
+                    "input_names": frozenset(),
+                    "resources": ["providers/b/vm.yaml"],
+                },
+            },
+        )
+        resolved["input_names"] = frozenset()
+        result = BlueprintValidator(resolved).validate()
+        a_result = next(p for p in result.providers if p.provider == "a")
+        b_result = next(p for p in result.providers if p.provider == "b")
+        assert a_result.errors == []
+        assert any("only_in_a" in e for e in b_result.errors)
+
+
+# ------------------------------------------------------------------
 # Custom filter tests
 # ------------------------------------------------------------------
 
@@ -272,9 +332,10 @@ class TestRealBlueprints:
     def test_aiqum_blueprint_no_errors(self):
         """Real aiqum blueprint should have zero validation errors.
 
-        The aiqum blueprint is single-provider and all template vars
-        should be covered by defaults (except per-instance vars like
-        vm_name, vmid, target_node, etc. supplied by packages).
+        All template variables (including per-instance ones like ``vm_name``,
+        ``vmid``, ``target_node``) are now declared in the blueprint's
+        ``inputs:`` section, so static analysis should report no undefined
+        variables.
         """
         resolver = self._get_real_resolver()
         if not resolver.exists("aiqum"):
@@ -283,30 +344,18 @@ class TestRealBlueprints:
         resolved = resolver.resolve("aiqum")
         result = BlueprintValidator(resolved).validate()
 
-        # Document expected undefined vars (per-instance, supplied by packages)
         assert not result.is_multi_provider
-        # These should NOT be errors — they are intentional.
-        # But since they're per-instance vars not in defaults, they will
-        # be reported. This test documents the expected behaviour.
         prov = result.providers[0]
-        expected_undefined = {
-            "vm_name",
-            "vmid",
-            "target_node",
-            "disk_storage",
-            "ip_address",
-            "dhcp_subnet",
-        }
-        actual_undefined_vars = {e.split("'")[1] for e in prov.errors if "Undefined variable" in e}
-        # All actual undefined vars should be in the expected set
-        assert actual_undefined_vars == expected_undefined
+        assert prov.errors == [], f"Unexpected undefined variables: {prov.errors}"
+        # Required per-instance inputs should appear in the declared set.
+        for required in ("vm_name", "vmid", "target_node", "ip_address", "dhcp_subnet"):
+            assert required in prov.defaults
 
     def test_k3s_cluster_blueprint_validation(self):
-        """Real k3s-cluster blueprint documents expected undefined vars.
+        """Real k3s-cluster blueprint validates cleanly post-migration.
 
-        The k3s-cluster blueprint is multi-provider. Per-instance variables
-        (server_name, agents, image, etc.) are supplied by packages and
-        will appear as undefined in static analysis.
+        Top-level and per-provider ``inputs:`` should cover every template
+        variable, producing no undefined-variable errors.
         """
         resolver = self._get_real_resolver()
         if not resolver.exists("k3s-cluster"):
@@ -318,16 +367,28 @@ class TestRealBlueprints:
         assert result.is_multi_provider
         assert len(result.providers) == 2
 
-        # Both providers will have undefined vars (per-instance values)
         proxmox = next(p for p in result.providers if p.provider == "proxmox")
         oci = next(p for p in result.providers if p.provider == "oci")
 
-        # Proxmox should reference per-instance vars not in defaults
-        proxmox_undefined = {e.split("'")[1] for e in proxmox.errors if "Undefined variable" in e}
-        assert "server_name" in proxmox_undefined
-        assert "agents" in proxmox_undefined
+        assert proxmox.errors == [], f"proxmox errors: {proxmox.errors}"
+        assert oci.errors == [], f"oci errors: {oci.errors}"
 
-        # OCI should reference per-instance vars not in defaults
-        oci_undefined = {e.split("'")[1] for e in oci.errors if "Undefined variable" in e}
-        assert "image" in oci_undefined
-        assert "ssh_public_key" in oci_undefined
+        # Proxmox-scoped required inputs should be declared for that provider.
+        for required in ("server_name", "agents", "server_mac", "server_ip"):
+            assert required in proxmox.defaults
+
+        # OCI-scoped required inputs should be declared for that provider.
+        for required in ("image", "ssh_public_key"):
+            assert required in oci.defaults
+
+    def test_all_real_blueprints_validate(self):
+        """Every blueprint shipped in the framework should validate cleanly."""
+        resolver = self._get_real_resolver()
+        for name in resolver.list_blueprints():
+            resolved = resolver.resolve(name)
+            result = BlueprintValidator(resolved).validate()
+            for provider in result.providers:
+                assert provider.errors == [], (
+                    f"Blueprint '{name}' provider '{provider.provider}' has "
+                    f"undefined variables: {provider.errors}"
+                )


### PR DESCRIPTION
## Description

Replaces the legacy `defaults:` section in blueprint manifests with a unified
`inputs:` list that declares every variable a blueprint reads. Each entry
carries a `name` and optional `description`, `type`, and `default`. Presence
of `default:` marks the input as optional; absence marks it as required. This
gives blueprint authors a single, self-documenting vocabulary for required
versus optional inputs and lets `config doctor --deep` produce actionable
signal instead of drowning real bugs in noise.

The change is a pre-release clean cutover — no backwards-compatibility shim
for the old `defaults:` shape, and declaring both `inputs:` and `defaults:`
in the same scope is a hard error at resolve time.

## Related Issue

Addresses #607

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (blueprint schema — pre-release, no external authors)
- [x] Documentation update

## Changes Made

- **Schema:** `inputs:` replaces `defaults:` as the single variable
  declaration section. Each entry: `name` (required), `description`, `type`,
  `default` (presence = optional).
- **Scoping:** Top-level `inputs:` applies to every provider; per-provider
  `inputs:` inside a `providers:` entry is only in scope for that provider.
  The validator checks each provider against the union of top-level and
  provider-scoped input names.
- **Resolver:** `BlueprintResolver.resolve` parses `inputs:` into an ordered
  list, synthesises a legacy-shape `defaults` dict (only entries that carry
  `default:`) so `package_loader.py` consumers keep working unchanged, and
  populates `input_names: frozenset[str]` at the top level and inside each
  provider block. The
  `blueprint.defaults < providers[x].defaults < package.variables`
  merge order is preserved exactly.
- **Validator:** `BlueprintValidator` checks template variables against
  `input_names` and reports
  `"Undefined variable: 'foo' (not declared in inputs)"` when a reference
  has no matching declaration.
- **Blueprints migrated:** `aiqum`, `k3s-cluster`, `ontap-cluster`,
  `rocky9-template`, `ubuntu-template`.
- **Docs:** `docs/configuration/blueprints.md` updated with the new schema,
  per-provider scoping, and a before/after migration example.
- **ADR:** `docs/decisions/0004-inputs-single-blueprint-variable-section.md`
  (Accepted). ADR-0003 updated with a superseded-schema cross-reference.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

- `doit check`: passes (format, lint, type, security, spell, test).
- `pytest`: 2860 tests pass.
- `foundry config doctor --deep` Blueprint check: went from FAIL (33 errors)
  to WARN (1 pre-existing asymmetric-var warning, tracked separately — out
  of scope for this PR).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- Pre-release clean cutover: no backwards-compatibility path for the legacy
  `defaults:` section. Declaring both in the same scope is a hard error.
- ADR: [docs/decisions/0004-inputs-single-blueprint-variable-section.md](../docs/decisions/0004-inputs-single-blueprint-variable-section.md).
- ADR-0003 (multi-provider blueprint support) was updated with a pointer to
  ADR-0004 noting the `defaults:` → `inputs:` schema change; the
  top-level-plus-per-provider scoping model it introduced is preserved.
