### PR TITLE
fix: wire proxmox config validators into generate_terraform

### DIFF
--- a/src/infrafoundry/providers/proxmox/__init__.py
+++ b/src/infrafoundry/providers/proxmox/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, ClassVar, override
 
 from infrafoundry.core.config.models import EnvironmentConfig
+from infrafoundry.core.exceptions import SchemaValidationError
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
 from infrafoundry.core.provider_mixins import (
     CloudInitMixin,
@@ -13,9 +14,14 @@ from infrafoundry.core.provider_mixins import (
     TerraformGeneratorMixin,
     sanitize_secret_ref_to_tf_var,
 )
-from infrafoundry.core.validation import ValidationReport
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
 
 from .validator import ProxmoxValidator
+from .validators import (
+    ContainerConfigValidator,
+    StorageConfigValidator,
+    VMConfigValidator,
+)
 
 
 class ProxmoxProvider(
@@ -91,6 +97,11 @@ class ProxmoxProvider(
         """Generate Terraform configuration for Proxmox resources."""
         resources_by_type = self.prepare_terraform_generation(resources)
 
+        # Field-level schema validation catches malformed configs (e.g., using
+        # ``type:`` instead of ``backend:`` for storage) before template
+        # rendering silently drops the resource. See issue #621.
+        self._validate_resource_configs(resources_by_type)
+
         # Pre-process VMs FIRST so any ``tailscale:`` blocks auto-populate
         # ``terraform_secrets`` on the resource. This must happen before
         # ``collect_terraform_secret_refs`` runs so the variables.tf
@@ -147,6 +158,39 @@ class ProxmoxProvider(
 
         # Generate outputs
         self.render_outputs_terraform(resources_by_type)
+
+    def _validate_resource_configs(
+        self, resources_by_type: dict[str, list[ResourceConfig]]
+    ) -> None:
+        """Run field-level config validation on storage, VM, and container resources.
+
+        Collects ERROR-level findings from the three ``*ConfigValidator`` classes and
+        raises ``SchemaValidationError`` with a multi-line summary if any are present.
+        WARNING-level findings (e.g., CIFS without ``username``) are collected but do
+        not block generation.
+
+        Args:
+            resources_by_type: Resources grouped by type, as returned by
+                ``prepare_terraform_generation``.
+
+        Raises:
+            SchemaValidationError: If one or more resources have ERROR-level
+                validation findings. The message lists every failing check by
+                name and description.
+        """
+        report = ValidationReport()
+        StorageConfigValidator(report).validate(resources_by_type.get("storage", []))
+        VMConfigValidator(report).validate(resources_by_type.get("vm", []))
+        ContainerConfigValidator(report).validate(resources_by_type.get("container", []))
+
+        if report.has_errors():
+            error_lines = [
+                f"  - [{r.check_name}] {r.message}"
+                for r in report.results
+                if not r.passed and r.level == ValidationLevel.ERROR
+            ]
+            message = "Proxmox resource configuration validation failed:\n" + "\n".join(error_lines)
+            raise SchemaValidationError(message)
 
     def _preprocess_vms_for_secrets(self, vms: list[ResourceConfig]) -> list[ResourceConfig]:
         """Pre-process VMs so tailscale: blocks auto-populate terraform_secrets.

--- a/tests/unit/providers/proxmox/test_generate_terraform_validation.py
+++ b/tests/unit/providers/proxmox/test_generate_terraform_validation.py
@@ -1,0 +1,217 @@
+"""Unit tests that the Proxmox provider wires its config validators into ``generate_terraform``.
+
+Covers the wiring (not the validator logic — those are covered in
+``test_storage_config_validator.py``, ``test_vm_config_validator.py``, and
+``test_container_config_validator.py``). Verifies that ERROR-level findings raise
+``SchemaValidationError`` before template rendering can silently drop a resource
+(see issue #621), and that WARNING-level findings do not block generation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from infrafoundry.core.exceptions import SchemaValidationError
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.proxmox import ProxmoxProvider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    """Create a ProxmoxProvider with ``test`` as the active environment."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    p = ProxmoxProvider(config_dir, output_dir)
+    p.set_environment("test")
+    return p
+
+
+def _storage(name: str, **config) -> ResourceConfig:
+    """Build a Proxmox storage ResourceConfig for testing."""
+    return ResourceConfig(
+        name=name,
+        type="storage",
+        provider="proxmox",
+        config={"name": name, **config},
+    )
+
+
+def _vm(name: str, **config) -> ResourceConfig:
+    """Build a minimal Proxmox VM ResourceConfig for testing."""
+    base: dict = {
+        "name": name,
+        "target_node": "pve1",
+        "vmid": 200,
+        "ssh_user": "ubuntu",
+    }
+    base.update(config)
+    return ResourceConfig(name=name, type="vm", provider="proxmox", config=base)
+
+
+def _container(name: str, **config) -> ResourceConfig:
+    """Build a minimal Proxmox LXC container ResourceConfig for testing."""
+    base: dict = {
+        "name": name,
+        "target_node": "pve1",
+        "vmid": 300,
+    }
+    base.update(config)
+    return ResourceConfig(name=name, type="container", provider="proxmox", config=base)
+
+
+class TestStorageValidationWiring:
+    """Wiring tests for StorageConfigValidator via ProxmoxProvider.generate_terraform."""
+
+    def test_missing_backend_raises(self, provider):
+        """A storage resource using ``type: nfs`` (not ``backend:``) raises.
+
+        Reproduces the exact bug from issue #621 — schema mismatch on the
+        ``backend`` key previously rendered an empty storage.tf silently.
+        """
+        storage = _storage(
+            "nas01-infra",
+            type="nfs",  # wrong key — should be ``backend``
+            server="192.168.10.50",
+            export="/export/infra",
+        )
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform([storage])
+        message = str(exc_info.value)
+        assert "nas01-infra" in message
+        assert "backend" in message
+
+    def test_invalid_content_types_raises(self, provider):
+        """A storage resource with an unknown content type raises."""
+        storage = _storage(
+            "nas01-infra",
+            backend="nfs",
+            server="192.168.10.50",
+            export="/export/infra",
+            content_types=["bogus"],
+        )
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform([storage])
+        message = str(exc_info.value)
+        assert "nas01-infra" in message
+        assert "bogus" in message
+
+
+class TestVMValidationWiring:
+    """Wiring tests for VMConfigValidator via ProxmoxProvider.generate_terraform."""
+
+    def test_invalid_machine_type_raises(self, provider):
+        """A VM with an unsupported ``machine`` value raises."""
+        vm = _vm("web01", machine="invalid-machine")
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform([vm])
+        message = str(exc_info.value)
+        assert "web01" in message
+        assert "machine" in message
+
+    def test_invalid_bios_raises(self, provider):
+        """A VM with an unsupported ``bios`` value raises."""
+        vm = _vm("web01", bios="award")
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform([vm])
+        message = str(exc_info.value)
+        assert "web01" in message
+        assert "bios" in message
+
+    def test_negative_balloon_raises(self, provider):
+        """A VM with a negative ``balloon`` value raises."""
+        vm = _vm("web01", balloon=-1)
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform([vm])
+        message = str(exc_info.value)
+        assert "web01" in message
+        assert "balloon" in message
+
+
+class TestContainerValidationWiring:
+    """Wiring tests for ContainerConfigValidator via ProxmoxProvider.generate_terraform."""
+
+    def test_missing_ostemplate_raises(self, provider):
+        """A container without ``ostemplate`` (and no ``clone``) raises."""
+        ct = _container("app01")  # no ostemplate, no clone
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform([ct])
+        message = str(exc_info.value)
+        assert "app01" in message
+        assert "ostemplate" in message
+
+    def test_zero_cores_raises(self, provider):
+        """A container with ``cores: 0`` raises."""
+        ct = _container(
+            "app01",
+            ostemplate="local:vztmpl/alpine.tar.xz",
+            cores=0,
+        )
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform([ct])
+        message = str(exc_info.value)
+        assert "app01" in message
+        assert "cores" in message
+
+
+class TestValidConfigPasses:
+    """Wiring tests confirming valid configs do not raise."""
+
+    def test_minimal_valid_storage_vm_container(self, provider):
+        """A canonical valid mix of storage, VM, and container generates without raising."""
+        storage = _storage(
+            "nas01-infra",
+            backend="nfs",
+            server="192.168.10.50",
+            export="/export/infra",
+        )
+        vm = _vm("web01")
+        ct = _container(
+            "app01",
+            ostemplate="local:vztmpl/alpine.tar.xz",
+        )
+        # Should not raise.
+        provider.generate_terraform([storage, vm, ct])
+
+
+class TestErrorAggregation:
+    """Wiring tests for multi-resource error collection."""
+
+    def test_multiple_bad_resources_single_raise(self, provider):
+        """Multiple invalid resources produce a single raise listing every failure."""
+        resources = [
+            _storage("bad-nfs", type="nfs", server="1.2.3.4", export="/e"),  # wrong key
+            _storage(
+                "bad-content",
+                backend="dir",
+                path="/mnt",
+                content_types=["bogus"],
+            ),
+            _vm("bad-vm", machine="invalid-machine"),
+            _container("bad-ct"),  # missing ostemplate
+        ]
+        with pytest.raises(SchemaValidationError) as exc_info:
+            provider.generate_terraform(resources)
+        message = str(exc_info.value)
+        # Each failing resource name must appear in the aggregated message.
+        assert "bad-nfs" in message
+        assert "bad-content" in message
+        assert "bad-vm" in message
+        assert "bad-ct" in message
+
+
+class TestWarningsDoNotBlock:
+    """Wiring tests confirming WARNING-level findings do not raise."""
+
+    def test_cifs_without_username_is_warning_only(self, provider):
+        """CIFS storage without ``username`` emits a WARNING — generation must succeed."""
+        storage = _storage(
+            "backup-share",
+            backend="cifs",
+            server="192.168.10.50",
+            share="backups",
+            # username omitted intentionally — validator emits WARNING, not ERROR
+        )
+        # Should not raise, despite the validator reporting a warning.
+        provider.generate_terraform([storage])


### PR DESCRIPTION
## Description

`ProxmoxProvider.generate_terraform` accepted any resource config without
field-level validation. When a user's YAML drifted from the expected schema
(e.g., `type: nfs` instead of `backend: nfs` on a storage resource), the
Jinja2 templates consulted the missing keys, failed silently under Jinja's
`Undefined` semantics, and rendered an **empty** `storage.tf` (or VM / CT
file). The resource then silently did not exist in the Terraform graph —
no warning, no error, no hint. Issue #621 reproduces the exact case on a
misconfigured `nas01-infra` storage entry.

### Root cause

Three config-schema validators already existed and had full unit-test
coverage since issue #294 landed:

- `StorageConfigValidator`
- `VMConfigValidator`
- `ContainerConfigValidator`

But **none of them were ever instantiated from production code.** They
were orphaned — imported nowhere outside their own tests. The templates
were the only thing between a malformed YAML config and a silently empty
`.tf` file.

### Fix

Wire the three existing validators into `generate_terraform` as a
single pre-template-rendering step:

1. New private method `_validate_resource_configs` is called at the top
   of `generate_terraform`, immediately after
   `prepare_terraform_generation`.
2. It builds a fresh `ValidationReport`, runs all three validators over
   the grouped resources (storage / vm / container), and if
   `report.has_errors()` is true, raises `SchemaValidationError` with
   a multi-line summary listing every ERROR-level finding by
   `[check_name]` and message.
3. `WARNING`-level findings (e.g., CIFS storage without an explicit
   `username`) are **not** raised — generation proceeds. This preserves
   the existing severity split the validators themselves define.

This PR adds zero validator *logic* — only **wiring**. The validator
classes themselves and their tests are untouched.

### Scope

All three orphaned validators (storage, vm, container) are wired in one
pass per the approved plan on the issue. Partial wiring would leave two
of the three silent-render failure modes still reachable, so the fix is
correctly scoped to close all of them together.

## Related Issue

Addresses #621

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/infrafoundry/providers/proxmox/__init__.py`:
  - Import `SchemaValidationError` and the three
    `*ConfigValidator` classes from `proxmox.validators`.
  - Call new `_validate_resource_configs` helper at the top of
    `generate_terraform`, after `prepare_terraform_generation`.
  - Implement `_validate_resource_configs`: aggregate ERROR-level
    findings from all three validators into a single
    `SchemaValidationError` with a multi-line message; let
    WARNING-level findings pass through.
- `tests/unit/providers/proxmox/test_generate_terraform_validation.py`
  (new): 10 wiring tests, organized into 5 classes:
  - `TestStorageValidationWiring` — reproduces the exact #621 case
    (`type: nfs` instead of `backend:`) and an unknown `content_types`
    entry.
  - `TestVMValidationWiring` — invalid `machine`, invalid `bios`,
    negative `balloon`.
  - `TestContainerValidationWiring` — missing `ostemplate`, zero
    `cores`.
  - `TestValidConfigPasses` — canonical valid mix of storage + vm +
    container does not raise.
  - `TestErrorAggregation` — four invalid resources produce a **single**
    raise whose message lists every offending resource name.
  - `TestWarningsDoNotBlock` — CIFS storage without `username`
    (WARNING-level) generates without raising.

## Testing

- [x] All existing tests pass (`doit check` clean — format, lint, mypy,
  bandit, codespell, and the full pytest suite, 2916 tests).
- [x] Added new tests for the fix — 10 wiring tests exercise every
  raise path and the two non-raise paths (valid configs, warnings).
- [x] Manually tested the changes — the original #621 repro case
  (`nas01-infra` storage with `type: nfs` instead of `backend: nfs`)
  now raises `SchemaValidationError` at plan time instead of rendering
  an empty `storage.tf`.

## User-visible impact

**This fix makes previously-silent failures loud.** Any Proxmox
storage / VM / container YAML config that the validators consider
ERROR-level-invalid will now fail `foundry infra plan` and
`foundry infra apply` with `SchemaValidationError`, listing every
failing resource.

- **Good:** configs that were silently generating empty `.tf` files will
  now surface as clear validation errors before Terraform ever runs.
- **Expected side effect:** issue #622 (service-vm blueprint's Proxmox
  config) will begin failing at plan time once this PR merges — that
  is exactly the intended behavior and a separate issue to resolve
  on the blueprint side.
- **No change** for users whose configs were already schema-correct.
- **No change** for WARNING-level findings (e.g., CIFS without
  `username`) — they still do not block generation.

Because all three validators existed and passed their own unit tests
since #294, their behaviour is already well-defined; this PR only
changes **where** they run, not **what** they check.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

No ADR is required — this is a bug fix (issue has `bug` + `needs-triage`
labels only; no `needs-adr`). The fix does not introduce a new
architectural pattern: the validator classes, their severity levels,
and the `ValidationReport` aggregation pattern all already exist and
were documented by their own tests under `tests/unit/providers/proxmox/`.
This PR simply connects them to the runtime path they were always
meant to guard.

No documentation changes are needed. The Proxmox provider has no
user-facing reference page under `docs/providers/` (only `esxi`,
`kubernetes`, and `oci` exist there today), and the existing
`docs/plugin_system/PROXMOX_PROVIDER_DESIGN.md` describes the provider
at a design level and does not enumerate validator wiring. The error
reference (`docs/reference/errors.md`) uses structured `IF-*` error
codes and does not itemize provider-specific `SchemaValidationError`
variants.
