### PR TITLE
fix: resolve terraform_secrets references during infra doctor

### DIFF
--- a/docs/development/implementing-providers.md
+++ b/docs/development/implementing-providers.md
@@ -75,7 +75,7 @@ Providers can override these optional methods to add advanced functionality:
 
 ```python
 def validate_connectivity(
-    self, env_config: EnvironmentData, report: ValidationReport
+    self, env_config: EnvironmentConfig, report: ValidationReport
 ) -> None:
     """Validate connectivity to provider API.
 
@@ -121,7 +121,7 @@ def validate_connectivity(self, env_config, report):
 def validate_references(
     self,
     resources: list[ResourceConfig],
-    env_config: EnvironmentData,
+    env_config: EnvironmentConfig,
     report: ValidationReport
 ) -> None:
     """Validate that referenced resources exist in the provider.

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -29,7 +29,6 @@ from infrafoundry.core.state import DeploymentStatus, ResourceState, StateManage
 from infrafoundry.core.types import (
     ApplyDeploymentMetadata,
     DestroyDeploymentMetadata,
-    EnvironmentData,
     PlanDeploymentMetadata,
     ResourceOutcome,
     RollbackData,
@@ -188,7 +187,6 @@ class ValidationOrchestrator:
             self.console.print(f"[red]✗ Environment '{env_name}' not found[/red]")
             return {}
 
-        env_data = cast(EnvironmentData, env_config.model_dump())
         all_resources, resources_by_provider = self._load_resources(env_name)
 
         # Convert to set for O(1) lookups
@@ -219,7 +217,7 @@ class ValidationOrchestrator:
             report = ValidationReport()
             self.console.print(f"[bold]Validating {provider_name}...[/bold]")
 
-            self._run_validation_checks(provider, env_data, resources, report)
+            self._run_validation_checks(provider, env_config, resources, report)
 
             summary = report.get_summary()
             passed = not report.has_errors()
@@ -242,19 +240,19 @@ class ValidationOrchestrator:
     def _run_validation_checks(
         self,
         provider: ProviderBase,
-        env_data: EnvironmentData,
+        env_config: EnvironmentConfig,
         resources: list[ResourceConfig],
         report: ValidationReport,
     ) -> None:
         """Invoke provider validation hooks with error protection."""
         try:
-            provider.validate_connectivity(env_data, report)
+            provider.validate_connectivity(env_config, report)
         except Exception as exc:
             self.console.print(f"[red]✗ Connectivity validation failed: {exc}[/red]")
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
 
         try:
-            provider.validate_references(resources, env_data, report)
+            provider.validate_references(resources, env_config, report)
         except Exception as exc:
             self.console.print(f"[red]✗ Reference validation failed: {exc}[/red]")
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback

--- a/src/infrafoundry/core/provider.py
+++ b/src/infrafoundry/core/provider.py
@@ -6,8 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.hooks.models import HooksConfig
-from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
 
 
@@ -154,7 +154,9 @@ class ProviderBase(ABC):
         """
         pass
 
-    def validate_connectivity(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def validate_connectivity(
+        self, env_config: EnvironmentConfig, report: ValidationReport
+    ) -> None:
         """Validate connectivity to provider API.
 
         Optional method for providers to implement API connectivity checks.
@@ -168,7 +170,10 @@ class ProviderBase(ABC):
         return None
 
     def validate_references(
-        self, resources: list[ResourceConfig], env_config: EnvironmentData, report: ValidationReport
+        self,
+        resources: list[ResourceConfig],
+        env_config: EnvironmentConfig,
+        report: ValidationReport,
     ) -> None:
         """Validate that referenced resources exist in the provider.
 

--- a/src/infrafoundry/core/validation_helpers/api_validator.py
+++ b/src/infrafoundry/core/validation_helpers/api_validator.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import requests
 from requests import Response
 
-from infrafoundry.core.types import EnvironmentData
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers.base_validator import BaseProviderValidator
 
@@ -22,7 +22,7 @@ class BaseAPIValidator:
     def __init__(
         self,
         provider_name: str,
-        env_config: EnvironmentData,
+        env_config: EnvironmentConfig,
         report: ValidationReport,
         env_prefix: str | None = None,
     ) -> None:

--- a/src/infrafoundry/core/validation_helpers/base_validator.py
+++ b/src/infrafoundry/core/validation_helpers/base_validator.py
@@ -8,8 +8,8 @@ import logging
 import traceback
 from typing import Any
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.exceptions import APIError, InfraFoundryError, ValidationError
-from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers.connectivity_validator import ConnectivityValidator
 from infrafoundry.core.validation_helpers.credential_validator import CredentialValidator
@@ -60,7 +60,7 @@ class BaseProviderValidator:
     def __init__(
         self,
         provider_name: str,
-        env_config: EnvironmentData,
+        env_config: EnvironmentConfig,
         report: ValidationReport,
     ) -> None:
         """Initialize provider validator with specialized validators.

--- a/src/infrafoundry/core/validation_helpers/credential_validator.py
+++ b/src/infrafoundry/core/validation_helpers/credential_validator.py
@@ -8,7 +8,7 @@ import logging
 import os
 from typing import Any
 
-from infrafoundry.core.types import EnvironmentData
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ class CredentialValidator:
     def __init__(
         self,
         provider_name: str,
-        env_config: EnvironmentData,
+        env_config: EnvironmentConfig,
         report: ValidationReport,
     ) -> None:
         """Initialize credential validator.
@@ -49,8 +49,7 @@ class CredentialValidator:
         self.provider_name = provider_name
         self.env_config = env_config
         self.report = report
-        provider_settings = env_config.get("provider_settings", {})
-        self.provider_settings = provider_settings.get(provider_name, {})
+        self.provider_settings = env_config.provider_settings.get(provider_name, {})
 
     def validate_credentials(
         self,

--- a/src/infrafoundry/core/validation_helpers/terraform_secrets_validator.py
+++ b/src/infrafoundry/core/validation_helpers/terraform_secrets_validator.py
@@ -12,8 +12,7 @@ inject empty values for sensitive variables.
 
 from __future__ import annotations
 
-from typing import Any
-
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.secrets.secret_manager import SecretManager
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
@@ -22,7 +21,7 @@ from infrafoundry.core.validation import ValidationLevel, ValidationReport
 def validate_terraform_secrets_references(
     provider_name: str,
     resources: list[ResourceConfig],
-    env_config: Any,
+    env_config: EnvironmentConfig,
     report: ValidationReport,
 ) -> None:
     """Validate ``terraform_secrets`` references on each resource.

--- a/src/infrafoundry/providers/esxi/__init__.py
+++ b/src/infrafoundry/providers/esxi/__init__.py
@@ -5,13 +5,13 @@ import logging
 from pathlib import Path
 from typing import Any, override
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.provider_mixins import (
     ResourceGrouperMixin,
     TemplateRendererMixin,
     TerraformGeneratorMixin,
 )
-from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
 
 from .validator import EsxiValidator
@@ -65,14 +65,19 @@ class EsxiProvider(
         return all(field in config for field in required_fields)
 
     @override
-    def validate_connectivity(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def validate_connectivity(
+        self, env_config: EnvironmentConfig, report: ValidationReport
+    ) -> None:
         """Validate connectivity to ESXi hosts."""
         validator = EsxiValidator(env_config, report)
         validator.validate_connectivity()
 
     @override
     def validate_references(
-        self, resources: list[ResourceConfig], env_config: EnvironmentData, report: ValidationReport
+        self,
+        resources: list[ResourceConfig],
+        env_config: EnvironmentConfig,
+        report: ValidationReport,
     ) -> None:
         """Validate that referenced ESXi resources exist."""
         validator = EsxiValidator(env_config, report)

--- a/src/infrafoundry/providers/esxi/validator.py
+++ b/src/infrafoundry/providers/esxi/validator.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.provider import ResourceConfig
-from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
 
@@ -24,7 +24,7 @@ class EsxiValidator:
     - Portgroup reference validation (VMs reference existing portgroups)
     """
 
-    def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def __init__(self, env_config: EnvironmentConfig, report: ValidationReport) -> None:
         """Initialize ESXi validator.
 
         Args:

--- a/src/infrafoundry/providers/kubernetes/validator.py
+++ b/src/infrafoundry/providers/kubernetes/validator.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import cast
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.provider import ResourceConfig
-from infrafoundry.core.types import EnvironmentData, KubernetesProviderSettings
+from infrafoundry.core.types import KubernetesProviderSettings
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.kubernetes.validators import (
@@ -24,7 +25,7 @@ class KubernetesValidator:
     run; API-based checks only run when connectivity is established.
     """
 
-    def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def __init__(self, env_config: EnvironmentConfig, report: ValidationReport) -> None:
         """Initialize Kubernetes validator.
 
         Args:

--- a/src/infrafoundry/providers/oci/__init__.py
+++ b/src/infrafoundry/providers/oci/__init__.py
@@ -4,6 +4,7 @@ import copy
 from pathlib import Path
 from typing import Any, ClassVar, override
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.provider_mixins import (
     CloudInitMixin,
@@ -13,7 +14,6 @@ from infrafoundry.core.provider_mixins import (
     sanitize_secret_ref_to_tf_var,
 )
 from infrafoundry.core.tailscale import process_tailscale_config
-from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
 
 from .validator import OCIValidator
@@ -54,14 +54,19 @@ class OCIProvider(
         return all(field in config for field in required_fields)
 
     @override
-    def validate_connectivity(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def validate_connectivity(
+        self, env_config: EnvironmentConfig, report: ValidationReport
+    ) -> None:
         """Validate connectivity to OCI API."""
         validator = OCIValidator(env_config, report)
         validator.validate_connectivity()
 
     @override
     def validate_references(
-        self, resources: list[ResourceConfig], env_config: EnvironmentData, report: ValidationReport
+        self,
+        resources: list[ResourceConfig],
+        env_config: EnvironmentConfig,
+        report: ValidationReport,
     ) -> None:
         """Validate that referenced OCI resources exist."""
         validator = OCIValidator(env_config, report)

--- a/src/infrafoundry/providers/oci/validator.py
+++ b/src/infrafoundry/providers/oci/validator.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.exceptions import APIError, ConfigurationError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.tailscale import TailscaleSchemaError, process_tailscale_config
-from infrafoundry.core.types import EnvironmentData, OCIProviderSettings
+from infrafoundry.core.types import OCIProviderSettings
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import (
     BaseAPIValidator,
@@ -32,7 +33,7 @@ class OCIValidator:
     - Image OCID validation via OCI API
     """
 
-    def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def __init__(self, env_config: EnvironmentConfig, report: ValidationReport) -> None:
         """Initialize OCI validator.
 
         Args:

--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -5,13 +5,13 @@ import logging
 from pathlib import Path
 from typing import Any, ClassVar, override
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.provider_mixins import (
     ResourceGrouperMixin,
     TemplateRendererMixin,
     TerraformGeneratorMixin,
 )
-from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
 
 from .validator import OPNsenseValidator
@@ -620,7 +620,9 @@ class OPNsenseProvider(
         }
 
     @override
-    def validate_connectivity(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def validate_connectivity(
+        self, env_config: EnvironmentConfig, report: ValidationReport
+    ) -> None:
         """Validate connectivity to OPNsense API."""
         validator = OPNsenseValidator(env_config, report)
         validator.validate_connectivity()
@@ -629,7 +631,7 @@ class OPNsenseProvider(
     def validate_references(
         self,
         resources: list[ResourceConfig],
-        env_config: EnvironmentData,
+        env_config: EnvironmentConfig,
         report: ValidationReport,
     ) -> None:
         """Validate that referenced OPNsense resources exist."""

--- a/src/infrafoundry/providers/opnsense/validator.py
+++ b/src/infrafoundry/providers/opnsense/validator.py
@@ -9,9 +9,10 @@ from typing import Any, TypedDict, cast
 
 import urllib3
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.exceptions import ReferenceValidationError
 from infrafoundry.core.provider import ResourceConfig
-from infrafoundry.core.types import EnvironmentData, OPNsenseProviderSettings
+from infrafoundry.core.types import OPNsenseProviderSettings
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.opnsense.validators import (
@@ -51,7 +52,7 @@ class OPNsenseValidator:
     - DHCP configuration validity
     """
 
-    def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def __init__(self, env_config: EnvironmentConfig, report: ValidationReport) -> None:
         """Initialize OPNsense validator.
 
         Args:

--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from typing import Any, ClassVar, override
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.provider_mixins import (
     CloudInitMixin,
@@ -12,7 +13,6 @@ from infrafoundry.core.provider_mixins import (
     TerraformGeneratorMixin,
     sanitize_secret_ref_to_tf_var,
 )
-from infrafoundry.core.types import EnvironmentData
 from infrafoundry.core.validation import ValidationReport
 
 from .validator import ProxmoxValidator
@@ -57,14 +57,19 @@ class ProxmoxProvider(
         return all(field in config for field in required_fields)
 
     @override
-    def validate_connectivity(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def validate_connectivity(
+        self, env_config: EnvironmentConfig, report: ValidationReport
+    ) -> None:
         """Validate connectivity to Proxmox API."""
         validator = ProxmoxValidator(env_config, report)
         validator.validate_connectivity()
 
     @override
     def validate_references(
-        self, resources: list[ResourceConfig], env_config: EnvironmentData, report: ValidationReport
+        self,
+        resources: list[ResourceConfig],
+        env_config: EnvironmentConfig,
+        report: ValidationReport,
     ) -> None:
         """Validate that referenced Proxmox resources exist."""
         validator = ProxmoxValidator(env_config, report)

--- a/src/infrafoundry/providers/proxmox/validator.py
+++ b/src/infrafoundry/providers/proxmox/validator.py
@@ -7,10 +7,11 @@ from typing import Any, TypedDict, cast
 
 import urllib3
 
+from infrafoundry.core.config.models import EnvironmentConfig
 from infrafoundry.core.exceptions import APIError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.tailscale import TailscaleSchemaError, process_tailscale_config
-from infrafoundry.core.types import EnvironmentData, ProxmoxProviderSettings
+from infrafoundry.core.types import ProxmoxProviderSettings
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import (
     BaseAPIValidator,
@@ -62,7 +63,7 @@ class ProxmoxValidator:
     - MAC address conflicts
     """
 
-    def __init__(self, env_config: EnvironmentData, report: ValidationReport) -> None:
+    def __init__(self, env_config: EnvironmentConfig, report: ValidationReport) -> None:
         """Initialize Proxmox validator.
 
         Args:

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers for InfraFoundry unit tests."""

--- a/tests/helpers/env.py
+++ b/tests/helpers/env.py
@@ -1,0 +1,26 @@
+"""Helpers for constructing ``EnvironmentConfig`` instances in tests.
+
+The validation pipeline receives a real ``EnvironmentConfig`` Pydantic model
+(as of issue #609), so tests that previously handed in a raw dict should use
+``make_env_config`` to build a model with the same fields.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from infrafoundry.core.config.models import EnvironmentConfig
+
+
+def make_env_config(*, name: str = "test", **overrides: Any) -> EnvironmentConfig:
+    """Build an ``EnvironmentConfig`` for tests.
+
+    Args:
+        name: Environment name (defaults to ``"test"``).
+        **overrides: Any additional ``EnvironmentConfig`` field values
+            (e.g. ``provider_settings``, ``secrets``, ``provider_ssh``).
+
+    Returns:
+        An ``EnvironmentConfig`` instance populated with the given values.
+    """
+    return EnvironmentConfig(name=name, **overrides)

--- a/tests/unit/core/validation_helpers/test_terraform_secrets_validator.py
+++ b/tests/unit/core/validation_helpers/test_terraform_secrets_validator.py
@@ -1,0 +1,55 @@
+"""Regression tests for ``validate_terraform_secrets_references``.
+
+Guards against the regression in issue #609 where a dict was passed in place
+of ``EnvironmentConfig``, causing ``getattr(env_config, "secrets", None)`` to
+silently return ``None`` and every ``terraform_secrets`` reference to be
+reported as "unknown".
+"""
+
+from __future__ import annotations
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationReport
+from infrafoundry.core.validation_helpers.terraform_secrets_validator import (
+    validate_terraform_secrets_references,
+)
+from tests.helpers.env import make_env_config
+
+
+def _resource(terraform_secrets: list[str]) -> ResourceConfig:
+    return ResourceConfig(
+        name="demo-vm",
+        type="vm",
+        provider="proxmox",
+        config={"terraform_secrets": terraform_secrets},
+    )
+
+
+def test_references_resolve_against_env_config_secrets() -> None:
+    """Declared terraform_secrets that exist in env.secrets pass validation."""
+    env_config = make_env_config(
+        secrets={"tailscale": {"oauth_client_id": "xxxx"}},
+    )
+    report = ValidationReport()
+    resources = [_resource(["tailscale.oauth_client_id"])]
+
+    validate_terraform_secrets_references("proxmox", resources, env_config, report)
+
+    assert not report.has_errors()
+    results = [r for r in report.results if r.check_name == "proxmox_terraform_secrets_demo-vm"]
+    assert len(results) == 1
+    assert results[0].passed
+
+
+def test_missing_reference_reports_error() -> None:
+    """Missing keys produce an error listing the unknown reference."""
+    env_config = make_env_config(secrets={})
+    report = ValidationReport()
+    resources = [_resource(["tailscale.oauth_client_id"])]
+
+    validate_terraform_secrets_references("proxmox", resources, env_config, report)
+
+    assert report.has_errors()
+    failures = [r for r in report.results if not r.passed]
+    assert len(failures) == 1
+    assert "tailscale.oauth_client_id" in failures[0].message

--- a/tests/unit/providers/esxi/test_validator.py
+++ b/tests/unit/providers/esxi/test_validator.py
@@ -8,6 +8,7 @@ from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.esxi.validator import EsxiValidator
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
@@ -16,12 +17,12 @@ def report():
     return MagicMock(spec=ValidationReport)
 
 
-def _make_env_config(hosts: dict | None = None) -> dict:
-    """Create an environment config dict."""
+def _make_env_config(hosts: dict | None = None):
+    """Create an ``EnvironmentConfig`` populated with ESXi provider settings."""
     esxi_settings: dict = {}
     if hosts is not None:
         esxi_settings["hosts"] = hosts
-    return {"provider_settings": {"esxi": esxi_settings}}
+    return make_env_config(provider_settings={"esxi": esxi_settings})
 
 
 class TestComposition:

--- a/tests/unit/providers/kubernetes/test_crd_validator.py
+++ b/tests/unit/providers/kubernetes/test_crd_validator.py
@@ -10,6 +10,7 @@ from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.kubernetes.validators.crd_validator import CRDValidator
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
@@ -21,10 +22,10 @@ def validation_report():
 @pytest.fixture
 def api_validator(validation_report):
     """Create a BaseAPIValidator instance."""
-    env_config = {
-        "name": "test-env",
-        "provider_settings": {"kubernetes": {}},
-    }
+    env_config = make_env_config(
+        name="test-env",
+        provider_settings={"kubernetes": {}},
+    )
     return BaseAPIValidator("kubernetes", env_config, validation_report)
 
 

--- a/tests/unit/providers/kubernetes/test_kubeconfig_validator.py
+++ b/tests/unit/providers/kubernetes/test_kubeconfig_validator.py
@@ -12,6 +12,7 @@ from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.kubernetes.validators.kubeconfig_validator import (
     KubeconfigValidator,
 )
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
@@ -23,10 +24,10 @@ def validation_report():
 @pytest.fixture
 def api_validator(validation_report):
     """Create a BaseAPIValidator instance."""
-    env_config = {
-        "name": "test-env",
-        "provider_settings": {"kubernetes": {"kubeconfig_path": "/path/to/kubeconfig"}},
-    }
+    env_config = make_env_config(
+        name="test-env",
+        provider_settings={"kubernetes": {"kubeconfig_path": "/path/to/kubeconfig"}},
+    )
     return BaseAPIValidator("kubernetes", env_config, validation_report)
 
 

--- a/tests/unit/providers/kubernetes/test_kubernetes_validator.py
+++ b/tests/unit/providers/kubernetes/test_kubernetes_validator.py
@@ -18,19 +18,20 @@ from infrafoundry.providers.kubernetes.validators import (
     KubeconfigValidator,
     NamespaceValidator,
 )
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
 def mock_env_config():
     """Create a mock environment config."""
-    return {
-        "name": "test-env",
-        "provider_settings": {
+    return make_env_config(
+        name="test-env",
+        provider_settings={
             "kubernetes": {
                 "kubeconfig_path": "/path/to/kubeconfig",
             }
         },
-    }
+    )
 
 
 @pytest.fixture
@@ -109,10 +110,10 @@ class TestKubernetesValidatorConnectivity:
 
     def test_validate_connectivity_no_kubeconfig_path_with_default(self, validation_report):
         """Test validation when no kubeconfig path specified but default exists."""
-        env_config = {
-            "name": "test-env",
-            "provider_settings": {"kubernetes": {}},
-        }
+        env_config = make_env_config(
+            name="test-env",
+            provider_settings={"kubernetes": {}},
+        )
 
         with patch.object(Path, "exists", return_value=True):
             validator = KubernetesValidator(env_config, validation_report)
@@ -123,10 +124,10 @@ class TestKubernetesValidatorConnectivity:
 
     def test_validate_connectivity_no_kubeconfig_path_no_default(self, validation_report):
         """Test validation when no kubeconfig path and no default."""
-        env_config = {
-            "name": "test-env",
-            "provider_settings": {"kubernetes": {}},
-        }
+        env_config = make_env_config(
+            name="test-env",
+            provider_settings={"kubernetes": {}},
+        )
 
         with patch.object(Path, "exists", return_value=False):
             validator = KubernetesValidator(env_config, validation_report)
@@ -148,15 +149,15 @@ class TestKubernetesValidatorConnectivity:
 
     def test_validate_connectivity_passes_context_override(self, validation_report):
         """Test that context override from settings is passed through."""
-        env_config = {
-            "name": "test-env",
-            "provider_settings": {
+        env_config = make_env_config(
+            name="test-env",
+            provider_settings={
                 "kubernetes": {
                     "kubeconfig_path": "/path/to/kubeconfig",
                     "context": "my-context",
                 }
             },
-        }
+        )
         validator = KubernetesValidator(env_config, validation_report)
         validator.kubeconfig_validator.validate = MagicMock()
         validator.validate_connectivity()

--- a/tests/unit/providers/kubernetes/test_namespace_validator.py
+++ b/tests/unit/providers/kubernetes/test_namespace_validator.py
@@ -11,6 +11,7 @@ from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.kubernetes.validators.namespace_validator import (
     NamespaceValidator,
 )
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
@@ -22,10 +23,10 @@ def validation_report():
 @pytest.fixture
 def api_validator(validation_report):
     """Create a BaseAPIValidator instance."""
-    env_config = {
-        "name": "test-env",
-        "provider_settings": {"kubernetes": {}},
-    }
+    env_config = make_env_config(
+        name="test-env",
+        provider_settings={"kubernetes": {}},
+    )
     return BaseAPIValidator("kubernetes", env_config, validation_report)
 
 

--- a/tests/unit/providers/oci/test_validator.py
+++ b/tests/unit/providers/oci/test_validator.py
@@ -13,13 +13,14 @@ from infrafoundry.providers.oci.validators import (
     ImageValidator,
     NetworkValidator,
 )
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
 def env_config():
     """Create a mock environment config."""
-    return {
-        "provider_settings": {
+    return make_env_config(
+        provider_settings={
             "oci": {
                 "tenancy_ocid": "ocid1.tenancy.oc1..example",
                 "user_ocid": "ocid1.user.oc1..example",
@@ -28,8 +29,8 @@ def env_config():
                 "region": "us-ashburn-1",
                 "compartment_ocid": "ocid1.compartment.oc1..example",
             }
-        }
-    }
+        },
+    )
 
 
 @pytest.fixture
@@ -240,8 +241,8 @@ class TestValidateAPIReferences:
 
     def test_skipped_when_no_compartment_ocid(self, report):
         """API validation skipped when compartment_ocid is missing."""
-        env_config = {
-            "provider_settings": {
+        env_config = make_env_config(
+            provider_settings={
                 "oci": {
                     "tenancy_ocid": "ocid1.tenancy.oc1..example",
                     "user_ocid": "ocid1.user.oc1..example",
@@ -250,8 +251,8 @@ class TestValidateAPIReferences:
                     "region": "us-ashburn-1",
                     # No compartment_ocid
                 }
-            }
-        }
+            },
+        )
         validator = OCIValidator(env_config, report)
 
         # Should not attempt to create client
@@ -261,8 +262,8 @@ class TestValidateAPIReferences:
 
     def test_skipped_when_no_region(self, report):
         """API validation skipped when region is missing."""
-        env_config = {
-            "provider_settings": {
+        env_config = make_env_config(
+            provider_settings={
                 "oci": {
                     "tenancy_ocid": "ocid1.tenancy.oc1..example",
                     "user_ocid": "ocid1.user.oc1..example",
@@ -271,8 +272,8 @@ class TestValidateAPIReferences:
                     "compartment_ocid": "ocid1.compartment.oc1..example",
                     # No region
                 }
-            }
-        }
+            },
+        )
         validator = OCIValidator(env_config, report)
 
         with patch.object(validator, "_create_client") as mock_create:
@@ -372,7 +373,7 @@ class TestValidateConnectivity:
 
     def test_missing_credentials(self, report):
         """Test connectivity validation with missing credentials."""
-        env_config = {"provider_settings": {"oci": {}}}
+        env_config = make_env_config(provider_settings={"oci": {}})
         validator = OCIValidator(env_config, report)
 
         validator.validate_connectivity()

--- a/tests/unit/providers/opnsense/test_opnsense_validator.py
+++ b/tests/unit/providers/opnsense/test_opnsense_validator.py
@@ -15,20 +15,21 @@ from infrafoundry.providers.opnsense.validators import (
     UnboundValidator,
     VLANValidator,
 )
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
 def env_config():
     """Create a valid environment config."""
-    return {
-        "provider_settings": {
+    return make_env_config(
+        provider_settings={
             "opnsense": {
                 "api_url": "https://opnsense.example.com",
                 "api_key": "test-key",
                 "api_secret": "test-secret",
             }
-        }
-    }
+        },
+    )
 
 
 @pytest.fixture

--- a/tests/unit/providers/proxmox/test_proxmox_validator.py
+++ b/tests/unit/providers/proxmox/test_proxmox_validator.py
@@ -17,20 +17,21 @@ from infrafoundry.providers.proxmox.validators import (
     TemplateValidator,
     VMIDValidator,
 )
+from tests.helpers.env import make_env_config
 
 
 @pytest.fixture
 def env_config():
     """Create a valid environment config."""
-    return {
-        "provider_settings": {
+    return make_env_config(
+        provider_settings={
             "proxmox": {
                 "api_url": "https://pve.example.com:8006/api2/json",
                 "api_token": "user@pam!token=secret",
                 "node": "pve1",
             }
-        }
-    }
+        },
+    )
 
 
 @pytest.fixture
@@ -74,15 +75,15 @@ class TestValidateConnectivity:
 
     def test_no_api_token_reports_error(self, report):
         """Reports error when no API token is available."""
-        env_config = {
-            "provider_settings": {
+        env_config = make_env_config(
+            provider_settings={
                 "proxmox": {
                     "api_url": "https://pve.example.com:8006/api2/json",
                     "node": "pve1",
                     # No api_token, api_token_id, or api_token_secret
                 }
-            }
-        }
+            },
+        )
         validator = ProxmoxValidator(env_config, report)
         validator.api_validator.get_credentials = MagicMock(
             return_value={"api_url": "https://pve.example.com:8006/api2/json", "node": "pve1"}
@@ -138,15 +139,15 @@ class TestValidateReferences:
 
     def test_no_client_returns_early(self, report):
         """Returns early when client can't be created."""
-        env_config = {
-            "provider_settings": {
+        env_config = make_env_config(
+            provider_settings={
                 "proxmox": {
                     "api_url": "https://pve.example.com:8006/api2/json",
                     "node": "pve1",
                     # No token
                 }
-            }
-        }
+            },
+        )
         validator = ProxmoxValidator(env_config, report)
 
         validator.validate_references([])

--- a/tests/unit/test_provider_validation.py
+++ b/tests/unit/test_provider_validation.py
@@ -7,6 +7,7 @@ import pytest
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationReport
 from infrafoundry.providers.proxmox import ProxmoxProvider
+from tests.helpers.env import make_env_config
 
 
 class TestProxmoxValidation:
@@ -24,20 +25,20 @@ class TestProxmoxValidation:
     @pytest.fixture
     def env_config(self):
         """Sample environment configuration."""
-        return {
-            "provider_settings": {
+        return make_env_config(
+            provider_settings={
                 "proxmox": {
                     "api_url": "https://pve01.example.com:8006",
                     "api_token": "PVEAPIToken=root@pam!test=12345678-1234-1234-1234-123456789abc",
                     "node": "pve01",
                 }
-            }
-        }
+            },
+        )
 
     def test_validate_connectivity_missing_credentials(self, proxmox_provider):
         """Test validation fails when credentials are missing."""
         report = ValidationReport()
-        env_config = {"provider_settings": {"proxmox": {}}}
+        env_config = make_env_config(provider_settings={"proxmox": {}})
 
         proxmox_provider.validate_connectivity(env_config, report)
 
@@ -201,7 +202,7 @@ class TestProxmoxValidation:
     def test_validate_references_no_credentials(self, proxmox_provider):
         """Test reference validation skips when no credentials."""
         report = ValidationReport()
-        env_config = {"provider_settings": {"proxmox": {}}}
+        env_config = make_env_config(provider_settings={"proxmox": {}})
         resources = [
             ResourceConfig(
                 provider="proxmox",

--- a/tests/unit/test_validation_helpers.py
+++ b/tests/unit/test_validation_helpers.py
@@ -6,6 +6,7 @@ import pytest
 
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
 from infrafoundry.core.validation_helpers import BaseProviderValidator, ResourceValidator
+from tests.helpers.env import make_env_config
 
 
 class TestBaseProviderValidator:
@@ -14,15 +15,15 @@ class TestBaseProviderValidator:
     @pytest.fixture
     def env_config(self):
         """Sample environment configuration."""
-        return {
-            "provider_settings": {
+        return make_env_config(
+            provider_settings={
                 "test_provider": {
                     "api_url": "https://api.example.com",
                     "api_key": "test-key",
                     "api_secret": "test-secret",
                 }
-            }
-        }
+            },
+        )
 
     @pytest.fixture
     def report(self):
@@ -43,7 +44,7 @@ class TestBaseProviderValidator:
         assert validator.provider_name == "test_provider"
         assert validator.env_config == env_config
         assert validator.report == report
-        assert validator.provider_settings == env_config["provider_settings"]["test_provider"]
+        assert validator.provider_settings == env_config.provider_settings["test_provider"]
 
     def test_validate_credentials_success(self, validator, report):
         """Test successful credential validation."""


### PR DESCRIPTION
## Description

`foundry infra doctor --env <name>` silently failed to resolve
`terraform_secrets` references, so required fields backed by SOPS-encrypted
secrets always reported as missing even when the secrets were valid and
present. The root cause was that the provider validation pipeline dumped the
`EnvironmentConfig` pydantic model to a plain `dict` via `model_dump()` and
then passed that dict down to the validators. The helper at
`core/validation_helpers/terraform_secrets_validator.py` reads the env's
decrypted secrets via `getattr(env_config, "secrets", None)`; on a `dict`
this always returns `None`, so the flattened secrets lookup was empty and
every `terraform_secrets` reference was reported as an unknown key —
regardless of what was actually in `envs/{env}/secrets.yaml`.

The fix threads the original `EnvironmentConfig` model all the way through
the validator chain so attribute access works as intended.

## Related Issue

Addresses #609

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `core/provider.py`, `core/orchestrator_workflows.py`: stop calling
  `model_dump()` on `EnvironmentConfig` before handing it to validators;
  pass the model through unchanged.
- `core/validation_helpers/{base_validator,api_validator,credential_validator,terraform_secrets_validator}.py`:
  update type hints and lookups to use `EnvironmentConfig` attribute access
  instead of dict `.get()` / `getattr()` on a dict.
- `providers/{esxi,kubernetes,oci,opnsense,proxmox}/validator.py` (and the
  provider `__init__.py` files that re-dispatch): propagate the same
  `EnvironmentConfig` type through each provider's validators.
- `tests/helpers/env.py` (new): `make_env_config(**overrides)` helper that
  builds a realistic `EnvironmentConfig` for validator tests, so existing
  tests no longer fake it with plain dicts.
- `tests/unit/core/validation_helpers/test_terraform_secrets_validator.py`
  (new): regression test covering both the positive path (reference
  resolves to the SOPS-decrypted value) and the negative path (missing
  secret key surfaces a clear validation error).
- Existing unit tests in `tests/unit/test_provider_validation.py`,
  `tests/unit/test_validation_helpers.py`, and
  `tests/unit/providers/*/test_*_validator.py` updated to use the new
  helper and exercise real model objects.
- `docs/development/implementing-providers.md`: corrected the documented
  validator signatures from the stale `EnvironmentData` placeholder to the
  actual `EnvironmentConfig` type.

### Deliberately out of scope

The following still consume an untyped/dict-shaped env payload and are
**not** touched in this PR to keep the fix focused:

- Terraform/Ansible exporters that accept env data.
- `cli/commands/infra/test.py` (separate call path).
- The `EnvironmentData` TypedDict alias, which is no longer used by the
  validator chain but is still referenced elsewhere; removing it is
  tracked as a follow-up cleanup.

## Testing

- [x] All existing tests pass (`doit check` clean — lint, format, mypy,
  bandit, codespell, and 2862 pytest tests all green).
- [x] Added new tests for new functionality — regression test for
  `terraform_secrets` resolution covering both hit and miss paths.
- [x] Manually tested the changes — `foundry infra doctor --env prod`
  against a real OCI + `tailscale-secrets` environment now returns 0
  errors where it previously reported every secret-backed field as
  missing.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No ADR is required — this is a bug fix, not an architectural decision, and
the issue is not labeled `needs-adr`. No existing ADR describes the
`EnvironmentConfig` → validator contract, so none needed updating.
