### PR TITLE
fix: surface sysctl failures in k3s node prep (sub-PR 4 of #655)

### DIFF
--- a/blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh
+++ b/blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh
@@ -182,15 +182,43 @@ EOF
         modprobe overlay
     "
 
-    # Set required sysctl parameters
-    remote_root_cmd "${ip}" "
+    # Set required sysctl parameters. `sysctl --system` reads every file under
+    # /usr/lib/sysctl.d/, /etc/sysctl.d/, and /etc/sysctl.conf; unrelated
+    # entries can cause a non-zero exit even when our required params apply
+    # fine. Decide fatal-vs-warn by reading the params back in memory after —
+    # see docs/development/blueprint-script-portability.md#non-fatal-warnings.
+    SYSCTL_RC=0
+    SYSCTL_OUT=$(remote_root_cmd "${ip}" "
         cat > /etc/sysctl.d/k3s.conf <<EOF
 net.bridge.bridge-nf-call-iptables = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 net.ipv4.ip_forward = 1
 EOF
-        sysctl --system > /dev/null 2>&1
-    "
+        sysctl --system 2>&1
+    ") || SYSCTL_RC=$?
+
+    # Authoritative check: the three required params must be 1 in memory.
+    OBSERVED=$(remote_root_cmd "${ip}" "sysctl -n net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables net.ipv4.ip_forward" 2>&1 || true)
+    if [ "$(printf '%s\n' "$OBSERVED" | grep -c '^1$' || true)" -ne 3 ]; then
+        echo "ERROR: k3s-required sysctl params did not apply on ${name} (${ip})" >&2
+        echo "  sysctl --system output:" >&2
+        printf '%s\n' "$SYSCTL_OUT" | sed 's/^/    /' >&2
+        echo "  Observed values (expected three lines of '1'):" >&2
+        printf '%s\n' "$OBSERVED" | sed 's/^/    /' >&2
+        exit 1
+    fi
+
+    # Required params applied. Non-zero exit from sysctl --system here means
+    # unrelated entries in /etc/sysctl.d/ — surface as a non-fatal warning so
+    # the operator sees it in the end-of-apply summary (PR #666).
+    if [ "$SYSCTL_RC" -ne 0 ] && [ -n "${INFRAFOUNDRY_WARNINGS_FILE:-}" ]; then
+        python3 -c 'import json,sys
+name = sys.argv[1]
+out = sys.stdin.read().strip()
+msg = "sysctl --system exited non-zero on " + name + " but all k3s-required params applied. Output:\n" + out
+print(json.dumps({"source": "k3s-post-terraform:sysctl", "message": msg}))
+' "${name}" <<<"$SYSCTL_OUT" >> "$INFRAFOUNDRY_WARNINGS_FILE"
+    fi
 
     # Disable firewalld (k3s manages its own iptables rules)
     remote_root_cmd "${ip}" "systemctl disable --now firewalld 2>/dev/null || true"


### PR DESCRIPTION
## Description

The per-node prep loop in `blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` silenced both stdout **and** stderr of `sysctl --system` with `> /dev/null 2>&1`, hiding two distinct failure modes. This is the last open finding (#8) from the stdio-swallowing audit in #655 — **sub-PR 4 of 4**. Merging closes out the umbrella.

**Shape is different from sub-PRs 1-3.** Those fixed wait loops (tmpfile + dump on timeout). This one is a one-shot operation whose failure has two meanings:

- `sysctl --system` exited non-zero **and** our required params didn't apply → real inconsistency, fatal.
- `sysctl --system` exited non-zero **but** our required params applied → unrelated noise from other entries in `/etc/sysctl.d/*.conf` on the Rocky 9 base image; non-fatal, worth surfacing as a warning.

The authoritative disambiguator is reading the params back from memory after — exit code alone can't tell these apart.

## Related Issue

Addresses #667. Sub-PR 4 of #655 (final).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

In `blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` only. +32 / -4 lines.

Original:

```bash
remote_root_cmd "${ip}" "
    cat > /etc/sysctl.d/k3s.conf <<EOF
net.bridge.bridge-nf-call-iptables = 1
net.bridge.bridge-nf-call-ip6tables = 1
net.ipv4.ip_forward = 1
EOF
    sysctl --system > /dev/null 2>&1
"
```

New flow:

1. Capture `sysctl --system 2>&1` into `$SYSCTL_OUT`, exit code into `$SYSCTL_RC` via `|| SYSCTL_RC=$?`.
2. Read back the three required keys from memory (`sysctl -n ...`) — authoritative check.
3. If any key isn't `1`: **`exit 1`** with both the `sysctl` output and the observed values dumped to stderr. We must not proceed to k3s install in an inconsistent state — broken sysctl here causes very confusing pod-network failures downstream (Calico / flannel / CoreDNS misbehaving).
4. If all three are `1` and `$SYSCTL_RC != 0`: emit one JSONL record to `$INFRAFOUNDRY_WARNINGS_FILE` (source `k3s-post-terraform:sysctl`, message includes the full output). Uses `python3` stdlib `json.dumps()` for safe escaping — the output can contain quotes, newlines, backslashes. Warning surfaces in PR #666's end-of-apply yellow summary panel.
5. If all three are `1` and `$SYSCTL_RC == 0`: no output, happy path unchanged.

Portability: `python3` stdlib only (`json`, `sys`). No `jq` / `yq` / third-party packages. Passes `doit lint_blueprints`.

## Testing

- [x] All existing tests pass
- [x] N/A — shell script change, no Python test surface
- [ ] Manually tested the changes (see below — not yet live-tested)

- `bash -n blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` parses clean.
- Python snippet hand-verified with a sample sysctl error message containing quotes, newlines, and a backslash — `json.loads` round-trips cleanly.
- `doit check` green — format, lint, lint_blueprints, type_check, security, spell_check, test (full suite).

**Real-world verification deferred to the next k3s deploy on the homelab** (planned as the follow-up after this PR lands). The change only takes effect when `sysctl --system` exits non-zero on a target, which requires either a broken module load (fatal path) or unrelated broken entries in `/etc/sysctl.d/` (warning path). Both are easy to inject for a smoke-test but not worth wiring up a VM for in isolation.

## Other Notes

- Closes the #655 audit umbrella. Recommend wrap-up comment on #655 summarizing all four sub-PRs after merge, matching the #643 close style.
- The `bash -n` check was the only static validation available — `shellcheck` is not installed in this sandbox. If a reviewer has it locally, a `shellcheck` pass would be welcome but not blocking.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (no Python test surface; shell script change, precedent set by sub-PRs 1-3)
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — N/A (the portability contract already documents the warnings pattern; no new doc surface)
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
