### PR TITLE
feat: rename config init to config create with SOPS support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Key commands (`foundry` via `uv run foundry ...`):
 - `config envs` – list configured environments with sync status
 - `config diff --env-a <a> --env-b <b>` – compare two environments
 - `config show --env <name>` – show resolved configuration
-- `config init <name>` – initialize a new environment
+- `config create <name>` – create a new environment
 - `config new create <blueprint> <dir>` – create infrastructure from blueprints
 - `config migrate --env <name> --provider <p> --component <c>` – migrate existing infra to config
 - `config export --env <name> --output <dir>` – export provider config to YAML

--- a/docs/plugin_system/CLI_DESIGN.md
+++ b/docs/plugin_system/CLI_DESIGN.md
@@ -835,7 +835,7 @@ $ foundry plugins list
 $ foundry proxmox info
 
 # Configures provider
-$ foundry config init
+$ foundry config create
 $ export PROXMOX_TOKEN=xxx
 
 # Uses provider

--- a/docs/usage/cli-reference.md
+++ b/docs/usage/cli-reference.md
@@ -41,7 +41,7 @@ InfraFoundry commands are organized into five domain groups plus two top-level u
 | List environments | `foundry config envs` |
 | Compare two environments | `foundry config diff --env-a dev --env-b prod` |
 | Show resolved config | `foundry config show --env <env>` |
-| Create a new environment | `foundry config init <name>` |
+| Create a new environment | `foundry config create <name>` |
 | Create from a blueprint | `foundry config new create <blueprint> <dir>` |
 | Export provider config to YAML | `foundry config export --env <env> --output <dir>` |
 | Generate JSON schemas for IDE | `foundry config schema export` |
@@ -177,14 +177,15 @@ foundry config show --env dev --settings-only
 
 **Options:** `-e/--env TEXT` (required), `-p/--provider TEXT`, `-t/--resource-type TEXT`, `-r/--resource TEXT`, `--format [table|yaml|json]`, `--settings-only`
 
-### `config init`
+### `config create`
 
-Initialize a new environment. Optionally scaffold from an existing environment.
+Create a new environment. Optionally scaffold from an existing environment.
+SOPS-encrypted settings.yaml files are handled transparently.
 
 ```bash
-foundry config init staging
-foundry config init staging --from dev
-foundry config init prod --from staging -d "Production environment"
+foundry config create staging
+foundry config create staging --from dev
+foundry config create prod --from staging -d "Production environment"
 ```
 
 **Options:** `--from TEXT`, `-d/--description TEXT`, `-f/--force`

--- a/src/infrafoundry/cli/commands/config/__init__.py
+++ b/src/infrafoundry/cli/commands/config/__init__.py
@@ -4,10 +4,10 @@ import click
 
 from ..proxmox.export_proxmox import export_proxmox as export_cmd
 from ..schema import schema
+from .create import create
 from .diff import diff
 from .doctor import doctor
 from .envs import envs
-from .init import init
 from .migrate import migrate
 from .new import new
 from .show import show
@@ -24,7 +24,7 @@ config.add_command(doctor)
 config.add_command(envs)
 config.add_command(diff)
 config.add_command(export_cmd, name="export")
-config.add_command(init)
+config.add_command(create)
 config.add_command(schema)
 config.add_command(show)
 config.add_command(new)

--- a/src/infrafoundry/cli/commands/config/create.py
+++ b/src/infrafoundry/cli/commands/config/create.py
@@ -1,4 +1,4 @@
-"""Init command to scaffold new environments."""
+"""Create command to scaffold new environments."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import click
 import yaml
 
 from infrafoundry.core.config import ConfigManager
+from infrafoundry.core.config.sops import load_yaml_with_sops, save_yaml_with_sops
 from infrafoundry.core.exceptions import EnvironmentNotFoundError
 
 from ...output import BULLET
@@ -20,14 +21,21 @@ def _copy_environment(
     target_dir: Path,
     new_env_name: str,
     description: str | None,
+    *,
+    config_dir: Path | None = None,
 ) -> None:
     """Copy environment directory and update settings.
+
+    Handles SOPS-encrypted settings.yaml files transparently: if the source
+    settings were encrypted, the target settings are re-encrypted after
+    modification.
 
     Args:
         source_dir: Source environment directory
         target_dir: Target environment directory
         new_env_name: Name for the new environment
         description: Optional description for the new environment
+        config_dir: Config repo root for .sops.yaml discovery
     """
     # Copy the entire directory
     shutil.copytree(source_dir, target_dir)
@@ -35,8 +43,11 @@ def _copy_environment(
     # Update settings.yaml with new environment info
     settings_file = target_dir / "settings.yaml"
     if settings_file.exists():
-        with open(settings_file) as f:
-            settings = yaml.safe_load(f) or {}
+        # Detect SOPS encryption before decrypting
+        raw = settings_file.read_text()
+        was_encrypted = "sops:" in raw and "ENC[AES256_GCM," in raw
+
+        settings = load_yaml_with_sops(settings_file)
 
         # Update environment-specific settings
         settings["name"] = new_env_name
@@ -45,8 +56,7 @@ def _copy_environment(
         elif "description" in settings:
             settings["description"] = "Environment scaffolded from source"
 
-        with open(settings_file, "w") as f:
-            yaml.safe_dump(settings, f, default_flow_style=False, sort_keys=False)
+        save_yaml_with_sops(settings_file, settings, encrypt=was_encrypted, config_dir=config_dir)
 
 
 def _create_minimal_environment(target_dir: Path, env_name: str, description: str | None) -> None:
@@ -109,28 +119,29 @@ def _create_minimal_environment(target_dir: Path, env_name: str, description: st
     help="Overwrite existing environment directory",
 )
 @click.pass_context
-def init(
+def create(
     ctx: click.Context,
     env_name: str,
     from_env: str | None,
     description: str | None,
     force: bool,
 ) -> None:
-    """Initialize a new environment.
+    """Create a new environment.
 
     Creates a new environment directory structure. Use --from to scaffold
     from an existing environment (copies configs and customizes for new env).
+    SOPS-encrypted settings.yaml files are handled transparently.
 
     Examples:
 
         # Create minimal new environment
-        foundry config init staging
+        foundry config create staging
 
         # Scaffold from existing environment
-        foundry config init staging --from dev
+        foundry config create staging --from dev
 
         # With description
-        foundry config init prod --from staging -d "Production environment"
+        foundry config create prod --from staging -d "Production environment"
     """
     config_dir = ctx.obj.get("config_dir")
 
@@ -165,7 +176,7 @@ def init(
             source_dir = envs_dir / from_env
             console.info(f"Scaffolding '{env_name}' from '{from_env}'...")
 
-            _copy_environment(source_dir, target_dir, env_name, description)
+            _copy_environment(source_dir, target_dir, env_name, description, config_dir=config_dir)
 
             console.success(f"Environment '{env_name}' created from '{from_env}'")
             console.info(f"  Location: {target_dir}")

--- a/src/infrafoundry/core/config/sops.py
+++ b/src/infrafoundry/core/config/sops.py
@@ -1,10 +1,11 @@
-"""Shared SOPS decryption utility for YAML files.
+"""Shared SOPS utilities for YAML files.
 
-Provides a standalone function to load YAML files with automatic SOPS
-decryption, used by both ConfigManager and PackageLoader.
+Provides standalone functions to load and save YAML files with automatic SOPS
+decryption/encryption, used by ConfigManager, PackageLoader, and the config
+create command.
 """
 
-import subprocess  # nosec B404 - needed for SOPS decryption
+import subprocess  # nosec B404 - needed for SOPS decryption/encryption
 from pathlib import Path
 from typing import Any
 
@@ -37,3 +38,38 @@ def load_yaml_with_sops(file_path: Path) -> dict[str, Any]:
         return yaml.safe_load(result.stdout) or {}
 
     return yaml.safe_load(raw) or {}
+
+
+def save_yaml_with_sops(
+    file_path: Path,
+    data: dict[str, Any],
+    *,
+    encrypt: bool = False,
+    config_dir: Path | None = None,
+) -> None:
+    """Write YAML data to a file, optionally re-encrypting with SOPS.
+
+    Writes ``data`` as YAML to ``file_path``. When ``encrypt`` is True,
+    runs ``sops --encrypt --in-place`` to re-encrypt the file using the
+    ``.sops.yaml`` rules discovered from ``config_dir``.
+
+    Args:
+        file_path: Path to write the YAML file.
+        data: Dictionary to serialize as YAML.
+        encrypt: Whether to encrypt the file with SOPS after writing.
+        config_dir: Config repo root used as cwd for .sops.yaml discovery.
+
+    Raises:
+        subprocess.CalledProcessError: If SOPS encryption fails.
+    """
+    with open(file_path, "w") as f:
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+
+    if encrypt:
+        subprocess.run(  # nosec B603 B607 - trusted sops command
+            ["sops", "--encrypt", "--in-place", str(file_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=str(config_dir) if config_dir else None,
+        )

--- a/tests/test_sops.py
+++ b/tests/test_sops.py
@@ -1,9 +1,10 @@
 """Tests for the shared SOPS decryption utility and SopsSecretProvider."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from infrafoundry.core.config.sops import load_yaml_with_sops
+from infrafoundry.core.config.sops import load_yaml_with_sops, save_yaml_with_sops
 from infrafoundry.core.secrets.providers.sops import SopsSecretProvider
 
 
@@ -83,6 +84,83 @@ class TestLoadYamlWithSops:
             result = load_yaml_with_sops(yaml_file)
 
         assert result == {}
+
+
+class TestSaveYamlWithSops:
+    """Tests for save_yaml_with_sops function."""
+
+    def test_save_yaml_with_sops_no_encrypt(self, tmp_path: Path) -> None:
+        """Plain YAML is written without calling sops when encrypt is False."""
+        yaml_file = tmp_path / "output.yaml"
+        data = {"name": "staging", "description": "Staging env"}
+
+        with patch("infrafoundry.core.config.sops.subprocess.run") as mock_run:
+            save_yaml_with_sops(yaml_file, data)
+
+        mock_run.assert_not_called()
+        assert yaml_file.exists()
+        content = yaml_file.read_text()
+        assert "name: staging" in content
+        assert "description: Staging env" in content
+
+    def test_save_yaml_with_sops_with_encrypt(self, tmp_path: Path) -> None:
+        """SOPS encrypt is called when encrypt is True."""
+        yaml_file = tmp_path / "output.yaml"
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        data = {"name": "staging", "providers": ["proxmox"]}
+
+        mock_result = type("Result", (), {"stdout": "", "returncode": 0})()
+
+        with patch(
+            "infrafoundry.core.config.sops.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            save_yaml_with_sops(yaml_file, data, encrypt=True, config_dir=config_dir)
+
+        mock_run.assert_called_once_with(
+            ["sops", "--encrypt", "--in-place", str(yaml_file)],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=str(config_dir),
+        )
+        # File should exist (written before encrypt call)
+        assert yaml_file.exists()
+
+    def test_save_yaml_with_sops_encrypt_failure(self, tmp_path: Path) -> None:
+        """CalledProcessError is raised when sops encryption fails."""
+        yaml_file = tmp_path / "output.yaml"
+        data = {"name": "staging"}
+
+        with patch(
+            "infrafoundry.core.config.sops.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "sops", stderr="encryption failed"),
+        ):
+            try:
+                save_yaml_with_sops(yaml_file, data, encrypt=True)
+                raise AssertionError("Expected CalledProcessError")
+            except subprocess.CalledProcessError:
+                pass
+
+    def test_save_yaml_with_sops_encrypt_no_config_dir(self, tmp_path: Path) -> None:
+        """SOPS encrypt passes cwd=None when config_dir is not provided."""
+        yaml_file = tmp_path / "output.yaml"
+        data = {"name": "staging"}
+
+        mock_result = type("Result", (), {"stdout": "", "returncode": 0})()
+
+        with patch(
+            "infrafoundry.core.config.sops.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            save_yaml_with_sops(yaml_file, data, encrypt=True)
+
+        mock_run.assert_called_once_with(
+            ["sops", "--encrypt", "--in-place", str(yaml_file)],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=None,
+        )
 
 
 class TestSopsSecretProvider:

--- a/tests/unit/test_cli_config_tools.py
+++ b/tests/unit/test_cli_config_tools.py
@@ -1,4 +1,4 @@
-"""Unit tests for config init and show CLI commands."""
+"""Unit tests for config create and show CLI commands."""
 
 from __future__ import annotations
 
@@ -52,18 +52,18 @@ def temp_config_dir(tmp_path):
     return config_dir
 
 
-class TestConfigInit:
-    """Tests for config init command."""
+class TestConfigCreate:
+    """Tests for config create command."""
 
-    def test_init_creates_minimal_environment(self, cli_runner, tmp_path):
-        """Test init creates minimal environment structure."""
+    def test_create_creates_minimal_environment(self, cli_runner, tmp_path):
+        """Test create creates minimal environment structure."""
         config_dir = tmp_path / "config"
         envs_dir = config_dir / "envs"
         envs_dir.mkdir(parents=True)
 
         result = cli_runner.invoke(
             main,
-            ["--config-dir", str(config_dir), "config", "init", "staging"],
+            ["--config-dir", str(config_dir), "config", "create", "staging"],
         )
 
         assert result.exit_code == 0
@@ -80,8 +80,8 @@ class TestConfigInit:
             settings = yaml.safe_load(f)
         assert settings["name"] == "staging"
 
-    def test_init_with_description(self, cli_runner, tmp_path):
-        """Test init with custom description."""
+    def test_create_with_description(self, cli_runner, tmp_path):
+        """Test create with custom description."""
         config_dir = tmp_path / "config"
         envs_dir = config_dir / "envs"
         envs_dir.mkdir(parents=True)
@@ -92,7 +92,7 @@ class TestConfigInit:
                 "--config-dir",
                 str(config_dir),
                 "config",
-                "init",
+                "create",
                 "prod",
                 "-d",
                 "Production environment",
@@ -105,15 +105,15 @@ class TestConfigInit:
             settings = yaml.safe_load(f)
         assert settings["description"] == "Production environment"
 
-    def test_init_from_existing_environment(self, cli_runner, temp_config_dir):
-        """Test init --from scaffolds from existing environment."""
+    def test_create_from_existing_environment(self, cli_runner, temp_config_dir):
+        """Test create --from scaffolds from existing environment."""
         result = cli_runner.invoke(
             main,
             [
                 "--config-dir",
                 str(temp_config_dir),
                 "config",
-                "init",
+                "create",
                 "staging",
                 "--from",
                 "dev",
@@ -135,15 +135,15 @@ class TestConfigInit:
             settings = yaml.safe_load(f)
         assert settings["name"] == "staging"
 
-    def test_init_from_nonexistent_environment(self, cli_runner, temp_config_dir):
-        """Test init --from with nonexistent source fails."""
+    def test_create_from_nonexistent_environment(self, cli_runner, temp_config_dir):
+        """Test create --from with nonexistent source fails."""
         result = cli_runner.invoke(
             main,
             [
                 "--config-dir",
                 str(temp_config_dir),
                 "config",
-                "init",
+                "create",
                 "staging",
                 "--from",
                 "nonexistent",
@@ -153,25 +153,25 @@ class TestConfigInit:
         assert result.exit_code != 0
         assert "not found" in result.output.lower()
 
-    def test_init_existing_environment_fails_without_force(self, cli_runner, temp_config_dir):
-        """Test init fails if environment exists without --force."""
+    def test_create_existing_environment_fails_without_force(self, cli_runner, temp_config_dir):
+        """Test create fails if environment exists without --force."""
         result = cli_runner.invoke(
             main,
-            ["--config-dir", str(temp_config_dir), "config", "init", "dev"],
+            ["--config-dir", str(temp_config_dir), "config", "create", "dev"],
         )
 
         assert result.exit_code != 0
         assert "already exists" in result.output
 
-    def test_init_existing_environment_with_force(self, cli_runner, temp_config_dir):
-        """Test init --force overwrites existing environment."""
+    def test_create_existing_environment_with_force(self, cli_runner, temp_config_dir):
+        """Test create --force overwrites existing environment."""
         result = cli_runner.invoke(
             main,
             [
                 "--config-dir",
                 str(temp_config_dir),
                 "config",
-                "init",
+                "create",
                 "dev",
                 "--force",
                 "-d",
@@ -186,17 +186,93 @@ class TestConfigInit:
             settings = yaml.safe_load(f)
         assert settings["description"] == "Recreated dev"
 
-    def test_init_without_config_dir(self, cli_runner, monkeypatch):
-        """Test init fails without config directory."""
+    def test_create_without_config_dir(self, cli_runner, monkeypatch):
+        """Test create fails without config directory."""
         # Clear the env var to ensure no config dir is set
         monkeypatch.delenv("INFRAFOUNDRY_CONFIG_REPO", raising=False)
 
         with cli_runner.isolated_filesystem():
-            result = cli_runner.invoke(main, ["config", "init", "test-env-no-config"])
+            result = cli_runner.invoke(main, ["config", "create", "test-env-no-config"])
 
             # Should fail because no config dir is set
             assert result.exit_code != 0
             assert "Config directory not set" in result.output or "config" in result.output.lower()
+
+    def test_create_from_sops_encrypted_settings(self, cli_runner, tmp_path):
+        """Test create --from handles SOPS-encrypted settings.yaml."""
+        config_dir = tmp_path / "config"
+        envs_dir = config_dir / "envs"
+
+        # Create source environment with SOPS-encrypted settings
+        dev_dir = envs_dir / "dev"
+        dev_dir.mkdir(parents=True)
+
+        sops_content = (
+            "name: ENC[AES256_GCM,data:abc123]\n"
+            "description: ENC[AES256_GCM,data:dev-desc]\n"
+            "providers:\n"
+            "- proxmox\n"
+            "sops:\n"
+            "    version: 3.7.3\n"
+        )
+        (dev_dir / "settings.yaml").write_text(sops_content)
+
+        decrypted_yaml = "name: dev\ndescription: Development environment\nproviders:\n- proxmox\n"
+        mock_decrypt = type("Result", (), {"stdout": decrypted_yaml, "returncode": 0})()
+        mock_encrypt = type("Result", (), {"stdout": "", "returncode": 0})()
+
+        def mock_run(cmd, **kwargs):
+            if "--decrypt" in cmd:
+                return mock_decrypt
+            if "--encrypt" in cmd:
+                return mock_encrypt
+            raise AssertionError(f"Unexpected sops command: {cmd}")
+
+        from unittest.mock import patch
+
+        with patch("infrafoundry.core.config.sops.subprocess.run", side_effect=mock_run):
+            result = cli_runner.invoke(
+                main,
+                [
+                    "--config-dir",
+                    str(config_dir),
+                    "config",
+                    "create",
+                    "staging",
+                    "--from",
+                    "dev",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Environment 'staging' created from 'dev'" in result.output
+
+    def test_create_from_unencrypted_settings_unchanged(self, cli_runner, temp_config_dir):
+        """Test create --from with unencrypted settings works without SOPS calls."""
+        from unittest.mock import patch
+
+        with patch("infrafoundry.core.config.sops.subprocess.run") as mock_run:
+            result = cli_runner.invoke(
+                main,
+                [
+                    "--config-dir",
+                    str(temp_config_dir),
+                    "config",
+                    "create",
+                    "staging",
+                    "--from",
+                    "dev",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # SOPS subprocess should not be called for unencrypted files
+        mock_run.assert_not_called()
+
+        # Verify settings were updated correctly
+        with open(temp_config_dir / "envs" / "staging" / "settings.yaml") as f:
+            settings = yaml.safe_load(f)
+        assert settings["name"] == "staging"
 
 
 class TestConfigShow:
@@ -361,25 +437,25 @@ class TestConfigShow:
         assert "No resources found" in result.output
 
 
-class TestConfigInitShowIntegration:
-    """Integration tests for init and show commands working together."""
+class TestConfigCreateShowIntegration:
+    """Integration tests for create and show commands working together."""
 
-    def test_init_then_show(self, cli_runner, temp_config_dir):
-        """Test creating environment with init then viewing with show."""
+    def test_create_then_show(self, cli_runner, temp_config_dir):
+        """Test creating environment with create then viewing with show."""
         # Create new environment from dev
-        init_result = cli_runner.invoke(
+        create_result = cli_runner.invoke(
             main,
             [
                 "--config-dir",
                 str(temp_config_dir),
                 "config",
-                "init",
+                "create",
                 "staging",
                 "--from",
                 "dev",
             ],
         )
-        assert init_result.exit_code == 0
+        assert create_result.exit_code == 0
 
         # Show the new environment
         show_result = cli_runner.invoke(


### PR DESCRIPTION
## Description

Rename `foundry config init` to `foundry config create` for clarity, and add transparent SOPS encryption support when scaffolding environments with `--from`. When the source environment has a SOPS-encrypted `settings.yaml`, the new environment's settings are automatically re-encrypted after modification.

## Related Issue

Addresses #577

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Renamed `config init` command to `config create` (CLI module, registration, docs)
- Added `save_yaml_with_sops()` to `core/config/sops.py` for writing YAML with optional SOPS re-encryption
- `_copy_environment()` now detects SOPS-encrypted source settings and re-encrypts the target after updating env name/description
- Updated CLI reference, CLI design doc, and AGENTS.md to reflect the new command name
- Added 4 unit tests for `save_yaml_with_sops()` (plain write, encrypt, encrypt failure, no config_dir)
- Added 2 CLI tests for SOPS-encrypted and unencrypted `--from` scaffolding paths

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes (format, lint, type-check, security, spell-check, tests).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The existing CHANGELOG.md entry for the original `config init` feature (from a prior release) was not modified -- it accurately describes the historical state at that release. The merge commit for this PR will generate the correct changelog entry via commitizen.
