### PR TITLE
feat: collect non-fatal warnings during apply and render a summary panel

### DIFF
--- a/docs/development/blueprint-script-portability.md
+++ b/docs/development/blueprint-script-portability.md
@@ -94,6 +94,35 @@ Exemplars in the codebase:
 - **Tool check:** `blueprints/ontap-cluster/scripts/ontap-post-terraform.sh` (`ansible-playbook` guard, added in PR #648).
 - **Env-var check:** `blueprints/aiqum/scripts/aiqum-post-terraform.sh` (required `INFRAFOUNDRY_PACKAGE_VARS`, added in PR #648).
 
+## Non-fatal warnings
+
+During `infra apply`, the framework exports `INFRAFOUNDRY_WARNINGS_FILE` with a
+path to a per-deployment JSONL file. Blueprint scripts running in any context
+(operator host, jumphost, or target VM via `ssh` with the env var forwarded)
+may append records of the form `{"source":"<handler>","message":"<text>"}` to
+that file; the framework reads and renders them in a yellow-bordered summary
+panel at the end of apply. On jumphost reexec, the remote wrapper seeds a file
+under the remote tmp dir and the orchestrator `scp`'s the contents back before
+cleanup, so remote warnings surface the same way local ones do.
+
+Use this for abnormalities that are non-fatal but worth the operator seeing —
+e.g. "sysctl reported errors but the params we care about did get set",
+"kubeconfig copied with one warning". **Do not put credentials or raw secret
+material into warning messages** — the file lives unencrypted in `/tmp` for
+the duration of the apply and is printed to the console.
+
+Simple append from a blueprint script (no tools beyond the portable baseline):
+
+```bash
+if [ -n "${INFRAFOUNDRY_WARNINGS_FILE:-}" ]; then
+    printf '%s\n' '{"source":"my-handler","message":"sysctl net.core.somaxconn not applied"}' \
+        >> "$INFRAFOUNDRY_WARNINGS_FILE"
+fi
+```
+
+The env var is only set during `infra apply`; guarding with `${…:-}` keeps
+scripts portable to other phases and to manual invocation.
+
 ## Target-VM scripts: the exemption
 
 Scripts that are uploaded to and executed on a blueprint-controlled target VM (context 3) are exempt from the portable baseline. Those scripts may assume any tool that the blueprint's VM template provides — `yum`, `apt`, `firewall-cmd`, `rpm`, distro-specific init systems, etc.

--- a/docs/development/event-system.md
+++ b/docs/development/event-system.md
@@ -86,6 +86,7 @@ events:
 | `INFRAFOUNDRY_DEPLOYMENT_ID` | `context.deployment_id` is set |
 | `INFRAFOUNDRY_TARGET_RESOURCES` | `-r` filter is active (comma-separated list) |
 | `INFRAFOUNDRY_INVENTORY` | Package has an `inventory:` block and a `.generated-inventory.yml` exists in the package directory |
+| `INFRAFOUNDRY_WARNINGS_FILE` | An `infra apply` is in progress. Scripts may append non-fatal warnings as JSONL records (`{"source":"x","message":"y"}`); the framework renders a summary panel at the end of apply. On jumphost reexec, the file lives under the remote tmp dir and is scp'd back automatically. |
 
 **Example (deprecated):** Run a script on `RUNNER_COMPLETED` (use resource lifecycle events instead):
 
@@ -231,6 +232,7 @@ Scripts and playbooks receive resource context via environment variables:
 | `INFRAFOUNDRY_VAR_<key>` | Individual package variable (uppercase key) |
 | `INFRAFOUNDRY_PACKAGE_VARS` | JSON dict of all merged package variables |
 | `INFRAFOUNDRY_INVENTORY` | Absolute path to the package's `.generated-inventory.yml` (set only when the package defines an `inventory:` block) |
+| `INFRAFOUNDRY_WARNINGS_FILE` | Per-apply JSONL warnings file (set during `infra apply`). Scripts may append records of the form `{"source":"x","message":"y"}`; the framework groups them by source and renders a summary panel at the end of apply. |
 
 ### Deprecation notice
 

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
 import re
 import subprocess  # nosec B404 - required for running user scripts
+import tempfile
 import threading
 import time
 import uuid
@@ -22,7 +24,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _build_remote_bash(remote_dir: str, script_name: str) -> str:
+def _build_remote_bash(
+    remote_dir: str,
+    script_name: str,
+    warnings_file: str | None = None,
+) -> str:
     """Build the remote bash invocation used by jumphost reexec.
 
     The wrapper:
@@ -38,19 +44,38 @@ def _build_remote_bash(remote_dir: str, script_name: str) -> str:
       with newlines/tabs/equals-signs intact.
     - Sets ``INFRAFOUNDRY_ON_JUMPHOST=1`` so blueprint shell helpers that
       implement their own reexec self-deactivate.
+    - When ``warnings_file`` is provided, seeds that file on the remote
+      side (``: > <path>``) and exports ``INFRAFOUNDRY_WARNINGS_FILE`` so
+      the remote script can append JSONL records that the orchestrator
+      later scp's back and folds into the local summary.
 
     Args:
         remote_dir: Absolute path of the rsynced script directory on the
             jumphost.
         script_name: Basename of the script to execute.
+        warnings_file: Optional absolute path on the jumphost where remote
+            code should append non-fatal warning JSONL records. When
+            ``None``, no warnings plumbing is emitted (keeps existing
+            callers that don't collect warnings simple).
 
     Returns:
         A single bash command string to pass to ``ssh``.
     """
+    if warnings_file:
+        # Seed the file first so scp-back always finds something to copy,
+        # and export INFRAFOUNDRY_WARNINGS_FILE for the inner script (and
+        # any nested subprocesses) to pick up.
+        warnings_setup = (
+            f': > "{warnings_file}"; export INFRAFOUNDRY_WARNINGS_FILE="{warnings_file}"; '
+        )
+    else:
+        warnings_setup = ""
+
     return (
         "command -v python3 >/dev/null 2>&1 || { "
         'echo "infrafoundry: python3 is required on the jumphost '
         'to expand INFRAFOUNDRY_VAR_* env vars" >&2; exit 127; }; '
+        f"{warnings_setup}"
         'INFRAFOUNDRY_ON_JUMPHOST=1 INFRAFOUNDRY_PACKAGE_VARS="$(cat)"; '
         "export INFRAFOUNDRY_ON_JUMPHOST INFRAFOUNDRY_PACKAGE_VARS; "
         'while IFS= read -r -d "" entry; do '
@@ -92,6 +117,12 @@ class ScriptHandler(BaseHandler):
         INFRAFOUNDRY_BLUEPRINT_DIR: Path to blueprint directory (if dispatched from blueprint)
         INFRAFOUNDRY_PACKAGE_VARS: JSON string of all package variables (if available)
         INFRAFOUNDRY_VAR_<key>: Individual package variable values (if available)
+        INFRAFOUNDRY_WARNINGS_FILE: Path to the per-apply JSONL warnings file
+            (forwarded from the current process; on jumphost reexec the remote
+            wrapper points this at a file under the remote tmp dir and the
+            contents are scp'd back into the orchestrator's warnings summary).
+            Scripts can append non-fatal warnings as one JSON object per line:
+            ``echo '{"source":"x","message":"y"}' >> "$INFRAFOUNDRY_WARNINGS_FILE"``.
 
     Example config:
         type: script
@@ -342,6 +373,15 @@ class ScriptHandler(BaseHandler):
             f"{script_dir}/",
             f"{jumphost}:{remote_dir}/",
         ]
+        # Warnings collection: if the orchestrator has set up a local
+        # warnings file, point the remote wrapper at a file under
+        # `remote_dir` so any JSONL records the remote script appends can
+        # be scp'd back and folded into the local summary. If the local
+        # env var is unset, skip the plumbing entirely so unrelated
+        # callers don't pay for it.
+        local_warnings_path = env.get("INFRAFOUNDRY_WARNINGS_FILE")
+        remote_warnings_path = f"{remote_dir}/warnings.jsonl" if local_warnings_path else None
+
         # Parity with _execute_locally: re-export each scalar package variable
         # as INFRAFOUNDRY_VAR_<key> on the remote side so scripts using the
         # documented contract work under `set -u`. Object/array values are
@@ -349,7 +389,9 @@ class ScriptHandler(BaseHandler):
         # round-trip as shell scalars. Uses null-delimited output from python3
         # so values containing newlines, tabs, or equals signs are safe.
         # Requires python3 on the jumphost (checked by the wrapper itself).
-        remote_bash = _build_remote_bash(remote_dir, script_path.name)
+        remote_bash = _build_remote_bash(
+            remote_dir, script_path.name, warnings_file=remote_warnings_path
+        )
         ssh_run_cmd = ["ssh", *ssh_opts, jumphost, remote_bash]
         cleanup_cmd = ["ssh", *ssh_opts, jumphost, f"rm -rf {remote_dir}"]
 
@@ -488,6 +530,17 @@ class ScriptHandler(BaseHandler):
                 handler_name=self.name,
             )
         finally:
+            # Pull any warnings emitted by the remote script back onto the
+            # operator's host and append them to the local warnings file.
+            # Best-effort: scp/read failures are non-fatal — we still
+            # clean up the remote dir below.
+            if local_warnings_path and remote_warnings_path:
+                self._fetch_remote_warnings(
+                    jumphost,
+                    ssh_opts,
+                    remote_warnings_path,
+                    Path(local_warnings_path),
+                )
             self._cleanup_remote(cleanup_cmd)
 
     def _cleanup_remote(self, cleanup_cmd: list[str]) -> None:
@@ -511,6 +564,85 @@ class ScriptHandler(BaseHandler):
                 )
         except (OSError, subprocess.TimeoutExpired) as e:
             logger.warning("Remote cleanup failed (ignored): %s", e)
+
+    def _fetch_remote_warnings(
+        self,
+        jumphost: str,
+        ssh_opts: list[str],
+        remote_warnings_path: str,
+        local_warnings_path: Path,
+    ) -> None:
+        """Copy the remote warnings file back and append it to the local one.
+
+        Uses ``scp`` (rather than ``ssh cat``) so stderr from the remote
+        shell cannot mix into the data stream. Failure — missing file,
+        empty file, ssh error — is non-fatal: the warnings collector is
+        supplemental and must not break an otherwise-successful apply.
+
+        Args:
+            jumphost: SSH destination.
+            ssh_opts: Shared ssh options (e.g. ``-o StrictHostKeyChecking=no``).
+            remote_warnings_path: Absolute path on the jumphost.
+            local_warnings_path: The orchestrator's local warnings file to
+                append the remote content to.
+        """
+        with tempfile.NamedTemporaryFile(  # nosec B108 - managed lifecycle
+            mode="wb",
+            suffix=".jsonl",
+            prefix="infrafoundry-remote-warnings-",
+            delete=False,
+        ) as staging:
+            staging_path = Path(staging.name)
+        try:
+            scp_cmd = [
+                "scp",
+                *ssh_opts,
+                f"{jumphost}:{remote_warnings_path}",
+                str(staging_path),
+            ]
+            try:
+                result = subprocess.run(  # nosec B603
+                    scp_cmd,
+                    capture_output=True,
+                    timeout=60,
+                )
+            except (OSError, subprocess.TimeoutExpired) as e:
+                logger.debug("scp of remote warnings file failed (ignored): %s", e)
+                return
+            if result.returncode != 0:
+                logger.debug(
+                    "scp of remote warnings file returned %d (ignored): %s",
+                    result.returncode,
+                    result.stderr.decode(errors="replace").strip() if result.stderr else "",
+                )
+                return
+            try:
+                remote_content = staging_path.read_bytes()
+            except OSError as e:
+                logger.debug("reading staged remote warnings failed (ignored): %s", e)
+                return
+            if not remote_content:
+                return
+            try:
+                with open(local_warnings_path, "ab") as fh:
+                    # Hold the lock for the duration of the append so we
+                    # don't interleave with any other thread/process
+                    # appending to the same file via emit_warning().
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                    try:
+                        fh.write(remote_content)
+                        if not remote_content.endswith(b"\n"):
+                            fh.write(b"\n")
+                        fh.flush()
+                    finally:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            except OSError as e:
+                logger.debug("appending remote warnings locally failed (ignored): %s", e)
+        finally:
+            try:
+                staging_path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.debug("removing staged remote warnings failed (ignored): %s", e)
 
     def _read_stream(
         self,

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 import traceback
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, cast
 
 from rich.console import Console
 from rich.table import Table
 
+from infrafoundry.core import warnings as infra_warnings
 from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
 from infrafoundry.core.drift_detector import DriftDetector
@@ -825,6 +829,22 @@ class ApplyOrchestrator(HookExecutionMixin):
         env_config = self._load_environment(env_name) if self._load_environment else None
         self._load_event_config(env_config)
 
+        # Set up a per-deployment warnings collection file. Event handlers
+        # (local subprocess, jumphost reexec) inherit the env var so they
+        # can append JSONL records. The file is read + rendered + unlinked
+        # in the `finally` below so the summary prints on both the success
+        # and failure paths.
+        warnings_tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115 - managed lifecycle; nosec B108
+            mode="w",
+            suffix=".jsonl",
+            prefix=f"infrafoundry-warnings-{deployment_id}-",
+            delete=False,
+        )
+        warnings_path = Path(warnings_tmp.name)
+        warnings_tmp.close()
+        prior_warnings_env = os.environ.get(infra_warnings.ENV_VAR)
+        os.environ[infra_warnings.ENV_VAR] = str(warnings_path)
+
         try:
             self._print_header("Applying", env_name, resource_filter, "bold green")
             all_resources, resources_by_provider = self._load_resources(env_name)
@@ -896,6 +916,23 @@ class ApplyOrchestrator(HookExecutionMixin):
             )
             self.console.print(traceback.format_exc(), style="dim red")  # Log full traceback
             raise
+        finally:
+            # Render the warnings summary (even on the failure path), then
+            # clean up the temp file and restore the prior env var for
+            # nesting safety (tests, library callers).
+            try:
+                collected = infra_warnings.read_warnings(warnings_path)
+                infra_warnings.render_warnings_panel(collected, self.console)
+            except Exception:
+                logger.exception("failed to render warnings summary")
+            try:
+                warnings_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.debug("failed to unlink warnings file %s: %s", warnings_path, exc)
+            if prior_warnings_env is None:
+                os.environ.pop(infra_warnings.ENV_VAR, None)
+            else:
+                os.environ[infra_warnings.ENV_VAR] = prior_warnings_env
 
         return results
 

--- a/src/infrafoundry/core/warnings.py
+++ b/src/infrafoundry/core/warnings.py
@@ -1,0 +1,189 @@
+"""File-based non-fatal warning collector for ``infra apply``.
+
+Provides a tiny contract used by both Python framework code and blueprint
+shell scripts to surface non-fatal abnormalities ("sysctl reported errors
+but the params we care about did get set", "kubeconfig copied with one
+warning", etc.) without swallowing them or burying them mid-log.
+
+Contract:
+
+- The framework creates a per-deployment temp file and exports its path via
+  the ``INFRAFOUNDRY_WARNINGS_FILE`` environment variable before any event
+  handlers run. Threads and subprocesses inherit it automatically (the
+  script handler already does ``env = os.environ.copy()``; jumphost reexec
+  explicitly re-exports it on the remote side).
+- Emitters append one JSON object per line: ``{"source": ..., "message": ...}``.
+  Shell scripts can ``echo '{"source":"x","message":"y"}' >> \
+  "$INFRAFOUNDRY_WARNINGS_FILE"``; Python code calls :func:`emit_warning`.
+- At the end of apply (in a ``finally`` block so failed applies still
+  summarize), the framework reads the file via :func:`read_warnings` and
+  renders a :class:`rich.panel.Panel` via :func:`render_warnings_panel`.
+
+Secrets caveat:
+    Warning messages are operator-readable via the panel and via the on-disk
+    JSONL file (which lives in ``/tmp`` for the duration of the apply).
+    **Do not put credentials, tokens, or raw secret material into warning
+    messages** — redact them at the emit site, the same way you would for
+    any log line.
+
+Concurrency:
+    :func:`emit_warning` uses :func:`fcntl.flock` for an exclusive lock
+    before appending. POSIX ``O_APPEND`` is only guaranteed atomic up to
+    ``PIPE_BUF`` (typically 4096 bytes), but warning messages from parallel
+    apply threads can exceed that. The lock prevents interleaved writes.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.panel import Panel
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "INFRAFOUNDRY_WARNINGS_FILE"
+
+
+def emit_warning(
+    source: str,
+    message: str,
+    file_path: Path | str | None = None,
+) -> None:
+    """Append a non-fatal warning to the active warnings file.
+
+    Args:
+        source: Short identifier of who emitted the warning (e.g.
+            ``"event:after_apply:notify"``, ``"provider:ontap"``).
+        message: Human-readable warning text. Must not contain credentials.
+        file_path: Explicit path to append to. When ``None`` (default), the
+            path is taken from the ``INFRAFOUNDRY_WARNINGS_FILE`` environment
+            variable. If both are unset, the call is a silent no-op so
+            library callers (e.g. unit tests) don't pay for framework
+            integration they aren't using.
+
+    Notes:
+        Uses an exclusive ``fcntl`` lock around the append to prevent
+        interleaved writes from parallel threads emitting large messages.
+        Errors opening or writing the file are logged at debug level and
+        swallowed — a warning collector must not itself raise.
+    """
+    if file_path is None:
+        env_value = os.environ.get(ENV_VAR)
+        if not env_value:
+            return
+        target = Path(env_value)
+    else:
+        target = Path(file_path)
+
+    record = json.dumps({"source": source, "message": message}) + "\n"
+
+    try:
+        # Open with O_APPEND so concurrent writers each seek to end before
+        # writing; the flock serializes the write-then-flush against other
+        # processes/threads using the same file.
+        with open(target, "a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                fh.write(record)
+                fh.flush()
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError as exc:
+        logger.debug("failed to write warning to %s: %s", target, exc)
+
+
+def read_warnings(file_path: Path | str) -> list[dict[str, str]]:
+    """Read a warnings JSONL file and return its records.
+
+    Args:
+        file_path: Path to the warnings file.
+
+    Returns:
+        One dict per parseable line. Missing files and empty files both
+        return ``[]``. Malformed JSON lines are logged at debug level and
+        skipped so a single bad writer cannot break the summary.
+    """
+    target = Path(file_path)
+    if not target.exists():
+        return []
+
+    try:
+        content = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug("failed to read warnings file %s: %s", target, exc)
+        return []
+
+    warnings_list: list[dict[str, str]] = []
+    for line_no, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            logger.debug("skipping malformed warning at %s:%d: %s", target, line_no, exc)
+            continue
+        if not isinstance(parsed, dict):
+            logger.debug("skipping non-object warning at %s:%d", target, line_no)
+            continue
+        # Coerce known fields to strings defensively.
+        warnings_list.append(
+            {
+                "source": str(parsed.get("source", "unknown")),
+                "message": str(parsed.get("message", "")),
+            }
+        )
+    return warnings_list
+
+
+def render_warnings_panel(
+    warnings_list: list[dict[str, str]],
+    console: Console,
+) -> None:
+    """Render a yellow-bordered panel summarizing warnings.
+
+    Args:
+        warnings_list: Warning records from :func:`read_warnings`.
+        console: Rich console to print the panel to.
+
+    Notes:
+        No-op when ``warnings_list`` is empty. Warnings are grouped by
+        ``source`` so operators can see at a glance which handler or
+        provider surfaced each abnormality.
+    """
+    if not warnings_list:
+        return
+
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for w in warnings_list:
+        grouped[w.get("source", "unknown")].append(w.get("message", ""))
+
+    body = Text()
+    first = True
+    for source, messages in grouped.items():
+        if not first:
+            body.append("\n")
+        first = False
+        body.append(f"{source}\n", style="bold yellow")
+        for msg in messages:
+            body.append(f"  - {msg}\n")
+
+    title = f"⚠ Warnings ({len(warnings_list)})"
+    console.print(
+        Panel(
+            body,
+            title=title,
+            title_align="left",
+            border_style="yellow",
+        )
+    )

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1184,3 +1184,58 @@ class TestScriptHandlerJumphostReexec:
         assert proc.returncode == 127
         assert "python3 is required" in proc.stderr
         assert "unreachable" not in proc.stdout
+
+    def test_remote_bash_exports_warnings_file(self, tmp_path: Path):
+        """When a warnings_file is provided, the wrapper seeds and exports it.
+
+        Regression for #661: the jumphost path must propagate
+        INFRAFOUNDRY_WARNINGS_FILE to remote scripts so they can emit
+        warnings the orchestrator can later scp back and summarize.
+        """
+        warnings_path = "/tmp/infrafoundry-abcd/warnings.jsonl"  # nosec B108
+        remote_bash = _build_remote_bash(str(tmp_path), "dump.sh", warnings_file=warnings_path)
+
+        # Seed: `: > "<path>"` creates/truncates so scp-back always finds it.
+        assert f': > "{warnings_path}"' in remote_bash
+        # Export: downstream processes inherit the env var.
+        assert f'export INFRAFOUNDRY_WARNINGS_FILE="{warnings_path}"' in remote_bash
+        # Without the arg, the wrapper must not emit the warnings plumbing.
+        plain = _build_remote_bash(str(tmp_path), "dump.sh")
+        assert "INFRAFOUNDRY_WARNINGS_FILE" not in plain
+
+    def test_remote_wrapper_appends_to_warnings_file_on_disk(self, tmp_path: Path):
+        """End-to-end: inner script appends to $INFRAFOUNDRY_WARNINGS_FILE on disk.
+
+        Runs the real bash+python3 wrapper and asserts that a warning
+        appended inside the inner script lands on disk at the expected
+        path, exercising the seed+export plumbing.
+        """
+        if shutil.which("python3") is None or shutil.which("bash") is None:
+            pytest.skip("requires python3 and bash")
+
+        remote_dir = tmp_path
+        warnings_path = tmp_path / "warnings.jsonl"
+        script = remote_dir / "emit.sh"
+        script.write_text(
+            "#!/bin/bash\nset -u\n"
+            'echo \'{"source":"remote","message":"hello"}\' '
+            '>> "$INFRAFOUNDRY_WARNINGS_FILE"\n'
+        )
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+
+        remote_bash = _build_remote_bash(
+            str(remote_dir), "emit.sh", warnings_file=str(warnings_path)
+        )
+        proc = subprocess.run(  # nosec B603
+            ["bash", "-c", remote_bash],
+            input=json.dumps({}),  # no package vars
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        assert proc.returncode == 0, f"stderr: {proc.stderr}"
+        assert warnings_path.exists()
+        content = warnings_path.read_text(encoding="utf-8")
+        assert '"source":"remote"' in content
+        assert '"message":"hello"' in content

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -1040,3 +1041,191 @@ def test_environment_config_default_empty_events():
     """EnvironmentConfig defaults to empty dict for events."""
     config = EnvironmentConfig(name="test")
     assert config.events == {}
+
+
+# ---------------------------------------------------------------------------
+# Warnings collector integration (#661)
+# ---------------------------------------------------------------------------
+
+
+def _apply_orchestrator_with_hooks(
+    load_resources_hook,
+    apply_serial_hook=None,
+):
+    """Build an ApplyOrchestrator whose load_resources callback runs a hook.
+
+    This lets individual tests inject assertions / side-effects at the
+    point where INFRAFOUNDRY_WARNINGS_FILE is already set but apply has
+    not yet returned.
+    """
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 42
+    event_manager = MagicMock()
+    console = MagicMock()
+
+    default_resources = ([_resource("vm1")], {"proxmox": [_resource("vm1")]})
+
+    def load_resources(env: str):
+        load_resources_hook(env)
+        return default_resources
+
+    apply_serial = apply_serial_hook or MagicMock(return_value={"proxmox": {"success": True}})
+
+    orchestrator = ApplyOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        load_resources,
+        apply_serial=apply_serial,
+        apply_parallel=MagicMock(),
+        get_current_user=lambda: "tester",
+    )
+    return orchestrator, console, state_manager
+
+
+def test_apply_renders_warnings_panel_when_warnings_present():
+    """A warning written mid-apply causes a Panel to be printed at the end."""
+    from rich.panel import Panel
+
+    from infrafoundry.core.warnings import ENV_VAR
+
+    def hook(_env: str) -> None:
+        # Simulate a handler emitting a warning into the file the
+        # orchestrator just set up.
+        path = Path(os.environ[ENV_VAR])
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write('{"source": "event:test", "message": "kubeconfig oddity"}\n')
+
+    orchestrator, console, _ = _apply_orchestrator_with_hooks(hook)
+
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+    )
+
+    # At least one console.print call must be a Panel whose title marks it
+    # as the warnings summary.
+    panel_calls = [
+        c for c in console.print.call_args_list if c.args and isinstance(c.args[0], Panel)
+    ]
+    assert len(panel_calls) == 1
+    panel = panel_calls[0].args[0]
+    assert "Warnings" in str(panel.title)
+    assert "1" in str(panel.title)
+    assert "kubeconfig oddity" in panel.renderable.plain
+    assert "event:test" in panel.renderable.plain
+
+
+def test_apply_no_panel_when_no_warnings():
+    """No warnings → no Panel is printed."""
+    from rich.panel import Panel
+
+    orchestrator, console, _ = _apply_orchestrator_with_hooks(lambda _env: None)
+
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+    )
+
+    panel_calls = [
+        c for c in console.print.call_args_list if c.args and isinstance(c.args[0], Panel)
+    ]
+    assert panel_calls == []
+
+
+def test_apply_renders_warnings_panel_on_failure_path():
+    """Warnings emitted before a failure still get summarized."""
+    from rich.panel import Panel
+
+    from infrafoundry.core.warnings import ENV_VAR
+
+    class _BoomError(RuntimeError):
+        pass
+
+    def hook(_env: str) -> None:
+        path = Path(os.environ[ENV_VAR])
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write('{"source": "event:pre-fail", "message": "half-applied"}\n')
+        raise _BoomError("synthetic failure")
+
+    orchestrator, console, state_manager = _apply_orchestrator_with_hooks(hook)
+
+    with pytest.raises(_BoomError):
+        orchestrator.apply(
+            env_name="dev",
+            resource_filter=None,
+            auto_approve=True,
+            parallel=False,
+            max_workers=1,
+        )
+
+    panel_calls = [
+        c for c in console.print.call_args_list if c.args and isinstance(c.args[0], Panel)
+    ]
+    assert len(panel_calls) == 1
+    panel = panel_calls[0].args[0]
+    assert "half-applied" in panel.renderable.plain
+    # And the deployment was marked failed before the re-raise.
+    state_manager.update_deployment_status.assert_any_call(
+        42, DeploymentStatus.FAILED, "synthetic failure"
+    )
+
+
+def test_apply_sets_and_restores_warnings_env_var(monkeypatch):
+    """INFRAFOUNDRY_WARNINGS_FILE is set during apply and restored after."""
+    from infrafoundry.core.warnings import ENV_VAR
+
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+    captured: dict[str, str | None] = {}
+
+    def hook(_env: str) -> None:
+        captured["mid_apply"] = os.environ.get(ENV_VAR)
+
+    orchestrator, _, _ = _apply_orchestrator_with_hooks(hook)
+
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+    )
+
+    # Mid-apply, the env var must be set and point at an existing path.
+    assert captured["mid_apply"] is not None
+    assert "infrafoundry-warnings-42-" in captured["mid_apply"]
+    # After apply returns, the env var was restored (not previously set).
+    assert ENV_VAR not in os.environ
+
+
+def test_apply_restores_prior_warnings_env_var(monkeypatch, tmp_path):
+    """A prior value of INFRAFOUNDRY_WARNINGS_FILE is restored after apply."""
+    from infrafoundry.core.warnings import ENV_VAR
+
+    prior = tmp_path / "outer.jsonl"
+    monkeypatch.setenv(ENV_VAR, str(prior))
+
+    captured: dict[str, str | None] = {}
+
+    def hook(_env: str) -> None:
+        captured["mid"] = os.environ.get(ENV_VAR)
+
+    orchestrator, _, _ = _apply_orchestrator_with_hooks(hook)
+
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+    )
+
+    assert captured["mid"] != str(prior)
+    assert os.environ.get(ENV_VAR) == str(prior)

--- a/tests/unit/test_warnings.py
+++ b/tests/unit/test_warnings.py
@@ -1,0 +1,234 @@
+"""Unit tests for infrafoundry.core.warnings."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from rich.panel import Panel
+
+from infrafoundry.core.warnings import (
+    ENV_VAR,
+    emit_warning,
+    read_warnings,
+    render_warnings_panel,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure INFRAFOUNDRY_WARNINGS_FILE doesn't leak between tests."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+
+@pytest.mark.unit
+def test_emit_warning_writes_jsonl(tmp_path: Path):
+    """A single emit_warning call produces one well-formed JSON line."""
+    target = tmp_path / "warnings.jsonl"
+
+    emit_warning("handler:one", "something noisy but survivable", file_path=target)
+
+    content = target.read_text(encoding="utf-8").splitlines()
+    assert len(content) == 1
+    record = json.loads(content[0])
+    assert record == {"source": "handler:one", "message": "something noisy but survivable"}
+
+
+@pytest.mark.unit
+def test_emit_warning_appends_multiple(tmp_path: Path):
+    """Repeated calls accumulate, one line each."""
+    target = tmp_path / "warnings.jsonl"
+
+    emit_warning("a", "first", file_path=target)
+    emit_warning("b", "second", file_path=target)
+    emit_warning("a", "third", file_path=target)
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert [json.loads(line) for line in lines] == [
+        {"source": "a", "message": "first"},
+        {"source": "b", "message": "second"},
+        {"source": "a", "message": "third"},
+    ]
+
+
+@pytest.mark.unit
+def test_emit_warning_no_op_when_unset(tmp_path: Path, monkeypatch):
+    """With env var unset and no file_path, emit_warning silently no-ops."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+    # Should not raise and should not create any stray files.
+    emit_warning("handler", "noise")
+
+    # Confirm no files were created in tmp_path (the test's workspace).
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.unit
+def test_emit_warning_uses_env_var_when_no_file_path(tmp_path: Path, monkeypatch):
+    """When file_path is None, the env var is used as the target."""
+    target = tmp_path / "env-warnings.jsonl"
+    monkeypatch.setenv(ENV_VAR, str(target))
+
+    emit_warning("env-source", "env-driven message")
+
+    content = target.read_text(encoding="utf-8").splitlines()
+    assert len(content) == 1
+    assert json.loads(content[0]) == {
+        "source": "env-source",
+        "message": "env-driven message",
+    }
+
+
+@pytest.mark.unit
+def test_emit_warning_explicit_path_overrides_env(tmp_path: Path, monkeypatch):
+    """An explicit file_path argument wins over the env var."""
+    env_target = tmp_path / "env.jsonl"
+    explicit_target = tmp_path / "explicit.jsonl"
+    monkeypatch.setenv(ENV_VAR, str(env_target))
+
+    emit_warning("s", "m", file_path=explicit_target)
+
+    assert not env_target.exists()
+    assert explicit_target.read_text(encoding="utf-8").strip() != ""
+
+
+@pytest.mark.unit
+def test_emit_warning_concurrent_appends_dont_interleave(tmp_path: Path):
+    """50 threads emitting 5KB messages each produce 50 intact JSON objects.
+
+    This exercises the fcntl lock: POSIX O_APPEND is only atomic up to
+    PIPE_BUF (4096 bytes), so a 5KB payload would interleave without it.
+    """
+    target = tmp_path / "concurrent.jsonl"
+    payload = "x" * 5000  # 5KB, deliberately exceeds PIPE_BUF
+    thread_count = 50
+
+    errors: list[BaseException] = []
+
+    def worker(idx: int) -> None:
+        try:
+            emit_warning(f"t-{idx}", payload, file_path=target)
+        except BaseException as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == thread_count
+    # Every line must be valid JSON with the expected payload.
+    parsed = [json.loads(line) for line in lines]
+    sources = sorted(p["source"] for p in parsed)
+    assert sources == sorted(f"t-{i}" for i in range(thread_count))
+    for p in parsed:
+        assert p["message"] == payload
+
+
+@pytest.mark.unit
+def test_read_warnings_returns_empty_for_missing_file(tmp_path: Path):
+    """Missing file → empty list; no exception raised."""
+    assert read_warnings(tmp_path / "does-not-exist.jsonl") == []
+
+
+@pytest.mark.unit
+def test_read_warnings_returns_empty_for_empty_file(tmp_path: Path):
+    """Empty file → empty list."""
+    target = tmp_path / "empty.jsonl"
+    target.write_text("", encoding="utf-8")
+
+    assert read_warnings(target) == []
+
+
+@pytest.mark.unit
+def test_read_warnings_parses_jsonl(tmp_path: Path):
+    """Multi-line file → list of dicts in order."""
+    target = tmp_path / "multi.jsonl"
+    target.write_text(
+        '{"source": "a", "message": "one"}\n'
+        '{"source": "b", "message": "two"}\n'
+        '{"source": "a", "message": "three"}\n',
+        encoding="utf-8",
+    )
+
+    result = read_warnings(target)
+    assert result == [
+        {"source": "a", "message": "one"},
+        {"source": "b", "message": "two"},
+        {"source": "a", "message": "three"},
+    ]
+
+
+@pytest.mark.unit
+def test_read_warnings_skips_malformed_lines(tmp_path: Path, caplog):
+    """Malformed JSON lines are skipped; other lines parse; no exception raised."""
+    target = tmp_path / "mixed.jsonl"
+    target.write_text(
+        '{"source": "good", "message": "one"}\n'
+        "this-is-not-json\n"
+        "\n"
+        '{"source": "good", "message": "two"}\n'
+        "[1, 2, 3]\n"  # valid JSON but not a dict
+        '{"source": "good", "message": "three"}\n',
+        encoding="utf-8",
+    )
+
+    result = read_warnings(target)
+    assert result == [
+        {"source": "good", "message": "one"},
+        {"source": "good", "message": "two"},
+        {"source": "good", "message": "three"},
+    ]
+
+
+@pytest.mark.unit
+def test_render_warnings_panel_groups_by_source():
+    """Panel body groups messages by their source identifier."""
+    console = MagicMock()
+    warnings_list = [
+        {"source": "handler-a", "message": "first"},
+        {"source": "handler-b", "message": "second"},
+        {"source": "handler-a", "message": "third"},
+    ]
+
+    render_warnings_panel(warnings_list, console)
+
+    console.print.assert_called_once()
+    (printed,), _ = console.print.call_args
+    assert isinstance(printed, Panel)
+    # Title encodes the count.
+    title = str(printed.title)
+    assert "Warnings" in title
+    assert "3" in title
+    # Body groups by source. Render the Text object to plain to inspect.
+    rendered_body = printed.renderable.plain
+    assert "handler-a" in rendered_body
+    assert "handler-b" in rendered_body
+    assert "first" in rendered_body
+    assert "second" in rendered_body
+    assert "third" in rendered_body
+    # Messages under handler-a should appear together.
+    a_idx = rendered_body.index("handler-a")
+    b_idx = rendered_body.index("handler-b")
+    first_idx = rendered_body.index("first")
+    third_idx = rendered_body.index("third")
+    # All handler-a messages fall before handler-b.
+    assert first_idx > a_idx and first_idx < b_idx
+    assert third_idx > a_idx and third_idx < b_idx
+
+
+@pytest.mark.unit
+def test_render_warnings_panel_no_op_when_empty():
+    """Empty list → no print call; callers can render unconditionally."""
+    console = MagicMock()
+
+    render_warnings_panel([], console)
+
+    console.print.assert_not_called()


### PR DESCRIPTION
## Description

Adds a lightweight framework-level mechanism for collecting non-fatal warnings
during `infra apply` and rendering a grouped summary panel at the end. Python
framework code, shell event handlers, and blueprint scripts (including scripts
reexec'd on a jumphost) can all append JSONL records to a per-deployment
warnings file; the orchestrator reads that file in its `finally` block and
renders a yellow-bordered `rich.Panel` on both the success and failure paths.

This unblocks future handlers that need to surface abnormalities without
either aborting the apply or burying the notice mid-log (e.g. "sysctl reported
errors but the params we care about did get set").

## Related Issue

Addresses #661

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **New module `src/infrafoundry/core/warnings.py`** exposing three functions:
  - `emit_warning(source, message, file_path=None)` — append helper that uses
    `fcntl.flock(LOCK_EX)` so concurrent appends from the `_apply_parallel`
    ThreadPool can't interleave when messages exceed `PIPE_BUF` (4KB).
  - `read_warnings(file_path)` — tolerant reader (missing files, empty files,
    malformed JSON lines).
  - `render_warnings_panel(warnings, console)` — no-op when empty; otherwise
    prints a `rich.Panel` with `border_style="yellow"` titled
    `⚠ Warnings (N)`, body grouped by source.
- **`INFRAFOUNDRY_WARNINGS_FILE` contract.** `Orchestrator.apply()` now creates
  a per-deployment JSONL temp file via `tempfile.NamedTemporaryFile` and sets
  the env var before any event handlers run. The `finally` block reads the
  file, renders the panel if non-empty, unlinks the file, and restores the
  prior env-var value (or removes it if unset).
- **Jumphost reexec support in `events/handlers/script.py`.** `_build_remote_bash`
  takes an optional `warnings_file` arg; when provided, the remote wrapper
  seeds the file with `: > "<path>"` and exports `INFRAFOUNDRY_WARNINGS_FILE`
  alongside the existing env-var plumbing. `_execute_on_jumphost` computes the
  remote path, passes it to the wrapper, and after the remote script
  completes `scp`'s the file back and appends its contents to the
  orchestrator's local warnings file. `scp` failures are non-fatal.
- **Local execution needed no changes** — `env = os.environ.copy()` at
  `script.py:680` already propagates the env var to subprocesses.
- **Documentation:**
  - `ScriptHandler` class docstring lists `INFRAFOUNDRY_WARNINGS_FILE` in the
    injected env vars.
  - `docs/development/event-system.md` env var tables (both
    `ScriptHandler` and resource-lifecycle sections) document the new var.
  - `docs/development/blueprint-script-portability.md` gets a
    "Non-fatal warnings" subsection showing the portable append pattern.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Test coverage added (`doit check` green, 2823 tests total):

- `tests/unit/test_warnings.py` — 12 new tests including a 50-thread × 5KB
  concurrent-append isolation test that proves `flock` prevents interleaving.
- `tests/unit/test_orchestrator_workflows_unit.py` — 5 new tests covering the
  success path, no-warnings path, failure path, and env-var set-and-restore
  behavior.
- `tests/unit/test_events.py::TestScriptHandlerJumphostReexec` — 2 new tests
  covering the remote bash wiring and end-to-end append to disk.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- **Secrets caveat:** warning messages are operator-readable via the panel and
  via the on-disk JSONL file (in `/tmp` for the apply's duration).
  Documentation explicitly notes that credentials or raw secret material must
  not be placed into warning messages.
- **No ADR required:** no `needs-adr` label on the issue; this is a small
  framework contract rather than a novel architectural decision. The existing
  ADRs cover state locking, CI, blueprints, variable sections, and provider
  CLI extensibility — none are touched by this change.
- **Consumers of the contract** land in follow-up PRs (e.g. #655 sub-PR 4
  sysctl handler). This PR is the plumbing only.
