### PR TITLE
chore: add pyproject-template divergence note

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -30,6 +30,10 @@ This section provides comprehensive guides for developing and extending InfraFou
 
 - **[Blueprint Script Portability](blueprint-script-portability.md)** - Portability contract for event-handler and target-VM scripts: tools you may assume, how to handle the rest, and why `jq` is not recommended
 
+## Maintenance & Operations
+
+- [pyproject-template Divergences](pyproject-template-divergences.md) — files we intentionally do not sync from the upstream template.
+
 ## See Also
 
 - [Architecture Overview](../architecture/overview.md) - High-level system architecture

--- a/docs/development/pyproject-template-divergences.md
+++ b/docs/development/pyproject-template-divergences.md
@@ -1,0 +1,131 @@
+# pyproject-template Divergences
+
+InfraFoundry was bootstrapped from [pyproject-template](https://github.com/endavis/pyproject-template)
+and periodically syncs from it. This document codifies the files InfraFoundry
+intentionally does **not** adopt from upstream, so every sync PR does not
+re-litigate the same decisions.
+
+## When to consult this document
+
+- **Reviewing a sync PR** (typically titled `chore: sync from pyproject-template …`):
+  use the categories below to decide whether a changed file should be adopted
+  verbatim, skipped, or hand-merged.
+- **Proposing upstream changes**: if a divergence is permanent, record it here
+  rather than in a PR comment that gets lost in history.
+
+## How to update this document
+
+Edit it in a **separate PR** with a `docs:` commit. Do not silently expand the
+skip-list inside a sync PR — that hides the decision. The divergence list is a
+deliberate policy artifact; additions deserve review on their own merits.
+
+A programmatic skip-list in `.config/pyproject_template/settings.toml` is a
+future improvement that would let tooling enforce these decisions. Until that
+lands, this doc is the MVP — a human reference consulted during sync-PR review.
+
+> **Scope note:** by omission, every file not mentioned in one of the three
+> categories below is adopted verbatim from upstream. There is no explicit
+> "adopt" list — keeping the doc small is the point.
+
+## 1. Template-skeleton files (never adopt)
+
+These files exist upstream as part of the generic skeleton a new project would
+start from. InfraFoundry is a real project with its own package structure,
+tests, and documentation; upstream changes to these files should always be
+skipped.
+
+### Skeleton source code
+- `src/package_name/` — skeleton package. InfraFoundry's package lives at
+  `src/infrafoundry/`.
+- `examples/api/` — skeleton FastAPI example.
+- `examples/basic_usage.py`, `examples/advanced_usage.py`,
+  `examples/cli_usage.py` — skeleton usage examples. InfraFoundry ships
+  `blueprints/` instead.
+
+### Skeleton tests
+- `tests/test_cli.py`, `tests/test_core.py`, `tests/test_logging.py`,
+  `tests/test_example.py` — skeleton tests for the placeholder package.
+- `tests/benchmarks/test_bench_core.py`,
+  `tests/benchmarks/test_bench_logging.py` — benchmarks for the skeleton
+  package.
+- `tests/template/` — tests upstream runs against the template itself (bootstrap,
+  cleanup, doit helpers). Not relevant once bootstrapped.
+
+### Skeleton documentation
+- `docs/examples/api.md`, `docs/examples/add-a-feature.md` — skeleton example
+  docs.
+- `docs/usage/basics.md`, `docs/usage/cli.md` — skeleton usage docs. Superseded
+  by InfraFoundry's `docs/usage/`.
+- `docs/reference/api.md` — auto-generated API reference for the skeleton
+  package.
+- `docs/template/` — upstream documentation about the template project itself
+  (bootstrap, migration, updates).
+- `docs/deployment/development.md`, `docs/deployment/production.md` — generic
+  deployment docs that do not apply to an infrastructure tool.
+- `docs/getting-started/installation.md` — generic install doc. InfraFoundry's
+  `docs/getting-started/setup-guide.md` is the real entry point.
+- `docs/development/extensions.md`,
+  `docs/development/install-tools-framework.md`,
+  `docs/development/tooling-roles.md`,
+  `docs/development/github-repository-settings.md`,
+  `docs/development/dependabot-automerge.md` — skeleton/meta docs about the
+  template's own tooling choices.
+- `docs/TABLE_OF_CONTENTS.md` — skeleton table of contents. Superseded by the
+  mkdocs-generated nav.
+
+### Other
+- `LICENSE` — InfraFoundry ships its own license; never overwrite.
+
+## 2. Infrafoundry-specific files (upstream changes never apply)
+
+These files exist only in InfraFoundry. They are listed here so reviewers know
+not to ask "should we sync this?" — there is nothing to sync from.
+
+- `src/infrafoundry/` — the actual framework code.
+- `blueprints/` — infrastructure blueprints.
+- `tools/lint_blueprint_portability.py` — custom linter enforcing the
+  blueprint-script portability contract.
+- `docs/development/blueprint-script-portability.md` — the contract the linter
+  enforces.
+- `docs/development/implementing-providers.md`,
+  `docs/development/implementing-runners.md`,
+  `docs/development/implementing-secret-providers.md`,
+  `docs/development/manager-patterns.md`,
+  `docs/development/event-system.md`,
+  `docs/development/credential-loader-system.md`,
+  `docs/development/runner-protocol-quick-reference.md` — framework-specific
+  developer guides.
+- InfraFoundry-authored ADRs under `docs/decisions/` and
+  `docs/architecture/decisions/` (files numbered `0001–0006` in each tree).
+  Upstream ships its own ADRs in the `9000-` series; those are adopted
+  separately.
+
+Note: `tools/doit/quality.py` is an upstream file but contains an
+infrafoundry-specific task (`task_lint_blueprints()`). See category 3.
+
+## 3. Files that require hand-merge every sync
+
+These files mix upstream skeleton content with InfraFoundry customization. They
+cannot be adopted blindly and cannot be skipped blindly — each sync must
+manually reconcile the two. For each, the "spot-check" column names the
+customization a reviewer must verify survived the merge.
+
+| File | Spot-check |
+| :--- | :--- |
+| `AGENTS.md` | Preserves InfraFoundry-specific CLI command tables, architecture sections, and the `foundry` CLI reference. |
+| `.claude/CLAUDE.md` | Preserves InfraFoundry TodoWrite rules, workflow mandates, and the `@../AGENTS.md` import. |
+| `.claude/settings.json` | Preserves project-specific permissions, hooks, and environment variables. |
+| `.github/CONTRIBUTING.md` | Preserves InfraFoundry branching/commit conventions and the issue-driven workflow description. |
+| `.gitignore` | Preserves entries for `generated/`, state DB paths, `endavis-infra/`, and other InfraFoundry-specific artifacts. |
+| `.envrc` | Preserves `INFRAFOUNDRY_*` environment variables and direnv layout specific to the framework. |
+| `.pre-commit-config.yaml` | Preserves InfraFoundry-specific hooks (blueprint linter, commit-msg format) alongside upstream quality hooks. |
+| `CHANGELOG.md` | InfraFoundry owns this — never replaced, only appended. |
+| `README.md` | Preserves InfraFoundry description, quickstart, and feature list. |
+| `dodo.py` | Preserves InfraFoundry-specific task imports. |
+| `mkdocs.yml` | Preserves the InfraFoundry nav tree (Providers, Runners, Configuration, etc.). |
+| `pyproject.toml` | Preserves project name, dependencies, CLI entry points, and mypy/ruff overrides specific to InfraFoundry. |
+| `tools/doit/quality.py` | Preserves `task_lint_blueprints()` and any sibling blueprint-specific tasks. |
+
+When reviewing a sync PR that touches any of the above, scroll through the diff
+with the spot-check note in mind. If the customization is missing from the
+proposed change, the merge lost it — push back and ask for a rework.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
     - Coding Standards: development/coding-standards.md
     - CI/CD Testing: development/ci-cd-testing.md
     - Release & Automation: development/release-and-automation.md
+    - pyproject-template Divergences: development/pyproject-template-divergences.md
     - Implementing Secret Providers: development/implementing-secret-providers.md
     - Secrets Handling: development/security/secrets-handling.md
 


### PR DESCRIPTION
## Description

Adds `docs/development/pyproject-template-divergences.md` — a permanent, human-reviewed
record of the files InfraFoundry intentionally does **not** adopt from upstream
[pyproject-template](https://github.com/endavis/pyproject-template) during sync PRs.
The doc organizes divergences into three categories (template-skeleton files,
InfraFoundry-specific files, and hand-merge files) with a spot-check table for
reviewers to validate that customizations survived each sync.

The goal is to stop re-litigating the same skip decisions in every sync PR.
Future syncs can cite this doc as the source of truth for "why was this file
skipped?" questions.

This is **Phase F of the pyproject-template sync tracker (#673)** and lands
first — out of phase-letter order — so Phases A–E can cite it when deciding
what to adopt vs. skip.

## Related Issue

Addresses #679

## Type of Change

- [x] Documentation update

## Changes Made

- Add `docs/development/pyproject-template-divergences.md` (132 lines) covering:
  - **Category 1 — Template-skeleton files (never adopt):** skeleton source
    (`src/package_name/`, `examples/*.py`), skeleton tests, skeleton docs, and
    `LICENSE`.
  - **Category 2 — InfraFoundry-specific files (nothing to sync from):** the
    framework package, blueprints, the blueprint-portability linter + contract,
    framework-specific developer guides, and the InfraFoundry-authored ADRs.
  - **Category 3 — Hand-merge files:** `AGENTS.md`, `.claude/CLAUDE.md`,
    `.claude/settings.json`, `.github/CONTRIBUTING.md`, `.gitignore`, `.envrc`,
    `.pre-commit-config.yaml`, `CHANGELOG.md`, `README.md`, `dodo.py`,
    `mkdocs.yml`, `pyproject.toml`, and `tools/doit/quality.py` — each with a
    spot-check note naming the customization reviewers must confirm survived.
- Add a "Maintenance & Operations" section to `docs/development/README.md`
  linking to the new doc.
- Add a nav entry under **Development** in `mkdocs.yml`.

Scope is deliberately a "by omission" policy: anything not listed is adopted
verbatim. The doc also notes a future improvement — a programmatic skip-list in
`.config/pyproject_template/settings.toml` — and explicitly scopes its own
updates to a separate `docs:` PR so the skip-list is never silently expanded
inside a sync PR.

## Testing

- [x] `doit check` passes (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [x] `doit docs_build` passes — the new page renders and the nav entry is live.
- [x] Manually reviewed the three changed files for accuracy against the current
  repo layout (package path, blueprint linter path, ADR numbering, etc.).

No code change; no new tests required.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (docs-only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR _is_ the documentation)
- [ ] I have updated the CHANGELOG.md — N/A; CHANGELOG is maintained automatically by commitizen at release time from conventional commits
- [x] My changes generate no new warnings

## Additional Notes

- **No ADR required.** The issue is not labeled `needs-adr`, and the decision
  is operational (which files to skip during sync) rather than architectural.
  The one existing ADR that mentions pyproject-template
  (`docs/decisions/0001-linux-only-ci-testing.md`) concerns the CI matrix
  strategy — a different concern — and does not need to be updated.
- **Relationship to the sync tracker (#673):** Phases A–E will open against
  this PR's merged state and reference the new doc in their "why we skipped X"
  justifications. This PR is deliberately small and independent so it can land
  without waiting on the rest of the sync.
