### PR TITLE
fix: surface curl failures in aiqum web-UI wait loops (sub-PR 3 of #655)

### DIFF
--- a/blueprints/aiqum/scripts/aiqum-post-terraform.sh
+++ b/blueprints/aiqum/scripts/aiqum-post-terraform.sh
@@ -131,13 +131,22 @@ remote_cmd_long "${ip_address}" "chmod +x /tmp/aiqum-install-remote.sh && AIQUM_
 echo "  AIQUM RPM installed successfully"
 
 # --- Phase 3: Wait for AIQUM web UI ---
+# Capture curl's stderr so a wait-loop timeout can dump the actual
+# error (connection refused, TLS handshake fail, etc.) instead of just
+# "not available after Ns".
+CURL_ERR=$(mktemp)
+trap 'rm -f "$PREFLIGHT_ERR" "$WAIT_ERR" "$CURL_ERR"' EXIT
 echo ""
 log "--- Phase 3: Waiting for AIQUM web UI ---"
 MAX_WAIT=600
 ELAPSED=0
-while ! curl -sk -o /dev/null -w "%{http_code}" "https://${ip_address}/" 2>/dev/null | grep -q "200\|302\|401"; do
+while ! curl -skS -o /dev/null -w "%{http_code}" "https://${ip_address}/" 2>"$CURL_ERR" | grep -q "200\|302\|401"; do
     if [ $ELAPSED -ge $MAX_WAIT ]; then
         echo "ERROR: AIQUM web UI not available after ${MAX_WAIT}s"
+        if [ -s "$CURL_ERR" ]; then
+            echo "  Last curl error:" >&2
+            sed 's/^/    /' "$CURL_ERR" >&2
+        fi
         exit 1
     fi
     echo "  Waiting for AIQUM web UI... (${ELAPSED}s)"
@@ -163,13 +172,18 @@ echo "  Client certificate regenerated"
 echo "  Restarting AIQUM services..."
 remote_cmd "${ip_address}" "sudo systemctl restart ocie ocieau"
 
-# Wait for web UI to come back
+# Wait for web UI to come back. Reuses $CURL_ERR from Phase 3 so the
+# timeout path can surface curl's actual error.
 echo "  Waiting for AIQUM web UI to restart..."
 sleep 15
 ELAPSED=0
-while ! curl -sk -o /dev/null -w "%{http_code}" "https://${ip_address}/" 2>/dev/null | grep -q "200\|302\|401"; do
+while ! curl -skS -o /dev/null -w "%{http_code}" "https://${ip_address}/" 2>"$CURL_ERR" | grep -q "200\|302\|401"; do
     if [ $ELAPSED -ge 300 ]; then
         echo "ERROR: AIQUM web UI not available after restart"
+        if [ -s "$CURL_ERR" ]; then
+            echo "  Last curl error:" >&2
+            sed 's/^/    /' "$CURL_ERR" >&2
+        fi
         exit 1
     fi
     sleep 10


### PR DESCRIPTION
## Description

Two curl wait loops in `blueprints/aiqum/scripts/aiqum-post-terraform.sh` silenced curl's stderr, hiding the actual cause when the wait timed out. Same class of failure as #658 / PR #659 (SSH wait loops) and #662 / PR #663 (kubectl wait loops) — sub-PR 3 of the audit in #655 (covers findings #6 and #7).

**Phase 3 (line ~138 → ~143):** wait for AIQUM web UI readiness after RPM install. Original used `2>/dev/null`, so a 600s timeout exited with `AIQUM web UI not available after 600s` and zero diagnostic.

**Phase 4 restart wait (line ~170 → ~180):** wait for AIQUM web UI to come back after the cert-regen `systemctl restart`. Identical pattern, identical silencing, 300s timeout.

**Latent bug fix discovered while smoke-testing.** See "Other notes" below.

## Related Issue

Addresses #664. Sub-PR 3 of #655.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**Phase 3 wait loop:**
- New `CURL_ERR=$(mktemp)`; EXIT trap extended to clean it up alongside `PREFLIGHT_ERR` / `WAIT_ERR`.
- `2>/dev/null` → `2>"$CURL_ERR"` so curl's actual error is captured each iteration.
- On 600s timeout, the operator gets:
  ```
  ERROR: AIQUM web UI not available after 600s
    Last curl error:
      curl: (7) Failed to connect to 192.168.1.50 port 443: Connection refused
  ```

**Phase 4 restart wait:**
- Same fix; reuses `$CURL_ERR` already declared in Phase 3.
- 300s timeout dumps the curl error too.

## Other Notes

**Latent bug fix:** the original loops used `curl -sk` where `-s` (silent) suppresses **both** progress and errors. Even with the new `2>"$CURL_ERR"` redirect, the file would have stayed empty — the fix would have looked correct in code review but produced nothing actionable in practice.

Switched to `curl -skS`. The `-S` flag (uppercase) tells curl "show errors even in silent mode", giving us errors-only output without the progress chatter. Verified by smoke-test: pointing curl at `192.0.2.1:443` (RFC 5737 TEST-NET-1, guaranteed unreachable) with `--connect-timeout 2` now produces `curl: (28) Failed to connect to 192.0.2.1 port 443 after 2002 ms: Timeout was reached` in `$CURL_ERR`, where the previous `-sk` would have left it empty.

## Testing

- [x] All existing tests pass
- [x] N/A — shell script change, no Python test surface
- [x] Manually tested the changes

- `bash -n blueprints/aiqum/scripts/aiqum-post-terraform.sh` parses clean.
- Smoke test of the curl pattern against `https://192.0.2.1/` (TEST-NET-1, guaranteed unreachable) with `--connect-timeout 2`: confirms `-skS` populates `$CURL_ERR` with the connect-timeout message; confirms grep correctly fails to match (no false-positive loop break); pattern is ready for the timeout dump.
- `doit check` green (2256 tests, format, lint, mypy, bandit, codespell, lint_blueprints).

Real-world verification will follow on the next AIQUM deploy.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (no Python test surface; verified via `bash -n` and local smoke test)
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
