### PR TITLE
docs: document Rocky 9 target and tool assumptions in aiqum-install-remote.sh

### DIFF
--- a/blueprints/aiqum/scripts/aiqum-install-remote.sh
+++ b/blueprints/aiqum/scripts/aiqum-install-remote.sh
@@ -1,8 +1,49 @@
 #!/bin/bash
-# AIQUM RPM install script — runs on the AIQUM VM itself
+# AIQUM RPM install script — runs on the target AIQUM VM
 #
-# Installs all prerequisites identified by pre_install_check.sh,
-# then installs the AIQUM RPM.
+# This is **not** a framework event-handler script and does **not** follow the
+# jumphost portability contract used by `aiqum-post-terraform.sh`. It is
+# specifically Rocky 9 RPM-family tooling and is uploaded + executed on the
+# provisioned AIQUM VM itself.
+#
+# Runs on:
+#   The AIQUM Rocky 9 Proxmox VM (cloned from the `rocky9-template` blueprint).
+#   NOT the jumphost, NOT the InfraFoundry orchestration host.
+#
+# Invoked by:
+#   `aiqum-post-terraform.sh` via `remote_upload` (scp) + `remote_cmd_long`
+#   (ssh) in Phase 2 of the post-deploy flow. The caller runs as the
+#   non-root `ansible` user; this script uses `sudo` for privileged steps.
+#
+# Environment variables:
+#   AIQUM_URL_BASE  Required. Base URL hosting the AIQUM RPM and sibling
+#                   install scripts:
+#                     - netapp-um-9.18-el9.x86_64.rpm (~1.9 GB)
+#                     - pre_install_check.sh
+#                     - install7zip.sh
+#
+# Target OS tool assumptions (all present in the Rocky 9 base install
+# unless noted):
+#   - bash 4+
+#   - sudo
+#   - yum (RPM package manager)
+#   - curl
+#   - systemctl (systemd)
+#   - firewall-cmd (installed by step 5 if absent — firewalld is not in the
+#     minimal Rocky 9 base)
+#   - rpm
+#   - awk, ls (coreutils)
+#   `wget` is NOT assumed — step 1 installs it before use.
+#
+# Side effects (on the target VM):
+#   - Installs `wget` + `unzip`
+#   - Configures the EPEL and MySQL 8.4 Community yum repositories
+#   - Installs 7-Zip (via the hosted `install7zip.sh`)
+#   - Installs and enables `firewalld`; opens AIQUM ports
+#     (80, 443, 8080, 9443, 56072, 56080, 56443)
+#   - Downloads the AIQUM RPM (~1.9 GB) to `/tmp/aiqum-install/`
+#   - Runs `pre_install_check.sh`
+#   - Installs the `netapp-um-9.18-el9.x86_64.rpm` + ~225 dependencies
 set -euo pipefail
 
 log() { echo "[$(date +%H:%M:%S)] $*"; }


### PR DESCRIPTION
## Description

`blueprints/aiqum/scripts/aiqum-install-remote.sh` is uploaded via scp by `aiqum-post-terraform.sh` to the AIQUM Rocky 9 VM and executed there. Unlike the event-handler scripts fixed in PR #646 / PR #648, this script is **not** subject to the "jumphost portability contract" — its target is a specific, blueprint-controlled OS (Rocky 9) where distro-specific tooling (`yum`, `firewalld`, `rpm`) is appropriate and intentional.

The previous header was 5 lines and didn't document any of that — a reader had to page through the full script to answer basic questions like "what OS is this for?", "how is it invoked?", "what env vars does it read?". This PR expands the header to spell out all of it.

Comments only. No behavior change. `bash -n` parse-clean.

## Related Issue

Addresses #649. Step 6 of the portability audit tracked in #643.

## Type of Change

- [x] Documentation update

## Changes Made

Expanded the script header into a structured block covering:

- **Runs on:** the AIQUM Rocky 9 Proxmox VM (cloned from `rocky9-template`). NOT the jumphost, NOT the InfraFoundry host. Explicit note that this script does **not** follow the jumphost portability contract used by `aiqum-post-terraform.sh` because its target is a blueprint-controlled OS.
- **Invoked by:** `aiqum-post-terraform.sh` via `remote_upload` (scp) + `remote_cmd_long` (ssh) in Phase 2. Runs as the non-root `ansible` user and uses `sudo` for privileged steps.
- **Environment variables:** `AIQUM_URL_BASE` (required) and what it must host (`netapp-um-9.18-el9.x86_64.rpm`, `pre_install_check.sh`, `install7zip.sh`).
- **Target OS tool assumptions:** bash 4+, sudo, yum, curl, systemctl, firewall-cmd (installed by step 5 if absent), rpm, awk, ls. Explicit note that `wget` is NOT assumed — step 1 installs it.
- **Side effects:** EPEL + MySQL 8.4 Community repos, 7-Zip, firewalld with AIQUM ports (80, 443, 8080, 9443, 56072, 56080, 56443), the AIQUM RPM (~1.9 GB) plus ~225 dependencies.

## Testing

- [x] All existing tests pass
- [x] N/A — documentation change

- `bash -n blueprints/aiqum/scripts/aiqum-install-remote.sh` parses clean.
- `doit check` green (2244 tests, format, lint, mypy, bandit, codespell).
- No behavior change, so no runtime verification needed beyond the parse check.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (comments only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR is the documentation)
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
