### PR TITLE
feat: inject provider variable into package template context

### DIFF
--- a/docs/configuration/blueprints.md
+++ b/docs/configuration/blueprints.md
@@ -127,6 +127,69 @@ inputs:
     default: 4096
 ```
 
+## Shared Resource Templates
+
+Multi-provider blueprints can use a single shared resource file with Jinja2
+provider conditionals instead of maintaining separate files per provider. The
+`provider` variable is automatically injected into the template rendering
+context, giving templates access to the effective provider name.
+
+### Pattern
+
+Use the resource-centric format (`resources:` key) in shared files so each
+provider block can declare its own resource type:
+
+```yaml
+# shared.yaml — one file, multiple providers (resource-centric format)
+resources:
+{% if provider == "proxmox" %}
+  - provider: proxmox
+    type: vm
+    name: {{ vm_name }}-node
+    config:
+      cores: {{ cores }}
+      memory: {{ memory_gb | to_mib }}
+{% elif provider == "oci" %}
+  - provider: oci
+    type: instance
+    name: {{ vm_name }}-node
+    config:
+      shape: VM.Standard.E4.Flex
+      ocpus: {{ cores }}
+      memory_in_gbs: {{ memory_gb }}
+{% endif %}
+```
+
+Reference the shared file from both provider blocks in `blueprint.yaml`:
+
+```yaml
+name: k3s-cluster
+defaults:
+  vm_name: k3s
+  cores: 2
+  memory_gb: 8
+providers:
+  proxmox:
+    resources:
+      - shared.yaml
+  oci:
+    resources:
+      - shared.yaml
+```
+
+### Guidance
+
+- **Use shared files** when the resource count is small and the conditional
+  logic is simple (a few `{% if %}`/`{% elif %}` blocks).
+- **Use separate per-provider files** when schemas differ significantly or
+  the template would become hard to read. This is the recommended default
+  for most multi-provider blueprints.
+- The `provider` variable is also available in event handler templates and
+  in non-blueprint packages.
+- If a user-defined variable named `provider` already exists in the
+  manifest's `variables`, the user value takes precedence over the
+  injected value.
+
 ## Validation and Checks
 
 - After creation, run `foundry infra doctor --env <env>` within the generated repo to ensure configs are sound.

--- a/docs/configuration/infrastructure-packages.md
+++ b/docs/configuration/infrastructure-packages.md
@@ -146,6 +146,43 @@ vm:
 - Resource type is derived from the filename (same as regular provider resources)
 - Both singular (`vm`) and plural (`vms`) keys are supported
 
+### Built-in Template Variables
+
+In addition to user-defined variables from `infrafoundry.yml`, the following
+variables are automatically injected into the Jinja2 rendering context:
+
+| Variable   | Type   | Description |
+|:-----------|:-------|:------------|
+| `provider` | string | The effective provider name for the package (e.g., `proxmox`, `oci`). Determined from the manifest's `provider` field or the parent directory name. |
+
+The `provider` variable is available in both resource templates and event
+handler configurations. If a user-defined variable named `provider` already
+exists in the manifest's `variables`, the user value takes precedence.
+
+**Usage in templates:**
+
+```yaml
+vm:
+  - name: {{ cluster_name }}-node1
+    description: "Deployed on {{ provider }}"
+```
+
+Or with conditionals for multi-provider blueprints (using the resource-centric
+format so each branch can declare its own resource type):
+
+```yaml
+resources:
+{% if provider == "proxmox" %}
+  - provider: proxmox
+    type: vm
+    name: {{ vm_name }}-node
+{% elif provider == "oci" %}
+  - provider: oci
+    type: instance
+    name: {{ vm_name }}-node
+{% endif %}
+```
+
 ### Custom Filters
 
 InfraFoundry registers the following custom Jinja2 filters for use in resource

--- a/docs/decisions/0003-multi-provider-blueprint-support.md
+++ b/docs/decisions/0003-multi-provider-blueprint-support.md
@@ -61,6 +61,7 @@ These are acceptable tradeoffs. The real duplication today is in the non-resourc
 - [#507](https://github.com/endavis/infrafoundry/issues/507): Original multi-provider blueprint design
 - [#571](https://github.com/endavis/infrafoundry/issues/571): Blueprint schema validation across providers (Phase 3 — mitigates the "no schema validation across providers" consequence above)
 - [#572](https://github.com/endavis/infrafoundry/issues/572): Base schema helpers (centralized Jinja2 filter factory for blueprint templates)
+- [#573](https://github.com/endavis/infrafoundry/issues/573): Single resource file for multi-provider blueprints (injects `provider` variable into template context)
 
 ## Superseded schema details
 

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -268,7 +268,9 @@ class PackageLoader:
         resources: list[ResourceConfig] = []
         for resource_file in manifest.resources:
             resource_path = self._resolve_package_file(resource_file, package_dir, blueprint_dir)
-            data = self._render_resource_file(resource_path, manifest.variables)
+            data = self._render_resource_file(
+                resource_path, manifest.variables, provider=effective_provider
+            )
             parsed = self._parse_resources_from_data(data, resource_file, effective_provider)
             resources.extend(parsed)
 
@@ -282,7 +284,10 @@ class PackageLoader:
             try:
                 events_env = create_jinja2_env(undefined=jinja2.Undefined)
                 events_template = events_env.from_string(events_json)
-                rendered_events_json = events_template.render(**manifest.variables)
+                events_context = dict(manifest.variables)
+                if effective_provider and "provider" not in events_context:
+                    events_context["provider"] = effective_provider
+                rendered_events_json = events_template.render(**events_context)
                 manifest.events = json.loads(rendered_events_json)
             except (jinja2.TemplateError, json.JSONDecodeError) as e:
                 logger.warning("Failed to render event templates: %s", e)
@@ -370,13 +375,20 @@ class PackageLoader:
         return manifest
 
     def _render_resource_file(
-        self, resource_path: Path, variables: dict[str, Any]
+        self,
+        resource_path: Path,
+        variables: dict[str, Any],
+        *,
+        provider: str | None = None,
     ) -> dict[str, Any]:
         """Read a resource template file, render with Jinja2, and parse as YAML.
 
         Args:
             resource_path: Path to the resource template file
             variables: Variables to substitute in the template
+            provider: Optional provider name injected as a built-in template
+                variable.  Does not overwrite a user-defined ``provider``
+                key already present in *variables*.
 
         Returns:
             Parsed YAML data as a dictionary
@@ -390,11 +402,16 @@ class PackageLoader:
 
         content = resource_path.read_text()
 
+        # Build render context: user variables + injected provider
+        render_context = dict(variables)
+        if provider is not None and "provider" not in render_context:
+            render_context["provider"] = provider
+
         # Render Jinja2 template with StrictUndefined
         try:
             env = create_jinja2_env(undefined=jinja2.StrictUndefined)
             template = env.from_string(content)
-            rendered = template.render(**variables)
+            rendered = template.render(**render_context)
         except jinja2.UndefinedError as e:
             raise InvalidConfigurationError(f"Undefined variable in {resource_path}: {e}") from e
         except jinja2.TemplateSyntaxError as e:

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -258,6 +258,35 @@ class TestRenderResourceFile:
         data = loader._render_resource_file(resource_path, {})
         assert data == {}
 
+    def test_render_resource_provider_variable_available(self, temp_dir):
+        """Provider kwarg is available as {{ provider }} in templates."""
+        loader = PackageLoader(temp_dir)
+        resource_path = temp_dir / "vm.yaml"
+        resource_path.write_text("vm:\n  - name: node-{{ provider }}\n")
+
+        data = loader._render_resource_file(resource_path, {}, provider="proxmox")
+        assert data["vm"][0]["name"] == "node-proxmox"
+
+    def test_render_resource_provider_not_injected_when_none(self, temp_dir):
+        """Default provider=None does not inject a provider variable."""
+        loader = PackageLoader(temp_dir)
+        resource_path = temp_dir / "vm.yaml"
+        resource_path.write_text("vm:\n  - name: simple-node\n")
+
+        data = loader._render_resource_file(resource_path, {})
+        assert data["vm"][0]["name"] == "simple-node"
+
+    def test_render_resource_provider_does_not_clobber_user_variable(self, temp_dir):
+        """User-defined 'provider' in variables takes precedence over injected value."""
+        loader = PackageLoader(temp_dir)
+        resource_path = temp_dir / "vm.yaml"
+        resource_path.write_text("vm:\n  - name: node-{{ provider }}\n")
+
+        data = loader._render_resource_file(
+            resource_path, {"provider": "user-defined"}, provider="proxmox"
+        )
+        assert data["vm"][0]["name"] == "node-user-defined"
+
 
 @pytest.mark.unit
 class TestParseResourcesFromData:

--- a/tests/unit/test_package_loader_multi_provider.py
+++ b/tests/unit/test_package_loader_multi_provider.py
@@ -742,3 +742,132 @@ class TestMultiProviderBlueprint:
         assert len(resources) == 1
         assert resources[0].name == "node-01"
         assert variables["vm_name"] == "node"
+
+
+@pytest.mark.unit
+class TestProviderTemplateVariable:
+    """Tests for the injected ``provider`` template variable."""
+
+    def test_shared_resource_with_provider_conditional(self, temp_dir):
+        """Single shared resource file uses provider conditionals for different providers.
+
+        Uses the resource-centric format (``resources:`` key) because the
+        provider-centric format derives the resource type from the filename,
+        which cannot vary per provider.
+        """
+        resolver = BlueprintResolver(temp_dir)
+        resolver.blueprints_dir = temp_dir.parent / "blueprints"
+
+        shared_resource = (
+            "resources:\n"
+            "{% if provider == 'proxmox' %}\n"
+            "  - provider: proxmox\n"
+            "    type: vm\n"
+            "    name: {{ vm_name }}-proxmox\n"
+            "    config:\n"
+            "      cores: 4\n"
+            "{% elif provider == 'oci' %}\n"
+            "  - provider: oci\n"
+            "    type: instance\n"
+            "    name: {{ vm_name }}-oci\n"
+            "    config:\n"
+            "      shape: VM.Standard.E4.Flex\n"
+            "{% endif %}\n"
+        )
+        _create_blueprint(
+            temp_dir,
+            "shared-bp",
+            {
+                "name": "shared-bp",
+                "defaults": {"vm_name": "node"},
+                "providers": {
+                    "proxmox": {"resources": ["shared.yaml"]},
+                    "oci": {"resources": ["shared.yaml"]},
+                },
+            },
+            {"shared.yaml": shared_resource},
+        )
+
+        loader = PackageLoader(temp_dir, blueprint_resolver=resolver)
+
+        # Load as proxmox
+        pkg_dir_px = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "shared-pkg",
+            {"name": "shared-pkg", "blueprint": "shared-bp"},
+        )
+        resources_px, _, _ = loader.load_package(pkg_dir_px, "proxmox", "dev")
+
+        assert len(resources_px) == 1
+        assert resources_px[0].name == "node-proxmox"
+        assert resources_px[0].type == "vm"
+        assert resources_px[0].provider == "proxmox"
+
+        # Load as oci
+        pkg_dir_oci = _create_package(
+            temp_dir,
+            "dev",
+            "oci",
+            "shared-pkg-oci",
+            {"name": "shared-pkg-oci", "blueprint": "shared-bp"},
+        )
+        resources_oci, _, _ = loader.load_package(pkg_dir_oci, "oci", "dev")
+
+        assert len(resources_oci) == 1
+        assert resources_oci[0].name == "node-oci"
+        assert resources_oci[0].type == "instance"
+        assert resources_oci[0].provider == "oci"
+
+    def test_provider_variable_in_plain_package(self, temp_dir):
+        """Non-blueprint package can use {{ provider }} in resource templates."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "plain-pkg",
+            "variables": {"vm_name": "web"},
+            "resources": ["vm.yaml"],
+        }
+        resource_content = "vm:\n  - name: {{ vm_name }}-{{ provider }}\n"
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "plain-pkg",
+            manifest,
+            {"vm.yaml": resource_content},
+        )
+
+        resources, _, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert len(resources) == 1
+        assert resources[0].name == "web-proxmox"
+
+    def test_provider_available_in_events_template(self, temp_dir):
+        """Event handler config can reference {{ provider }}."""
+        loader = PackageLoader(temp_dir)
+        manifest = {
+            "name": "events-provider-pkg",
+            "variables": {"vm_name": "web"},
+            "events": {
+                "AFTER_APPLY": [
+                    {
+                        "type": "script",
+                        "script": "scripts/setup.sh",
+                        "description": "setup for {{ provider }}",
+                    }
+                ],
+            },
+        }
+        pkg_dir = _create_package(
+            temp_dir,
+            "dev",
+            "proxmox",
+            "events-provider-pkg",
+            manifest,
+            {"scripts/setup.sh": "#!/bin/bash\necho setup\n"},
+        )
+
+        _, events, _ = loader.load_package(pkg_dir, "proxmox", "dev")
+
+        assert events["AFTER_APPLY"][0]["description"] == "setup for proxmox"


### PR DESCRIPTION
## Description

Inject `provider` as a built-in Jinja2 template variable in PackageLoader so a
single resource file can use `{% if provider == "proxmox" %}` conditionals to
target multiple providers. The variable is available in both resource templates
and event handler templates. User-defined variables named `provider` take
precedence over the injected value, preserving backward compatibility.

Addresses #573

## Related Issue

Addresses #573

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Inject `provider` into `_render_resource_file()` Jinja2 context (keyword-only arg, does not overwrite user variables)
- Inject `provider` into event handler template rendering with the same precedence rule
- Add "Shared Resource Templates" section to `docs/configuration/blueprints.md`
- Add "Built-in Template Variables" section to `docs/configuration/infrastructure-packages.md`
- Update ADR-0003 with reference to issue #573
- 3 unit tests in `test_package_loader.py` covering injection, user-override precedence, and None-provider skip
- 3 end-to-end tests in `test_package_loader_multi_provider.py` covering shared resource file rendering across providers

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Added new tests for new functionality (6 tests total across two files)
- [x] Manually verified `doit check` passes with no warnings

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
