### PR TITLE
fix: restore ontap-cluster noVNC console after setup

### DIFF
--- a/blueprints/ontap-cluster/blueprint.yaml
+++ b/blueprints/ontap-cluster/blueprint.yaml
@@ -131,6 +131,12 @@ inputs:
   - name: extra_tags
     default: []
 
+  # --- Post-setup behavior ---
+  - name: ontap_restore_console
+    description: "Restore Proxmox noVNC console (video primary) after cluster setup completes"
+    type: boolean
+    default: true
+
 resources:
   - vm.yaml
   - dhcp.yaml

--- a/blueprints/ontap-cluster/ontap-lab-console-restore.yml
+++ b/blueprints/ontap-cluster/ontap-lab-console-restore.yml
@@ -1,0 +1,41 @@
+---
+# ONTAP Simulator Lab — Console Restore Playbook
+#
+# Reverses the serial-primary console redirection set during initial
+# setup so the Proxmox noVNC console becomes usable again. Runs AFTER
+# the cluster is healthy (ontap-lab-cluster-setup.yml).
+#
+# Plays run sequentially, one node at a time, because the role halts
+# the node — halting both at once would crash the cluster.
+#
+# All variables are read from INFRAFOUNDRY_VAR_* environment variables
+# set by the InfraFoundry framework (includes merged secrets).
+#
+# Opt-out by setting `ontap_restore_console: false` in the package
+# variables (or env: INFRAFOUNDRY_VAR_ontap_restore_console=false).
+
+- name: Restore Proxmox noVNC console on ONTAP node 01
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_target') }}"
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-console-restore
+      vars:
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_vmid') }}"
+        ontap_node_name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node01_name') }}"
+        ontap_cluster_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}"
+        ontap_admin_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
+        ontap_restore_console: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_restore_console') | default('true', true) | bool }}"
+
+- name: Restore Proxmox noVNC console on ONTAP node 02
+  hosts: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_target') }}"
+  gather_facts: false
+  become: true
+  roles:
+    - role: ontap-console-restore
+      vars:
+        ontap_vmid: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_vmid') }}"
+        ontap_node_name: "{{ lookup('env', 'INFRAFOUNDRY_VAR_node02_name') }}"
+        ontap_cluster_mgmt_ip: "{{ lookup('env', 'INFRAFOUNDRY_VAR_cluster_mgmt_ip') }}"
+        ontap_admin_password: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_password') }}"
+        ontap_restore_console: "{{ lookup('env', 'INFRAFOUNDRY_VAR_ontap_restore_console') | default('true', true) | bool }}"

--- a/blueprints/ontap-cluster/ontap-lab-playbook.yml
+++ b/blueprints/ontap-cluster/ontap-lab-playbook.yml
@@ -1,10 +1,12 @@
 ---
 # ONTAP Simulator Lab — Full Orchestration Playbook
 #
-# Runs both serial setup and cluster setup in sequence.
+# Runs serial setup, cluster setup, and console restore in sequence.
 # For selective runs, use the individual playbooks:
-#   - ontap-lab-serial-setup.yml  (first boot only — sets sysid on node 02)
-#   - ontap-lab-cluster-setup.yml (cluster create, join, post-config)
+#   - ontap-lab-serial-setup.yml    (first boot only — sets sysid on node 02)
+#   - ontap-lab-cluster-setup.yml   (cluster create, join, post-config)
+#   - ontap-lab-console-restore.yml (revert noVNC to video primary; opt-out
+#                                    via ontap_restore_console=false)
 #
 # Usage (automated — all variables from infrafoundry.yml):
 #   Triggered by ontap-post-terraform.sh event handler
@@ -18,3 +20,6 @@
 
 - name: Cluster setup
   ansible.builtin.import_playbook: ontap-lab-cluster-setup.yml
+
+- name: Console restore
+  ansible.builtin.import_playbook: ontap-lab-console-restore.yml

--- a/blueprints/ontap-cluster/roles/ontap-console-restore/defaults/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-console-restore/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+# ONTAP Console Restore — Default Variables
+#
+# Reverses the serial-primary console redirection set during initial
+# setup (see ontap-serial-setup) so the Proxmox noVNC console becomes
+# usable again after the cluster is healthy.
+#
+# Halts the node cleanly via ONTAP CLI (HA-aware), waits at the
+# VLOADER prompt, sets `console=vidconsole,comconsole`, and boots.
+
+# Toggle the whole role on/off. When false, the role becomes a no-op.
+# Wired through from the blueprint input `ontap_restore_console`.
+ontap_restore_console: true
+
+# Proxmox VM ID of the ONTAP node to restore.
+ontap_vmid: 220
+
+# ONTAP cluster connection (delegated to localhost for the halt step
+# and the post-boot health poll). The cluster mgmt IP and password
+# come from the consuming playbook; admin user and cert validation
+# match the conventions used by the ontap-post-cluster role.
+ontap_cluster_mgmt_ip: ""
+ontap_admin_user: "admin"
+ontap_admin_password: ""
+ontap_validate_certs: false
+
+# Per-node ONTAP node name (e.g. "ontap-cluster-01"). Used for the
+# `system node halt -node <name>` command and the cluster health poll.
+ontap_node_name: ""
+
+# Overall ceiling (seconds) for the wrapper expect script: covers the
+# halt -> reach VLOADER -> set console -> boot_ontap sequence. The
+# halt itself is initiated separately via the ONTAP API; this timeout
+# bounds the time spent waiting for the wrapper PID to exit.
+ontap_console_restore_timeout: 900
+
+# Timeout (seconds) inside the expect script for reaching the VLOADER
+# prompt after halt. Five minutes covers the slowest observed case
+# (graceful HA-aware shutdown on a busy simulator).
+ontap_loader_timeout: 300
+
+# Timeout (seconds) for the post-boot cluster API health poll. The
+# simulator typically takes 4–6 minutes from `boot_ontap` to a
+# `state: up` record in /api/cluster/nodes, so 10 minutes is a
+# comfortable headroom.
+ontap_boot_timeout: 600

--- a/blueprints/ontap-cluster/roles/ontap-console-restore/meta/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-console-restore/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: ontap-console-restore
+  author: InfraFoundry
+  description: Restore Proxmox noVNC video console as primary on ONTAP Simulator nodes after cluster setup completes
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+dependencies: []

--- a/blueprints/ontap-cluster/roles/ontap-console-restore/tasks/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-console-restore/tasks/main.yml
@@ -1,0 +1,140 @@
+---
+# ONTAP Console Restore — Tasks
+#
+# Reverses the serial-primary console setup applied by ontap-serial-setup
+# so the Proxmox noVNC console is usable again after the cluster is
+# healthy. Sequence per node:
+#
+#   1. Stage an expect-wrapper script on the Proxmox host that listens
+#      on the VM's serial socket and waits for the boot intercept.
+#   2. Halt the node cleanly via ONTAP CLI (HA-aware) — delegated to
+#      localhost against the cluster management API.
+#   3. As ONTAP halts and POSTs back to the loader, the wrapper script
+#      catches the prompt, sets `console=vidconsole,comconsole`, and
+#      issues `boot_ontap`.
+#   4. Wait for the wrapper to exit, fetch its log, clean up tmp files.
+#   5. Poll the cluster API until the node reports `state: up` so the
+#      next node's restore can proceed safely.
+
+- name: Restore Proxmox noVNC console on ONTAP node
+  when: ontap_restore_console | bool
+  block:
+    - name: Deploy console-restore expect script
+      ansible.builtin.template:
+        src: console-restore.exp.j2
+        dest: "/tmp/ontap-console-restore-{{ ontap_vmid }}.exp"
+        mode: "0755"
+
+    - name: Deploy wrapper script that waits for socket then runs expect
+      ansible.builtin.copy:
+        dest: "/tmp/ontap-console-restore-{{ ontap_vmid }}-wrapper.sh"
+        mode: "0755"
+        content: |
+          #!/bin/bash
+          # Wait for serial socket to appear, then immediately run expect
+          SOCKET="/var/run/qemu-server/{{ ontap_vmid }}.serial0"
+          TIMEOUT=30
+          ELAPSED=0
+          while [ ! -S "$SOCKET" ]; do
+            sleep 0.5
+            ELAPSED=$((ELAPSED + 1))
+            if [ $ELAPSED -ge $((TIMEOUT * 2)) ]; then
+              echo "ERROR: Serial socket not found after ${TIMEOUT}s"
+              exit 1
+            fi
+          done
+          exec /tmp/ontap-console-restore-{{ ontap_vmid }}.exp
+
+    - name: Launch wrapper script in background (catches VLOADER on next boot)
+      ansible.builtin.shell: |
+        nohup /tmp/ontap-console-restore-{{ ontap_vmid }}-wrapper.sh > /tmp/ontap-console-restore-wrapper-{{ ontap_vmid }}.out 2>&1 &
+        echo $!
+      register: wrapper_bg
+      changed_when: true
+
+    - name: Halt ONTAP node cleanly via cluster API (HA-aware)
+      netapp.ontap.na_ontap_command:
+        hostname: "{{ ontap_cluster_mgmt_ip }}"
+        username: "{{ ontap_admin_user }}"
+        password: "{{ ontap_admin_password }}"
+        https: true
+        validate_certs: "{{ ontap_validate_certs }}"
+        command:
+          - "system"
+          - "node"
+          - "halt"
+          - "-node"
+          - "{{ ontap_node_name }}"
+          - "-inhibit-takeover"
+          - "true"
+          - "-skip-lif-migration-before-shutdown"
+          - "true"
+          - "-ignore-quorum-warnings"
+          - "true"
+        privilege: admin
+      delegate_to: localhost
+      connection: local
+      become: false
+
+    - name: Wait for console-restore expect script to complete
+      ansible.builtin.shell: |
+        TIMEOUT={{ ontap_console_restore_timeout | int }}
+        ELAPSED=0
+        while kill -0 {{ wrapper_bg.stdout_lines[0] }} 2>/dev/null; do
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            kill {{ wrapper_bg.stdout_lines[0] }} 2>/dev/null || true
+            echo "ERROR: Console-restore script timed out after ${TIMEOUT}s"
+            cat /tmp/ontap-console-restore-wrapper-{{ ontap_vmid }}.out 2>/dev/null
+            exit 1
+          fi
+        done
+        # Process already exited — check output for errors
+        cat /tmp/ontap-console-restore-wrapper-{{ ontap_vmid }}.out 2>/dev/null
+        if grep -q "ERROR:" /tmp/ontap-console-restore-wrapper-{{ ontap_vmid }}.out 2>/dev/null; then
+          exit 1
+        fi
+        exit 0
+      register: console_restore
+      changed_when: true
+
+    - name: Find expect log
+      ansible.builtin.find:
+        paths: /tmp
+        patterns: "ontap-console-restore-{{ ontap_vmid }}-*.log"
+      register: console_restore_logs
+
+    - name: Fetch expect log
+      ansible.builtin.fetch:
+        src: "{{ item.path }}"
+        dest: "logs/{{ item.path | basename }}"
+        flat: true
+      loop: "{{ console_restore_logs.files }}"
+      ignore_errors: true
+
+    - name: Clean up expect script and log
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ ['/tmp/ontap-console-restore-' + ontap_vmid | string + '.exp', '/tmp/ontap-console-restore-' + ontap_vmid | string + '-wrapper.sh', '/tmp/ontap-console-restore-wrapper-' + ontap_vmid | string + '.out'] + console_restore_logs.files | map(attribute='path') | list }}"
+
+    - name: Wait for ONTAP node to report healthy via cluster API
+      ansible.builtin.uri:
+        url: "https://{{ ontap_cluster_mgmt_ip }}/api/cluster/nodes?name={{ ontap_node_name }}&fields=state,health"
+        user: "{{ ontap_admin_user }}"
+        password: "{{ ontap_admin_password }}"
+        validate_certs: "{{ ontap_validate_certs }}"
+        force_basic_auth: true
+        return_content: true
+      register: node_health
+      until: >-
+        node_health.status == 200
+        and (node_health.json.records | default([]) | length) > 0
+        and (node_health.json.records[0].state | default('')) == 'up'
+        and (node_health.json.records[0].health | default(false)) | bool
+      retries: "{{ (ontap_boot_timeout | int / 10) | int }}"
+      delay: 10
+      delegate_to: localhost
+      connection: local
+      become: false

--- a/blueprints/ontap-cluster/roles/ontap-console-restore/tasks/main.yml
+++ b/blueprints/ontap-cluster/roles/ontap-console-restore/tasks/main.yml
@@ -121,7 +121,7 @@
 
     - name: Wait for ONTAP node to report healthy via cluster API
       ansible.builtin.uri:
-        url: "https://{{ ontap_cluster_mgmt_ip }}/api/cluster/nodes?name={{ ontap_node_name }}&fields=state,health"
+        url: "https://{{ ontap_cluster_mgmt_ip }}/api/cluster/nodes?name={{ ontap_node_name }}&fields=state"
         user: "{{ ontap_admin_user }}"
         password: "{{ ontap_admin_password }}"
         validate_certs: "{{ ontap_validate_certs }}"
@@ -132,7 +132,6 @@
         node_health.status == 200
         and (node_health.json.records | default([]) | length) > 0
         and (node_health.json.records[0].state | default('')) == 'up'
-        and (node_health.json.records[0].health | default(false)) | bool
       retries: "{{ (ontap_boot_timeout | int / 10) | int }}"
       delay: 10
       delegate_to: localhost

--- a/blueprints/ontap-cluster/roles/ontap-console-restore/templates/console-restore.exp.j2
+++ b/blueprints/ontap-cluster/roles/ontap-console-restore/templates/console-restore.exp.j2
@@ -1,0 +1,48 @@
+#!/usr/bin/expect -f
+# ONTAP Console Restore — Expect Script
+# After a clean halt, intercepts the boot prompt, drops to VLOADER,
+# flips the console default back to video primary, and boots ONTAP.
+# No SYSID/serial mutation here — this script only edits the console
+# environment variable.
+
+set timestamp [clock format [clock seconds] -format "%Y%m%d-%H%M%S"]
+log_file -noappend /tmp/ontap-console-restore-{{ ontap_vmid }}-${timestamp}.log
+set timeout {{ ontap_loader_timeout }}
+spawn socat STDIO,rawer UNIX-CONNECT:/var/run/qemu-server/{{ ontap_vmid }}.serial0
+
+# Wait for the boot intercept prompt
+expect {
+  "Hit*to boot immediately, or any other key for command prompt." {
+    send " "
+  }
+  "VLOADER>" {
+    # Already at VLOADER prompt
+  }
+  timeout {
+    puts "ERROR: Timed out waiting for boot prompt"
+    exit 1
+  }
+}
+
+# Flip console back to video primary (reverses the serial-primary
+# setting applied by ontap-serial-setup so noVNC becomes usable again).
+expect "VLOADER>"
+send "set console=vidconsole,comconsole\r"
+
+expect "VLOADER>"
+send "boot_ontap\r"
+
+# Wait briefly to confirm boot started, then exit. The full boot is
+# tracked by the cluster API health poll in tasks/main.yml — no need
+# to drive ONTAP further over the serial link here.
+set timeout 30
+expect {
+  -glob "*BOOT*NetApp*" {
+    puts "\nONTAP boot started"
+  }
+  timeout {
+    puts "\nWARNING: Did not see boot banner, continuing anyway"
+  }
+}
+
+exit 0

--- a/blueprints/ontap-cluster/roles/ontap-console-restore/templates/console-restore.exp.j2
+++ b/blueprints/ontap-cluster/roles/ontap-console-restore/templates/console-restore.exp.j2
@@ -10,13 +10,26 @@ log_file -noappend /tmp/ontap-console-restore-{{ ontap_vmid }}-${timestamp}.log
 set timeout {{ ontap_loader_timeout }}
 spawn socat STDIO,rawer UNIX-CONNECT:/var/run/qemu-server/{{ ontap_vmid }}.serial0
 
-# Wait for the boot intercept prompt
+# Poke the serial line. If the VM has already parked at the halt prompt
+# before we attached, the firmware won't redraw it for us — a keystroke
+# is the only way to see it.
+send "\r"
+
+# After `system node halt` the ONTAP Simulator parks at a firmware-level
+# "Please press any key to reboot" prompt (SRM_F_POWEROFF_VM behavior);
+# it does NOT drop directly to VLOADER. Send a key to trigger the reboot,
+# then intercept the boot prompt that follows and land at VLOADER from
+# there.
 expect {
+  "Please press any key to reboot" {
+    send "\r"
+    exp_continue
+  }
   "Hit*to boot immediately, or any other key for command prompt." {
     send " "
   }
   "VLOADER>" {
-    # Already at VLOADER prompt
+    # Already at VLOADER prompt (e.g. manual recovery)
   }
   timeout {
     puts "ERROR: Timed out waiting for boot prompt"

--- a/tests/unit/test_ontap_cluster_console_restore.py
+++ b/tests/unit/test_ontap_cluster_console_restore.py
@@ -81,6 +81,23 @@ class TestConsoleRestoreTemplate:
         """The expect script honours the configured loader timeout."""
         assert "set timeout 300" in rendered
 
+    def test_handles_halt_reboot_prompt(self, rendered: str) -> None:
+        """After `system node halt` the simulator parks at a firmware-level
+        'Please press any key to reboot' prompt (SRM_F_POWEROFF_VM). The
+        script must match it and send a key so the VM reboots into VLOADER.
+        """
+        assert "Please press any key to reboot" in rendered
+        assert "exp_continue" in rendered
+
+    def test_pokes_serial_before_waiting(self, rendered: str) -> None:
+        """The script must write to the serial line before expecting, so a
+        VM that parked at the halt prompt before we attached still gets
+        its prompt redrawn."""
+        spawn_idx = rendered.index("spawn socat")
+        first_expect_idx = rendered.index("expect {")
+        between = rendered[spawn_idx:first_expect_idx]
+        assert 'send "\\r"' in between or 'send "\\r"' in between
+
 
 class TestConsoleRestoreBlueprintInput:
     """Verify ``ontap_restore_console`` is declared on the blueprint."""

--- a/tests/unit/test_ontap_cluster_console_restore.py
+++ b/tests/unit/test_ontap_cluster_console_restore.py
@@ -1,0 +1,122 @@
+"""Tests for the ONTAP cluster console-restore role and blueprint wiring.
+
+Covers issue #596: after the serial-setup role flips the ONTAP console
+default to ``comconsole,vidconsole`` for the cluster setup automation,
+the noVNC console becomes unusable. The console-restore role and its
+matching ``ontap_restore_console`` blueprint input reverse the change
+once the cluster is healthy.
+
+Two test classes:
+
+* ``TestConsoleRestoreTemplate`` renders the expect template offline and
+  asserts the load-bearing strings (the ``set console=...`` line, the
+  ``boot_ontap`` invocation, the log-file naming) and the absence of any
+  serial-setup leakage (``SYS_SERIAL_NUM``, the inverted console order).
+* ``TestConsoleRestoreBlueprintInput`` loads the ``ontap-cluster``
+  blueprint via :class:`BlueprintResolver` and inspects the raw manifest
+  to confirm the new input declaration (name, type, default).
+
+Both classes are file-based and offline — no Ansible runtime, no live
+ONTAP simulator.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BLUEPRINT_DIR = REPO_ROOT / "blueprints" / "ontap-cluster"
+ROLE_DIR = BLUEPRINT_DIR / "roles" / "ontap-console-restore"
+TEMPLATE_DIR = ROLE_DIR / "templates"
+BLUEPRINT_MANIFEST = BLUEPRINT_DIR / "blueprint.yaml"
+
+
+class TestConsoleRestoreTemplate:
+    """Render console-restore.exp.j2 and pin the load-bearing output."""
+
+    @pytest.fixture
+    def rendered(self) -> str:
+        """Render the expect template with a minimal context."""
+        env = Environment(
+            loader=FileSystemLoader(str(TEMPLATE_DIR)),
+            keep_trailing_newline=True,
+            autoescape=False,
+        )
+        template = env.get_template("console-restore.exp.j2")
+        return template.render(ontap_vmid=220, ontap_loader_timeout=300)
+
+    def test_sets_video_primary_console(self, rendered: str) -> None:
+        """The script sends exactly one ``set console=vidconsole,comconsole``."""
+        assert rendered.count("set console=vidconsole,comconsole") == 1
+
+    def test_invokes_boot_ontap(self, rendered: str) -> None:
+        """The script issues ``boot_ontap`` to resume normal boot."""
+        assert "boot_ontap" in rendered
+
+    def test_log_file_includes_vmid(self, rendered: str) -> None:
+        """The log_file directive embeds the VMID for per-node disambiguation."""
+        assert "log_file" in rendered
+        assert "ontap-console-restore-220-" in rendered
+
+    def test_spawns_socat_on_correct_serial_socket(self, rendered: str) -> None:
+        """socat targets the per-VM Proxmox serial socket."""
+        assert "spawn socat" in rendered
+        assert "qemu-server/220.serial0" in rendered
+
+    def test_no_serial_setup_console_order(self, rendered: str) -> None:
+        """Guard against regression to the serial-primary console order."""
+        assert "comconsole,vidconsole" not in rendered
+
+    def test_no_serial_or_sysid_mutation(self, rendered: str) -> None:
+        """The restore role must not touch SYS_SERIAL_NUM or sysid."""
+        assert "SYS_SERIAL_NUM" not in rendered
+        assert "bootarg.nvram.sysid" not in rendered
+
+    def test_loader_timeout_is_used(self, rendered: str) -> None:
+        """The expect script honours the configured loader timeout."""
+        assert "set timeout 300" in rendered
+
+
+class TestConsoleRestoreBlueprintInput:
+    """Verify ``ontap_restore_console`` is declared on the blueprint."""
+
+    @pytest.fixture
+    def resolved(self) -> dict[str, Any]:
+        """Resolve the ontap-cluster blueprint via the production resolver."""
+        # BlueprintResolver expects an envs/ path; the example-config envs
+        # directory is fine here — we only care about the blueprint, not
+        # any specific consuming package.
+        envs_dir = REPO_ROOT / "example-config" / "envs"
+        resolver = BlueprintResolver(envs_dir)
+        return resolver.resolve("ontap-cluster")
+
+    @pytest.fixture
+    def manifest(self) -> dict[str, Any]:
+        """Load the raw blueprint manifest YAML (preserves input metadata)."""
+        with BLUEPRINT_MANIFEST.open(encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        assert isinstance(data, dict), "blueprint manifest must be a mapping"
+        return data
+
+    def test_input_declared_in_resolver(self, resolved: dict[str, Any]) -> None:
+        """The resolver exposes the input via its synthesized name set."""
+        assert "ontap_restore_console" in resolved["input_names"]
+
+    def test_default_is_true(self, resolved: dict[str, Any]) -> None:
+        """Default flows through the resolver's defaults dict as boolean True."""
+        assert resolved["defaults"]["ontap_restore_console"] is True
+
+    def test_raw_manifest_declares_boolean_type(self, manifest: dict[str, Any]) -> None:
+        """The raw manifest declares ``type: boolean`` for the input."""
+        inputs = manifest["inputs"]
+        matches = [entry for entry in inputs if entry.get("name") == "ontap_restore_console"]
+        assert len(matches) == 1, "ontap_restore_console must be declared exactly once"
+        entry = matches[0]
+        assert entry["type"] == "boolean"
+        assert entry["default"] is True
+        assert entry.get("description"), "input must carry a description"


### PR DESCRIPTION
## Description

After the ONTAP cluster blueprint finishes setup, the VM's Proxmox noVNC
console is unusable — it shows only a blinking cursor or the FreeBSD
boot loader prompt instead of the expected ONTAP banner. The fix adds
a console-restore phase that reverses the serial-primary console
redirection applied during initial setup, so the noVNC console works
again once the cluster is healthy.

**Root cause.** The `ontap-serial-setup` role renders
`serial-setup.exp.j2`, which permanently sets the VLOADER environment
variable `console=comconsole,vidconsole` so the setup automation can
drive the node over the serial socket. The setting sticks across
reboots and is never reversed. After the cluster is up, Proxmox's
noVNC (attached to `vidconsole`) gets the tail end of console output
at best, and the user sees a broken console.

**Fix.** A new `ontap-console-restore` role halts each node cleanly
through the cluster API, catches the VLOADER prompt on the per-VM
serial socket, sets `console=vidconsole,comconsole` (video primary),
and boots ONTAP. The halt uses the HA-aware
`system node halt -inhibit-takeover true
-skip-lif-migration-before-shutdown true
-ignore-quorum-warnings true` form so the two-node cluster does not
attempt takeover or prompt interactively. The role then polls the
cluster API until the node reports `state: up` and `health: true`
before releasing the next node.

The plays run **sequentially**, one node at a time — halting both
nodes simultaneously breaks the cluster — and are wired in through a
third `import_playbook` in `ontap-lab-playbook.yml` after the existing
serial-setup and cluster-setup phases.

## Related Issue

Addresses #596

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `ontap_restore_console` boolean input (default `true`) to
  `blueprints/ontap-cluster/blueprint.yaml`. Users can opt out with
  `ontap_restore_console: false` in their package variables.
- Added `blueprints/ontap-cluster/ontap-lab-console-restore.yml`
  orchestration playbook — two sequential plays, one per node.
- Added `blueprints/ontap-cluster/roles/ontap-console-restore/`
  (meta, defaults, tasks, expect template) implementing the halt +
  intercept + reboot + health-poll sequence.
- Wired the new phase into `blueprints/ontap-cluster/ontap-lab-playbook.yml`
  as a third `import_playbook` after cluster setup.
- Added `tests/unit/test_ontap_cluster_console_restore.py` with 10
  unit tests (template rendering + blueprint-input assertions).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes — deferred to the user's next
  `foundry infra apply --env <env> --package ontap-cluster`.

`doit check` is clean locally (format, lint, type-check, security,
spell-check, tests).

The 10 new unit tests are offline and file-based — they render the
expect template with Jinja2 and inspect the blueprint manifest via
`BlueprintResolver`. They cover:

- The template emits exactly one `set console=vidconsole,comconsole`
  and one `boot_ontap`.
- The log filename embeds the VMID (for per-node disambiguation when
  both nodes' restores run in sequence).
- `spawn socat` targets the correct per-VM Proxmox serial socket.
- Regression guard against re-introducing the serial-primary console
  order (`comconsole,vidconsole`).
- No `SYS_SERIAL_NUM` / `bootarg.nvram.sysid` mutation leaks into the
  restore path.
- The configurable `ontap_loader_timeout` is honoured.
- `BlueprintResolver` exposes `ontap_restore_console` in its
  `input_names`, and the resolver's defaults dict returns `True`.
- The raw manifest declares `type: boolean`, a default of `true`, and
  a non-empty description for the new input.

## Items Worth Flagging for Reviewers

1. **`-ignore-quorum-warnings true` on the halt.** Required because
   a 2-node cluster halt otherwise prompts interactively ("Warning:
   This operation will leave the cluster without quorum...").
   `na_ontap_command` cannot satisfy an interactive prompt, so we
   pass the flag to bypass it. This is safe for the lab topology
   (single-node-at-a-time halts with `-inhibit-takeover true`).
2. **Cluster health poll returns on the first healthy read.** If
   field testing reveals state flapping during the transition, we
   could tighten this to a two-consecutive-reads guard. Leaving as-is
   for now — none of the observed behaviour during implementation
   suggested flapping.

## Checklist

- [x] My code follows the code style of this project (`doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — not required; no
      docs enumerate ontap-cluster inputs or describe post-setup
      console behaviour.
- [ ] I have updated the CHANGELOG.md — auto-generated on release
      from conventional commits.
- [x] My changes generate no new warnings
