### PR TITLE
fix: drop PyYAML dependency from ontap and aiqum event-handler scripts

### DIFF
--- a/blueprints/aiqum/scripts/aiqum-post-terraform.sh
+++ b/blueprints/aiqum/scripts/aiqum-post-terraform.sh
@@ -28,24 +28,17 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # resolves to the blueprint dir, which is wrong for a consuming package.
 PACKAGE_DIR="${INFRAFOUNDRY_PACKAGE_DIR:?required: run via foundry, not directly}"
 
-# Read variables from INFRAFOUNDRY_PACKAGE_VARS or fall back to infrafoundry.yml
-if [ -n "${INFRAFOUNDRY_PACKAGE_VARS:-}" ]; then
-    eval "$(python3 -c "
+# Read variables from INFRAFOUNDRY_PACKAGE_VARS (JSON, set by framework).
+if [ -z "${INFRAFOUNDRY_PACKAGE_VARS:-}" ]; then
+    echo "ERROR: INFRAFOUNDRY_PACKAGE_VARS is not set — run via 'foundry infra apply', not directly" >&2
+    exit 1
+fi
+eval "$(python3 -c "
 import json, os
 v = json.loads(os.environ['INFRAFOUNDRY_PACKAGE_VARS'])
 for k, val in v.items():
     print(f'{k}={val}')
 ")"
-else
-    eval "$(python3 -c "
-import sys, yaml
-with open('${PACKAGE_DIR}/infrafoundry.yml') as f:
-    data = yaml.safe_load(f)
-v = data.get('variables', {})
-for k, val in v.items():
-    print(f'{k}={val}')
-")"
-fi
 
 JUMPHOST="${jumphost:-}"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"

--- a/blueprints/ontap-cluster/scripts/ontap-post-terraform.sh
+++ b/blueprints/ontap-cluster/scripts/ontap-post-terraform.sh
@@ -32,23 +32,26 @@ if [ ! -f "$PLAYBOOK" ]; then
     exit 1
 fi
 
-# Generate Ansible inventory from package variables
+if ! command -v ansible-playbook >/dev/null 2>&1; then
+    echo "ERROR: ansible-playbook is required but was not found on PATH" >&2
+    echo "Install ansible and ensure ansible-playbook is on PATH (on the jumphost if jumphost is set in the package)" >&2
+    exit 127
+fi
+
+if [ -z "${INFRAFOUNDRY_PACKAGE_VARS:-}" ]; then
+    echo "ERROR: INFRAFOUNDRY_PACKAGE_VARS is not set — run via 'foundry infra apply', not directly" >&2
+    exit 1
+fi
+
+# Generate Ansible inventory from package variables (JSON — ansible accepts
+# JSON inventories natively, so stdlib json is enough; no PyYAML needed).
 echo "Generating Ansible inventory from environment variables..."
-INVENTORY="${PACKAGE_DIR}/.generated-inventory.yml"
+INVENTORY="${PACKAGE_DIR}/.generated-inventory.json"
 
 python3 -c "
-import json, os, sys, yaml
+import json, os, sys
 
-# Read variables from INFRAFOUNDRY_PACKAGE_VARS env var (set by framework)
-vars_json = os.environ.get('INFRAFOUNDRY_PACKAGE_VARS')
-if vars_json:
-    v = json.loads(vars_json)
-else:
-    # Fallback: read from infrafoundry.yml directly (for manual runs)
-    print('Warning: INFRAFOUNDRY_PACKAGE_VARS not set, reading from infrafoundry.yml')
-    with open(sys.argv[1]) as f:
-        data = yaml.safe_load(f)
-    v = data.get('variables', {})
+v = json.loads(os.environ['INFRAFOUNDRY_PACKAGE_VARS'])
 
 # Build host lookup from target names
 host_lookup = {}
@@ -97,9 +100,9 @@ inventory = {
     },
 }
 
-with open(sys.argv[2], 'w') as f:
-    yaml.dump(inventory, f, default_flow_style=False)
-" "${PACKAGE_DIR}/infrafoundry.yml" "$INVENTORY"
+with open(sys.argv[1], 'w') as f:
+    json.dump(inventory, f, indent=2)
+" "$INVENTORY"
 
 echo "Running ONTAP lab cluster setup playbook..."
 cd "$BLUEPRINT_DIR"


### PR DESCRIPTION
## Description

Two blueprint event-handler scripts (`ontap-post-terraform.sh`, `aiqum-post-terraform.sh`) embed inline Python that imports `yaml` (PyYAML — not stdlib). PyYAML is not in the base install of a minimal Debian/Ubuntu jumphost, so on such a host the inline `python3` aborts with `ModuleNotFoundError: No module named 'yaml'` before the script can do any useful work. Same class of portability failure as the `jq` dependency fixed in #645 / PR #646, just with a different missing package.

Both scripts also carried a "manual run" fallback that read `${PACKAGE_DIR}/infrafoundry.yml` via `yaml.safe_load`. That fallback was dead code under the normal framework invocation, *and* broken under jumphost reexec anyway: the framework rsyncs the blueprint script directory to the jumphost but not the consuming package dir, so `${PACKAGE_DIR}` doesn't resolve to anything readable on the remote side. Removing the fallback is a net simplification.

## Related Issue

Addresses #647. Part of the broader portability audit tracked in #643.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

### `blueprints/ontap-cluster/scripts/ontap-post-terraform.sh`

- Added `command -v ansible-playbook` presence check (`exit 127` + clear error) right after the existing `PLAYBOOK` file-existence check. Consistent with the guard added for the OCI k3s variant in PR #646.
- Added a required-var check that fails fast with `exit 1` + clear error if `INFRAFOUNDRY_PACKAGE_VARS` is not set, pointing the user at `foundry infra apply`.
- Removed `yaml` from the inline-Python imports; dropped the `else` branch that read `infrafoundry.yml` via `yaml.safe_load`.
- Swapped `yaml.dump(inventory, f, default_flow_style=False)` for `json.dump(inventory, f, indent=2)`.
- Renamed the generated inventory file `.generated-inventory.yml` → `.generated-inventory.json`. Ansible auto-detects format by file extension; no behavior change.
- Dropped the unused first arg to the inline python (was the `${PACKAGE_DIR}/infrafoundry.yml` path consumed by the removed fallback). The inline python now takes only the output path.

### `blueprints/aiqum/scripts/aiqum-post-terraform.sh`

- Replaced the `if INFRAFOUNDRY_PACKAGE_VARS then json else yaml` branch with an early fail-fast check: `exit 1` + clear error if the env var is unset.
- Removed the `else` branch entirely — gone are `import yaml`, `yaml.safe_load(...)`, and the `${PACKAGE_DIR}/infrafoundry.yml` read.
- Happy path unchanged — `json.loads(os.environ['INFRAFOUNDRY_PACKAGE_VARS'])` + the `eval`-based shell-var population pattern continues to work.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

No new unit tests — shell scripts aren't exercised by the project's test infra. Verified manually:

1. **`bash -n`** parse-clean on both scripts.
2. **Ontap inventory generation** — ran the modified inline python against two representative payloads:
   - Same-host case (`node01_target == node02_target`): both VMIDs end up on the single host entry via `ontap_node02_vmid`.
   - Different-host case (distinct targets): two host entries with distinct `ontap_vmid`s.
3. **Ansible JSON parsing** — ran `ansible-inventory --list -i /tmp/.../.generated-inventory.json`. All three hosts (`pve1`, `pve2`, `ontap-cluster`) and both groups (`proxmox_hosts`, `ontap_cluster`) parse correctly, with hostvars preserved.
4. **Aiqum fail-fast** — ran the script with `INFRAFOUNDRY_PACKAGE_VARS` unset: exits 1 with the clear error pointing at `foundry infra apply`.
5. **Aiqum happy path** — ran with populated `INFRAFOUNDRY_PACKAGE_VARS`: shell vars `vm_name`, `ip_address`, `jumphost`, `ssh_user`, `aiqum_admin_user`, `aiqum_url_base` all populate via the eval pattern.
6. `doit check` green (2244 tests, format, lint, mypy, bandit, codespell).

Real-world verification will follow when the k3s-homelab deploy moves on to ontap/aiqum packages.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
