### PR TITLE
chore: enforce blueprint script portability contract via doit lint

### DIFF
--- a/tests/unit/test_blueprint_portability_lint.py
+++ b/tests/unit/test_blueprint_portability_lint.py
@@ -1,0 +1,138 @@
+"""Tests for tools/lint_blueprint_portability.py.
+
+Covers the find_violations() core: detection of disallowed tools,
+exemption-marker handling (inline + above-line), comment-line skipping,
+and word-boundary correctness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.lint_blueprint_portability import find_violations, lint_blueprints
+
+
+class TestFindViolations:
+    """Unit tests for the line-level violation detector."""
+
+    def test_clean_script_no_violations(self):
+        text = """#!/bin/bash
+set -euo pipefail
+
+mapfile -t NAMES < <(python3 -c 'import json,sys
+for i in json.load(sys.stdin): print(i)' <<< "$DATA")
+"""
+        assert find_violations(text) == []
+
+    def test_jq_usage_flagged(self):
+        text = """#!/bin/bash
+set -euo pipefail
+
+NAMES=$(echo "$DATA" | jq -r '.items[]')
+"""
+        violations = find_violations(text)
+        assert len(violations) == 1
+        line_no, tool, content = violations[0]
+        assert line_no == 4
+        assert tool == "jq"
+        assert "jq -r" in content
+
+    def test_yq_usage_flagged(self):
+        text = """#!/bin/bash
+echo "$DATA" | yq -r '.items'
+"""
+        violations = find_violations(text)
+        assert len(violations) == 1
+        assert violations[0][1] == "yq"
+
+    def test_inline_exemption_silences_violation(self):
+        text = """#!/bin/bash
+NAMES=$(echo "$DATA" | jq -r '.items[]')  # SCRIPT_PORTABILITY_EXEMPT: jq: legacy parser
+"""
+        assert find_violations(text) == []
+
+    def test_above_line_exemption_silences_violation(self):
+        text = """#!/bin/bash
+# SCRIPT_PORTABILITY_EXEMPT: jq: installed by step 3
+NAMES=$(echo "$DATA" | jq -r '.items[]')
+"""
+        assert find_violations(text) == []
+
+    def test_exemption_for_wrong_tool_does_not_silence(self):
+        text = """#!/bin/bash
+# SCRIPT_PORTABILITY_EXEMPT: yq: I meant the other one
+NAMES=$(echo "$DATA" | jq -r '.items[]')
+"""
+        violations = find_violations(text)
+        assert len(violations) == 1
+        assert violations[0][1] == "jq"
+
+    def test_jq_in_comment_is_not_flagged(self):
+        text = """#!/bin/bash
+# This script used to use jq but now uses python3
+echo "ok"
+"""
+        assert find_violations(text) == []
+
+    def test_jq_in_indented_comment_is_not_flagged(self):
+        text = """#!/bin/bash
+if true; then
+    # We dropped the jq dependency in PR #646
+    echo ok
+fi
+"""
+        assert find_violations(text) == []
+
+    def test_word_boundary_does_not_match_substrings(self):
+        text = """#!/bin/bash
+# These should NOT trigger:
+mkdir jquery_data
+PROJ=mkjq
+echo $PROJ
+"""
+        # `jquery` and `mkjq` don't have `jq` as a standalone word.
+        assert find_violations(text) == []
+
+    def test_multiple_violations_on_different_lines(self):
+        text = """#!/bin/bash
+NAMES=$(echo "$DATA" | jq -r '.names[]')
+IPS=$(echo "$DATA" | jq -r '.ips[]')
+TAGS=$(echo "$DATA" | yq -r '.tags[]')
+"""
+        violations = find_violations(text)
+        assert [(v[0], v[1]) for v in violations] == [(2, "jq"), (3, "jq"), (4, "yq")]
+
+    def test_two_blank_lines_between_marker_and_use_breaks_link(self):
+        # The above-line marker only applies to the line *immediately* above.
+        text = """#!/bin/bash
+# SCRIPT_PORTABILITY_EXEMPT: jq: not adjacent
+
+NAMES=$(echo "$DATA" | jq -r '.items[]')
+"""
+        violations = find_violations(text)
+        assert len(violations) == 1
+        assert violations[0][1] == "jq"
+
+
+class TestLintBlueprintsCurrentTree:
+    """Sanity check the lint against the live blueprints/ tree.
+
+    After PR #646 / #648 / #650 the tree should be jq-free, so the lint
+    must report zero violations on the current state. Catches regressions
+    in the lint script itself (e.g., a flawed regex that triggers false
+    positives on an existing exemplar).
+    """
+
+    def test_current_blueprints_tree_has_no_violations(self, capsys):
+        repo_root = Path(__file__).resolve().parents[2]
+        blueprint_dir = repo_root / "blueprints"
+        if not blueprint_dir.is_dir():
+            pytest.skip("blueprints/ not present in this checkout")
+        total_violations, total_scripts = lint_blueprints(blueprint_dir)
+        captured = capsys.readouterr()
+        assert total_violations == 0, (
+            f"expected zero violations, got {total_violations}; output:\n{captured.out}"
+        )
+        assert total_scripts > 0, "expected to scan at least one script"

--- a/tools/doit/quality.py
+++ b/tools/doit/quality.py
@@ -69,10 +69,33 @@ def task_maintainability() -> dict[str, Any]:
     }
 
 
+def task_lint_blueprints() -> dict[str, Any]:
+    """Lint blueprint scripts for portability contract violations.
+
+    Enforces docs/development/blueprint-script-portability.md by scanning
+    blueprints/**/*.sh for tools (currently `jq`, `yq`) that are
+    not-recommended on remote hosts. See the docs page for the exemption
+    marker if a violation is justified.
+    """
+    return {
+        "actions": ["uv run python tools/lint_blueprint_portability.py"],
+        "title": title_with_actions,
+        "verbosity": 0,
+    }
+
+
 def task_check() -> dict[str, Any]:
     """Run all checks (format, lint, type check, security, spelling, test)."""
     return {
         "actions": [success_message],
-        "task_dep": ["format_check", "lint", "type_check", "security", "spell_check", "test"],
+        "task_dep": [
+            "format_check",
+            "lint",
+            "lint_blueprints",
+            "type_check",
+            "security",
+            "spell_check",
+            "test",
+        ],
         "title": title_with_actions,
     }

--- a/tools/lint_blueprint_portability.py
+++ b/tools/lint_blueprint_portability.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Lint blueprint scripts for portability contract violations.
+
+Scans ``blueprints/**/*.sh`` for tools that
+``docs/development/blueprint-script-portability.md`` calls out as
+not-recommended (currently ``jq`` and ``yq``). False positives can be
+silenced with an inline marker on the violating line:
+
+.. code-block:: bash
+
+    foo | jq -r '.bar'  # SCRIPT_PORTABILITY_EXEMPT: jq: <reason>
+
+Or on the line directly above:
+
+.. code-block:: bash
+
+    # SCRIPT_PORTABILITY_EXEMPT: jq: <reason>
+    foo | jq -r '.bar'
+
+Comment-only lines are ignored unconditionally so headers, docstrings,
+and prose can freely discuss the tools without tripping the lint.
+
+Exits 0 if no unexempted violations were found, 1 otherwise.
+
+Usage:
+    python tools/lint_blueprint_portability.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+DISALLOWED_TOOLS: tuple[str, ...] = ("jq", "yq")
+EXEMPT_MARKER_RE = re.compile(r"#\s*SCRIPT_PORTABILITY_EXEMPT:\s*(\w+)\s*:")
+COMMENT_LINE_RE = re.compile(r"^\s*#")
+TOOL_RES: dict[str, re.Pattern[str]] = {
+    tool: re.compile(rf"\b{tool}\b") for tool in DISALLOWED_TOOLS
+}
+
+
+def find_violations(text: str) -> list[tuple[int, str, str]]:
+    """Return a list of (line_number, tool, line_content) violations.
+
+    A violation is a non-comment line that matches one of the disallowed
+    tool patterns and is not silenced by an inline or above-line
+    SCRIPT_PORTABILITY_EXEMPT marker for the same tool.
+
+    Args:
+        text: Full contents of the script file.
+
+    Returns:
+        List of (1-based line number, tool name, stripped line content).
+    """
+    lines = text.splitlines()
+    violations: list[tuple[int, str, str]] = []
+    for i, line in enumerate(lines, start=1):
+        if COMMENT_LINE_RE.match(line):
+            continue
+        for tool, pattern in TOOL_RES.items():
+            if not pattern.search(line):
+                continue
+            if _is_exempted(tool, line, lines, i):
+                continue
+            violations.append((i, tool, line.rstrip()))
+    return violations
+
+
+def _is_exempted(tool: str, line: str, all_lines: list[str], line_no: int) -> bool:
+    """Check inline and above-line exemption markers for the given tool."""
+    inline = EXEMPT_MARKER_RE.search(line)
+    if inline and inline.group(1) == tool:
+        return True
+    if line_no >= 2:
+        prev = all_lines[line_no - 2]
+        prev_match = EXEMPT_MARKER_RE.search(prev)
+        if prev_match and prev_match.group(1) == tool:
+            return True
+    return False
+
+
+def lint_blueprints(blueprint_dir: Path) -> tuple[int, int]:
+    """Lint all .sh files under blueprint_dir.
+
+    Returns:
+        Tuple of (total_violations, total_scripts_scanned).
+    """
+    scripts = sorted(blueprint_dir.rglob("*.sh"))
+    total_violations = 0
+    repo_root = blueprint_dir.parent
+    for script in scripts:
+        violations = find_violations(script.read_text())
+        if not violations:
+            continue
+        rel = script.relative_to(repo_root)
+        for line_no, tool, content in violations:
+            print(f"{rel}:{line_no}: uses '{tool}' (not recommended)")
+            print(f"    {content}")
+        total_violations += len(violations)
+    return total_violations, len(scripts)
+
+
+def main() -> int:
+    repo_root = Path(__file__).parent.parent
+    blueprint_dir = repo_root / "blueprints"
+    if not blueprint_dir.is_dir():
+        print(f"ERROR: blueprints/ not found at {blueprint_dir}", file=sys.stderr)
+        return 1
+
+    total_violations, total_scripts = lint_blueprints(blueprint_dir)
+
+    if total_violations:
+        print(file=sys.stderr)
+        print(
+            f"Found {total_violations} portability violation(s) across "
+            f"{total_scripts} blueprint script(s).",
+            file=sys.stderr,
+        )
+        print(
+            "See docs/development/blueprint-script-portability.md for guidance.",
+            file=sys.stderr,
+        )
+        print(
+            "To silence a justified use, add an inline or above-line marker:",
+            file=sys.stderr,
+        )
+        print("    # SCRIPT_PORTABILITY_EXEMPT: <tool>: <reason>", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

PR #652 wrote down the blueprint script portability contract at `docs/development/blueprint-script-portability.md`. That gives us a written reference, but no mechanical enforcement — a future blueprint author can still reintroduce `jq` or another not-recommended tool with no automated push-back, the same way the bugs in #641, #645, and #647 were introduced silently.

This PR is the mechanical complement to step 7: a CI lint over `blueprints/**/*.sh` that fails the build on unexempted use of disallowed tools (currently `jq` and `yq`).

This is the final step in the portability audit tracked in #643. After it lands, the contract is both documented (#652) and enforced (this PR).

## Related Issue

Addresses #653. Closes the audit tracked in #643.

## Type of Change

- [x] Tooling improvement (chore)

## Changes Made

### `tools/lint_blueprint_portability.py` (new, ~110 lines)

A Python script that walks `blueprints/**/*.sh` and reports unexempted uses of disallowed tools.

- **Scope:** scans non-comment lines for `\bjq\b` / `\byq\b`. Comment-only lines are skipped unconditionally so headers, docstrings, and prose can mention the tools freely (e.g., "this script used to use jq, now uses python3" is fine).
- **Word-boundary matching:** `\bjq\b` won't match `jquery_data`, `mkjq`, etc. — verified by a unit test.
- **Exemption marker** for justified uses, either inline on the violating line OR on the line directly above:

  ```bash
  foo | jq -r '.bar'  # SCRIPT_PORTABILITY_EXEMPT: jq: legacy parser

  # SCRIPT_PORTABILITY_EXEMPT: jq: installed by step 3
  bar | jq -r '.baz'
  ```

  The above-line marker requires immediate adjacency (a blank line breaks the link, by design — a marker far above can drift away from what it actually justifies).

- **Output format:** `path:line: uses 'tool' (not recommended)` followed by the offending line. Footer points readers at the docs page and the exemption pattern. Exit 0 when clean, exit 1 otherwise.

- **Public surface for tests:** `find_violations(text)` and `lint_blueprints(blueprint_dir)`.

### `tools/doit/quality.py`

- New `task_lint_blueprints` invoking `uv run python tools/lint_blueprint_portability.py`. Available as `doit lint_blueprints` standalone.
- Added `lint_blueprints` to `task_check`'s `task_dep`, between `lint` and `type_check`, so the standard `doit check` gate runs it.

### `tests/unit/test_blueprint_portability_lint.py` (new, 12 tests)

`TestFindViolations` — 11 tests on the line-level detector:
- Clean script (no violations)
- `jq` flagged
- `yq` flagged
- Inline exemption silences
- Above-line exemption silences
- Wrong-tool exemption does not silence (`# ...EXEMPT: yq:` does not silence a `jq` line)
- `jq` in a top-level comment is not flagged
- `jq` in an indented comment is not flagged
- Word-boundary correctness (`jquery`/`mkjq` ignored)
- Multiple violations across different lines
- Two-blank-lines-between-marker-and-use breaks the exemption link

`TestLintBlueprintsCurrentTree` — 1 sanity test:
- Runs the lint against the live `blueprints/` tree and asserts zero violations. This catches regressions in the lint script itself (e.g., a flawed regex that triggers false positives on a cleaned-up exemplar from PRs #646 / #648 / #650).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

- `doit lint_blueprints` exits 0 against the current tree.
- Manual sanity check: a synthetic `blueprints/fake/scripts/bad.sh` containing `jq -r '.items[]'` produces `bad.sh:3: uses 'jq' (not recommended)` and exit 1, with the trailing pointer to the docs.
- `doit check` green — `lint_blueprints` runs as part of the aggregate.
- Full test suite: 2256 tests pass (was 2244, +12 new).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (the docs landed separately in PR #652; this PR is the enforcement layer that doc page describes)
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
