### PR TITLE
fix: forward INFRAFOUNDRY_VAR_* env vars on jumphost reexec

### DIFF
--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -22,6 +22,44 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _build_remote_bash(remote_dir: str, script_name: str) -> str:
+    """Build the remote bash invocation used by jumphost reexec.
+
+    The wrapper:
+    - Reads the full package-vars JSON blob from stdin into
+      ``INFRAFOUNDRY_PACKAGE_VARS`` (no secrets on the ssh command line).
+    - Re-exports each scalar entry as ``INFRAFOUNDRY_VAR_<key>`` so remote
+      scripts see the same env var contract as local execution
+      (``script.py:528-531``). Null-delimited jq output keeps values with
+      newlines/tabs/equals-signs intact.
+    - Sets ``INFRAFOUNDRY_ON_JUMPHOST=1`` so blueprint shell helpers that
+      implement their own reexec self-deactivate.
+
+    Args:
+        remote_dir: Absolute path of the rsynced script directory on the
+            jumphost.
+        script_name: Basename of the script to execute.
+
+    Returns:
+        A single bash command string to pass to ``ssh``.
+    """
+    return (
+        'INFRAFOUNDRY_ON_JUMPHOST=1 INFRAFOUNDRY_PACKAGE_VARS="$(cat)"; '
+        "export INFRAFOUNDRY_ON_JUMPHOST INFRAFOUNDRY_PACKAGE_VARS; "
+        'while IFS= read -r -d "" entry; do '
+        'k="${entry%%=*}"; v="${entry#*=}"; '
+        'export "INFRAFOUNDRY_VAR_$k=$v"; '
+        "done < <("
+        'printf %s "$INFRAFOUNDRY_PACKAGE_VARS" | '
+        "jq -j 'to_entries[] "
+        '| select(.value | type != "object" and type != "array") '
+        '| "\\(.key)=\\(.value|tostring)\\u0000"'
+        "'"
+        "); "
+        f"bash {remote_dir}/{script_name}"
+    )
+
+
 class ScriptHandler(BaseHandler):
     """Handler that executes a shell script.
 
@@ -294,10 +332,14 @@ class ScriptHandler(BaseHandler):
             f"{script_dir}/",
             f"{jumphost}:{remote_dir}/",
         ]
-        remote_bash = (
-            f'INFRAFOUNDRY_ON_JUMPHOST=1 INFRAFOUNDRY_PACKAGE_VARS="$(cat)" '
-            f"bash {remote_dir}/{script_path.name}"
-        )
+        # Parity with _execute_locally: re-export each scalar package variable
+        # as INFRAFOUNDRY_VAR_<key> on the remote side so scripts using the
+        # documented contract work under `set -u`. Object/array values are
+        # only exposed via INFRAFOUNDRY_PACKAGE_VARS (JSON) since they can't
+        # round-trip as shell scalars. Uses null-delimited output from jq so
+        # values containing newlines, tabs, or equals signs are safe. Requires
+        # jq on the jumphost.
+        remote_bash = _build_remote_bash(remote_dir, script_path.name)
         ssh_run_cmd = ["ssh", *ssh_opts, jumphost, remote_bash]
         cleanup_cmd = ["ssh", *ssh_opts, jumphost, f"rm -rf {remote_dir}"]
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,6 +1,7 @@
 """Unit tests for EventManager and event handlers."""
 
 import json
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -11,7 +12,7 @@ import pytest
 from infrafoundry.core.events import Event, EventHandlerError, EventManager, EventType
 from infrafoundry.core.events.bus import UnifiedEventBus
 from infrafoundry.core.events.context import EventContext, EventResult
-from infrafoundry.core.events.handlers.script import ScriptHandler
+from infrafoundry.core.events.handlers.script import ScriptHandler, _build_remote_bash
 
 
 @pytest.mark.unit
@@ -1078,3 +1079,73 @@ class TestScriptHandlerJumphostReexec:
         # Local path signature: first arg list is [str(script)]
         assert mock_popen.call_args[0][0] == [str(script)]
         assert result.success
+
+    def test_remote_bash_contains_var_reexport(self, tmp_path: Path):
+        """Remote wrapper re-exports each package var as INFRAFOUNDRY_VAR_<key>.
+
+        Regression for #639: the jumphost path previously only forwarded
+        INFRAFOUNDRY_PACKAGE_VARS (JSON), breaking scripts that consume the
+        documented INFRAFOUNDRY_VAR_<key> contract under ``set -u``.
+        """
+        handler, _ = self._handler(tmp_path)
+        context = self._context(jumphost="jh", server_ip="10.0.0.1", cluster_name="k3s")
+
+        run_result = MagicMock(returncode=0, stdout="", stderr="")
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                return_value=run_result,
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=0),
+            ) as mock_popen,
+        ):
+            handler.execute(context)
+
+        remote_bash = mock_popen.call_args[0][0][-1]
+        assert "INFRAFOUNDRY_VAR_$k" in remote_bash
+        assert "jq -j 'to_entries[]" in remote_bash
+        assert "\\u0000" in remote_bash
+
+    def test_remote_wrapper_sets_var_env_via_real_shell(self, tmp_path: Path):
+        """End-to-end: running the remote wrapper under bash+jq populates INFRAFOUNDRY_VAR_<key>.
+
+        Executes the generated remote bash string against a local bash+jq so
+        the shell-level re-export loop is exercised for real, not merely
+        asserted against the string.
+        """
+        if shutil.which("jq") is None or shutil.which("bash") is None:
+            pytest.skip("requires jq and bash")
+
+        remote_dir = tmp_path
+        script = remote_dir / "dump.sh"
+        script.write_text(
+            '#!/bin/bash\nset -u\necho "ip=${INFRAFOUNDRY_VAR_server_ip}"\n'
+            'echo "name=${INFRAFOUNDRY_VAR_cluster_name}"\n'
+            'echo "num=${INFRAFOUNDRY_VAR_count}"\n'
+            'echo "pkg=${INFRAFOUNDRY_PACKAGE_VARS}"\n'
+        )
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+
+        remote_bash = _build_remote_bash(str(remote_dir), "dump.sh")
+        pkg_vars = {
+            "server_ip": "10.0.0.1",
+            "cluster_name": "k3s-test",
+            "count": 3,
+            "agents": [{"name": "a1"}],  # object/array — only in JSON blob
+        }
+        proc = subprocess.run(  # nosec B603
+            ["bash", "-c", remote_bash],
+            input=json.dumps(pkg_vars),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        assert proc.returncode == 0, f"stderr: {proc.stderr}"
+        assert "ip=10.0.0.1" in proc.stdout
+        assert "name=k3s-test" in proc.stdout
+        assert "num=3" in proc.stdout
+        # Full JSON remains available (incl. the array value that scalars skip).
+        assert '"agents"' in proc.stdout


### PR DESCRIPTION
## Description

`ScriptHandler._execute_on_jumphost` only forwarded `INFRAFOUNDRY_PACKAGE_VARS` (JSON) to the remote bash invocation, breaking the documented `INFRAFOUNDRY_VAR_<key>` env var contract (`script.py:46`, `script.py:528-531`). Scripts that use `set -u` and consume `${INFRAFOUNDRY_VAR_<key>}` — e.g., `blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh:26` — failed on unbound-variable errors.

Extracted `_build_remote_bash(remote_dir, script_name)` as a module-level helper. The new wrapper reads the JSON blob, parses it with `jq`, and re-exports each scalar entry as `INFRAFOUNDRY_VAR_<key>` before `bash`-ing the target script. Null-delimited output keeps values with newlines/tabs/equals-signs intact. Object/array values remain available only via `INFRAFOUNDRY_PACKAGE_VARS` since they can't round-trip as shell scalars. Stdin-based secret transport is preserved: values never appear on the ssh command line or in remote `ps` output.

Adds a dependency on `jq` being installed on the jumphost.

## Related Issue

Addresses #639

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Extracted `_build_remote_bash()` as a module-level helper in `src/infrafoundry/core/events/handlers/script.py`.
- Remote wrapper now re-exports each scalar `INFRAFOUNDRY_VAR_<key>` before execing the target script, restoring parity with `_execute_locally`.
- Added `test_remote_bash_contains_var_reexport` and `test_remote_wrapper_sets_var_env_via_real_shell` to `tests/unit/test_events.py`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

End-to-end test exercises the generated wrapper under real `bash`+`jq` with mixed scalar/array package vars and `set -u` in the inner script, confirming `INFRAFOUNDRY_VAR_server_ip`, `cluster_name`, and `count` all resolve and the JSON blob remains available.

Real-world verification against the k3s-homelab Proxmox cluster will follow after merge.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
