### PR TITLE
fix: surface kubectl failures in proxmox k3s wait loops (sub-PR 2 of #655)

### DIFF
--- a/blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh
+++ b/blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh
@@ -214,12 +214,18 @@ remote_root_cmd "${SERVER_IP}" "
         --node-name ${SERVER_NAME}
 "
 
-# Wait for k3s server to be ready (kubectl as ansible user)
+# Wait for k3s server to be ready (kubectl as ansible user).
+# Capture combined output each iteration so the timeout path can dump
+# kubectl's actual error instead of a black-box "not ready after 180s".
+KUBECTL_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR" "$WAIT_ERR" "$KUBECTL_ERR"' EXIT
 echo "  Waiting for k3s server to be ready..."
 ELAPSED=0
-while ! remote_kubectl "${SERVER_IP}" "kubectl get nodes" &>/dev/null; do
+while ! remote_kubectl "${SERVER_IP}" "kubectl get nodes" >"$KUBECTL_ERR" 2>&1; do
     if [ $ELAPSED -ge 180 ]; then
         echo "ERROR: k3s server not ready after 180s"
+        echo "  Last kubectl attempt:" >&2
+        sed 's/^/    /' "$KUBECTL_ERR" >&2
         exit 1
     fi
     sleep 5
@@ -259,17 +265,33 @@ done
 echo ""
 echo "--- Phase 5: Verifying cluster ---"
 
-# Wait for all nodes to be Ready
+# Wait for all nodes to be Ready. Split the kubectl call so stdout (the
+# count) and stderr (diagnostics) are separable on the local side; the
+# previous remote-side `2>/dev/null` discarded errors before they could
+# cross the ssh boundary, leaving the operator staring at "0/4 ready"
+# with no clue why.
+KUBECTL_OUT=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR" "$WAIT_ERR" "$KUBECTL_ERR" "$KUBECTL_OUT"' EXIT
 echo "  Waiting for all ${EXPECTED_NODES} nodes to be Ready..."
 ELAPSED=0
 while true; do
-    READY_COUNT=$(remote_kubectl "${SERVER_IP}" "kubectl get nodes --no-headers 2>/dev/null | grep -c ' Ready ' || echo 0")
+    if remote_kubectl "${SERVER_IP}" "kubectl get nodes --no-headers" >"$KUBECTL_OUT" 2>"$KUBECTL_ERR"; then
+        # grep -c exits 1 with stdout '0' when there are zero matches; `|| true`
+        # keeps the assignment clean (the original `|| echo 0` produced '0\n0').
+        READY_COUNT=$(grep -c ' Ready ' "$KUBECTL_OUT" || true)
+    else
+        READY_COUNT=0
+    fi
     if [ "${READY_COUNT}" -ge "${EXPECTED_NODES}" ]; then
         break
     fi
     if [ $ELAPSED -ge 180 ]; then
         echo "ERROR: Not all nodes ready after 180s (${READY_COUNT}/${EXPECTED_NODES})"
-        remote_kubectl "${SERVER_IP}" "kubectl get nodes"
+        if [ -s "$KUBECTL_ERR" ]; then
+            echo "  Last kubectl error:" >&2
+            sed 's/^/    /' "$KUBECTL_ERR" >&2
+        fi
+        remote_kubectl "${SERVER_IP}" "kubectl get nodes" >&2 || true
         exit 1
     fi
     echo "  ${READY_COUNT}/${EXPECTED_NODES} nodes ready... (${ELAPSED}s)"


### PR DESCRIPTION
## Description

Two kubectl wait loops in `blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` silenced kubectl's stderr/output, hiding the actual cause when the wait timed out. Same class of failure as #658 / PR #659 (which covered the SSH wait loops) — sub-PR 2 of the audit in #655 (covers findings #2 and #3).

**Phase 3 (line ~218):** wait for k3s server API readiness. Original used `&>/dev/null` so a 180s timeout exited with `k3s server not ready after 180s` and zero diagnostic.

**Phase 5 (line ~263):** poll for all nodes Ready. Original passed the entire `kubectl ... 2>/dev/null | grep -c ... || echo 0` pipeline to the remote shell, so kubectl's stderr was discarded **on the remote side** before it could cross the ssh boundary. Operator could watch `0/4 nodes ready... (10s)` repeat for 180s with no clue why.

**Bonus latent-bug fix discovered while smoke-testing.** See "Other notes" below.

## Related Issue

Addresses #662. Sub-PR 2 of #655.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**Phase 3 wait loop (`k3s server is ready`):**
- New `KUBECTL_ERR=$(mktemp)`; EXIT trap extended to clean it up alongside the existing `PREFLIGHT_ERR` / `WAIT_ERR`.
- Wait loop now redirects combined output to `$KUBECTL_ERR` each iteration.
- On 180s timeout, the operator gets:
  ```
  ERROR: k3s server not ready after 180s
    Last kubectl attempt:
      <actual kubectl error here>
  ```

**Phase 5 wait loop (`Waiting for all N nodes to be Ready`):**
- New `KUBECTL_OUT=$(mktemp)`; EXIT trap extended again.
- Split the previously-monolithic remote pipeline into two steps locally:
  1. `if remote_kubectl ... >"$KUBECTL_OUT" 2>"$KUBECTL_ERR"; then ...`
  2. `READY_COUNT=$(grep -c ' Ready ' "$KUBECTL_OUT" || true)` on the local file.
- On 180s timeout, dumps the last kubectl stderr (if non-empty) in addition to the existing `kubectl get nodes` recap (which is now also redirected to stderr instead of stdout for consistency with the rest of the failure path).

## Other Notes

**Latent bug fix:** the original Phase 5 used `READY_COUNT=$(... | grep -c ' Ready ' || echo 0)`. When there are zero matches, `grep -c` outputs `0` AND exits 1 — which triggers the `|| echo 0` fallback, producing **multi-line output `0\n0`**. The variable assignment then held a two-line string. The subsequent `[ "${READY_COUNT}" -ge "${EXPECTED_NODES}" ]` test failed with `integer expression expected`, but the `if` wrapper around it caught the test failure under `set -e` and treated it as "not ready, keep waiting". So the script appeared to work, but Phase 5's no-match path was always running on a subtly-broken comparison. Replacing with `|| true` keeps grep's clean single-line `0` output without appending another, restoring correct integer-comparison behavior. No observable change in the success path; the no-match path now compares correctly instead of via a bash error eaten by `if`.

## Testing

- [x] All existing tests pass
- [x] N/A — shell script change, no Python test surface
- [x] Manually tested the changes

- `bash -n blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` parses clean.
- Smoke test of the Phase 5 split-call logic against three scenarios:
  - 4 ready nodes → `READY_COUNT=4`, loop breaks (success path).
  - 1 NotReady node → `READY_COUNT=0` (single line, integer-comparable), loop continues correctly.
  - kubectl auth failure (non-zero exit) → `READY_COUNT=0`, `$KUBECTL_ERR` populated with `error: You must be logged in to the server (Unauthorized)` ready for the eventual timeout dump.
- `doit check` green (2256 tests, format, lint, mypy, bandit, codespell, lint_blueprints).

Real-world verification will follow on the next k3s-homelab apply that gets past Phase 3 (which requires the larger network/jumphost issue debug to be sorted first — orthogonal).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (no Python test surface; verified via `bash -n` and local smoke test)
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
