### PR TITLE
refactor: extract service-vm blueprint and convert prod infra-web

### DIFF
--- a/blueprints/service-vm/README.md
+++ b/blueprints/service-vm/README.md
@@ -1,0 +1,105 @@
+# service-vm Blueprint
+
+Reusable blueprint for lightweight infrastructure service VMs. It clones a
+Proxmox template, creates an OPNsense DHCP reservation, and (optionally)
+attaches a Proxmox NFS storage mount. Typical consumers are bastion hosts,
+log aggregators, internal web servers, CI runners, or any "single VM plus
+DHCP" deployment.
+
+This sits one tier above the framework-bundled `basic-vm` blueprint
+(`src/infrafoundry/core/blueprints/basic-vm/`): it adds a DHCP reservation,
+optional NFS mount, cloud-init snippet wiring, and multi-instance safety.
+Use `basic-vm` when you just want a throwaway template scaffold; use
+`service-vm` when you want a reusable, DHCP-integrated service node.
+
+## Usage
+
+A package consumes this blueprint with a thin manifest that supplies only
+the per-instance values:
+
+```yaml
+# envs/<env>/proxmox/<package>/infrafoundry.yml
+name: my-service
+description: "My infrastructure service VM"
+blueprint: service-vm
+
+variables:
+  vm_name: my-service
+  vmid: 210
+  target_node: pve1
+  mac_address: "BC:24:11:F8:F4:7D"
+  ip_address: "192.168.10.60"
+  dhcp_subnet: opt1-infrastructure
+  cloud_init_snippets:
+    - system/hostname
+    - users/ansible
+    - network/dhcp
+    - packages/qemu-agent
+  tags: ["infra", "web"]
+```
+
+Then:
+
+```bash
+foundry infra apply --env <env> --package my-service
+```
+
+## Variables
+
+### Required (must be set in the consuming package)
+
+| Variable        | Description                                                         | Example                |
+| --------------- | ------------------------------------------------------------------- | ---------------------- |
+| `vm_name`       | VM hostname (also DHCP hostname, storage mount name, etc.)          | `infra-web`            |
+| `vmid`          | Proxmox VM ID                                                       | `210`                  |
+| `target_node`   | Proxmox host to place the VM on                                     | `pve1`                 |
+| `mac_address`   | VM NIC MAC address (also used for DHCP reservation, lowercased)     | `BC:24:11:F8:F4:7D`    |
+| `ip_address`    | VM IP address (assigned via DHCP reservation)                       | `192.168.10.60`        |
+| `dhcp_subnet`   | OPNsense Kea subnet reference                                       | `opt1-infrastructure`  |
+
+### Optional (blueprint defaults)
+
+| Variable                 | Default                        | Description                                            |
+| ------------------------ | ------------------------------ | ------------------------------------------------------ |
+| `template_vmid`          | `900`                          | Source template VM ID to clone from                    |
+| `template_node`          | `pve1`                         | Node hosting the template                              |
+| `cores`                  | `2`                            | vCPU count                                             |
+| `memory`                 | `2048`                         | Memory in MiB                                          |
+| `disk_storage`           | `local-lvm`                    | Proxmox storage pool for the VM disk                   |
+| `disk_size`              | `32`                           | Disk size in GiB                                       |
+| `bridge`                 | `vmbr0`                        | Network bridge                                         |
+| `vlan_tag`               | `10`                           | VLAN tag for the VM NIC                                |
+| `agent`                  | `true`                         | Enable the qemu-guest-agent integration                |
+| `onboot`                 | `true`                         | Start the VM automatically when the host boots         |
+| `cloud_init_snippets`    | `[]`                           | List of cloud-init snippet names to attach             |
+| `extra_cloud_init_vars`  | `{}`                           | Extra cloud-init vars merged with the `HOSTNAME` entry |
+| `tags`                   | `[]`                           | Proxmox tags applied to the VM                         |
+| `dhcp_description`       | `""` (falls back to `vm_name`) | Description written on the DHCP reservation            |
+| `nfs_server`             | `""` (no NFS resource created) | NFS server address                                     |
+| `nfs_export`             | `""`                           | Export path on the NFS server                          |
+| `nfs_content`            | `["snippets", "images"]`       | Proxmox storage content types for the NFS mount        |
+| `nfs_mount`              | `""` (falls back to `vm_name`) | Proxmox storage mount name for the NFS resource        |
+
+## Prerequisites
+
+- A cloud-init-capable template (e.g. `rocky9-template` VMID `901` or
+  `ubuntu-template` VMID `900`) exists on `template_node`.
+- The OPNsense Kea subnet referenced by `dhcp_subnet` is defined.
+- If `nfs_server` is set, the NFS share is reachable from `target_node`.
+
+## What gets created
+
+- **Proxmox VM** (`proxmox.vm`, name `{{ vm_name }}`): cloned from the
+  template, attached to `bridge`/`vlan_tag`, MAC pinned to `mac_address`,
+  tagged with `tags`, optionally carrying `cloud_init_snippets` and the
+  `HOSTNAME` cloud-init variable.
+- **DHCP reservation** (`opnsense.kea_reservation`, name `{{ vm_name }}`):
+  binds `ip_address` to `mac_address` on the `dhcp_subnet`, with
+  `hostname = {{ vm_name }}` and description falling back to `vm_name`.
+- **NFS storage (optional)** (`proxmox.storage`, name `{{ vm_name }}-nfs`):
+  only emitted when `nfs_server` is set. Mount name defaults to
+  `{{ vm_name }}` (override via `nfs_mount`) so multiple instances don't
+  collide.
+
+All resource names are templated so this blueprint is safe to instantiate
+multiple times in the same environment (regression guard for #511).

--- a/blueprints/service-vm/blueprint.yaml
+++ b/blueprints/service-vm/blueprint.yaml
@@ -1,0 +1,96 @@
+name: service-vm
+description: "Lightweight service VM (template clone + DHCP reservation + optional NFS mount)"
+version: "1.0.0"
+
+inputs:
+  # --- Required per-instance inputs (no default) ---
+  - name: vm_name
+    description: "Hostname and Proxmox VM name"
+  - name: vmid
+    description: "Proxmox VM ID"
+    type: integer
+  - name: target_node
+    description: "Proxmox node to deploy the VM onto"
+  - name: mac_address
+    description: "VM NIC MAC address (lowercased for DHCP reservation)"
+  - name: ip_address
+    description: "Static IPv4 address for the VM (DHCP reservation)"
+  - name: dhcp_subnet
+    description: "OPNsense DHCP subnet identifier used for the reservation"
+
+  # --- VM hardware ---
+  - name: template_vmid
+    description: "Source template VMID to clone from"
+    type: integer
+    default: 900
+  - name: template_node
+    description: "Proxmox node hosting the template"
+    default: pve1
+  - name: cores
+    type: integer
+    default: 2
+  - name: memory
+    description: "Memory in MiB"
+    type: integer
+    default: 2048
+  - name: disk_storage
+    description: "Proxmox storage pool for the VM disk"
+    default: local-lvm
+  - name: disk_size
+    description: "Disk size in GiB"
+    type: integer
+    default: 32
+
+  # --- Network ---
+  - name: bridge
+    default: vmbr0
+  - name: vlan_tag
+    type: integer
+    default: 10
+
+  # --- VM behaviour ---
+  - name: agent
+    description: "Enable the qemu-guest-agent integration"
+    type: boolean
+    default: true
+  - name: onboot
+    description: "Start the VM automatically when the host boots"
+    type: boolean
+    default: true
+
+  # --- Cloud-init ---
+  - name: cloud_init_snippets
+    description: "List of cloud-init snippet names to attach to the VM"
+    default: []
+  - name: extra_cloud_init_vars
+    description: "Additional cloud-init variables merged on top of HOSTNAME"
+    default: {}
+
+  # --- Tags & DHCP description ---
+  - name: tags
+    description: "Proxmox tags applied to the VM"
+    default: []
+  - name: dhcp_description
+    description: "DHCP reservation description (falls back to vm_name when empty)"
+    default: ""
+
+  # --- Optional NFS storage mount ---
+  - name: nfs_server
+    description: "NFS server address. Empty: no NFS storage resource is created."
+    default: ""
+  - name: nfs_export
+    description: "NFS export path on the server (used when nfs_server is set)"
+    default: ""
+  - name: nfs_content
+    description: "Proxmox storage content types for the NFS mount"
+    default:
+      - snippets
+      - images
+  - name: nfs_mount
+    description: "Proxmox mount name for the NFS storage. Empty: falls back to vm_name."
+    default: ""
+
+resources:
+  - vm.yaml
+  - dhcp.yaml
+  - storage.yaml

--- a/blueprints/service-vm/dhcp.yaml
+++ b/blueprints/service-vm/dhcp.yaml
@@ -1,0 +1,14 @@
+{#- Service VM DHCP reservation — opnsense kea_reservation in a proxmox-providered
+   package directory. Resource-centric format because the reservation provider
+   differs from the package directory provider. Outer name is templated for
+   multi-instance safety. -#}
+resources:
+  - provider: opnsense
+    type: kea_reservation
+    name: "{{ vm_name }}"
+    config:
+      subnet_ref: "{{ dhcp_subnet }}"
+      hw_address: "{{ mac_address | lower }}"
+      ip_address: "{{ ip_address }}"
+      hostname: "{{ vm_name }}"
+      description: "{{ dhcp_description or vm_name }}"

--- a/blueprints/service-vm/storage.yaml
+++ b/blueprints/service-vm/storage.yaml
@@ -1,0 +1,19 @@
+{#- Optional NFS storage mount. The outer resource is wrapped in
+   {% if nfs_server %} so packages that don't need an NFS mount (the default)
+   produce no storage resource — an empty ``resources: []`` list is rendered
+   so the file always yields a valid resource-centric document. When the
+   resource is emitted, the outer name is templated for multi-instance safety. -#}
+{% if nfs_server %}
+resources:
+  - provider: proxmox
+    type: storage
+    name: "{{ vm_name }}-nfs"
+    config:
+      type: nfs
+      server: "{{ nfs_server }}"
+      export: "{{ nfs_export }}"
+      content: {{ nfs_content | tojson }}
+      mount: "{{ nfs_mount or vm_name }}"
+{% else %}
+resources: []
+{% endif %}

--- a/blueprints/service-vm/vm.yaml
+++ b/blueprints/service-vm/vm.yaml
@@ -1,0 +1,30 @@
+{#- Service VM — shorthand vms: format (proxmox provider, vm type inferred).
+   Multi-instance safe: outer name is templated. -#}
+vms:
+  - name: "{{ vm_name }}"
+    vmid: {{ vmid }}
+    target_node: "{{ target_node }}"
+    clone:
+      vm_id: {{ template_vmid }}
+      node_name: "{{ template_node }}"
+    cores: {{ cores }}
+    memory: {{ memory }}
+    agent: {{ agent }}
+    disk:
+      storage: "{{ disk_storage }}"
+      size: {{ disk_size }}
+    network:
+      - bridge: "{{ bridge }}"
+        tag: {{ vlan_tag }}
+        macaddr: "{{ mac_address }}"
+    cloud_init_snippets:
+{% for snippet in cloud_init_snippets %}
+      - {{ snippet }}
+{% endfor %}
+    cloud_init_vars:
+      HOSTNAME: "{{ vm_name }}"
+{% for key, value in extra_cloud_init_vars.items() %}
+      {{ key }}: {{ value | tojson }}
+{% endfor %}
+    tags: {{ tags | tojson }}
+    onboot: {{ onboot }}

--- a/docs/configuration/blueprints.md
+++ b/docs/configuration/blueprints.md
@@ -190,6 +190,43 @@ providers:
   manifest's `variables`, the user value takes precedence over the
   injected value.
 
+## Optional Resources (File-Level Gating)
+
+A blueprint resource file may conditionally emit nothing when an input is
+unset, so packages that don't need the resource produce no output instead of
+carrying an empty placeholder. Wrap the file's `resources:` block in a
+top-level Jinja2 `{% if %}` and provide an explicit `resources: []` in the
+`{% else %}` branch so the file always yields a valid resource-centric
+document.
+
+```yaml
+{% if nfs_server %}
+resources:
+  - provider: proxmox
+    type: storage
+    name: "{{ vm_name }}-nfs"
+    config:
+      type: nfs
+      server: "{{ nfs_server }}"
+      export: "{{ nfs_export }}"
+{% else %}
+resources: []
+{% endif %}
+```
+
+This pattern pairs naturally with an optional input that defaults to an empty
+string or list. Declare the gating input in `inputs:` and leave the default
+empty so packages that don't need the resource can stay silent:
+
+```yaml
+inputs:
+  - name: nfs_server
+    description: "NFS server address. Empty: no NFS storage resource is created."
+    default: ""
+```
+
+Reference blueprint: `blueprints/service-vm/storage.yaml`.
+
 ## Validation and Checks
 
 - After creation, run `foundry infra doctor --env <env>` within the generated repo to ensure configs are sound.

--- a/example-config/envs/dev/proxmox/service-vm/README.md
+++ b/example-config/envs/dev/proxmox/service-vm/README.md
@@ -1,0 +1,26 @@
+# service-vm (example consumer)
+
+Example thin-instantiation of the `service-vm` blueprint. Deploys a single
+infrastructure VM on Proxmox, a matching OPNsense DHCP reservation, and no
+NFS mount (the default).
+
+The deployment logic lives in `blueprints/service-vm/`. This package only
+supplies per-instance values.
+
+See `blueprints/service-vm/README.md` for the full variable reference.
+
+## Usage
+
+```bash
+foundry infra apply --env dev --package service-vm
+```
+
+## What this package demonstrates
+
+- Minimal required inputs (`vm_name`, `vmid`, `target_node`, `mac_address`,
+  `ip_address`, `dhcp_subnet`).
+- A few common optional overrides (`cloud_init_snippets`, `tags`,
+  `dhcp_description`).
+- `nfs_server` is left at its empty default, so no `proxmox.storage`
+  resource is emitted. To add an NFS mount, set `nfs_server` and
+  `nfs_export` in `variables:`.

--- a/example-config/envs/dev/proxmox/service-vm/infrafoundry.yml
+++ b/example-config/envs/dev/proxmox/service-vm/infrafoundry.yml
@@ -1,0 +1,33 @@
+# Service VM — example consumer of the service-vm blueprint.
+#
+# All deployment logic (VM definition, DHCP reservation, optional NFS mount)
+# lives in blueprints/service-vm/. This file only supplies the per-instance
+# values.
+#
+# See blueprints/service-vm/README.md for the full variable reference.
+#
+# Run: foundry infra apply --env dev --package service-vm
+
+name: service-vm
+description: "Example infrastructure service VM"
+blueprint: service-vm
+
+variables:
+  # --- Required per-instance values ---
+  vm_name: infra-web
+  vmid: 210
+  target_node: pve1
+  mac_address: "BC:24:11:F8:F4:7D"
+  ip_address: "192.168.10.60"
+  dhcp_subnet: opt1-infrastructure
+
+  # --- Optional overrides ---
+  cloud_init_snippets:
+    - system/hostname
+    - users/ansible
+    - network/dhcp
+    - packages/qemu-agent
+  tags:
+    - infra
+    - web
+  dhcp_description: "Infrastructure web server (example)"

--- a/tests/unit/test_service_vm_blueprint.py
+++ b/tests/unit/test_service_vm_blueprint.py
@@ -1,0 +1,327 @@
+"""Integration test for the service-vm blueprint.
+
+Loads the example-config service-vm package via PackageLoader and asserts
+that the merged configuration (blueprint defaults + package overrides)
+produces the expected proxmox VM and opnsense DHCP resources, plus a
+tmp_path-based check for the optional NFS storage path and a multi-instance
+regression guard for issue #511.
+
+The test depends only on files checked into this repository:
+  - blueprints/service-vm/                          (the blueprint)
+  - example-config/envs/dev/proxmox/service-vm/     (the example consumer)
+
+It does NOT depend on the private endavis-infra/ config repo.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+from infrafoundry.core.config.package_loader import PackageLoader
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_ENVS = REPO_ROOT / "example-config" / "envs"
+PACKAGE_DIR = EXAMPLE_ENVS / "dev" / "proxmox" / "service-vm"
+
+
+@pytest.fixture
+def loader() -> PackageLoader:
+    """PackageLoader pointed at the real example-config envs/ directory."""
+    resolver = BlueprintResolver(EXAMPLE_ENVS)
+    return PackageLoader(EXAMPLE_ENVS, blueprint_resolver=resolver)
+
+
+def test_service_vm_example_package_loads_blueprint(loader: PackageLoader) -> None:
+    """The service-vm example package loads via the blueprint resolver and
+    merges blueprint defaults with per-instance overrides."""
+    _resources, _events, variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    # --- Per-instance overrides come from the package manifest ---
+    assert variables["vm_name"] == "infra-web"
+    assert variables["vmid"] == 210
+    assert variables["target_node"] == "pve1"
+    assert variables["mac_address"] == "BC:24:11:F8:F4:7D"
+    assert variables["ip_address"] == "192.168.10.60"
+    assert variables["dhcp_subnet"] == "opt1-infrastructure"
+    assert variables["tags"] == ["infra", "web"]
+    assert variables["dhcp_description"] == "Infrastructure web server (example)"
+
+    # --- Blueprint defaults flow through unchanged ---
+    assert variables["template_vmid"] == 900
+    assert variables["template_node"] == "pve1"
+    assert variables["cores"] == 2
+    assert variables["memory"] == 2048
+    assert variables["disk_storage"] == "local-lvm"
+    assert variables["disk_size"] == 32
+    assert variables["bridge"] == "vmbr0"
+    assert variables["vlan_tag"] == 10
+    assert variables["agent"] is True
+    assert variables["onboot"] is True
+    assert variables["nfs_server"] == ""
+    assert variables["nfs_export"] == ""
+    assert variables["nfs_content"] == ["snippets", "images"]
+    assert variables["nfs_mount"] == ""
+
+
+def test_service_vm_renders_vm_and_dhcp_resources(loader: PackageLoader) -> None:
+    """Default path (no NFS): exactly two resources are rendered — a proxmox
+    VM and an opnsense kea_reservation, both named after vm_name."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    assert len(resources) == 2
+
+    by_provider = {r.provider: r for r in resources}
+    assert set(by_provider) == {"proxmox", "opnsense"}
+
+    vm = by_provider["proxmox"]
+    assert vm.type == "vm"
+    assert vm.name == "infra-web"
+
+    dhcp = by_provider["opnsense"]
+    assert dhcp.type == "kea_reservation"
+    assert dhcp.name == "infra-web"
+
+
+def test_service_vm_vm_config_uses_merged_values(loader: PackageLoader) -> None:
+    """Rendered VM config combines blueprint defaults with package overrides."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    vm = next(r for r in resources if r.provider == "proxmox" and r.type == "vm")
+    config = vm.config
+
+    # Per-instance overrides
+    assert config["name"] == "infra-web"
+    assert config["vmid"] == 210
+    assert config["target_node"] == "pve1"
+
+    # Blueprint defaults
+    assert config["clone"] == {"vm_id": 900, "node_name": "pve1"}
+    assert config["cores"] == 2
+    assert config["memory"] == 2048
+    assert config["disk"] == {"storage": "local-lvm", "size": 32}
+    assert config["agent"] is True
+    assert config["onboot"] is True
+
+    # Network: single NIC with bridge + vlan tag + mac from per-instance values
+    assert len(config["network"]) == 1
+    assert config["network"][0]["bridge"] == "vmbr0"
+    assert config["network"][0]["tag"] == 10
+    assert config["network"][0]["macaddr"] == "BC:24:11:F8:F4:7D"
+
+    # Cloud-init snippets from the package override, HOSTNAME from vm_name
+    assert config["cloud_init_snippets"] == [
+        "system/hostname",
+        "users/ansible",
+        "network/dhcp",
+        "packages/qemu-agent",
+    ]
+    assert config["cloud_init_vars"]["HOSTNAME"] == "infra-web"
+
+    # Tags from the package override
+    assert config["tags"] == ["infra", "web"]
+
+
+def test_service_vm_dhcp_config_uses_merged_values(loader: PackageLoader) -> None:
+    """Rendered kea_reservation config uses per-instance values and lowercases
+    the hw_address."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    dhcp = next(r for r in resources if r.provider == "opnsense" and r.type == "kea_reservation")
+    config = dhcp.config
+
+    assert config["subnet_ref"] == "opt1-infrastructure"
+    # hw_address must be lowercased by the blueprint template
+    assert config["hw_address"] == "bc:24:11:f8:f4:7d"
+    assert config["ip_address"] == "192.168.10.60"
+    assert config["hostname"] == "infra-web"
+    assert config["description"] == "Infrastructure web server (example)"
+
+
+def test_service_vm_with_nfs_renders_storage_resource(tmp_path: Path) -> None:
+    """When nfs_server is set the proxmox storage resource is emitted, named
+    ``{{ vm_name }}-nfs`` for multi-instance safety."""
+    envs = tmp_path / "envs"
+    pkg = envs / "test" / "proxmox" / "svc"
+    pkg.mkdir(parents=True)
+
+    (pkg / "infrafoundry.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: svc
+            description: "Service VM with NFS"
+            blueprint: service-vm
+            variables:
+              vm_name: svc
+              vmid: 211
+              target_node: pve1
+              mac_address: "AA:BB:CC:DD:EE:FF"
+              ip_address: "192.168.10.61"
+              dhcp_subnet: opt1-infrastructure
+              nfs_server: "192.168.10.50"
+              nfs_export: "/export/infra"
+            """
+        )
+    )
+
+    resolver = BlueprintResolver(envs)
+    pkg_loader = PackageLoader(envs, blueprint_resolver=resolver)
+
+    resources, _events, _variables = pkg_loader.load_package(
+        pkg, provider="proxmox", env_name="test"
+    )
+
+    assert len(resources) == 3
+    types_by_provider = {(r.provider, r.type) for r in resources}
+    assert ("proxmox", "vm") in types_by_provider
+    assert ("opnsense", "kea_reservation") in types_by_provider
+    assert ("proxmox", "storage") in types_by_provider
+
+    storage = next(r for r in resources if r.provider == "proxmox" and r.type == "storage")
+    assert storage.name == "svc-nfs"
+    assert storage.config["type"] == "nfs"
+    assert storage.config["server"] == "192.168.10.50"
+    assert storage.config["export"] == "/export/infra"
+    assert storage.config["content"] == ["snippets", "images"]
+    # Mount uses vm_name so multiple instances don't collide on the Proxmox host
+    assert storage.config["mount"] == "svc"
+
+
+def test_service_vm_nfs_mount_override(tmp_path: Path) -> None:
+    """Setting ``nfs_mount`` overrides the default ``vm_name`` mount name
+    without affecting the templated storage resource name."""
+    envs = tmp_path / "envs"
+    pkg = envs / "test" / "proxmox" / "svc"
+    pkg.mkdir(parents=True)
+
+    (pkg / "infrafoundry.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: svc
+            description: "Service VM with NFS mount override"
+            blueprint: service-vm
+            variables:
+              vm_name: infra-web
+              vmid: 212
+              target_node: pve1
+              mac_address: "AA:BB:CC:DD:EE:FF"
+              ip_address: "192.168.10.62"
+              dhcp_subnet: opt1-infrastructure
+              nfs_server: "192.168.10.50"
+              nfs_export: "/export/infra"
+              nfs_mount: infra
+            """
+        )
+    )
+
+    resolver = BlueprintResolver(envs)
+    pkg_loader = PackageLoader(envs, blueprint_resolver=resolver)
+
+    resources, _events, _variables = pkg_loader.load_package(
+        pkg, provider="proxmox", env_name="test"
+    )
+
+    storage = next(r for r in resources if r.provider == "proxmox" and r.type == "storage")
+    # Framework resource identifier still templated for multi-instance safety
+    assert storage.name == "infra-web-nfs"
+    # Mount is the override value, not the vm_name fallback
+    assert storage.config["mount"] == "infra"
+
+
+def test_service_vm_blueprint_supports_multiple_instances(tmp_path: Path) -> None:
+    """Two packages instantiating the service-vm blueprint must produce
+    distinct resources without colliding on the framework resource identifier.
+
+    Regression guard against #511-style bugs: the outer ``name`` of every
+    blueprint resource must be templated so multi-instance use is safe.
+    """
+    envs = tmp_path / "envs"
+    pkg_a = envs / "test" / "proxmox" / "svc-a"
+    pkg_b = envs / "test" / "proxmox" / "svc-b"
+    pkg_a.mkdir(parents=True)
+    pkg_b.mkdir(parents=True)
+
+    (pkg_a / "infrafoundry.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: svc-a
+            description: "Service VM A"
+            blueprint: service-vm
+            variables:
+              vm_name: svc-a
+              vmid: 220
+              target_node: pve1
+              mac_address: "AA:AA:AA:AA:AA:01"
+              ip_address: "192.168.10.71"
+              dhcp_subnet: subnet-a
+              nfs_server: "192.168.10.50"
+              nfs_export: "/export/a"
+            """
+        )
+    )
+    (pkg_b / "infrafoundry.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: svc-b
+            description: "Service VM B"
+            blueprint: service-vm
+            variables:
+              vm_name: svc-b
+              vmid: 221
+              target_node: pve2
+              mac_address: "BB:BB:BB:BB:BB:02"
+              ip_address: "192.168.10.72"
+              dhcp_subnet: subnet-b
+              nfs_server: "192.168.10.51"
+              nfs_export: "/export/b"
+            """
+        )
+    )
+
+    resolver = BlueprintResolver(envs)
+    pkg_loader = PackageLoader(envs, blueprint_resolver=resolver)
+
+    resources_a, _events_a, _ = pkg_loader.load_package(pkg_a, provider="proxmox", env_name="test")
+    resources_b, _events_b, _ = pkg_loader.load_package(pkg_b, provider="proxmox", env_name="test")
+
+    assert len(resources_a) == 3
+    assert len(resources_b) == 3
+
+    # VM resources have distinct templated identifiers
+    vm_a = next(r for r in resources_a if r.type == "vm")
+    vm_b = next(r for r in resources_b if r.type == "vm")
+    assert vm_a.name == "svc-a"
+    assert vm_b.name == "svc-b"
+    assert vm_a.config["vmid"] == 220
+    assert vm_b.config["vmid"] == 221
+    assert vm_a.config["target_node"] == "pve1"
+    assert vm_b.config["target_node"] == "pve2"
+
+    # DHCP reservations also distinct
+    dhcp_a = next(r for r in resources_a if r.type == "kea_reservation")
+    dhcp_b = next(r for r in resources_b if r.type == "kea_reservation")
+    assert dhcp_a.name == "svc-a"
+    assert dhcp_b.name == "svc-b"
+    assert dhcp_a.config["ip_address"] == "192.168.10.71"
+    assert dhcp_b.config["ip_address"] == "192.168.10.72"
+    assert dhcp_a.config["subnet_ref"] == "subnet-a"
+    assert dhcp_b.config["subnet_ref"] == "subnet-b"
+
+    # Storage mounts are distinct per instance
+    storage_a = next(r for r in resources_a if r.type == "storage")
+    storage_b = next(r for r in resources_b if r.type == "storage")
+    assert storage_a.name == "svc-a-nfs"
+    assert storage_b.name == "svc-b-nfs"
+    assert storage_a.config["server"] == "192.168.10.50"
+    assert storage_b.config["server"] == "192.168.10.51"
+    assert storage_a.config["mount"] == "svc-a"
+    assert storage_b.config["mount"] == "svc-b"


### PR DESCRIPTION
## Description

Extracts the `endavis-infra/envs/prod/proxmox/infra-web/` package shape — a
Proxmox VM clone + opnsense DHCP reservation + optional NFS storage mount —
into a reusable `blueprints/service-vm/` blueprint, and ships an example
consumer under `example-config/envs/dev/proxmox/service-vm/`.

Follows the same "extract recipe → blueprint" trajectory as #502 (aiqum) and
#504 (k3s-cluster). Sits one tier above the framework-bundled `basic-vm`
(`src/infrafoundry/core/blueprints/basic-vm/`): `basic-vm` is a bare template
scaffold, `service-vm` adds DHCP integration, optional NFS, cloud-init
snippet wiring, and multi-instance safety.

### What's new in this blueprint: file-level optional-resource gating

`storage.yaml` is the first in-repo blueprint resource file to use full
file-level `{% if nfs_server %}` gating with an explicit `resources: []`
else branch. When `nfs_server` is unset (the default), no `proxmox.storage`
resource is emitted at all — the file still yields a valid resource-centric
document via the empty list. aiqum/ontap use inline `{% if %}` within a
resource; this is the first case of the whole resource being optional.

The pattern has been added to `docs/configuration/blueprints.md` under a new
"Optional Resources (File-Level Gating)" section so future blueprint authors
have it documented alongside the existing `inputs:` / multi-provider /
shared-template patterns.

### Blueprint shape

- **`blueprint.yaml`** — `inputs:` schema (per ADR-0004). 6 required inputs
  (`vm_name`, `vmid`, `target_node`, `mac_address`, `ip_address`,
  `dhcp_subnet`) and ~15 optional inputs with sensible defaults.
- **`vm.yaml`** — shorthand `vms:` format for the proxmox VM (provider
  matches package directory). Templates all cloud-init snippets, tags,
  cloud_init_vars, network MAC.
- **`dhcp.yaml`** — generic `resources:` format for the opnsense
  `kea_reservation` (cross-provider; `hw_address` lowercased).
- **`storage.yaml`** — generic `resources:` format for the optional
  `proxmox.storage` NFS mount, file-gated on `nfs_server`.
- **`README.md`** — required-vs-optional variable reference, relationship to
  `basic-vm`, and "what gets created" summary.

All outer `name` fields are templated (`{{ vm_name }}`, `{{ vm_name }}-nfs`)
to keep the blueprint safe to instantiate multiple times in the same
environment (regression guard for #511-style bugs).

### One deviation from the plan: added `nfs_mount` input

The plan called for a straight extract, but the existing prod package pinned
the Proxmox NFS mount name to `infra` (not `vm_name`). A strict extract would
have flipped the mount to `vm_name=infra-web` at the first `plan` run and
caused storage churn. Added an optional `nfs_mount: ""` input that falls back
to `vm_name` when empty, so:

- New packages get sensible `mount = vm_name` defaults.
- The prod `infra-web` package can set `nfs_mount: infra` and preserve the
  existing mount name with zero drift.

This trades one extra input for zero-churn migration, and is covered by the
`test_service_vm_nfs_mount_override` test.

### Private homelab consumer (separate repo)

The user's private homelab `endavis-infra/envs/prod/proxmox/infra-web/` was
also converted to consume the new blueprint (using `nfs_mount: infra` to
preserve the existing mount name). **Those changes live in a gitignored
private repo on-disk and are NOT part of this PR's git diff** — the user
will commit them in the private repo separately after this PR merges.

## Related Issue

Addresses #618

## Type of Change

- [x] Code refactoring

## Changes Made

**Created (new blueprint):**
- `blueprints/service-vm/blueprint.yaml` — `inputs:` schema with 6 required
  + ~15 optional inputs.
- `blueprints/service-vm/vm.yaml` — proxmox VM template (shorthand `vms:`).
- `blueprints/service-vm/dhcp.yaml` — opnsense kea reservation (resource-
  centric, cross-provider).
- `blueprints/service-vm/storage.yaml` — optional NFS storage mount with
  file-level `{% if nfs_server %}` gating.
- `blueprints/service-vm/README.md` — full variable reference + relationship
  to `basic-vm`.

**Created (example consumer):**
- `example-config/envs/dev/proxmox/service-vm/infrafoundry.yml` — thin
  blueprint instantiation (no NFS — exercises the default path).
- `example-config/envs/dev/proxmox/service-vm/README.md` — example consumer
  doc pointing at the blueprint.

**Tests:**
- `tests/unit/test_service_vm_blueprint.py` — 7 tests, all passing:
  - Blueprint defaults + per-instance overrides merge correctly.
  - Default path renders exactly 2 resources (VM + DHCP), no storage.
  - VM config combines blueprint defaults with package overrides.
  - DHCP config lowercases `hw_address` and uses merged values.
  - NFS path: setting `nfs_server` emits the storage resource with
    `mount = vm_name` by default.
  - `nfs_mount` override preserves the templated resource name and swaps
    only the mount value (covers the plan deviation).
  - Multi-instance regression guard (two packages, distinct resources, no
    collisions).

**Documentation:**
- `docs/configuration/blueprints.md` — new "Optional Resources (File-Level
  Gating)" section documenting the `{% if %}` / `resources: []` pattern,
  pointing at `blueprints/service-vm/storage.yaml` as reference.

**Not in this PR (separate private repo):**
- `endavis-infra/envs/prod/proxmox/infra-web/` conversion — committed by the
  user in the private repo after this PR merges.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Test summary:**
- 7 new tests in `tests/unit/test_service_vm_blueprint.py`, all passing.
- `doit check` green locally (format, lint, type_check, security,
  spell_check, test).
- The example consumer was loaded end-to-end via `PackageLoader`; the merged
  configuration produces the expected proxmox VM and opnsense DHCP reservation
  with correct per-instance values.
- Multi-instance regression guard covers #511-style outer-name collisions.

**Test plan checklist:**

- [x] `doit check` passes
- [x] New tests pass (`uv run pytest tests/unit/test_service_vm_blueprint.py -v`)
- [x] Multi-instance regression guard passes
- [x] NFS default-off path renders exactly VM + DHCP (no storage resource)
- [x] NFS on path renders VM + DHCP + storage, mount defaults to `vm_name`
- [x] `nfs_mount` override preserves templated resource name, swaps only
      the mount value
- [ ] Reviewer: confirm the `nfs_mount` input + default-to-`vm_name` fallback
      is an acceptable deviation from the original plan (rationale: avoids
      storage churn on the first prod apply)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (new blueprint README;
      new example README; new docs section for optional-resource gating)
- [x] My changes generate no new warnings

## Additional Notes

- **No ADR changes needed** — the blueprint pattern itself is already
  documented in ADR-0003 (multi-provider) and ADR-0004 (`inputs:`). Adding an
  individual blueprint is not an architectural decision. Issue does not
  carry the `needs-adr` label.
- **Builds on prior conversions** — see PR #513 (aiqum, #502) and PR #514
  (proxmox-k3s-cluster, #504) for the established pattern. This PR reuses
  the same `PackageLoader`-based test approach, the same format-split rule
  (shorthand `vms:` where single-provider, resource-centric elsewhere), and
  the same multi-instance regression guard.
- **First file-level-gated resource** — future blueprints with optional
  resources can copy the pattern from `blueprints/service-vm/storage.yaml`
  and the `nfs_server`/`nfs_mount` input shape.

Addresses #618
