### PR TITLE
feat: add outputs declaration to script handler for jumphost pullback

### DIFF
--- a/docs/decisions/0006-explicit-script-handler-output-declarations.md
+++ b/docs/decisions/0006-explicit-script-handler-output-declarations.md
@@ -1,0 +1,159 @@
+# ADR-0006: Explicit script handler output declarations
+
+## Status
+
+Accepted
+
+Related issue: [#660](https://github.com/endavis/infrafoundry/issues/660)
+
+## Context
+
+When a blueprint event-handler script runs on a jumphost via
+`ScriptHandler._execute_on_jumphost`, any file the script writes to a
+path like `~/.kube/k3s-homelab.yaml` lands on the **jumphost's**
+filesystem — because `~` expands against the jumphost user's home, not
+the operator's. The concrete motivator was Phase 6 of
+`blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh`, which
+emits a rendered kubeconfig that the operator then has to `scp` back
+from the jumphost on every apply.
+
+This is a generic gap in the jumphost reexec story. Any blueprint that
+produces operator-consumable artifacts (kubeconfigs, CA certs, deploy
+reports, Terraform outputs) hits the same problem, and every blueprint
+author reaches for ad-hoc `scp` glue inside the script. That glue:
+
+- Has to know the operator's workstation address and user from inside
+  the jumphost context, where those aren't naturally available.
+- Duplicates transport logic that the framework already performs
+  elsewhere (e.g. `_fetch_remote_warnings`).
+- Makes the blueprint script non-portable to the local execution path,
+  because the `scp` glue is predicated on a jumphost being present.
+
+Two options were considered for a framework-level solution:
+
+- **Option A — Convention-based outputs directory.** The framework
+  exports `INFRAFOUNDRY_OUTPUTS_DIR` pointing at a per-handler temp dir
+  on the execution host, and rsync's its contents back at the end of
+  the run. Cheap to add, but loose: anything the script drops into the
+  dir ships back, without the blueprint author having declared the
+  contract. Renaming, permissions, and conditional outputs end up
+  scattered across shell scripts.
+- **Option B — Explicit per-output declaration.** Blueprints declare
+  what they produce (`outputs: [{source, dest}]`) and the framework
+  maps each declared source to a specific operator-side dest.
+
+## Decision
+
+**Adopt Option B.** The `script` event handler gains an optional
+`outputs:` field on its config:
+
+```yaml
+events:
+  on_create:
+    - type: script
+      script: scripts/proxmox/k3s-post-terraform.sh
+      outputs:
+        - source: "/tmp/k3s-{{ cluster_name }}/kubeconfig.yaml"
+          dest:   "{{ kubeconfig_local_path }}"
+```
+
+Contract:
+
+- `outputs:` is optional. Missing / `None` / `[]` means no pull-back —
+  fully backwards compatible with every existing handler config.
+- Each entry is a mapping with two required string keys: `source`
+  (path on the execution host — jumphost during reexec, operator host
+  during local execution) and `dest` (path on the operator's
+  workstation).
+- Both values are rendered through the same Jinja2 environment the
+  blueprint resolver uses (`create_jinja2_env`) against the package
+  variables carried on `EventContext`. Rendering happens at execute
+  time so runtime-computed variables are visible.
+- Both rendered paths must be absolute (start with `/` or `~`). A
+  non-absolute path emits a warning and skips that entry without
+  failing the handler.
+- Pull-back runs **only when the script succeeds** (exit code 0). Failed
+  runs skip outputs processing entirely so partial or stale artifacts
+  don't leak to the operator.
+- Transport:
+  - Local execution: `shutil.copy2(source, dest)`; if the two resolve
+    to the same path, the copy is a no-op.
+  - Jumphost execution: one `scp` per entry, run inside the existing
+    `finally` block between `_fetch_remote_warnings(...)` and
+    `_cleanup_remote(...)` so the remote tmp dir still contains the
+    artifact when `scp` executes.
+- `Path(dest).parent.mkdir(parents=True, exist_ok=True)` is applied
+  before every copy/scp so authors don't have to pre-create
+  `~/.kube/`, `~/reports/`, etc.
+- Failure modes — missing source, scp non-zero, permission errors,
+  template errors — are **non-fatal**. Each surfaces as a JSONL record
+  under the source tag `script_handler_outputs` via the existing
+  `INFRAFOUNDRY_WARNINGS_FILE` mechanism, which renders in the apply
+  summary panel.
+
+Structural validation (shape of the list and entry keys) runs at config
+load time inside `ScriptHandler.validate_config`. The absolute-path
+check is deferred to execute time because values may be Jinja2-templated
+and need runtime context to resolve.
+
+## Consequences
+
+**Easier:**
+
+- Blueprint authors declare artifacts once, in the manifest, and the
+  framework handles transport. No more ad-hoc `scp` glue inside
+  scripts.
+- Local and jumphost execution are covered by the same declaration —
+  authors don't branch on `jumphost` to decide whether to copy.
+- Operators don't rerun a manual post-apply step to fetch the
+  kubeconfig. The deploy is genuinely one-shot.
+- The declaration is discoverable in the manifest instead of buried in
+  a shell script.
+
+**More difficult:**
+
+- Blueprint authors must now think about *where* a script writes an
+  artifact on the execution host. Previously that detail lived inside
+  the script; now the manifest points at it too, and the two must
+  agree. The `{{ package variables }}` rendering on both sides
+  mitigates this, but it's one more coupling point.
+- The schema is additive, so existing config is unaffected — but any
+  blueprint that currently does its own `scp` back needs a follow-up
+  to migrate to `outputs:`. A separate issue tracks the k3s-cluster
+  migration.
+
+**Neutral:**
+
+- No new Python dependency. `jinja2` is already a project dep and the
+  framework's own `create_jinja2_env` helper (with all custom filters
+  registered) is reused.
+- The warnings-file mechanism already existed; this ADR just adds a
+  new well-known source tag (`script_handler_outputs`) to it.
+- The restructure of `_execute_on_jumphost` to track a `success` flag
+  across the `try`/`finally` boundary is small (one flag, two
+  assignments) and the existing warning-fetch/cleanup ordering is
+  preserved.
+
+## Implementation
+
+- Handler: `src/infrafoundry/core/events/handlers/script.py`
+  - `validate_config` — structural validation of the new field.
+  - `_process_outputs`, `_process_output_local`,
+    `_process_output_remote`, `_is_absolute_output_path` — new
+    helpers.
+  - `_execute_locally` — call `_process_outputs(outputs, context)` on
+    success.
+  - `_execute_on_jumphost` — track `success`; call
+    `_process_outputs(..., jumphost=..., ssh_opts=...)` in the
+    `finally` block between the remote warnings fetch and the remote
+    tmp-dir cleanup.
+- Tests: `tests/unit/test_events.py` — new
+  `TestScriptHandlerOutputs` class covering validation, absent/empty
+  no-ops, local copy / same-path / missing-source / relative-path /
+  template / parent-dir / failure-skip cases, and jumphost
+  scp-on-success / skipped-on-failure / non-fatal-scp-error /
+  multiple-outputs / cleanup-ordering / ssh-opts-forwarded cases.
+- Documentation:
+  - [Event System → Declaring script outputs](../development/event-system.md#declaring-script-outputs)
+  - [Blueprint script portability → Outputs](../development/blueprint-script-portability.md#outputs-pulling-artifacts-back-to-the-operator)
+

--- a/docs/development/blueprint-script-portability.md
+++ b/docs/development/blueprint-script-portability.md
@@ -123,6 +123,38 @@ fi
 The env var is only set during `infra apply`; guarding with `${…:-}` keeps
 scripts portable to other phases and to manual invocation.
 
+## Outputs: pulling artifacts back to the operator
+
+Blueprint scripts that produce operator-consumable artifacts — a
+kubeconfig, a CA cert, a deploy report — must not hardcode paths on the
+operator's workstation (e.g. `~/.kube/config`). When the script runs on a
+jumphost (context 2), `~/` expands against the jumphost user's home, so
+the file lands there and never reaches the operator.
+
+Instead, write the artifact to a predictable path on the **execution
+host** (typically under `/tmp/`) and declare it in the script handler's
+`outputs:` list:
+
+```yaml
+# blueprint.yaml or package blueprint reference
+events:
+  on_create:
+    - type: script
+      script: scripts/proxmox/k3s-post-terraform.sh
+      outputs:
+        - source: "/tmp/k3s-{{ cluster_name }}/kubeconfig.yaml"
+          dest:   "{{ kubeconfig_local_path }}"
+```
+
+The framework renders both paths against the package variables, then
+copies (`shutil.copy2`) or `scp`'s (one `scp` per entry, when a jumphost
+is set) the rendered source to the rendered dest after the script
+reports success. All pull-back failures are non-fatal warnings, so
+missing or conditional outputs don't fail the handler.
+
+See [Event System → Declaring script outputs](event-system.md#declaring-script-outputs)
+for the full schema and semantics.
+
 ## Target-VM scripts: the exemption
 
 Scripts that are uploaded to and executed on a blueprint-controlled target VM (context 3) are exempt from the portable baseline. Those scripts may assume any tool that the blueprint's VM template provides — `yum`, `apt`, `firewall-cmd`, `rpm`, distro-specific init systems, etc.

--- a/docs/development/event-system.md
+++ b/docs/development/event-system.md
@@ -135,6 +135,75 @@ tools the blueprint script itself needs. SSH must be reachable from the
 operator's host using the value of `jumphost` as a destination (e.g.
 `ansible@jump.example.com` or an alias defined in `~/.ssh/config`).
 
+### Declaring script outputs
+
+Blueprint event-handler scripts often produce artifact files the operator
+needs on their workstation — a rendered kubeconfig, a CA cert, a deploy
+report. When the script runs on a jumphost via the framework's reexec
+path, those artifacts land on the jumphost, not on the operator's host,
+because `~/…` expands against the jumphost's home directory. The `outputs:`
+field on the script handler tells the framework which files to pull back
+after a successful run.
+
+```yaml
+events:
+  on_create:
+    - type: script
+      script: scripts/proxmox/k3s-post-terraform.sh
+      outputs:
+        - source: "/tmp/k3s-{{ cluster_name }}/kubeconfig.yaml"
+          dest:   "{{ kubeconfig_local_path }}"
+```
+
+Local execution — the same declaration works for packages that don't set
+`jumphost`; the framework uses `shutil.copy2` instead of `scp`:
+
+```yaml
+events:
+  after_apply:
+    - type: script
+      script: scripts/render-report.sh
+      outputs:
+        - source: "/tmp/report-{{ environment }}.txt"
+          dest:   "~/reports/{{ environment }}.txt"
+```
+
+Contract:
+
+- `outputs:` is optional. Missing or empty means no pull-back (backwards
+  compatible).
+- Each entry is a mapping with two required string keys:
+  - `source`: path on the **execution host** (the jumphost during
+    reexec, the operator's host for local execution).
+  - `dest`: path on the **operator's workstation**.
+- Both values are Jinja2-rendered against the package variables. The
+  same filter set the blueprint resolver uses is available.
+- Both rendered paths must be absolute (start with `/` or `~`). A
+  non-absolute value emits a warning and skips that entry without
+  failing the handler. `~` is expanded on the operator side; on a
+  jumphost source it is expanded by the remote shell via `scp`.
+- Pull-back runs **only when the script succeeds** (exit code 0).
+  Failed runs skip outputs processing entirely so partial artifacts
+  don't leak to the operator.
+- Transport:
+  - Local execution: `shutil.copy2(source, dest)`; when `source == dest`
+    the copy is a no-op.
+  - Jumphost execution: one `scp` per entry, run between the remote
+    warnings fetch and the remote tmp-dir cleanup so the source file
+    still exists when `scp` runs.
+- Parent directories of `dest` are created with `mkdir -p` automatically.
+- Failure modes — missing source after success, non-zero scp, permission
+  errors — are **non-fatal**. Each failure appends a warning to
+  `INFRAFOUNDRY_WARNINGS_FILE` under the source tag
+  `script_handler_outputs`, which surfaces in the apply summary panel.
+- Permissions beyond what `scp` / `shutil.copy2` preserve are the
+  script's responsibility (e.g. if the kubeconfig needs `chmod 600` on
+  the operator host, the script that produced it should `chmod 600` it
+  before `ScriptHandler` ships it back).
+
+See [ADR-0006](../decisions/0006-explicit-script-handler-output-declarations.md)
+for the design rationale and the alternatives that were considered.
+
 ### Real-Time Output Streaming
 
 Script handlers stream stdout and stderr to the console in real-time, line by line, instead of buffering all output until the script completes. This is essential for long-running handlers (e.g., Ansible playbooks) where the user needs to see progress.

--- a/src/infrafoundry/core/events/handlers/script.py
+++ b/src/infrafoundry/core/events/handlers/script.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess  # nosec B404 - required for running user scripts
 import tempfile
 import threading
@@ -15,8 +16,12 @@ import uuid
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, override
 
+import jinja2
+
+from infrafoundry.core.config.filters import create_jinja2_env
 from infrafoundry.core.events.context import EventContext, EventResult
 from infrafoundry.core.events.handlers.base import BaseHandler
+from infrafoundry.core.warnings import emit_warning
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -104,6 +109,17 @@ class ScriptHandler(BaseHandler):
         timeout: Maximum execution time in seconds (default: 300)
         continue_on_error: If True, don't abort on failure (default: False)
         description: Optional description for logging
+        outputs: Optional list of artifact files the script produces, to be
+            pulled back to the operator's workstation after a successful run.
+            Each entry is ``{source: <path>, dest: <path>}``. Both fields are
+            Jinja2-rendered against the package variables, and both must
+            resolve to absolute paths (``/...`` or ``~/...``). During jumphost
+            reexec the ``source`` is scp'd from the jumphost; during local
+            execution it is copied with ``shutil.copy2``. All pull-back
+            failures (missing source, scp error, permission denied) are
+            non-fatal and logged as warnings via
+            ``INFRAFOUNDRY_WARNINGS_FILE``. See
+            ``docs/development/event-system.md`` for details.
 
     Environment variables injected:
         INFRAFOUNDRY_ENV: Environment name
@@ -130,6 +146,15 @@ class ScriptHandler(BaseHandler):
         timeout: 60
         env:
           SLACK_CHANNEL: "#infra"
+
+    Example with outputs (jumphost-executed blueprint writes a kubeconfig
+    on the jumphost; framework scp's it back to the operator)::
+
+        type: script
+        script: scripts/proxmox/k3s-post-terraform.sh
+        outputs:
+          - source: "/tmp/k3s-{{ cluster_name }}/kubeconfig.yaml"
+            dest:   "{{ kubeconfig_local_path }}"
     """
 
     # Pattern to match {{ secrets.key }} or {{ secrets.key.subkey }}
@@ -166,6 +191,26 @@ class ScriptHandler(BaseHandler):
         timeout = self.config.get("timeout", 300)
         if not isinstance(timeout, int) or timeout < 1 or timeout > 14400:
             errors.append("Timeout must be an integer between 1 and 14400")
+
+        # Structural validation of optional outputs: list of dicts each with
+        # string ``source`` and ``dest`` keys. The absolute-path check is
+        # deferred to execute-time since the values may be Jinja2-templated
+        # and need the runtime package variables to resolve.
+        outputs = self.config.get("outputs")
+        if outputs is not None:
+            if not isinstance(outputs, list):
+                errors.append("outputs must be a list")
+            else:
+                for idx, entry in enumerate(outputs):
+                    if not isinstance(entry, dict):
+                        errors.append(f"outputs[{idx}] must be a mapping")
+                        continue
+                    source = entry.get("source")
+                    dest = entry.get("dest")
+                    if not isinstance(source, str) or not source:
+                        errors.append(f"outputs[{idx}] requires a non-empty 'source' string")
+                    if not isinstance(dest, str) or not dest:
+                        errors.append(f"outputs[{idx}] requires a non-empty 'dest' string")
 
         return errors
 
@@ -233,13 +278,14 @@ class ScriptHandler(BaseHandler):
         jumphost = str((context.package_variables or {}).get("jumphost", "")).strip()
         if jumphost and not os.environ.get("INFRAFOUNDRY_ON_JUMPHOST"):
             return self._execute_on_jumphost(script_path, env, context, jumphost)
-        return self._execute_locally(script_path, working_dir, env)
+        return self._execute_locally(script_path, working_dir, env, context)
 
     def _execute_locally(
         self,
         script_path: Path,
         working_dir: Path,
         env: dict[str, str],
+        context: EventContext,
     ) -> EventResult:
         """Execute the script on the local host with real-time streaming.
 
@@ -247,6 +293,9 @@ class ScriptHandler(BaseHandler):
             script_path: Absolute path to the script to run
             working_dir: Working directory for the subprocess
             env: Environment variables for the subprocess
+            context: Event context; forwarded to ``_process_outputs`` so
+                declared ``outputs`` can be rendered against package
+                variables on successful completion.
 
         Returns:
             EventResult with captured stdout/stderr and exit status
@@ -301,6 +350,10 @@ class ScriptHandler(BaseHandler):
             duration = time.monotonic() - start_time
 
             success = process.returncode == 0
+            if success:
+                outputs = self.config.get("outputs") or []
+                if outputs:
+                    self._process_outputs(outputs, context)
             return EventResult(
                 success=success,
                 abort=not success and not self.config.get("continue_on_error", False),
@@ -456,6 +509,7 @@ class ScriptHandler(BaseHandler):
         # Step 3: run the script remotely with streaming output.
         stdout_lines: list[str] = []
         stderr_lines: list[str] = []
+        success = False
         try:
             try:
                 process = subprocess.Popen(  # nosec B603
@@ -541,6 +595,19 @@ class ScriptHandler(BaseHandler):
                     remote_warnings_path,
                     Path(local_warnings_path),
                 )
+            # Pull declared outputs back from the jumphost. Gated on
+            # ``success`` so failed runs don't ship partial artifacts; run
+            # before cleanup so the remote tmp dir still exists. All scp
+            # failures are non-fatal and surface as warnings.
+            if success:
+                outputs = self.config.get("outputs") or []
+                if outputs:
+                    self._process_outputs(
+                        outputs,
+                        context,
+                        jumphost=jumphost,
+                        ssh_opts=ssh_opts,
+                    )
             self._cleanup_remote(cleanup_cmd)
 
     def _cleanup_remote(self, cleanup_cmd: list[str]) -> None:
@@ -643,6 +710,169 @@ class ScriptHandler(BaseHandler):
                 staging_path.unlink(missing_ok=True)
             except OSError as e:
                 logger.debug("removing staged remote warnings failed (ignored): %s", e)
+
+    def _process_outputs(
+        self,
+        outputs: list[dict[str, Any]],
+        context: EventContext,
+        *,
+        jumphost: str | None = None,
+        ssh_opts: list[str] | None = None,
+    ) -> None:
+        """Copy declared script outputs back to the operator's workstation.
+
+        Runs after a script handler reports success. Each entry's ``source``
+        and ``dest`` are Jinja2-rendered against the package variables, both
+        must resolve to absolute paths, and the destination's parent
+        directory is created before the copy. When ``jumphost`` is provided
+        the transport is ``scp`` (one invocation per entry); otherwise the
+        copy is local (``shutil.copy2``). All failure modes — template
+        errors, non-absolute paths, missing sources, scp non-zero, permission
+        issues — are non-fatal: they emit a warning via
+        :func:`infrafoundry.core.warnings.emit_warning` and the loop
+        continues to the next entry.
+
+        Args:
+            outputs: The validated (possibly empty) ``outputs`` list from the
+                handler config.
+            context: The event context; ``package_variables`` is used as the
+                Jinja2 template context.
+            jumphost: SSH destination when the script ran on a jumphost.
+                ``None`` for local execution.
+            ssh_opts: Shared ssh options (e.g.
+                ``["-o", "StrictHostKeyChecking=no"]``). Only used when
+                ``jumphost`` is set.
+        """
+        if not outputs:
+            return
+
+        template_env = create_jinja2_env(undefined=jinja2.Undefined)
+        template_context = dict(context.package_variables or {})
+
+        for entry in outputs:
+            raw_source = entry.get("source", "")
+            raw_dest = entry.get("dest", "")
+            try:
+                rendered_source = template_env.from_string(raw_source).render(**template_context)
+                rendered_dest = template_env.from_string(raw_dest).render(**template_context)
+            except jinja2.TemplateError as exc:
+                message = (
+                    f"failed to render output template "
+                    f"(source={raw_source!r}, dest={raw_dest!r}): {exc}"
+                )
+                logger.debug(message)
+                emit_warning("script_handler_outputs", message)
+                continue
+
+            if not self._is_absolute_output_path(rendered_source):
+                message = f"output source must be an absolute path (got {rendered_source!r})"
+                logger.debug(message)
+                emit_warning("script_handler_outputs", message)
+                continue
+            if not self._is_absolute_output_path(rendered_dest):
+                message = f"output dest must be an absolute path (got {rendered_dest!r})"
+                logger.debug(message)
+                emit_warning("script_handler_outputs", message)
+                continue
+
+            # Expand ~ on the operator-side dest only. ``source`` is either
+            # local (also operator-side, where expanding ~ is also fine) or
+            # on the jumphost, in which case ``scp`` will expand ~ against
+            # the remote user's home for us.
+            local_dest = Path(rendered_dest).expanduser()
+            try:
+                local_dest.parent.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                message = f"failed to create parent directory for {local_dest}: {exc}"
+                logger.debug(message)
+                emit_warning("script_handler_outputs", message)
+                continue
+
+            if jumphost is None:
+                self._process_output_local(rendered_source, local_dest)
+            else:
+                self._process_output_remote(
+                    jumphost,
+                    ssh_opts or [],
+                    rendered_source,
+                    local_dest,
+                )
+
+    @staticmethod
+    def _is_absolute_output_path(value: str) -> bool:
+        """Return True if ``value`` looks like an absolute path for outputs.
+
+        Absolute paths start with ``/``; ``~``-prefixed paths (``~`` alone,
+        ``~/...``) are also accepted because they're resolvable either by
+        :py:meth:`pathlib.Path.expanduser` on the operator side or by the
+        remote shell when handed to ``scp``.
+        """
+        return value.startswith("/") or value.startswith("~")
+
+    def _process_output_local(self, source: str, dest: Path) -> None:
+        """Copy a single declared output between two local paths.
+
+        Args:
+            source: Rendered source path (absolute; ``~`` accepted).
+            dest: Rendered destination path, already ``expanduser``'d.
+        """
+        source_path = Path(source).expanduser()
+        if source_path == dest:
+            logger.debug("output source == dest (%s); skipping local copy", dest)
+            return
+        if not source_path.exists():
+            message = f"output source not found: {source_path}"
+            logger.debug(message)
+            emit_warning("script_handler_outputs", message)
+            return
+        try:
+            shutil.copy2(source_path, dest)
+        except OSError as exc:
+            message = f"failed to copy {source_path} -> {dest}: {exc}"
+            logger.debug(message)
+            emit_warning("script_handler_outputs", message)
+
+    def _process_output_remote(
+        self,
+        jumphost: str,
+        ssh_opts: list[str],
+        source: str,
+        dest: Path,
+    ) -> None:
+        """Fetch a single declared output from the jumphost via ``scp``.
+
+        Args:
+            jumphost: SSH destination (``user@host`` or alias).
+            ssh_opts: Shared ssh options reused from the parent handler.
+            source: Absolute path on the jumphost. May contain ``~``, which
+                the remote shell expands.
+            dest: Destination path on the operator's workstation, already
+                ``expanduser``'d and with its parent created.
+        """
+        scp_cmd = [
+            "scp",
+            *ssh_opts,
+            f"{jumphost}:{source}",
+            str(dest),
+        ]
+        try:
+            result = subprocess.run(  # nosec B603
+                scp_cmd,
+                capture_output=True,
+                timeout=60,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            message = f"scp of output {source} -> {dest} failed: {exc}"
+            logger.debug(message)
+            emit_warning("script_handler_outputs", message)
+            return
+        if result.returncode != 0:
+            stderr_text = result.stderr.decode(errors="replace").strip() if result.stderr else ""
+            message = (
+                f"scp of output {source} -> {dest} returned {result.returncode}: {stderr_text}"
+            )
+            logger.debug(message)
+            emit_warning("script_handler_outputs", message)
 
     def _read_stream(
         self,

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1239,3 +1239,508 @@ class TestScriptHandlerJumphostReexec:
         content = warnings_path.read_text(encoding="utf-8")
         assert '"source":"remote"' in content
         assert '"message":"hello"' in content
+
+
+@pytest.mark.unit
+class TestScriptHandlerOutputs:
+    """Tests for the ``outputs:`` pull-back affordance on ScriptHandler (#660).
+
+    Declared ``outputs`` let blueprint authors tell the framework which
+    artifact files a script produces and where the operator wants them
+    to land. Local execution uses ``shutil.copy2``; jumphost execution
+    uses ``scp``. All pull-back failures are non-fatal warnings.
+    """
+
+    def _handler(
+        self,
+        tmp_path: Path,
+        outputs: list[dict[str, str]] | None = None,
+        script_content: str = "#!/bin/bash\necho hi\n",
+    ) -> tuple[ScriptHandler, Path]:
+        """Build a ScriptHandler with optional ``outputs`` config."""
+        env_dir = tmp_path / "envs" / "dev"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        script = env_dir / "run.sh"
+        script.write_text(script_content)
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+        config: dict = {"script": "run.sh"}
+        if outputs is not None:
+            config["outputs"] = outputs
+        handler = ScriptHandler(config, config_base_dir=tmp_path)
+        return handler, script
+
+    def _context(self, **vars: object) -> EventContext:
+        return EventContext(
+            event_type=EventType.AFTER_APPLY,
+            environment="dev",
+            package_variables=dict(vars),
+        )
+
+    # -- Validation -----------------------------------------------------
+
+    def test_validate_config_accepts_absent_outputs(self, tmp_path: Path):
+        """Missing ``outputs`` field is valid (back-compat default)."""
+        handler, _ = self._handler(tmp_path)
+        assert handler.validate_config() == []
+
+    def test_validate_config_accepts_empty_outputs_list(self, tmp_path: Path):
+        """Empty ``outputs: []`` is valid."""
+        handler, _ = self._handler(tmp_path, outputs=[])
+        assert handler.validate_config() == []
+
+    def test_validate_config_rejects_non_list_outputs(self, tmp_path: Path):
+        """``outputs`` as a non-list produces a validation error."""
+        env_dir = tmp_path / "envs" / "dev"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        script = env_dir / "run.sh"
+        script.write_text("#!/bin/bash\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+        handler = ScriptHandler(
+            {"script": "run.sh", "outputs": "not-a-list"},
+            config_base_dir=tmp_path,
+        )
+        errors = handler.validate_config()
+        assert any("outputs must be a list" in e for e in errors)
+
+    def test_validate_config_rejects_entry_missing_source(self, tmp_path: Path):
+        """An entry without ``source`` is invalid."""
+        handler, _ = self._handler(tmp_path, outputs=[{"dest": "/tmp/x"}])
+        errors = handler.validate_config()
+        assert any("source" in e for e in errors)
+
+    def test_validate_config_rejects_entry_missing_dest(self, tmp_path: Path):
+        """An entry without ``dest`` is invalid."""
+        handler, _ = self._handler(tmp_path, outputs=[{"source": "/tmp/x"}])
+        errors = handler.validate_config()
+        assert any("dest" in e for e in errors)
+
+    def test_validate_config_rejects_non_mapping_entry(self, tmp_path: Path):
+        """A list entry that isn't a mapping is invalid."""
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=["just-a-string"],  # type: ignore[list-item]
+        )
+        errors = handler.validate_config()
+        assert any("outputs[0]" in e and "mapping" in e for e in errors)
+
+    # -- Absent / empty are no-ops --------------------------------------
+
+    def test_outputs_absent_is_noop(self, tmp_path: Path):
+        """With no ``outputs`` config, no copy/scp happens."""
+        handler, _ = self._handler(tmp_path)
+        context = self._context()
+        with patch("infrafoundry.core.events.handlers.script.shutil.copy2") as mock_copy:
+            result = handler.execute(context)
+        assert result.success
+        assert mock_copy.call_count == 0
+
+    def test_outputs_empty_list_is_noop(self, tmp_path: Path):
+        """``outputs: []`` behaves identically to absent."""
+        handler, _ = self._handler(tmp_path, outputs=[])
+        context = self._context()
+        with patch("infrafoundry.core.events.handlers.script.shutil.copy2") as mock_copy:
+            result = handler.execute(context)
+        assert result.success
+        assert mock_copy.call_count == 0
+
+    # -- Local execution paths ------------------------------------------
+
+    def test_local_copies_source_to_dest(self, tmp_path: Path):
+        """On success, source is copied to dest with different paths."""
+        src = tmp_path / "src.txt"
+        src.write_text("hello world")
+        dst = tmp_path / "out" / "dst.txt"
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": str(src), "dest": str(dst)}],
+            script_content="#!/bin/bash\necho ok\n",
+        )
+        result = handler.execute(self._context())
+        assert result.success
+        assert dst.exists()
+        assert dst.read_text() == "hello world"
+
+    def test_local_same_path_is_noop(self, tmp_path: Path):
+        """When source == dest, no copy is attempted."""
+        both = tmp_path / "file.txt"
+        both.write_text("unchanged")
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": str(both), "dest": str(both)}],
+        )
+        with patch("infrafoundry.core.events.handlers.script.shutil.copy2") as mock_copy:
+            result = handler.execute(self._context())
+        assert result.success
+        assert mock_copy.call_count == 0
+        # File is unmodified.
+        assert both.read_text() == "unchanged"
+
+    def test_local_missing_source_warns(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Missing source after success: warning emitted, handler still succeeds."""
+        warnings_file = tmp_path / "warnings.jsonl"
+        monkeypatch.setenv("INFRAFOUNDRY_WARNINGS_FILE", str(warnings_file))
+        missing = tmp_path / "does-not-exist.txt"
+        dst = tmp_path / "dst.txt"
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": str(missing), "dest": str(dst)}],
+        )
+        result = handler.execute(self._context())
+        assert result.success
+        assert not dst.exists()
+        assert warnings_file.exists()
+        content = warnings_file.read_text()
+        assert "output source not found" in content
+        assert "script_handler_outputs" in content
+
+    def test_local_relative_path_warns_and_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Non-absolute rendered paths warn and skip the entry."""
+        warnings_file = tmp_path / "warnings.jsonl"
+        monkeypatch.setenv("INFRAFOUNDRY_WARNINGS_FILE", str(warnings_file))
+        # dest is a bare relative name; source is absolute.
+        src = tmp_path / "src.txt"
+        src.write_text("x")
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": str(src), "dest": "foo-relative"}],
+        )
+        with patch("infrafoundry.core.events.handlers.script.shutil.copy2") as mock_copy:
+            result = handler.execute(self._context())
+        assert result.success
+        assert mock_copy.call_count == 0
+        assert warnings_file.exists()
+        assert "dest must be an absolute path" in warnings_file.read_text()
+
+    def test_local_template_vars_rendered(self, tmp_path: Path):
+        """Jinja2 templates in source/dest resolve against package vars."""
+        src = tmp_path / "k3s-prod.yaml"
+        src.write_text("# kubeconfig")
+        dst = tmp_path / "prod.yaml"
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[
+                {
+                    "source": str(tmp_path) + "/k3s-{{ cluster_name }}.yaml",
+                    "dest": str(tmp_path) + "/{{ cluster_name }}.yaml",
+                }
+            ],
+        )
+        result = handler.execute(self._context(cluster_name="prod"))
+        assert result.success
+        assert dst.exists()
+        assert dst.read_text() == "# kubeconfig"
+
+    def test_local_creates_dest_parent_dir(self, tmp_path: Path):
+        """Nonexistent dest parent dir is created automatically."""
+        src = tmp_path / "src.txt"
+        src.write_text("payload")
+        dst = tmp_path / "nested" / "deeper" / "dst.txt"
+        assert not dst.parent.exists()
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": str(src), "dest": str(dst)}],
+        )
+        result = handler.execute(self._context())
+        assert result.success
+        assert dst.exists()
+        assert dst.read_text() == "payload"
+
+    def test_local_outputs_skipped_on_script_failure(self, tmp_path: Path):
+        """Non-zero script exit skips outputs processing entirely."""
+        src = tmp_path / "src.txt"
+        src.write_text("payload")
+        dst = tmp_path / "dst.txt"
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": str(src), "dest": str(dst)}],
+            script_content="#!/bin/bash\nexit 1\n",
+        )
+        result = handler.execute(self._context())
+        assert result.success is False
+        assert not dst.exists()
+
+    # -- Jumphost (scp) paths -------------------------------------------
+
+    def _jumphost_run_ok(self, scp_calls: list[list[str]] | None = None):
+        """Build a subprocess.run side effect that records scp invocations."""
+
+        def side_effect(cmd, *_args, **_kwargs):
+            if cmd[0] == "scp" and scp_calls is not None:
+                scp_calls.append(list(cmd))
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        return side_effect
+
+    def test_remote_scp_invoked_on_success(self, tmp_path: Path):
+        """A successful remote run triggers one scp per output."""
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "/tmp/remote/out.txt", "dest": str(tmp_path / "out.txt")}],
+        )
+        context = self._context(jumphost="jump@host")
+        scp_calls: list[list[str]] = []
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                side_effect=self._jumphost_run_ok(scp_calls),
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=0),
+            ),
+        ):
+            result = handler.execute(context)
+        assert result.success
+        assert len(scp_calls) == 1
+        scp_cmd = scp_calls[0]
+        assert scp_cmd[0] == "scp"
+        assert "jump@host:/tmp/remote/out.txt" in scp_cmd
+        assert str(tmp_path / "out.txt") in scp_cmd
+
+    def test_remote_scp_skipped_on_script_failure(self, tmp_path: Path):
+        """A failed remote run skips scp entirely."""
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "/tmp/remote/out.txt", "dest": str(tmp_path / "out.txt")}],
+        )
+        context = self._context(jumphost="jump@host")
+        scp_calls: list[list[str]] = []
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                side_effect=self._jumphost_run_ok(scp_calls),
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=7),
+            ),
+        ):
+            result = handler.execute(context)
+        assert result.success is False
+        assert scp_calls == []
+
+    def test_remote_scp_failure_warns_but_handler_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A non-zero scp returncode surfaces as a warning, not a handler failure."""
+        warnings_file = tmp_path / "warnings.jsonl"
+        monkeypatch.setenv("INFRAFOUNDRY_WARNINGS_FILE", str(warnings_file))
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "/tmp/remote/out.txt", "dest": str(tmp_path / "out.txt")}],
+        )
+        context = self._context(jumphost="jump@host")
+
+        def run_side_effect(cmd, *_args, **_kwargs):
+            if cmd[0] == "scp":
+                return MagicMock(returncode=1, stdout=b"", stderr=b"no such file")
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                side_effect=run_side_effect,
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=0),
+            ),
+        ):
+            result = handler.execute(context)
+
+        assert result.success
+        assert warnings_file.exists()
+        content = warnings_file.read_text()
+        assert "scp of output" in content
+        assert "no such file" in content
+
+    def test_remote_multiple_outputs_all_attempted(self, tmp_path: Path):
+        """Multiple outputs: one failure does not skip subsequent entries."""
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[
+                {"source": "/tmp/remote/first.txt", "dest": str(tmp_path / "first.txt")},
+                {"source": "/tmp/remote/second.txt", "dest": str(tmp_path / "second.txt")},
+            ],
+        )
+        context = self._context(jumphost="jump@host")
+        scp_calls: list[list[str]] = []
+
+        def run_side_effect(cmd, *_args, **_kwargs):
+            if cmd[0] == "scp":
+                scp_calls.append(list(cmd))
+                # First scp fails, second succeeds.
+                if "first.txt" in cmd[-2]:
+                    return MagicMock(returncode=1, stdout=b"", stderr=b"err")
+                return MagicMock(returncode=0, stdout=b"", stderr=b"")
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                side_effect=run_side_effect,
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=0),
+            ),
+        ):
+            result = handler.execute(context)
+
+        assert result.success
+        # Filter out any scp from the unrelated warnings-collector plumbing
+        # (only present when INFRAFOUNDRY_WARNINGS_FILE is set); the outputs
+        # pull-back uses /tmp/remote/* sources.
+        output_scps = [c for c in scp_calls if "/tmp/remote/" in c[-2]]
+        assert len(output_scps) == 2
+        assert any("first.txt" in c[-2] for c in output_scps)
+        assert any("second.txt" in c[-2] for c in output_scps)
+
+    def test_remote_cleanup_runs_after_outputs_processing(self, tmp_path: Path):
+        """Remote cleanup (rm -rf) always fires after scp attempts."""
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "/tmp/remote/out.txt", "dest": str(tmp_path / "out.txt")}],
+        )
+        context = self._context(jumphost="jump@host")
+        order: list[str] = []
+
+        def run_side_effect(cmd, *_args, **_kwargs):
+            if cmd[0] == "scp":
+                order.append("scp")
+                # Make scp fail so we also verify cleanup still runs after a
+                # non-fatal pull-back error.
+                return MagicMock(returncode=1, stdout=b"", stderr=b"boom")
+            if cmd[0] == "ssh" and "rm -rf" in cmd[-1]:
+                order.append("cleanup")
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                side_effect=run_side_effect,
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=0),
+            ),
+        ):
+            result = handler.execute(context)
+
+        assert result.success
+        # scp must run before the remote cleanup so the remote tmp dir
+        # still contains the artifact when scp executes.
+        assert order == ["scp", "cleanup"]
+
+    def test_remote_ssh_opts_forwarded_to_scp(self, tmp_path: Path):
+        """scp inherits the same StrictHostKeyChecking=no used by the handler."""
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "/tmp/remote/out.txt", "dest": str(tmp_path / "out.txt")}],
+        )
+        context = self._context(jumphost="jump@host")
+        scp_calls: list[list[str]] = []
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                side_effect=self._jumphost_run_ok(scp_calls),
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=0),
+            ),
+        ):
+            handler.execute(context)
+        assert len(scp_calls) == 1
+        assert "-o" in scp_calls[0]
+        assert "StrictHostKeyChecking=no" in scp_calls[0]
+
+    # -- Extra error-handling paths -------------------------------------
+
+    def test_local_template_error_warns_and_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A malformed Jinja2 template surfaces a warning and skips the entry."""
+        warnings_file = tmp_path / "warnings.jsonl"
+        monkeypatch.setenv("INFRAFOUNDRY_WARNINGS_FILE", str(warnings_file))
+        # Unclosed expression -> jinja2.TemplateSyntaxError.
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "/tmp/{{ broken", "dest": str(tmp_path / "x.txt")}],
+        )
+        with patch("infrafoundry.core.events.handlers.script.shutil.copy2") as mock_copy:
+            result = handler.execute(self._context())
+        assert result.success
+        assert mock_copy.call_count == 0
+        assert warnings_file.exists()
+        assert "failed to render output template" in warnings_file.read_text()
+
+    def test_local_source_relative_warns_and_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A non-absolute rendered source also triggers a warning."""
+        warnings_file = tmp_path / "warnings.jsonl"
+        monkeypatch.setenv("INFRAFOUNDRY_WARNINGS_FILE", str(warnings_file))
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "relative.txt", "dest": str(tmp_path / "x.txt")}],
+        )
+        with patch("infrafoundry.core.events.handlers.script.shutil.copy2") as mock_copy:
+            result = handler.execute(self._context())
+        assert result.success
+        assert mock_copy.call_count == 0
+        assert "source must be an absolute path" in warnings_file.read_text()
+
+    def test_local_copy_oserror_warns(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """A raising ``shutil.copy2`` surfaces as a warning (not a failure)."""
+        warnings_file = tmp_path / "warnings.jsonl"
+        monkeypatch.setenv("INFRAFOUNDRY_WARNINGS_FILE", str(warnings_file))
+        src = tmp_path / "src.txt"
+        src.write_text("hi")
+        dst = tmp_path / "dst.txt"
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": str(src), "dest": str(dst)}],
+        )
+        with patch(
+            "infrafoundry.core.events.handlers.script.shutil.copy2",
+            side_effect=PermissionError("denied"),
+        ):
+            result = handler.execute(self._context())
+        assert result.success
+        content = warnings_file.read_text()
+        assert "failed to copy" in content
+
+    def test_remote_scp_oserror_warns(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """An ``OSError`` from ``subprocess.run`` during scp is also a warning."""
+        warnings_file = tmp_path / "warnings.jsonl"
+        monkeypatch.setenv("INFRAFOUNDRY_WARNINGS_FILE", str(warnings_file))
+        handler, _ = self._handler(
+            tmp_path,
+            outputs=[{"source": "/tmp/remote/out.txt", "dest": str(tmp_path / "out.txt")}],
+        )
+        context = self._context(jumphost="jump@host")
+
+        def run_side_effect(cmd, *_args, **_kwargs):
+            if cmd[0] == "scp":
+                raise OSError("scp binary missing")
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.run",
+                side_effect=run_side_effect,
+            ),
+            patch(
+                "infrafoundry.core.events.handlers.script.subprocess.Popen",
+                return_value=_make_fake_process(returncode=0),
+            ),
+        ):
+            result = handler.execute(context)
+
+        assert result.success
+        content = warnings_file.read_text()
+        assert "scp of output" in content
+        assert "scp binary missing" in content


### PR DESCRIPTION
## Description

Add an `outputs:` field to the `script` event handler so blueprints can declare
artifact files produced on the execution host and have the framework pull them
back to the operator's workstation.

Today, when a blueprint event-handler script runs on a jumphost via
`ScriptHandler._execute_on_jumphost`, anything it writes to `~/.kube/...` or
similar lands on the **jumphost's** filesystem (because `~` expands against the
jumphost user's home). The concrete motivator was Phase 6 of
`blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh`, which emits a
rendered kubeconfig the operator then has to `scp` back manually on every
apply. This is a generic gap in the jumphost reexec story — every blueprint
that produces operator-consumable artifacts (kubeconfigs, CA certs, deploy
reports) hits the same problem and reaches for ad-hoc `scp` glue inside the
script.

This change adds a framework primitive that makes blueprint scripts declarative
and portable between local and jumphost execution.

## Related Issue

Addresses #660

See the design-rationale plan comment on #660 for the full alternatives
analysis.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **`src/infrafoundry/core/events/handlers/script.py`**
  - New optional `outputs:` schema field on `ScriptHandler` (list of
    `{source, dest}` mappings).
  - `validate_config` gains structural validation (shape, mandatory keys,
    mapping entries).
  - New helpers: `_process_outputs`, `_process_output_local`,
    `_process_output_remote`, `_is_absolute_output_path`.
  - Both `source` and `dest` are rendered at execute time through the
    framework's shared `create_jinja2_env` against the package variables on
    `EventContext`.
  - Absolute-path check (must start with `/` or `~`) is deferred to execute
    time since values may be Jinja2-templated.
  - Transport is dispatched by context: `shutil.copy2(source, dest)` for local
    execution, one `scp` per entry on jumphost execution, wedged into the
    existing `finally` block between `_fetch_remote_warnings(...)` and
    `_cleanup_remote(...)` so the remote tmp dir still holds the artifact.
  - `Path(dest).parent.mkdir(parents=True, exist_ok=True)` runs before every
    copy/scp.
  - Pull-back runs **only on script success** (exit code 0). Failure modes
    (missing source, non-zero scp, permission errors, template errors) are
    non-fatal: each surfaces as a JSONL record under the source tag
    `script_handler_outputs` via `INFRAFOUNDRY_WARNINGS_FILE` and renders in
    the apply summary panel.
  - `_execute_on_jumphost` now tracks a `success` flag across the `try` /
    `finally` boundary so the outputs step can read it without re-parsing
    the return value.

- **`tests/unit/test_events.py`** — new `TestScriptHandlerOutputs` class (25
  tests) covering: config validation (6), absent/empty no-op, local
  copy / same-path / missing-source / relative-dest / relative-source /
  template rendering / template error / parent-dir creation / OSError /
  skip-on-failure, jumphost scp-on-success / skip-on-failure /
  non-fatal scp error / OSError / multiple outputs / cleanup ordering /
  ssh-opts forwarded.

- **`docs/development/event-system.md`** — new `### Declaring script outputs`
  subsection with both jumphost and local-execution examples and the full
  contract.

- **`docs/development/blueprint-script-portability.md`** — new
  `## Outputs: pulling artifacts back to the operator` section pointing at
  the Event System doc for full semantics.

- **`docs/decisions/0006-explicit-script-handler-output-declarations.md`** —
  new ADR created via `doit adr`. Explains the context, the two alternatives
  (convention-based outputs dir vs. explicit declaration), the chosen
  approach, and the consequences. Links to both implementation docs above.

## Testing

- [x] `doit check` passes (format, lint, blueprint portability lint,
  mypy, bandit, codespell, pytest).
- [x] 3043 tests pass; project coverage 81.66% (gate is 70%).
- [x] 25 new tests in `TestScriptHandlerOutputs` exercise validation,
  local transport, jumphost transport, non-fatal failure surfacing,
  cleanup ordering, and template rendering.
- [x] Added new tests for new functionality.

## Documentation

- `docs/development/event-system.md` — user-facing contract with examples.
- `docs/development/blueprint-script-portability.md` — placement in the
  broader portability story.
- `docs/decisions/0006-explicit-script-handler-output-declarations.md` —
  design rationale ADR.

## Out of Scope

Intentionally not in this PR (framework primitive only):

- **k3s-cluster blueprint migration.** Phase 6 of
  `blueprints/k3s-cluster/scripts/proxmox/k3s-post-terraform.sh` still does
  its own kubeconfig pull-back; a separate follow-up will swap that for an
  `outputs:` declaration on the blueprint's handler.
- Pull-back from **target VMs** (scripts that ssh into VMs they've
  provisioned). Out of scope — those scripts already control their own
  transport and are covered by the "target-VM exemption" in the portability
  doc.
- **Artifact lifecycle** on the operator host (rotation, cleanup, permissions
  beyond what `scp` / `shutil.copy2` preserve). Blueprint authors are
  responsible for `chmod`'ing artifacts in the script that produces them
  before the framework ships them.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`).
- [x] I have run linting checks (`doit lint`).
- [x] I have run type checking (`doit type_check`).
- [x] I have added tests that prove my feature works.
- [x] All new and existing tests pass (`doit test`).
- [x] I have updated the documentation accordingly.
- [x] ADR created and linked to implementation docs (per AGENTS.md rule:
  every ADR must link to docs in `docs/`).
- [x] My changes generate no new warnings.
- [ ] CHANGELOG.md — handled by commitizen at release time.
