### PR TITLE
fix: use python3 instead of jq in jumphost reexec wrapper

### DIFF
--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -26,12 +26,16 @@ def _build_remote_bash(remote_dir: str, script_name: str) -> str:
     """Build the remote bash invocation used by jumphost reexec.
 
     The wrapper:
+    - Fails fast if ``python3`` is missing on the jumphost. Python 3 is a
+      hard requirement for ansible and is present in the base install of
+      every modern Linux distro, making it strictly more portable than
+      ``jq`` (which is not installed by default on Debian/Ubuntu).
     - Reads the full package-vars JSON blob from stdin into
       ``INFRAFOUNDRY_PACKAGE_VARS`` (no secrets on the ssh command line).
     - Re-exports each scalar entry as ``INFRAFOUNDRY_VAR_<key>`` so remote
       scripts see the same env var contract as local execution
-      (``script.py:528-531``). Null-delimited jq output keeps values with
-      newlines/tabs/equals-signs intact.
+      (``script.py:528-531``). Null-delimited python output keeps values
+      with newlines/tabs/equals-signs intact.
     - Sets ``INFRAFOUNDRY_ON_JUMPHOST=1`` so blueprint shell helpers that
       implement their own reexec self-deactivate.
 
@@ -44,6 +48,9 @@ def _build_remote_bash(remote_dir: str, script_name: str) -> str:
         A single bash command string to pass to ``ssh``.
     """
     return (
+        "command -v python3 >/dev/null 2>&1 || { "
+        'echo "infrafoundry: python3 is required on the jumphost '
+        'to expand INFRAFOUNDRY_VAR_* env vars" >&2; exit 127; }; '
         'INFRAFOUNDRY_ON_JUMPHOST=1 INFRAFOUNDRY_PACKAGE_VARS="$(cat)"; '
         "export INFRAFOUNDRY_ON_JUMPHOST INFRAFOUNDRY_PACKAGE_VARS; "
         'while IFS= read -r -d "" entry; do '
@@ -51,9 +58,12 @@ def _build_remote_bash(remote_dir: str, script_name: str) -> str:
         'export "INFRAFOUNDRY_VAR_$k=$v"; '
         "done < <("
         'printf %s "$INFRAFOUNDRY_PACKAGE_VARS" | '
-        "jq -j 'to_entries[] "
-        '| select(.value | type != "object" and type != "array") '
-        '| "\\(.key)=\\(.value|tostring)\\u0000"'
+        "python3 -c '"
+        "import json,sys;"
+        "d=json.load(sys.stdin);"
+        '[sys.stdout.buffer.write(f"{k}={v}\\0".encode()) '
+        "for k,v in d.items() "
+        "if not isinstance(v,(dict,list))]"
         "'"
         "); "
         f"bash {remote_dir}/{script_name}"
@@ -336,9 +346,9 @@ class ScriptHandler(BaseHandler):
         # as INFRAFOUNDRY_VAR_<key> on the remote side so scripts using the
         # documented contract work under `set -u`. Object/array values are
         # only exposed via INFRAFOUNDRY_PACKAGE_VARS (JSON) since they can't
-        # round-trip as shell scalars. Uses null-delimited output from jq so
-        # values containing newlines, tabs, or equals signs are safe. Requires
-        # jq on the jumphost.
+        # round-trip as shell scalars. Uses null-delimited output from python3
+        # so values containing newlines, tabs, or equals signs are safe.
+        # Requires python3 on the jumphost (checked by the wrapper itself).
         remote_bash = _build_remote_bash(remote_dir, script_path.name)
         ssh_run_cmd = ["ssh", *ssh_opts, jumphost, remote_bash]
         cleanup_cmd = ["ssh", *ssh_opts, jumphost, f"rm -rf {remote_dir}"]

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -793,7 +793,7 @@ class TestScriptHandlerJumphostReexec:
         assert "StrictHostKeyChecking=no" in cmd
         assert "ansible@jump" in cmd
         # The last arg is the remote bash command string
-        assert cmd[-1].startswith("INFRAFOUNDRY_ON_JUMPHOST=1")
+        assert "INFRAFOUNDRY_ON_JUMPHOST=1" in cmd[-1]
         assert "bash /tmp/infrafoundry-" in cmd[-1]
 
     def test_jumphost_stripped_from_forwarded_json(self, tmp_path: Path):
@@ -1105,18 +1105,21 @@ class TestScriptHandlerJumphostReexec:
 
         remote_bash = mock_popen.call_args[0][0][-1]
         assert "INFRAFOUNDRY_VAR_$k" in remote_bash
-        assert "jq -j 'to_entries[]" in remote_bash
-        assert "\\u0000" in remote_bash
+        assert "python3 -c '" in remote_bash
+        assert "command -v python3" in remote_bash
+        assert "\\0" in remote_bash
+        # Regression for #641: must not silently depend on jq.
+        assert "jq " not in remote_bash
 
     def test_remote_wrapper_sets_var_env_via_real_shell(self, tmp_path: Path):
-        """End-to-end: running the remote wrapper under bash+jq populates INFRAFOUNDRY_VAR_<key>.
+        """End-to-end: the wrapper under bash+python3 populates INFRAFOUNDRY_VAR_<key>.
 
-        Executes the generated remote bash string against a local bash+jq so
-        the shell-level re-export loop is exercised for real, not merely
+        Executes the generated remote bash string against a local bash+python3
+        so the shell-level re-export loop is exercised for real, not merely
         asserted against the string.
         """
-        if shutil.which("jq") is None or shutil.which("bash") is None:
-            pytest.skip("requires jq and bash")
+        if shutil.which("python3") is None or shutil.which("bash") is None:
+            pytest.skip("requires python3 and bash")
 
         remote_dir = tmp_path
         script = remote_dir / "dump.sh"
@@ -1149,3 +1152,35 @@ class TestScriptHandlerJumphostReexec:
         assert "num=3" in proc.stdout
         # Full JSON remains available (incl. the array value that scalars skip).
         assert '"agents"' in proc.stdout
+
+    def test_remote_wrapper_fails_fast_without_python3(self, tmp_path: Path):
+        """Regression for #641: wrapper fails fast with a clear error when python3 is absent.
+
+        Previously (PR #640) the wrapper silently depended on ``jq`` — when
+        missing, the subshell emitted ``jq: command not found`` but the outer
+        bash kept going and the inner script surfaced an unbound-variable
+        error that didn't point at the real cause.
+        """
+        bash_path = shutil.which("bash")
+        if bash_path is None:
+            pytest.skip("requires bash")
+
+        script = tmp_path / "dump.sh"
+        script.write_text("#!/bin/bash\necho unreachable\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+
+        remote_bash = _build_remote_bash(str(tmp_path), "dump.sh")
+        # Use absolute path to bash and clear PATH so the wrapper's
+        # `command -v python3` check cannot find python3.
+        proc = subprocess.run(  # nosec B603
+            [bash_path, "-c", remote_bash],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env={"PATH": ""},
+            timeout=10,
+        )
+
+        assert proc.returncode == 127
+        assert "python3 is required" in proc.stderr
+        assert "unreachable" not in proc.stdout


### PR DESCRIPTION
## Description

PR #640 (the #639 fix) silently added `jq` as a runtime dependency on the jumphost. On a jumphost without `jq`, the process substitution emits `jq: command not found` to stderr but bash continues, the re-export loop reads zero entries, and the inner script fails with an unbound-variable error that doesn't point at the real cause — exactly the failure mode #639 was supposed to eliminate.

Swap `jq` for `python3` in `_build_remote_bash`. Python 3 is a hard requirement for ansible (and therefore guaranteed on any ansible jumphost) and is present in the base install of every modern Linux distro, making it strictly more portable than `jq` — which is not installed by default on Debian/Ubuntu.

Also add `command -v python3 >/dev/null 2>&1 || { echo "..." >&2; exit 127; }` at the top of the wrapper so a missing interpreter fails fast with a clear, actionable error message instead of degrading into the same silent-unbound-var failure mode. `exit 127` matches the conventional "command not found" exit code.

Same stdin-based secret transport (JSON blob via `$(cat)`), same null-delimited output, same scalar-only filter, same re-export loop — only the JSON parser changes.

## Related Issue

Addresses #641

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/infrafoundry/core/events/handlers/script.py`:
  - `_build_remote_bash`: prepended `command -v python3` presence check with `exit 127`.
  - Swapped `jq -j 'to_entries[] | select(...) | "..."'` for `python3 -c 'import json,sys;d=json.load(sys.stdin);[sys.stdout.buffer.write(f"{k}={v}\0".encode()) for k,v in d.items() if not isinstance(v,(dict,list))]'`.
  - Updated docstring and call-site comment.
- `tests/unit/test_events.py`:
  - `test_remote_bash_contains_var_reexport`: asserts `python3 -c '`, `command -v python3`, and `\0` are present; asserts `jq ` is **not** present — regression guard.
  - `test_remote_wrapper_sets_var_env_via_real_shell`: skip guard updated (`python3` instead of `jq`).
  - `test_jumphost_set_triggers_reexec`: loosened a `startswith` check to `in` since the presence check now prefixes the wrapper.
  - **New** `test_remote_wrapper_fails_fast_without_python3`: runs the wrapper under real `bash` with `PATH=""`, asserts `rc == 127`, stderr contains `"python3 is required"`, and the inner script did not run.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Manually verified locally:
- Happy path (`PATH` with `python3`): wrapper populates `INFRAFOUNDRY_VAR_server_ip`, `cluster_name`, `count`; full JSON still in `INFRAFOUNDRY_PACKAGE_VARS`; array values skipped from re-export.
- Missing-`python3` path (`PATH=""`): wrapper prints `infrafoundry: python3 is required on the jumphost to expand INFRAFOUNDRY_VAR_* env vars` to stderr and exits 127 before the inner script runs.

Real-world verification against the k3s-homelab Proxmox cluster (whose jumphost has no `jq`) will follow after merge.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
