### PR TITLE
fix: surface ssh failures + add Phase 0 preflight in k3s and aiqum scripts

### DIFF
--- a/blueprints/aiqum/scripts/aiqum-post-terraform.sh
+++ b/blueprints/aiqum/scripts/aiqum-post-terraform.sh
@@ -63,14 +63,45 @@ else
     echo "Jumphost: (direct SSH)"
 fi
 
+# --- Phase 0: Preflight — catch obvious local SSH problems before the wait
+# loop. Loops that silently retry for minutes are confusing when ssh-agent has
+# no keys loaded or the first hop is fundamentally broken.
+echo ""
+log "--- Phase 0: Preflight checks ---"
+
+if ! ssh-add -l >/dev/null 2>&1; then
+    rc=$?
+    if [ $rc -eq 1 ]; then
+        echo "ERROR: ssh-agent on $(hostname) has no keys loaded" >&2
+        echo "       Load your key (e.g. 'ssh-add ~/.ssh/id_ed25519') and re-apply" >&2
+    else
+        echo "ERROR: cannot reach ssh-agent on $(hostname) (rc=$rc, SSH_AUTH_SOCK=${SSH_AUTH_SOCK:-unset})" >&2
+    fi
+    exit 1
+fi
+echo "  ssh-agent: $(ssh-add -l | wc -l) key(s) loaded"
+
+PREFLIGHT_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR"' EXIT
+if ! remote_cmd "${ip_address}" "echo ok" >"$PREFLIGHT_ERR" 2>&1; then
+    echo "ERROR: preflight ssh to ${vm_name} (${ip_address}) failed:" >&2
+    sed 's/^/    /' "$PREFLIGHT_ERR" >&2
+    exit 1
+fi
+echo "  ssh probe to ${vm_name} (${ip_address}): OK"
+
 # --- Phase 1: Wait for VM to be reachable ---
 echo ""
 log "--- Phase 1: Waiting for VM to be reachable ---"
 MAX_WAIT=300
 ELAPSED=0
-while ! remote_cmd "${ip_address}" "echo ready" &>/dev/null; do
+WAIT_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR" "$WAIT_ERR"' EXIT
+while ! remote_cmd "${ip_address}" "echo ready" >"$WAIT_ERR" 2>&1; do
     if [ $ELAPSED -ge $MAX_WAIT ]; then
         echo "ERROR: VM not reachable after ${MAX_WAIT}s"
+        echo "  Last ssh attempt:" >&2
+        sed 's/^/    /' "$WAIT_ERR" >&2
         exit 1
     fi
     echo "  Waiting for SSH... (${ELAPSED}s)"

--- a/blueprints/k3s-cluster/scripts/oci/k3s-post-terraform.sh
+++ b/blueprints/k3s-cluster/scripts/oci/k3s-post-terraform.sh
@@ -127,18 +127,50 @@ echo "Inventory: ${INVENTORY_FILE}"
 echo "Roles:     ${ROLES_DIR}"
 echo "Playbook:  ${PLAYBOOK}"
 
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+
+# --- Phase 0: Preflight — catch obvious local SSH problems before the wait
+# loop. Loops that silently retry for minutes are confusing when ssh-agent has
+# no keys loaded or the first hop is fundamentally broken.
+echo ""
+echo "--- Phase 0: Preflight checks ---"
+
+if ! ssh-add -l >/dev/null 2>&1; then
+    rc=$?
+    if [ ${rc} -eq 1 ]; then
+        echo "ERROR: ssh-agent on $(hostname) has no keys loaded" >&2
+        echo "       Load your key (e.g. 'ssh-add ~/.ssh/id_ed25519') and re-apply" >&2
+    else
+        echo "ERROR: cannot reach ssh-agent on $(hostname) (rc=${rc}, SSH_AUTH_SOCK=${SSH_AUTH_SOCK:-unset})" >&2
+    fi
+    exit 1
+fi
+echo "  ssh-agent: $(ssh-add -l | wc -l) key(s) loaded"
+
+PREFLIGHT_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR"' EXIT
+if ! ${SSH} "ubuntu@${CONTROL_HOST}" "echo ok" >"${PREFLIGHT_ERR}" 2>&1; then
+    echo "ERROR: preflight ssh to ${CONTROL_NAME} (${CONTROL_HOST}) failed:" >&2
+    sed 's/^/    /' "${PREFLIGHT_ERR}" >&2
+    exit 1
+fi
+echo "  ssh probe to ${CONTROL_NAME} (${CONTROL_HOST}): OK"
+
 # --- Phase 1: wait for SSH reachability on every host ---
 echo ""
 echo "--- Phase 1: waiting for SSH reachability ---"
-SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
 MAX_WAIT=600
+WAIT_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR" "$WAIT_ERR"' EXIT
 
 wait_for_ssh() {
     local host="$1"
     local elapsed=0
-    while ! ${SSH} "ubuntu@${host}" "echo ready" &>/dev/null; do
+    while ! ${SSH} "ubuntu@${host}" "echo ready" >"${WAIT_ERR}" 2>&1; do
         if [ ${elapsed} -ge ${MAX_WAIT} ]; then
             echo "ERROR: ${host} not reachable after ${MAX_WAIT}s"
+            echo "  Last ssh attempt:" >&2
+            sed 's/^/    /' "${WAIT_ERR}" >&2
             return 1
         fi
         echo "  Waiting for ${host}... (${elapsed}s)"

--- a/blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh
+++ b/blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh
@@ -106,19 +106,52 @@ done
 echo "Jumphost: ${JUMPHOST:-<direct>}"
 
 # ===========================================================================
+# Phase 0: Preflight — catch obvious local SSH problems before the wait loop.
+# Loops that silently retry for minutes are confusing when ssh-agent has no
+# keys loaded or the first hop is fundamentally broken.
+# ===========================================================================
+echo ""
+echo "--- Phase 0: Preflight checks ---"
+
+if ! ssh-add -l >/dev/null 2>&1; then
+    rc=$?
+    if [ $rc -eq 1 ]; then
+        echo "ERROR: ssh-agent on $(hostname) has no keys loaded" >&2
+        echo "       Load your key (e.g. 'ssh-add ~/.ssh/id_ed25519') and re-apply" >&2
+    else
+        echo "ERROR: cannot reach ssh-agent on $(hostname) (rc=$rc, SSH_AUTH_SOCK=${SSH_AUTH_SOCK:-unset})" >&2
+    fi
+    exit 1
+fi
+echo "  ssh-agent: $(ssh-add -l | wc -l) key(s) loaded"
+
+PREFLIGHT_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR"' EXIT
+if ! remote_cmd "${SERVER_IP}" "echo ok" >"$PREFLIGHT_ERR" 2>&1; then
+    echo "ERROR: preflight ssh to ${SERVER_NAME} (${SERVER_IP}) failed:" >&2
+    sed 's/^/    /' "$PREFLIGHT_ERR" >&2
+    exit 1
+fi
+echo "  ssh probe to ${SERVER_NAME} (${SERVER_IP}): OK"
+
+# ===========================================================================
 # Phase 1: Wait for all VMs to be reachable
 # ===========================================================================
 echo ""
 echo "--- Phase 1: Waiting for all VMs to be reachable ---"
 MAX_WAIT=300
+WAIT_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR" "$WAIT_ERR"' EXIT
 
 for i in "${!ALL_IPS[@]}"; do
     ip="${ALL_IPS[$i]}"
     name="${ALL_NAMES[$i]}"
     ELAPSED=0
-    while ! remote_cmd "${ip}" "echo ready" &>/dev/null; do
+    while ! remote_cmd "${ip}" "echo ready" >"$WAIT_ERR" 2>&1; do
         if [ $ELAPSED -ge $MAX_WAIT ]; then
             echo "ERROR: ${name} (${ip}) not reachable after ${MAX_WAIT}s"
+            echo "  Last ssh attempt:" >&2
+            sed 's/^/    /' "$WAIT_ERR" >&2
             exit 1
         fi
         echo "  Waiting for ${name} (${ip})... (${ELAPSED}s)"


### PR DESCRIPTION
## Description

Three blueprint event-handler scripts have a "wait for SSH" loop that silences the ssh probe's stderr via `&>/dev/null`, then exits with a generic `not reachable after Ns` message after a 5-10 minute timeout. The actual cause — ssh-agent missing keys, network unreachable, auth failure, firewall block — is hidden, so the operator has to re-run the probe manually to find out what went wrong.

Hit in real use this week: an `infra apply` against the k3s-cluster package sat in a 5-minute Phase 1 wait loop and exited with `ERROR: k3s-server (192.168.10.70) not reachable after 300s` — turned out the ssh-agent on the jumphost had no keys loaded. With this fix the operator gets a one-line `ERROR: ssh-agent on <jumphost> has no keys loaded` from Phase 0 in under a second instead of a 5-minute black-box timeout.

This is **sub-PR 1 of the audit in #655** — addresses findings #1, #4, #5 from the audit table. The other five Category B findings will land in subsequent PRs.

The framework-level home for the same preflight idea is tracked in **#657** (extend `infra doctor` with package-aware jumphost preflight). This PR is the immediate per-script affordance that lands today; #657 is the strategic, reusable form.

## Related Issue

Addresses #658. Sub-PR 1 of #655.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

Each of the three affected scripts gets the same two-part change:

**1. New "Phase 0: Preflight"** — runs before any other phase:

- `ssh-add -l` check. Branches on the exit code so the error message is actionable:
  - `rc=1` → "ssh-agent on `<host>` has no keys loaded — load your key (`ssh-add ~/.ssh/id_ed25519`) and re-apply"
  - `rc=2` → "cannot reach ssh-agent on `<host>` (rc=`<rc>`, SSH_AUTH_SOCK=`<value>`)"
- One-shot verbose ssh probe to the first target (`SERVER_IP` for proxmox k3s, `CONTROL_HOST` for OCI k3s, `ip_address` for aiqum). Captures combined output to a tmpfile; dumps it to stderr indented on failure, then exits 1.

**2. Phase 1 wait loop** (modified, not replaced) — each iteration redirects the probe's combined output to a `WAIT_ERR` tmpfile (overwritten each iteration). On `MAX_WAIT` timeout the last attempt's output is dumped to stderr indented before `exit 1`. So if the wait genuinely times out (slow boot, etc.) the operator still sees the actual ssh-side error.

Trap-based cleanup of both tmpfiles on EXIT.

**Files modified:**

- `blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` — Phase 0 inserted before the existing Phase 1 wait, Phase 1 loop modified.
- `blueprints/k3s-cluster/scripts/oci/k3s-post-terraform.sh` — same; the `SSH=` definition was moved above Phase 0 so both phases can share it.
- `blueprints/aiqum/scripts/aiqum-post-terraform.sh` — same.

## Testing

- [x] All existing tests pass
- [x] N/A — shell-script change, no Python test surface
- [x] Manually tested the changes

- `bash -n` parse-clean on all three scripts.
- Smoke-test of the `ssh-add -l` branching, run locally:
  - rc=0 (agent reachable, keys loaded) → preflight passes.
  - `unset SSH_AUTH_SOCK` → rc=2, takes the "cannot reach agent" branch with the right error message.
  - `SSH_AUTH_SOCK=/nonexistent/agent.sock` → rc=2, same branch.
  - rc=1 (agent reachable, no keys) is the documented `ssh-add` exit code for that state per `man ssh-add`; cannot easily simulate without removing keys but the branch logic is straightforward.
- `doit check` green (2256 tests, format, lint, mypy, bandit, codespell, lint_blueprints).

Real-world verification will follow on the next k3s-homelab apply.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (no Python test surface; verified via `bash -n` and local smoke test)
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
