### PR TITLE
refactor: extract minio blueprint and convert prod minio package

### DIFF
--- a/blueprints/minio/README.md
+++ b/blueprints/minio/README.md
@@ -1,0 +1,144 @@
+# MinIO Distributed Object Storage Blueprint
+
+Reusable blueprint that deploys the [MinIO](https://min.io/) Operator and a
+distributed MinIO tenant on an existing k3s (or other Kubernetes) cluster. All
+resources are managed declaratively via the InfraFoundry Kubernetes provider
+(Helm releases, namespace, credentials secret, NodePort Service manifest) — no
+shell scripts.
+
+Companion to the `k3s-cluster` blueprint: deploy k3s first, then layer MinIO
+on top. See `blueprints/aiqum/README.md` for a structural reference.
+
+## Usage
+
+A package consumes this blueprint with a thin manifest that supplies only the
+per-instance values:
+
+```yaml
+# envs/<env>/proxmox/<package>/infrafoundry.yml
+name: minio
+description: "MinIO distributed object storage on k3s cluster"
+provider: proxmox
+blueprint: minio
+
+variables:
+  tenant_name: homelab
+  tenant_servers: 4
+  tenant_volume_size: "25Gi"
+  # minio_root_password — supply via secrets.yaml (SOPS-encrypted)
+```
+
+Then:
+
+```bash
+export KUBECONFIG=~/.kube/<cluster>.yaml
+infra apply --env <env> --package minio
+```
+
+## Variables
+
+### Required (must be set in the consuming package)
+
+| Variable | Description | Example |
+|---|---|---|
+| `tenant_name` | Tenant identifier; becomes the tenant Helm release name and is templated into all tenant-scoped resource names | `homelab` |
+| `minio_root_password` | MinIO root password (store in SOPS-encrypted `secrets.yaml`) | (secret) |
+
+### Optional (blueprint defaults)
+
+| Variable | Default | Description |
+|---|---|---|
+| `operator_namespace` | `minio-operator` | Namespace for the MinIO Operator |
+| `operator_chart_version` | `6.0.4` | MinIO Operator/Tenant Helm chart version |
+| `tenant_namespace` | `minio-tenant` | Namespace for the tenant resources |
+| `tenant_servers` | `4` | Servers in pool-0 (distributed mode requires >= 4) |
+| `tenant_volumes_per_server` | `1` | Volumes per server |
+| `tenant_volume_size` | `25Gi` | PersistentVolume size per server |
+| `tenant_storage_class` | `local-path` | StorageClass for tenant PVCs |
+| `minio_root_user` | `minioadmin` | MinIO root username |
+| `minio_cpu_request` | `250m` | CPU request per pod |
+| `minio_memory_request` | `512Mi` | Memory request per pod |
+| `minio_cpu_limit` | `1` | CPU limit per pod |
+| `minio_memory_limit` | `2Gi` | Memory limit per pod |
+| `api_node_port` | `30900` | NodePort for the S3 API (port 9000) |
+| `console_node_port` | `30909` | NodePort for the web console (port 9090) |
+
+## Prerequisites
+
+- A Kubernetes cluster is already up and all nodes are `Ready` (for homelab, see
+  the `k3s-cluster` blueprint).
+- `KUBECONFIG` is exported for the target cluster.
+- All target nodes are labeled with `minio=true`:
+  ```bash
+  kubectl label node --all minio=true
+  ```
+- The `tenant_storage_class` (default `local-path`) is installed on the cluster.
+
+## Architecture
+
+This blueprint creates five Kubernetes resources:
+
+| Resource | Type | Name | Description |
+|---|---|---|---|
+| Operator Helm release | `helm_releases` | `minio-operator` | MinIO Operator (CRDs + controller) |
+| Tenant namespace | `namespaces` | `{tenant_name}-ns` | Namespace for tenant resources |
+| Credentials secret | `secrets` | `{tenant_name}-env-configuration` | Holds `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` |
+| Tenant Helm release | `helm_releases` | `{tenant_name}` | MinIO tenant (pool config, resources, node selector) |
+| NodePort Service | `manifests` | `{tenant_name}-external` | Exposes API (9000) and console (9090) on the node IPs |
+
+The tenant Helm release depends on both the operator (for the CRDs) and the
+credentials secret (referenced via `tenant.configuration.name` and
+`tenant.configSecret.name` with `existingSecret=true`).
+
+### Design notes
+
+- **Distributed mode with erasure coding**: 4 servers x 1 drive each
+  (MinIO uses EC:2, surviving up to 2 drive/node failures for reads, 1 for
+  writes). Increase `tenant_servers` for larger clusters.
+- **Local-path storage by default**: Each MinIO pod gets a PersistentVolume on
+  the node's local filesystem. Override `tenant_storage_class` to use a
+  different provisioner (e.g. `longhorn`, `rook-ceph-block`).
+- **No TLS**: `tenant.certificate.requestAutoCert=false`. Add a TLS ingress
+  in front if needed.
+- **NodePort exposure**: The operator creates a ClusterIP Service; this
+  blueprint adds a second NodePort Service for direct external access without
+  an ingress controller.
+
+## Access and Credentials
+
+Once applied:
+
+- **S3 API**: `http://<any-node-ip>:<api_node_port>` (default `30900`)
+- **Console**: `http://<any-node-ip>:<console_node_port>` (default `30909`)
+- **Username**: value of `minio_root_user` (default `minioadmin`)
+- **Password**: value of `minio_root_password` (from SOPS-encrypted
+  `secrets.yaml` in the consuming package)
+
+The Helm tenant chart is configured with `configSecret.existingSecret=true`,
+so it reads the credentials from the Terraform-managed secret instead of
+creating its own. `accessKey`/`secretKey` are blanked out to avoid chart
+validation errors.
+
+## Multi-instance usage
+
+All tenant-scoped resource names are templated on `tenant_name`, so multiple
+tenants can coexist on the same cluster:
+
+```yaml
+# minio-a package
+variables:
+  tenant_name: team-a
+  tenant_namespace: minio-team-a
+  api_node_port: 30910
+  console_node_port: 30919
+
+# minio-b package
+variables:
+  tenant_name: team-b
+  tenant_namespace: minio-team-b
+  api_node_port: 30920
+  console_node_port: 30929
+```
+
+The `minio-operator` Helm release is cluster-global and shared across tenants;
+it is intentionally kept as a literal name.

--- a/blueprints/minio/blueprint.yaml
+++ b/blueprints/minio/blueprint.yaml
@@ -1,0 +1,61 @@
+name: minio
+description: "MinIO distributed object storage on k3s (operator + tenant)"
+version: "1.0.0"
+
+inputs:
+  # --- Required per-instance inputs (no default) ---
+  - name: tenant_name
+    description: "Tenant identifier (used as the tenant Helm release name and in templated resource names)"
+  - name: minio_root_password
+    description: "MinIO root password (SOPS-encrypted in secrets.yaml)"
+
+  # --- MinIO Operator ---
+  - name: operator_namespace
+    default: minio-operator
+  - name: operator_chart_version
+    description: "MinIO Operator/Tenant Helm chart version"
+    default: "6.0.4"
+
+  # --- MinIO Tenant ---
+  - name: tenant_namespace
+    default: minio-tenant
+  - name: tenant_servers
+    description: "Number of MinIO servers in the pool (distributed mode requires >= 4)"
+    type: integer
+    default: 4
+  - name: tenant_volumes_per_server
+    type: integer
+    default: 1
+  - name: tenant_volume_size
+    description: "PersistentVolume size per server (e.g. 25Gi)"
+    default: "25Gi"
+  - name: tenant_storage_class
+    default: local-path
+
+  # --- MinIO Access ---
+  - name: minio_root_user
+    default: minioadmin
+
+  # --- Resource Limits ---
+  - name: minio_cpu_request
+    default: "250m"
+  - name: minio_memory_request
+    default: "512Mi"
+  - name: minio_cpu_limit
+    default: "1"
+  - name: minio_memory_limit
+    default: "2Gi"
+
+  # --- NodePort Access ---
+  - name: api_node_port
+    description: "NodePort for the MinIO S3 API (port 9000)"
+    type: integer
+    default: 30900
+  - name: console_node_port
+    description: "NodePort for the MinIO web console (port 9090)"
+    type: integer
+    default: 30909
+
+resources:
+  - operator.yaml
+  - tenant.yaml

--- a/blueprints/minio/operator.yaml
+++ b/blueprints/minio/operator.yaml
@@ -1,0 +1,18 @@
+# MinIO Operator Helm release.
+#
+# Uses the generic resources: format (not the shorthand) because the resource
+# provider (kubernetes) differs from the package directory provider (proxmox)
+# in the current homelab consumer. One operator per cluster — the resource
+# name is literal, not templated.
+resources:
+  - provider: kubernetes
+    type: helm_releases
+    name: minio-operator
+    config:
+      chart: operator
+      repository: https://operator.min.io
+      version: "{{ operator_chart_version }}"
+      namespace: "{{ operator_namespace }}"
+      create_namespace: true
+      wait: true
+      timeout: 300

--- a/blueprints/minio/tenant.yaml
+++ b/blueprints/minio/tenant.yaml
@@ -1,0 +1,99 @@
+# MinIO Tenant resources (namespace, credentials secret, tenant Helm release,
+# NodePort Service). All outer resource names are templated on tenant_name so
+# multiple tenants can coexist on the same cluster (multi-instance safety per
+# the #511 regression pattern).
+resources:
+  # --- Tenant Namespace ---
+  # Created separately so the credentials secret can be placed before the
+  # tenant Helm release.
+  - provider: kubernetes
+    type: namespaces
+    name: "{{ tenant_name }}-ns"
+    config:
+      name: "{{ tenant_namespace }}"
+
+  # --- MinIO Credentials Secret ---
+  - provider: kubernetes
+    type: secrets
+    name: "{{ tenant_name }}-env-configuration"
+    config:
+      namespace: "{{ tenant_namespace }}"
+      string_data:
+        config.env: "export MINIO_ROOT_USER={{ minio_root_user }}\\nexport MINIO_ROOT_PASSWORD={{ minio_root_password }}\\n"
+
+  # --- MinIO Tenant (Helm) ---
+  # depends_on operator (for CRDs) and the credentials secret.
+  - provider: kubernetes
+    type: helm_releases
+    name: "{{ tenant_name }}"
+    config:
+      chart: tenant
+      repository: https://operator.min.io
+      version: "{{ operator_chart_version }}"
+      namespace: "{{ tenant_namespace }}"
+      wait: true
+      timeout: 600
+      depends_on:
+        - helm_release.minio_operator
+        - kubernetes_secret.{{ (tenant_name ~ "-env-configuration") | replace("-", "_") }}
+      set:
+        - name: tenant.name
+          value: "{{ tenant_name }}"
+        - name: tenant.pools[0].name
+          value: pool-0
+        - name: tenant.pools[0].servers
+          value: "{{ tenant_servers }}"
+        - name: tenant.pools[0].volumesPerServer
+          value: "{{ tenant_volumes_per_server }}"
+        - name: tenant.pools[0].size
+          value: "{{ tenant_volume_size }}"
+        - name: tenant.pools[0].storageClassName
+          value: "{{ tenant_storage_class }}"
+        - name: tenant.pools[0].resources.requests.cpu
+          value: "{{ minio_cpu_request }}"
+        - name: tenant.pools[0].resources.requests.memory
+          value: "{{ minio_memory_request }}"
+        - name: tenant.pools[0].resources.limits.cpu
+          value: "{{ minio_cpu_limit }}"
+        - name: tenant.pools[0].resources.limits.memory
+          value: "{{ minio_memory_limit }}"
+        - name: tenant.pools[0].nodeSelector.minio
+          value: "true"
+          type: string
+        - name: tenant.configuration.name
+          value: "{{ tenant_name }}-env-configuration"
+        - name: tenant.configSecret.name
+          value: "{{ tenant_name }}-env-configuration"
+        - name: tenant.configSecret.existingSecret
+          value: "true"
+        - name: tenant.configSecret.accessKey
+          value: ""
+        - name: tenant.configSecret.secretKey
+          value: ""
+        - name: tenant.certificate.requestAutoCert
+          value: "false"
+
+  # --- NodePort Service for external access ---
+  - provider: kubernetes
+    type: manifests
+    name: "{{ tenant_name }}-external"
+    config:
+      manifest:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: "{{ tenant_name }}-external"
+          namespace: "{{ tenant_namespace }}"
+        spec:
+          type: NodePort
+          selector:
+            v1.min.io/tenant: "{{ tenant_name }}"
+          ports:
+            - name: api
+              port: 9000
+              targetPort: 9000
+              nodePort: {{ api_node_port }}
+            - name: console
+              port: 9090
+              targetPort: 9090
+              nodePort: {{ console_node_port }}

--- a/example-config/envs/dev/proxmox/minio/README.md
+++ b/example-config/envs/dev/proxmox/minio/README.md
@@ -1,0 +1,28 @@
+# MinIO — Example
+
+Example package consuming the `minio` blueprint. All deployment logic lives in
+`blueprints/minio/`; this directory only supplies the per-instance values.
+
+See `blueprints/minio/README.md` for the full variable reference, prerequisites,
+and architecture.
+
+## Quick Start
+
+```bash
+export KUBECONFIG=~/.kube/<cluster>.yaml
+
+# Deploy operator + tenant
+foundry infra apply --env dev --package minio
+
+# Destroy
+foundry infra destroy --env dev --package minio
+```
+
+## What This Example Demonstrates
+
+- A minimal two-server tenant (`tenant_servers: 2`) with 5Gi volumes, so the
+  example fits on a small dev cluster.
+- A placeholder `minio_root_password: "CHANGE_ME"` — replace this (typically
+  via a SOPS-encrypted `secrets.yaml`) before applying.
+- All other variables (operator version, storage class, NodePorts, resource
+  limits) inherited from the blueprint defaults.

--- a/example-config/envs/dev/proxmox/minio/infrafoundry.yml
+++ b/example-config/envs/dev/proxmox/minio/infrafoundry.yml
@@ -1,0 +1,23 @@
+# MinIO Object Storage — example consumer of the minio blueprint.
+#
+# All deployment logic (operator/tenant Helm releases, namespace, credentials
+# secret, NodePort Service) lives in blueprints/minio/. This file only supplies
+# the per-instance values.
+#
+# See blueprints/minio/README.md for the full variable reference.
+#
+# Run: foundry infra apply --env dev --package minio
+
+name: minio
+description: "MinIO distributed object storage (example)"
+provider: proxmox
+blueprint: minio
+
+variables:
+  # --- Required ---
+  tenant_name: example
+  minio_root_password: "CHANGE_ME"
+
+  # --- Smaller footprint for dev ---
+  tenant_servers: 2
+  tenant_volume_size: "5Gi"

--- a/tests/unit/test_minio_blueprint.py
+++ b/tests/unit/test_minio_blueprint.py
@@ -1,0 +1,312 @@
+"""Integration test for the minio blueprint conversion.
+
+Loads the real example-config minio package via PackageLoader and asserts that
+the merged configuration (blueprint defaults + package overrides) produces the
+expected kubernetes resources (operator + tenant namespace + credentials
+secret + tenant helm release + NodePort service manifest).
+
+This is the regression guard for issue #619 and follows the pattern
+established by ``test_aiqum_blueprint.py`` (see #502, #511).
+
+The test depends only on files checked into this repository:
+  - blueprints/minio/                          (the blueprint)
+  - example-config/envs/dev/proxmox/minio/     (the example consumer)
+
+It does NOT depend on the private endavis-infra/ config repo.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from infrafoundry.core.config.blueprint_resolver import BlueprintResolver
+from infrafoundry.core.config.package_loader import PackageLoader
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_ENVS = REPO_ROOT / "example-config" / "envs"
+PACKAGE_DIR = EXAMPLE_ENVS / "dev" / "proxmox" / "minio"
+
+
+@pytest.fixture
+def loader() -> PackageLoader:
+    """PackageLoader pointed at the real example-config envs/ directory."""
+    resolver = BlueprintResolver(EXAMPLE_ENVS)
+    return PackageLoader(EXAMPLE_ENVS, blueprint_resolver=resolver)
+
+
+def test_minio_example_package_loads_blueprint(loader: PackageLoader) -> None:
+    """The minio example package loads via the blueprint resolver and merges
+    blueprint defaults with per-instance overrides."""
+    _resources, _events, variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    # --- Per-instance overrides come from the package manifest ---
+    assert variables["tenant_name"] == "example"
+    assert variables["minio_root_password"] == "CHANGE_ME"
+    assert variables["tenant_servers"] == 2
+    assert variables["tenant_volume_size"] == "5Gi"
+
+    # --- Blueprint defaults flow through unchanged ---
+    assert variables["operator_namespace"] == "minio-operator"
+    assert variables["operator_chart_version"] == "6.0.4"
+    assert variables["tenant_namespace"] == "minio-tenant"
+    assert variables["tenant_volumes_per_server"] == 1
+    assert variables["tenant_storage_class"] == "local-path"
+    assert variables["minio_root_user"] == "minioadmin"
+    assert variables["minio_cpu_request"] == "250m"
+    assert variables["minio_memory_request"] == "512Mi"
+    assert variables["minio_cpu_limit"] == "1"
+    assert variables["minio_memory_limit"] == "2Gi"
+    assert variables["api_node_port"] == 30900
+    assert variables["console_node_port"] == 30909
+
+
+def test_minio_example_renders_all_kubernetes_resources(loader: PackageLoader) -> None:
+    """The merged config produces exactly five kubernetes resources: an
+    operator Helm release, a tenant namespace, a credentials secret, a tenant
+    Helm release, and a NodePort Service manifest. All outer names templated
+    on tenant_name where applicable (multi-instance safety)."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    assert len(resources) == 5
+    assert {r.provider for r in resources} == {"kubernetes"}
+
+    # Count resources by type
+    types = [r.type for r in resources]
+    assert types.count("helm_releases") == 2
+    assert types.count("namespaces") == 1
+    assert types.count("secrets") == 1
+    assert types.count("manifests") == 1
+
+    # Outer names — operator is literal, all tenant-scoped names templated on
+    # tenant_name ("example" in the example consumer).
+    names = {r.name for r in resources}
+    assert names == {
+        "minio-operator",
+        "example-ns",
+        "example-env-configuration",
+        "example",
+        "example-external",
+    }
+
+
+def test_minio_operator_helm_release_config(loader: PackageLoader) -> None:
+    """The operator helm_release uses the MinIO chart, creates its own
+    namespace, and pulls its version from blueprint defaults."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    operator = next(r for r in resources if r.name == "minio-operator")
+    assert operator.type == "helm_releases"
+    assert operator.provider == "kubernetes"
+
+    config = operator.config
+    assert config["chart"] == "operator"
+    assert config["repository"] == "https://operator.min.io"
+    assert config["version"] == "6.0.4"
+    assert config["namespace"] == "minio-operator"
+    assert config["create_namespace"] is True
+    assert config["wait"] is True
+    assert config["timeout"] == 300
+
+
+def test_minio_tenant_helm_release_config(loader: PackageLoader) -> None:
+    """The tenant helm_release depends on the operator and the credentials
+    secret, and its ``set:`` entries reflect the merged variable values."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    tenant = next(r for r in resources if r.type == "helm_releases" and r.name == "example")
+    config = tenant.config
+
+    assert config["chart"] == "tenant"
+    assert config["repository"] == "https://operator.min.io"
+    assert config["version"] == "6.0.4"
+    assert config["namespace"] == "minio-tenant"
+    assert config["wait"] is True
+    assert config["timeout"] == 600
+
+    # depends_on — templated with tenant_name so multi-tenant setups don't
+    # collide on the generated Terraform identifier.
+    assert config["depends_on"] == [
+        "helm_release.minio_operator",
+        "kubernetes_secret.example_env_configuration",
+    ]
+
+    # Flatten the set: list into a name -> value map for assertion simplicity.
+    set_by_name = {entry["name"]: entry["value"] for entry in config["set"]}
+    assert set_by_name["tenant.name"] == "example"
+    assert set_by_name["tenant.pools[0].name"] == "pool-0"
+    # Helm set values are strings even when the input is an integer.
+    assert set_by_name["tenant.pools[0].servers"] == "2"
+    assert set_by_name["tenant.pools[0].volumesPerServer"] == "1"
+    assert set_by_name["tenant.pools[0].size"] == "5Gi"
+    assert set_by_name["tenant.pools[0].storageClassName"] == "local-path"
+    assert set_by_name["tenant.pools[0].resources.requests.cpu"] == "250m"
+    assert set_by_name["tenant.pools[0].resources.requests.memory"] == "512Mi"
+    assert set_by_name["tenant.pools[0].resources.limits.cpu"] == "1"
+    assert set_by_name["tenant.pools[0].resources.limits.memory"] == "2Gi"
+    assert set_by_name["tenant.pools[0].nodeSelector.minio"] == "true"
+    assert set_by_name["tenant.configuration.name"] == "example-env-configuration"
+    assert set_by_name["tenant.configSecret.name"] == "example-env-configuration"
+    assert set_by_name["tenant.configSecret.existingSecret"] == "true"
+    assert set_by_name["tenant.certificate.requestAutoCert"] == "false"
+
+    # The nodeSelector entry carries an explicit ``type: string`` so Helm
+    # doesn't coerce "true" into a boolean.
+    node_selector_entry = next(
+        entry for entry in config["set"] if entry["name"] == "tenant.pools[0].nodeSelector.minio"
+    )
+    assert node_selector_entry.get("type") == "string"
+
+
+def test_minio_credentials_secret_config(loader: PackageLoader) -> None:
+    """The credentials secret lives in the tenant namespace and its
+    ``config.env`` string contains both the rendered MINIO_ROOT_USER and
+    MINIO_ROOT_PASSWORD env-var exports."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    secret = next(r for r in resources if r.type == "secrets")
+    assert secret.name == "example-env-configuration"
+
+    config = secret.config
+    assert config["namespace"] == "minio-tenant"
+
+    config_env = config["string_data"]["config.env"]
+    assert "MINIO_ROOT_USER=minioadmin" in config_env
+    assert "MINIO_ROOT_PASSWORD=CHANGE_ME" in config_env
+
+
+def test_minio_nodeport_service_manifest(loader: PackageLoader) -> None:
+    """The NodePort Service manifest exposes ports 9000 (API) and 9090
+    (console) at the blueprint-default NodePorts, and selects pods via the
+    standard MinIO tenant label."""
+    resources, _events, _variables = loader.load_package(
+        PACKAGE_DIR, provider="proxmox", env_name="dev"
+    )
+
+    svc_resource = next(r for r in resources if r.type == "manifests")
+    assert svc_resource.name == "example-external"
+
+    manifest = svc_resource.config["manifest"]
+    assert manifest["apiVersion"] == "v1"
+    assert manifest["kind"] == "Service"
+    assert manifest["metadata"]["name"] == "example-external"
+    assert manifest["metadata"]["namespace"] == "minio-tenant"
+
+    spec = manifest["spec"]
+    assert spec["type"] == "NodePort"
+    assert spec["selector"] == {"v1.min.io/tenant": "example"}
+
+    ports_by_name = {p["name"]: p for p in spec["ports"]}
+    assert ports_by_name["api"]["port"] == 9000
+    assert ports_by_name["api"]["targetPort"] == 9000
+    assert ports_by_name["api"]["nodePort"] == 30900
+    assert ports_by_name["console"]["port"] == 9090
+    assert ports_by_name["console"]["targetPort"] == 9090
+    assert ports_by_name["console"]["nodePort"] == 30909
+
+
+def test_minio_blueprint_supports_multiple_instances(tmp_path: Path) -> None:
+    """Two packages instantiating the minio blueprint must produce distinct
+    tenant-scoped resources without colliding on the framework resource
+    identifier.
+
+    Regression guard against #511-style bugs: every tenant-scoped outer
+    ``name`` must be templated on ``tenant_name`` so multi-instance use is
+    safe. The operator Helm release is intentionally a literal cluster-global
+    name and is shared across tenants.
+    """
+    envs = tmp_path / "envs"
+    pkg_a = envs / "test" / "proxmox" / "minio-a"
+    pkg_b = envs / "test" / "proxmox" / "minio-b"
+    pkg_a.mkdir(parents=True)
+    pkg_b.mkdir(parents=True)
+
+    (pkg_a / "infrafoundry.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: minio-a
+            description: "MinIO instance A"
+            provider: proxmox
+            blueprint: minio
+            variables:
+              tenant_name: team-a
+              tenant_namespace: minio-team-a
+              minio_root_password: "pw-a"
+              api_node_port: 30910
+              console_node_port: 30919
+            """
+        )
+    )
+    (pkg_b / "infrafoundry.yml").write_text(
+        textwrap.dedent(
+            """\
+            name: minio-b
+            description: "MinIO instance B"
+            provider: proxmox
+            blueprint: minio
+            variables:
+              tenant_name: team-b
+              tenant_namespace: minio-team-b
+              minio_root_password: "pw-b"
+              api_node_port: 30920
+              console_node_port: 30929
+            """
+        )
+    )
+
+    resolver = BlueprintResolver(envs)
+    loader = PackageLoader(envs, blueprint_resolver=resolver)
+
+    resources_a, _, _ = loader.load_package(pkg_a, provider="proxmox", env_name="test")
+    resources_b, _, _ = loader.load_package(pkg_b, provider="proxmox", env_name="test")
+
+    assert len(resources_a) == 5
+    assert len(resources_b) == 5
+
+    names_a = {r.name for r in resources_a}
+    names_b = {r.name for r in resources_b}
+
+    # Tenant-scoped outer names are templated and therefore distinct.
+    assert names_a == {
+        "minio-operator",
+        "team-a-ns",
+        "team-a-env-configuration",
+        "team-a",
+        "team-a-external",
+    }
+    assert names_b == {
+        "minio-operator",
+        "team-b-ns",
+        "team-b-env-configuration",
+        "team-b",
+        "team-b-external",
+    }
+
+    # Operator is intentionally shared (same literal name in both packages);
+    # all other names are disjoint.
+    tenant_names_a = names_a - {"minio-operator"}
+    tenant_names_b = names_b - {"minio-operator"}
+    assert tenant_names_a.isdisjoint(tenant_names_b)
+
+    # depends_on references in each tenant helm_release point at that tenant's
+    # own credentials secret, not the other tenant's.
+    tenant_a = next(r for r in resources_a if r.type == "helm_releases" and r.name == "team-a")
+    tenant_b = next(r for r in resources_b if r.type == "helm_releases" and r.name == "team-b")
+    assert tenant_a.config["depends_on"] == [
+        "helm_release.minio_operator",
+        "kubernetes_secret.team_a_env_configuration",
+    ]
+    assert tenant_b.config["depends_on"] == [
+        "helm_release.minio_operator",
+        "kubernetes_secret.team_b_env_configuration",
+    ]


### PR DESCRIPTION
## Description

Extracts the `endavis-infra/envs/prod/proxmox/minio/` package shape — the
MinIO Operator plus a distributed MinIO tenant running on an existing k3s
(Kubernetes) cluster — into a reusable `blueprints/minio/` blueprint, and
ships an example consumer under `example-config/envs/dev/proxmox/minio/`.

Follows the same "extract recipe → blueprint" trajectory as #502 (aiqum),
#504 (k3s-cluster), and #618 (service-vm). Pairs with the `k3s-cluster`
blueprint: deploy the cluster first, then layer MinIO on top.

### Blueprint shape

- **`blueprint.yaml`** — `inputs:` schema per ADR-0004. Two required inputs
  (`tenant_name`, `minio_root_password`) and 15 optional inputs with sensible
  defaults (operator/tenant namespaces, chart version, pool sizing, storage
  class, CPU/memory requests and limits, NodePort numbers, root user).
- **`operator.yaml`** — resource-centric format. One cluster-global resource:
  the MinIO Operator Helm release (`minio-operator`, literal name — shared
  across tenants).
- **`tenant.yaml`** — resource-centric format. Four tenant-scoped resources
  with outer names templated on `tenant_name` for multi-instance safety:
  tenant namespace, credentials secret, tenant Helm release, and a NodePort
  Service manifest exposing the S3 API (9000) and console (9090). The tenant
  Helm release's `depends_on` list references the operator's Terraform
  identifier plus the per-tenant credentials secret (name rewritten from
  `{{ tenant_name }}-env-configuration` to the Terraform-identifier form via
  `replace("-", "_")`).
- **`README.md`** — required-vs-optional input reference, prerequisites
  (cluster up, KUBECONFIG exported, `minio=true` node label, storage class),
  architecture table of the five resources, multi-instance usage example.

Both resource files use the generic `resources:` format (not shorthand)
because the blueprint deploys `kubernetes`-provider resources while the
package `provider` is `proxmox` (the consuming k3s cluster runs on Proxmox
VMs). Shorthand is single-provider only.

### ⚠ Breaking change for existing `minio` consumers

The tenant namespace resource's outer `name` changed from the literal
`minio_tenant_ns` (as it was hardcoded in the pre-blueprint
`endavis-infra/envs/prod/proxmox/minio/resources.yaml`) to the templated
`{{ tenant_name }}-ns` required by multi-instance safety. Terraform sees this
as a rename from `kubernetes_namespace.minio_tenant_ns` to
`kubernetes_namespace.<tenant_name>_ns`, so consumers with live state MUST
run `terraform state mv` before the next apply, or Terraform will destroy
the running namespace (and the tenant pods on it) and recreate it under the
new identifier.

For the prod `endavis-infra` consumer (which has `tenant_name: homelab`):

```bash
foundry infra plan --env prod --package minio   # see the rename as a "destroy + create" pair
cd generated/prod/terraform/kubernetes
terraform state mv kubernetes_namespace.minio_tenant_ns kubernetes_namespace.homelab_ns
foundry infra plan --env prod --package minio   # now shows "no changes"
```

Consumers who adopt this blueprint from scratch (no prior state) are
unaffected — it's a first-apply creation.

### Private homelab consumer (separate repo)

The user's private homelab `endavis-infra/envs/prod/proxmox/minio/` was also
converted to consume the new blueprint. The old files (`resources.yaml`,
`README.md`, `scripts/`) were deleted. **Those changes live in a gitignored
private repo on-disk and are NOT part of this PR's git diff** — the user
will commit them in the private repo separately after this PR merges, after
performing the `terraform state mv` noted above.

## Related Issue

Addresses #619

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring

## Changes Made

**Created (new blueprint):**

- `blueprints/minio/blueprint.yaml` — `inputs:` schema (2 required + 15
  optional inputs).
- `blueprints/minio/operator.yaml` — cluster-global MinIO Operator Helm
  release (literal name).
- `blueprints/minio/tenant.yaml` — tenant namespace, credentials secret,
  tenant Helm release, NodePort Service manifest (all tenant-scoped names
  templated on `tenant_name`).
- `blueprints/minio/README.md` — full variable reference, prerequisites,
  architecture, multi-instance usage.

**Created (example consumer):**

- `example-config/envs/dev/proxmox/minio/infrafoundry.yml` — thin blueprint
  instantiation with a smaller dev-friendly footprint (`tenant_servers: 2`,
  `tenant_volume_size: 5Gi`).
- `example-config/envs/dev/proxmox/minio/README.md` — example consumer doc
  pointing at the blueprint README.

**Tests:**

- `tests/unit/test_minio_blueprint.py` — 7 tests, all passing:
  - Blueprint defaults + per-instance overrides merge correctly.
  - Example package renders exactly 5 kubernetes resources with the expected
    types and outer names.
  - Operator Helm release config (chart, repository, version, namespace,
    create_namespace, wait, timeout).
  - Tenant Helm release config including `depends_on` with the templated
    Terraform identifier for the tenant credentials secret, and all `set:`
    entries reflecting merged variables.
  - Credentials secret's `string_data.config.env` contains the rendered
    `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` env-var exports.
  - NodePort Service manifest exposes ports 9000/9090 at the default
    NodePorts with the correct MinIO tenant label selector.
  - Multi-instance regression guard: two packages (`team-a`, `team-b`) on
    the same framework produce disjoint tenant-scoped names, sharing only
    the literal `minio-operator` release.

**Not in this PR (separate private repo):**

- `endavis-infra/envs/prod/proxmox/minio/` conversion — committed by the
  user in the private repo after this PR merges, after performing the
  `terraform state mv` described above.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Test summary:**

- 7 new tests in `tests/unit/test_minio_blueprint.py`, all passing.
- `doit check` green locally (format, lint, type_check, security,
  spell_check, test).
- The example consumer was loaded end-to-end via
  `foundry -c example-config config show --env dev`; `minio-operator` and
  the templated tenant resources appear alongside the other example
  packages.

**Test plan checklist:**

- [x] `doit check` passes
- [x] `uv run pytest tests/unit/test_minio_blueprint.py -v` — 7/7 pass
- [x] `foundry -c example-config config show --env dev` renders the minio
      resources with correct per-instance values
- [x] Multi-instance regression guard passes (two tenants produce disjoint
      outer names; only `minio-operator` is shared)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (new blueprint README +
      new example README)
- [x] My changes generate no new warnings

## Additional Notes

- **No ADR changes needed.** The blueprint pattern itself is already
  documented in ADR-0003 (multi-provider) and ADR-0004 (`inputs:`). Adding
  an individual blueprint is not an architectural decision. Issue does not
  carry the `needs-adr` label.
- **No new docs sections needed.** This blueprint reuses existing patterns
  (resource-centric format, templated outer names for multi-instance safety,
  `inputs:` per ADR-0004) — nothing novel that would warrant a new section
  in `docs/configuration/blueprints.md`. Contrast with #618/PR #620 which
  introduced and documented the file-level optional-resource gating pattern.
- **Builds on prior conversions** — see PRs #513 (aiqum, #502), #514
  (proxmox-k3s-cluster, #504), #543 (ubuntu-template, #542), and #620
  (service-vm, #618) for the established pattern. This PR reuses the same
  `PackageLoader`-based test approach and the same multi-instance regression
  guard.
- **Operator name stays literal** — `minio-operator` is a cluster-global
  singleton (one operator per cluster, all tenants share its CRDs). Only
  tenant-scoped resources are templated on `tenant_name`. The multi-instance
  test locks this in.
