### PR TITLE
docs: add blueprint script portability contract

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -26,6 +26,10 @@ This section provides comprehensive guides for developing and extending InfraFou
 - **[Event System](event-system.md)** - Documentation of the internal event system for orchestration
 - **[Credential Loader System](credential-loader-system.md)** - How the credential loading system works
 
+## Writing Blueprint Scripts
+
+- **[Blueprint Script Portability](blueprint-script-portability.md)** - Portability contract for event-handler and target-VM scripts: tools you may assume, how to handle the rest, and why `jq` is not recommended
+
 ## See Also
 
 - [Architecture Overview](../architecture/overview.md) - High-level system architecture

--- a/docs/development/blueprint-script-portability.md
+++ b/docs/development/blueprint-script-portability.md
@@ -1,0 +1,122 @@
+# Blueprint Script Portability
+
+Blueprint event-handler scripts (`on_create`, `after_apply`, `before_destroy`, etc.) do not always run on the InfraFoundry orchestration host. Depending on the consuming package's configuration, the framework may rsync a script to a remote jumphost and execute it there, or a script may upload sibling helpers onto a target VM and run them via ssh. Each of those contexts has its own set of tools you can safely assume exist.
+
+This page documents the portability contract that blueprint scripts must respect, so they don't silently break on minimal hosts the way #641 and #645 did.
+
+## Execution contexts
+
+A blueprint script may run in one of three contexts:
+
+### 1. InfraFoundry orchestration host
+
+The default — the host running `foundry infra apply`. Tools available here are whatever the user installed to operate InfraFoundry. `python3` and `uv` are always present.
+
+### 2. Jumphost (framework reexec)
+
+When the consuming package sets `jumphost` in its variables (`user@host`), the framework's `ScriptHandler._execute_on_jumphost` rsync's the blueprint's script directory to a temp dir on the jumphost and runs the script there via ssh. The wrapper (`src/infrafoundry/core/events/handlers/script.py`) forwards `INFRAFOUNDRY_PACKAGE_VARS` and re-exports each scalar as `INFRAFOUNDRY_VAR_<key>` on the remote side, matching local execution semantics.
+
+The jumphost may be a minimal Debian/Ubuntu/Rocky host. **Treat it as a stock base install** — do not assume anything beyond the portable baseline below.
+
+### 3. Target VM (scp + ssh)
+
+A script running in context 1 or 2 may upload sibling scripts to a target VM (via `scp` / `rsync`) and execute them there via `ssh`. Example: `blueprints/aiqum/scripts/aiqum-post-terraform.sh` uploads `aiqum-install-remote.sh` to the AIQUM VM and runs it via `remote_cmd_long`.
+
+Target VMs are **blueprint-controlled** — the OS is known because the blueprint provisions it. Target-VM scripts may reach for distro-specific tooling (`yum`, `apt`, `firewalld`, etc.), subject to the exemption rules below.
+
+## The portable baseline
+
+Every script that might run in context 1 or 2 must use only these tools:
+
+| Tool | Notes |
+|---|---|
+| `bash` | 4+ (`mapfile` / `readarray`, process substitution, `<<<` here-strings) |
+| `python3` | **stdlib only.** Allowed modules include `json`, `urllib.request`, `urllib.parse`, `os`, `sys`, `subprocess`, `pathlib`, `base64`, `re`, `smtplib`, `email.mime.*`. No `requests`, no `PyYAML`, no `jinja2`, no `boto3`. |
+| GNU coreutils | `cat`, `printf`, `sed`, `grep`, `awk`, `mkdir`, `chmod`, `ls`, `mapfile`/`readarray`, etc. |
+| `ssh`, `scp`, `rsync`, `curl` | Standard on any modern Linux host. |
+
+Anything else requires an explicit presence check — see below.
+
+## `jq` is not recommended
+
+`jq` is the obvious tool for parsing JSON in bash, and it's tempting. **Don't use it in blueprint scripts.** It is not in the base install of:
+
+- Debian / Ubuntu (all current versions)
+- Rocky / RHEL / CentOS (all current versions)
+- Alpine
+- Most public cloud base images (AWS, Azure, GCP, OCI)
+- Most minimal container base images
+
+When `jq` is missing, `echo "$JSON" | jq -r '.foo'` emits `jq: command not found` to stderr but the outer `$(...)` or `< <(...)` substitution still returns an empty string, so the caller silently proceeds with an empty list or an empty variable. That failure mode is what caused the `Agents (0):` bug in #645.
+
+Use stdlib `python3` instead. Equivalent one-liners:
+
+| `jq` | Python equivalent |
+|---|---|
+| `jq -r '.foo'` | `python3 -c 'import json,sys; print(json.load(sys.stdin).get("foo",""))'` |
+| `jq -r '.items[].name'` | `python3 -c 'import json,sys
+for i in json.load(sys.stdin).get("items",[]): print(i["name"])'` |
+| `jq -r '.items[] \| select(.x == true) \| .id'` | `python3 -c 'import json,sys
+for i in json.load(sys.stdin).get("items",[]):
+    if i.get("x"): print(i["id"])'` |
+
+See `blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` (lines 34-37) and `blueprints/k3s-cluster/scripts/oci/cleanup-tailscale-devices.sh` for in-tree examples after the swap in PR #646.
+
+## Tools outside the baseline
+
+Scripts in context 1 or 2 may still need tools outside the baseline — `ansible-playbook`, `kubectl`, `yq`, `terraform`, etc. That's allowed, but the script must **fail fast with a clear error** if the tool is missing rather than degrading into a confusing later failure.
+
+Put a presence check at the top of the script, near the `set -euo pipefail`:
+
+```bash
+if ! command -v ansible-playbook >/dev/null 2>&1; then
+    echo "ERROR: ansible-playbook is required but was not found on PATH" >&2
+    echo "Install ansible and ensure ansible-playbook is on PATH (on the jumphost if jumphost is set in the package)" >&2
+    exit 127
+fi
+```
+
+For Python packages outside stdlib (`requests`, `pyyaml`, etc.), use an `import` check:
+
+```bash
+if ! python3 -c 'import requests' >/dev/null 2>&1; then
+    echo "ERROR: the python3 'requests' package is required but is not installed" >&2
+    echo "Install it via your system package manager or pip" >&2
+    exit 127
+fi
+```
+
+Exit code `127` is the conventional "command not found" status, so CI and shell-aware callers can detect it distinctly.
+
+Exemplars in the codebase:
+
+- **Tool check:** `blueprints/k3s-cluster/scripts/oci/k3s-post-terraform.sh` (`ansible-playbook` guard, added in PR #646).
+- **Tool check:** `blueprints/ontap-cluster/scripts/ontap-post-terraform.sh` (`ansible-playbook` guard, added in PR #648).
+- **Env-var check:** `blueprints/aiqum/scripts/aiqum-post-terraform.sh` (required `INFRAFOUNDRY_PACKAGE_VARS`, added in PR #648).
+
+## Target-VM scripts: the exemption
+
+Scripts that are uploaded to and executed on a blueprint-controlled target VM (context 3) are exempt from the portable baseline. Those scripts may assume any tool that the blueprint's VM template provides — `yum`, `apt`, `firewall-cmd`, `rpm`, distro-specific init systems, etc.
+
+In exchange, a target-VM script **must**:
+
+1. Have a header that documents (a) the target OS the script expects, (b) how it is invoked (upload-and-exec pattern), (c) required environment variables, and (d) every tool it assumes is on the target.
+2. Be referenced from the blueprint's `README.md` so the OS expectation is discoverable without reading the script.
+
+Exemplar: `blueprints/aiqum/scripts/aiqum-install-remote.sh` (headed up in PR #650).
+
+## Checklist for blueprint authors
+
+Before submitting a PR that adds or changes a blueprint script:
+
+- [ ] Identify which execution context(s) this script runs in (1, 2, or 3). If it's an `on_create` / `after_apply` / `before_destroy` handler on a blueprint whose consumers might set `jumphost`, assume context 2.
+- [ ] If context 1 or 2: confirm the script uses only the portable baseline. No `jq`, no `yq`, no third-party Python packages, no `ansible-playbook` / `kubectl` / etc. without a presence check.
+- [ ] If the script uses a tool outside the baseline, add a `command -v` or `python3 -c 'import X'` check at the top with `exit 127` and a clear error message.
+- [ ] If context 3 (target-VM upload): document the target OS, invocation pattern, env vars, and tool assumptions in the script header; confirm the blueprint README also states the OS expectation.
+- [ ] Use `python3 -c 'import json ...'` (stdlib) instead of `jq` for JSON parsing.
+
+## Related documentation
+
+- [Event System](event-system.md) — how `on_create` / `after_apply` / etc. handlers are dispatched.
+- `src/infrafoundry/core/events/handlers/script.py` — the framework's `ScriptHandler`, including `_execute_on_jumphost` and `_build_remote_bash`.
+- [Issue #643](https://github.com/endavis/infrafoundry/issues/643) — the portability audit that produced this contract.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
     - Runner Protocol Reference: development/runner-protocol-quick-reference.md
     - Manager Patterns: development/manager-patterns.md
     - Event System: development/event-system.md
+    - Blueprint Script Portability: development/blueprint-script-portability.md
     - Credential Loader: development/credential-loader-system.md
     - Coding Standards: development/coding-standards.md
     - CI/CD Testing: development/ci-cd-testing.md


### PR DESCRIPTION
## Description

Blueprint event-handler scripts (`on_create`, `after_apply`, `before_destroy`) may be executed on hosts other than the InfraFoundry orchestration host — on a jumphost via the framework's rsync+ssh reexec path when a package sets `jumphost`, or on a target VM via `scp` + `ssh` when a script uploads helpers. Until this series of PRs, there was no written policy for what tools scripts could assume on those remote hosts; PRs #642, #646, #648, and #650 each fixed a class of silent failure caused by that gap.

This PR codifies the policy into a developer guide so future blueprint authors have a reference and the CI lint (step 8 of #643) has something to enforce.

## Related Issue

Addresses #651. Step 7 of the portability audit tracked in #643.

## Type of Change

- [x] Documentation update

## Changes Made

**New file: `docs/development/blueprint-script-portability.md`** (~140 lines)

- **Three execution contexts** — InfraFoundry orchestration host, jumphost (framework reexec via `ScriptHandler._execute_on_jumphost`), and target VM (scp+ssh uploads). Each context is described with a concrete in-tree example.
- **The portable baseline** for contexts 1-2: `bash` 4+, `python3` with stdlib only (explicit module list: `json`, `urllib.request`, `urllib.parse`, `os`, `sys`, `subprocess`, `pathlib`, `base64`, `re`, `smtplib`, `email.mime.*`), GNU coreutils, `ssh`/`scp`/`rsync`/`curl`.
- **Explicit "`jq` is not recommended anywhere"** section explaining why (not in the base install of Debian/Ubuntu, Rocky/RHEL, Alpine, most cloud images, most minimal container images) and what the failure mode looks like (empty substitution output, silent misconfiguration — the bug from #645). Includes a `jq`→`python3 -c 'import json'` equivalence table with three common patterns.
- **Presence-check pattern** for tools outside the baseline (`ansible-playbook`, `kubectl`, `yq`, etc.): `command -v <tool>` with `exit 127` and a clear error, pointing readers at the exemplars added in PRs #646 and #648. Same pattern for 3rd-party Python packages via `python3 -c 'import X'`.
- **Target-VM script exemption**: scripts uploaded to blueprint-controlled VMs may assume distro-specific tooling, but must document the target OS + tool assumptions in the script header and blueprint README. Exemplar: `aiqum-install-remote.sh` (PR #650).
- **Author checklist** — 5 bullets a blueprint author self-reviews against before submitting a PR.
- Cross-references to `docs/development/event-system.md`, `src/infrafoundry/core/events/handlers/script.py`, and #643.

**`docs/development/README.md`**
- New "Writing Blueprint Scripts" section with a one-line index entry linking the new page.

**`mkdocs.yml`**
- Added the page to the Development nav between "Event System" and "Credential Loader" so it's discoverable in the rendered site.

## Testing

- [x] All existing tests pass
- [x] N/A — documentation only

- `doit docs_build` renders cleanly. No new warnings about the new page (the remaining warnings in the build output are pre-existing for unrelated files).
- `doit check` green (2244 tests, format, lint, mypy, bandit, codespell).
- Docs-only PR; no runtime behavior change.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (docs only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR is the documentation)
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
