### PR TITLE
chore: adopt upstream dependabot automerge + labels

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -366,6 +366,10 @@ If your repository requires PR approvals (branch protection → "Require approva
 
 The label and approval are independent checks - both must pass. The label serves as an explicit final confirmation after review and CI are complete.
 
+**Dependabot PRs:**
+
+Patch- and minor-bump dependabot PRs are auto-labeled `ready-to-merge` and have GitHub auto-merge enabled by the `dependabot-automerge.yml` workflow (subject to the sensitive-dependency blocklist and blocking labels in `.github/automerge-config.json`). The manual flow above only applies to major-version bumps or PRs labeled `automerge-blocked` / `do-not-merge`.
+
 ### After Merge
 
 - Delete your branch

--- a/.github/automerge-config.json
+++ b/.github/automerge-config.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Auto-merge configuration for dependabot PRs. See docs/development/dependabot-automerge.md.",
+  "sensitive_dependencies": [
+    "crypt*",
+    "*ssl*",
+    "*security*",
+    "auth*",
+    "*jwt*",
+    "*oauth*"
+  ],
+  "allowed_update_types": [
+    "version-update:semver-patch",
+    "version-update:semver-minor"
+  ],
+  "blocking_labels": [
+    "do-not-merge",
+    "automerge-blocked"
+  ]
+}

--- a/.github/hooks/copilot-hooks.json
+++ b/.github/hooks/copilot-hooks.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,56 @@
+# GitHub label definitions for this repository.
+#
+# Source of truth for labels replicated to GitHub. Edit this file and run
+# `doit labels_sync` (or `doit labels_sync --dry-run` to preview) to reconcile
+# the repository's labels with the list below.
+#
+# Fields:
+#   name        (required) Label name exactly as it appears on GitHub.
+#   color       6-char hex (no leading "#"). Defaults to "ededed".
+#   description Plain text description. Defaults to "".
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+- name: refactor
+  color: F9D0C4
+  description: Code refactoring and cleanup
+- name: chore
+  color: FEF2C0
+  description: Maintenance, tooling, CI tasks
+- name: needs-triage
+  color: FBCA04
+  description: Needs review and prioritization
+- name: needs-adr
+  color: d4c5f9
+  description: This issue requires an Architecture Decision Record
+- name: ready-to-merge
+  color: 0E8A16
+  description: PR is reviewed and ready to merge
+- name: full-matrix
+  color: 1D76DB
+  description: Run CI on all supported Python versions
+- name: automerge-blocked
+  color: B60205
+  description: Block dependabot auto-merge for this PR
+- name: do-not-merge
+  color: B60205
+  description: Prevent the merge gate from allowing this PR
+- name: security
+  color: d73a4a
+  description: Security vulnerability or fix
+- name: automated
+  color: 02db74
+  description: Created or managed by automation
+- name: dependencies
+  color: 0366d6
+  description: Pull requests that update a dependency file
+- name: github_actions
+  color: "000000"
+  description: Pull requests that update GitHub Actions code

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,288 @@
+# Requires the `allow_auto_merge` repository setting to be enabled.
+# See docs/development/github-repository-settings.md for the full list
+# of required repository settings, and docs/development/dependabot-automerge.md
+# for how this workflow uses it.
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: Evaluate dependabot PR
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.actor == 'dependabot[bot]'
+    outputs:
+      qualifies: ${{ steps.decide.outputs.qualifies }}
+      reason: ${{ steps.decide.outputs.reason }}
+      pr_number: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide eligibility
+        id: decide
+        uses: actions/github-script@v9
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = '.github/automerge-config.json';
+            const config = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+            const updateType = process.env.UPDATE_TYPE || '';
+            const depNames = (process.env.DEPENDENCY_NAMES || '')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
+            const prLabels = (context.payload.pull_request.labels || [])
+              .map(l => l.name);
+
+            // Glob to regex: '*' -> '.*', anchored.
+            const globToRegex = (glob) => {
+              const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+              return new RegExp('^' + escaped.replace(/\*/g, '.*') + '$', 'i');
+            };
+
+            const sensitiveRegexes = (config.sensitive_dependencies || [])
+              .map(globToRegex);
+
+            let qualifies = true;
+            let reason = 'eligible for auto-merge';
+
+            // Check update type.
+            if (updateType === 'version-update:semver-major') {
+              qualifies = false;
+              reason = 'major version bump';
+            }
+
+            // Check sensitive dependencies.
+            if (qualifies) {
+              for (const dep of depNames) {
+                const match = sensitiveRegexes.find(re => re.test(dep));
+                if (match) {
+                  qualifies = false;
+                  reason = `sensitive dependency: ${dep}`;
+                  break;
+                }
+              }
+            }
+
+            // Check blocking labels.
+            if (qualifies) {
+              const blocking = config.blocking_labels || [];
+              const hit = prLabels.find(l => blocking.includes(l));
+              if (hit) {
+                qualifies = false;
+                reason = `blocking label present: ${hit}`;
+              }
+            }
+
+            // Optionally enforce allowed update types (defense in depth).
+            if (qualifies) {
+              const allowed = config.allowed_update_types || [];
+              if (allowed.length && updateType && !allowed.includes(updateType)) {
+                qualifies = false;
+                reason = `update type not in allowlist: ${updateType}`;
+              }
+            }
+
+            core.setOutput('qualifies', String(qualifies));
+            core.setOutput('reason', reason);
+            core.info(`update-type=${updateType} deps=${depNames.join(',')} qualifies=${qualifies} reason=${reason}`);
+
+  enable-automerge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    needs: evaluate
+    if: needs.evaluate.outputs.qualifies == 'true'
+    env:
+      PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+    steps:
+      - name: Generate App token
+        id: app-token
+        if: ${{ vars.RELEASE_APP_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Add ready-to-merge label
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label ready-to-merge
+
+      - name: Enable auto-merge (squash)
+        id: automerge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+
+      - name: Post sticky status comment
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          AUTOMERGE_OUTCOME: ${{ steps.automerge.outcome }}
+          APP_TOKEN_CONFIGURED: ${{ steps.app-token.outputs.token != '' }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const marker = '<!-- dependabot-automerge:status -->';
+            const succeeded = process.env.AUTOMERGE_OUTCOME === 'success';
+            const appTokenConfigured = process.env.APP_TOKEN_CONFIGURED === 'true';
+
+            let body;
+            if (succeeded) {
+              body = marker +
+                '\n✅ **Auto-merge enabled.** This PR will merge automatically when required CI checks pass. To block, add label `automerge-blocked`.';
+            } else if (!appTokenConfigured) {
+              body = marker +
+                '\n⚠️ **Auto-merge could not be enabled, and the App token is not configured.** The `ready-to-merge` label has been applied with `GITHUB_TOKEN`, which does not trigger downstream workflows — so the Merge Gate will **not** re-run automatically. To unstick this PR, either remove and re-add the `ready-to-merge` label manually (which will trigger the Merge Gate as your user), or configure the `RELEASE_APP_ID` variable and `RELEASE_APP_PRIVATE_KEY` secret so future runs can apply the label with an App token. See `docs/development/dependabot-automerge.md` for details.';
+            } else {
+              body = marker +
+                '\n⚠️ **Auto-merge could not be enabled**, but the `ready-to-merge` label has been applied so the Merge Gate is satisfied. A maintainer will need to merge this PR manually (or re-run the workflow once the underlying issue is resolved). See the workflow run logs for details. To opt this PR out of auto-merge entirely, add the `automerge-blocked` label.';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  comment-skip:
+    name: Comment skip reason
+    runs-on: ubuntu-latest
+    needs: evaluate
+    if: needs.evaluate.outputs.qualifies == 'false'
+    steps:
+      - name: Post sticky skip comment
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          REASON: ${{ needs.evaluate.outputs.reason }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const reason = process.env.REASON || 'unknown';
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              `\n⏸️ **Auto-merge skipped:** ${reason}. Human review required.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  request-rebase:
+    name: Request dependabot rebase for stale PRs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Find stale dependabot PRs and request rebase
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const oneHourAgo = Date.now() - 60 * 60 * 1000;
+
+            for (const pr of prs) {
+              if (!pr.user || pr.user.login !== 'dependabot[bot]') continue;
+
+              const labels = (pr.labels || []).map(l => l.name);
+              if (!labels.includes('ready-to-merge')) continue;
+
+              // Fetch fresh PR to get mergeable_state.
+              const { data: fresh } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              if (fresh.mergeable_state !== 'behind') continue;
+
+              // Skip if @dependabot rebase was requested in the last hour.
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const recentRebase = comments.some(c =>
+                c.body && c.body.includes('@dependabot rebase') &&
+                new Date(c.created_at).getTime() > oneHourAgo
+              );
+              if (recentRebase) {
+                core.info(`PR #${pr.number}: recent rebase request; skipping`);
+                continue;
+              }
+
+              core.info(`PR #${pr.number}: requesting @dependabot rebase`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: '@dependabot rebase',
+              });
+            }

--- a/.github/workflows/dependabot-blocked-label.yml
+++ b/.github/workflows/dependabot-blocked-label.yml
@@ -1,0 +1,62 @@
+name: Dependabot Blocked Label
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  handle-blocked-label:
+    name: Handle blocking label
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      (github.event.label.name == 'automerge-blocked' || github.event.label.name == 'do-not-merge')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      LABEL_NAME: ${{ github.event.label.name }}
+    steps:
+      - name: Disable auto-merge
+        run: gh pr merge --disable-auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" || true
+
+      - name: Remove ready-to-merge label
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label ready-to-merge || true
+
+      - name: Post sticky blocked comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const label = process.env.LABEL_NAME;
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              `\n🛑 **Auto-merge disabled** by \`${label}\` label.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,13 @@ gh pr list --state open
 
 ### Dependabot PRs
 
+Patch- and minor-bump dependabot PRs are handled automatically by the
+`dependabot-automerge.yml` workflow (enables GitHub auto-merge and adds
+`ready-to-merge` once eligibility checks pass). The manual flow below
+applies only to PRs the workflow skips — major-version bumps, PRs the
+workflow labels with `automerge-blocked`, or sensitive-dependency
+updates listed in `.github/automerge-config.json`.
+
 When merging dependabot PRs that are behind `main`, **never** use the GitHub API `update-branch` endpoint or local rebase to update the branch. This strips the verified commit signatures from dependabot commits, which are required by branch protection rules.
 
 Instead, use dependabot's own rebase command:

--- a/docs/development/pyproject-template-divergences.md
+++ b/docs/development/pyproject-template-divergences.md
@@ -129,3 +129,19 @@ customization a reviewer must verify survived the merge.
 When reviewing a sync PR that touches any of the above, scroll through the diff
 with the spot-check note in mind. If the customization is missing from the
 proposed change, the merge lost it — push back and ask for a rework.
+
+## 4. Temporarily deferred files
+
+Unlike the categories above, these files **will** be adopted — just not in the
+current sync phase. They are listed here so a reviewer opening this doc after
+Phase A does not assume they were skipped permanently. Remove each entry once
+the referenced follow-up phase lands.
+
+- `.github/workflows/ci-full-matrix.yml` and
+  `tests/test_ci_full_matrix_workflow.py` — deferred from Phase A to Phase E
+  of sync tracker #673. Upstream `ci-full-matrix.yml` calls
+  `./.github/workflows/ci.yml` with `with: full_matrix: true`, but our
+  `ci.yml` does not declare that `workflow_call` input. Phase E will add the
+  input (and switch the label-check logic to read from it), at which point
+  these two files can be adopted verbatim. Remove this note once Phase E
+  lands.

--- a/tests/test_dependabot_automerge_workflow.py
+++ b/tests/test_dependabot_automerge_workflow.py
@@ -1,0 +1,397 @@
+"""Tests for the dependabot auto-merge GitHub Actions workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow — they only verify its shape. The most important guarantee here is the
+step ordering inside the ``enable-automerge`` job (see issue #423): the
+``ready-to-merge`` label must be applied *before* ``gh pr merge --auto`` is
+invoked so that a failure of the merge call cannot skip the label.
+
+Issue #424 split the blocked-label handler out into a sibling workflow
+(``dependabot-blocked-label.yml``) so this workflow no longer fires on
+``labeled`` events. The ``TestOnTriggers`` and ``TestConcurrency`` classes
+below guard that split.
+
+Issue #428 added a preceding ``Generate App token`` step to the
+``enable-automerge`` job. Applying the ``ready-to-merge`` label with a GitHub
+App token (instead of the workflow's ``GITHUB_TOKEN``) is what allows the
+downstream ``Merge Gate`` workflow to re-run on the ``labeled`` event —
+``GITHUB_TOKEN`` is prohibited from triggering further workflow runs to
+prevent recursion. The ``TestAppTokenStep`` class and several assertions in
+``TestEnableAutomergeStepOrdering`` and ``TestStickyCommentStep`` guard that
+wiring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "dependabot-automerge.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the dependabot auto-merge workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _enable_automerge_steps() -> list[dict[str, Any]]:
+    """Return the list of steps in the ``enable-automerge`` job."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["enable-automerge"]
+    steps: list[dict[str, Any]] = job["steps"]
+    return steps
+
+
+class TestDependabotAutomergeWorkflowExists:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The dependabot auto-merge workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+
+
+class TestEnableAutomergeJobShape:
+    """The ``enable-automerge`` job has the expected top-level shape."""
+
+    def test_enable_automerge_job_exists(self) -> None:
+        """Workflow should define the ``enable-automerge`` job."""
+        workflow = _load_workflow()
+        assert "enable-automerge" in workflow["jobs"]
+
+    def test_enable_automerge_needs_evaluate(self) -> None:
+        """``enable-automerge`` must depend on the ``evaluate`` job."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["enable-automerge"]
+        assert job["needs"] == "evaluate"
+
+    def test_enable_automerge_qualifies_guard(self) -> None:
+        """The job should only run when ``evaluate`` reports ``qualifies == 'true'``."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["enable-automerge"]
+        assert job["if"] == "needs.evaluate.outputs.qualifies == 'true'"
+
+    def test_enable_automerge_job_does_not_set_gh_token_globally(self) -> None:
+        """Regression guard for issue #428.
+
+        The job-level ``env.GH_TOKEN`` was dropped in favour of per-step
+        ``GH_TOKEN`` so the App-token-vs-``GITHUB_TOKEN`` distinction is
+        explicit on each step instead of being shadowed by a job default.
+        A future refactor that re-introduces a job-level ``GH_TOKEN`` would
+        silently apply ``GITHUB_TOKEN`` to the label step again and reproduce
+        the bug this issue fixes.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["enable-automerge"]
+        job_env = job.get("env", {})
+        assert "GH_TOKEN" not in job_env, (
+            "enable-automerge must not set GH_TOKEN at the job level; "
+            "set it per-step so the App-token vs GITHUB_TOKEN choice is explicit."
+        )
+
+
+class TestAppTokenStep:
+    """Regression guard for issue #428.
+
+    The first step in ``enable-automerge`` generates a GitHub App token when
+    the App is configured. The label step then uses that token (with
+    ``GITHUB_TOKEN`` fallback) so the label event is attributed to the App
+    and the Merge Gate workflow re-runs. Removing or mis-wiring this step
+    would reintroduce the ``GITHUB_TOKEN`` loop-prevention gap where
+    Dependabot PRs get stuck with a stale ``require-label: FAILURE`` check.
+    """
+
+    def test_first_step_generates_app_token(self) -> None:
+        """Step 0 must be the App-token generation step."""
+        steps = _enable_automerge_steps()
+        assert steps[0]["name"] == "Generate App token"
+
+    def test_first_step_has_app_token_id(self) -> None:
+        """The App-token step must have ``id: app-token`` so later steps and
+        the sticky comment can reference ``steps.app-token.outputs.token``."""
+        steps = _enable_automerge_steps()
+        assert steps[0].get("id") == "app-token"
+
+    def test_first_step_uses_create_github_app_token_v3(self) -> None:
+        """The App-token step must use ``actions/create-github-app-token@v3``.
+
+        Pinning to ``@v3`` (not ``@v1`` or an older major) matches the
+        documented example in ``.github/CONTRIBUTING.md``; a drift between
+        the two would confuse maintainers setting up the App for the first
+        time.
+        """
+        steps = _enable_automerge_steps()
+        assert steps[0]["uses"] == "actions/create-github-app-token@v3"
+
+    def test_app_token_conditional_on_release_app_id(self) -> None:
+        """The App-token step must be guarded by ``if: ${{ vars.RELEASE_APP_ID != '' }}``.
+
+        The fallback path through ``GITHUB_TOKEN`` is only safe because this
+        guard lets the step no-op cleanly when the App is not configured.
+        Removing the guard would fail the whole job in repositories that
+        haven't set up the App — a silent regression.
+        """
+        steps = _enable_automerge_steps()
+        assert steps[0].get("if") == "${{ vars.RELEASE_APP_ID != '' }}"
+
+    def test_app_token_inputs_reference_vars_and_secrets(self) -> None:
+        """Inputs must reference ``vars.RELEASE_APP_ID`` and ``secrets.RELEASE_APP_PRIVATE_KEY``.
+
+        ``RELEASE_APP_ID`` is a repo Variable (per ``.github/CONTRIBUTING.md``),
+        not a Secret. Wiring it as ``secrets.RELEASE_APP_ID`` would silently
+        produce an empty string at runtime and cause a confusing failure.
+        """
+        steps = _enable_automerge_steps()
+        with_block = steps[0].get("with", {})
+        assert with_block.get("app-id") == "${{ vars.RELEASE_APP_ID }}"
+        assert with_block.get("private-key") == "${{ secrets.RELEASE_APP_PRIVATE_KEY }}"
+
+
+class TestEnableAutomergeStepOrdering:
+    """Regression guard for issue #423 (and the issue #428 renumbering).
+
+    The label must be applied before the auto-merge call so a merge failure
+    cannot skip the label. The sticky comment must run last and use
+    ``if: always()`` so it posts on both success and failure. After issue
+    #428, the App-token step is inserted at index 0 and every other step
+    shifts by one.
+    """
+
+    def test_has_four_steps(self) -> None:
+        """``enable-automerge`` should have exactly four steps after #428.
+
+        The App-token step (index 0) was added ahead of the existing three
+        steps (label, auto-merge, sticky comment).
+        """
+        steps = _enable_automerge_steps()
+        assert len(steps) == 4, f"expected 4 steps, got {len(steps)}: {steps}"
+
+    def test_second_step_is_label(self) -> None:
+        """The label step must run second (right after the App-token step).
+
+        This is the core regression guard for issue #423 — if the merge call
+        is reordered to run before the label, a merge failure will skip the
+        label and the Merge Gate will stay red forever. After #428 the label
+        step moved from index 0 to index 1 (behind the App-token generator).
+        """
+        steps = _enable_automerge_steps()
+        assert steps[1]["name"] == "Add ready-to-merge label"
+
+    def test_label_step_adds_ready_to_merge(self) -> None:
+        """The label step should add the ``ready-to-merge`` label via ``gh pr edit``."""
+        steps = _enable_automerge_steps()
+        label_step = steps[1]
+        assert "--add-label ready-to-merge" in label_step["run"]
+
+    def test_label_step_token_uses_app_token_with_fallback(self) -> None:
+        """Core regression guard for issue #428.
+
+        The label step's ``GH_TOKEN`` must resolve to the App token when the
+        App is configured, and fall back to ``GITHUB_TOKEN`` only when it is
+        not. A refactor that hard-codes ``secrets.GITHUB_TOKEN`` here would
+        reintroduce the ``GITHUB_TOKEN`` loop-prevention gap: labels applied
+        by ``GITHUB_TOKEN`` do not trigger downstream workflows, so the
+        Merge Gate would not re-run on the ``labeled`` event.
+        """
+        steps = _enable_automerge_steps()
+        label_env = steps[1].get("env", {})
+        assert label_env.get("GH_TOKEN") == (
+            "${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}"
+        ), (
+            "label step GH_TOKEN must prefer the App token with a "
+            "GITHUB_TOKEN fallback; see issue #428."
+        )
+
+    def test_third_step_is_enable_automerge(self) -> None:
+        """The auto-merge call runs third, after the label is already applied."""
+        steps = _enable_automerge_steps()
+        assert steps[2]["name"] == "Enable auto-merge (squash)"
+
+    def test_enable_automerge_step_has_id(self) -> None:
+        """The merge step needs ``id: automerge`` so the comment step can read its outcome."""
+        steps = _enable_automerge_steps()
+        assert steps[2].get("id") == "automerge"
+
+    def test_enable_automerge_step_uses_squash(self) -> None:
+        """The merge step should use the squash strategy with ``--auto``."""
+        steps = _enable_automerge_steps()
+        merge_step = steps[2]
+        assert "gh pr merge --auto --squash" in merge_step["run"]
+
+    def test_enable_automerge_step_uses_github_token(self) -> None:
+        """The merge step should use ``GITHUB_TOKEN`` (not the App token).
+
+        The auto-merge call does not need the App token — it only enables
+        GitHub's native auto-merge flag on the PR and does not trigger any
+        downstream event. Passing the App token here would only consume App
+        rate limit with no benefit.
+        """
+        steps = _enable_automerge_steps()
+        merge_env = steps[2].get("env", {})
+        assert merge_env.get("GH_TOKEN") == "${{ secrets.GITHUB_TOKEN }}"
+
+    def test_fourth_step_is_sticky_comment(self) -> None:
+        """The sticky status comment runs last."""
+        steps = _enable_automerge_steps()
+        assert steps[3]["name"] == "Post sticky status comment"
+
+
+class TestStickyCommentStep:
+    """The sticky comment step is outcome-aware and always runs."""
+
+    def test_sticky_comment_uses_always(self) -> None:
+        """``if: always()`` ensures the comment runs even when the merge step fails."""
+        steps = _enable_automerge_steps()
+        assert steps[3].get("if") == "always()"
+
+    def test_sticky_comment_uses_github_script(self) -> None:
+        """The sticky comment step should use ``actions/github-script``."""
+        steps = _enable_automerge_steps()
+        assert steps[3]["uses"] == "actions/github-script@v9"
+
+    def test_sticky_comment_exposes_automerge_outcome(self) -> None:
+        """The sticky comment step must expose ``AUTOMERGE_OUTCOME`` via ``env``."""
+        steps = _enable_automerge_steps()
+        env = steps[3].get("env", {})
+        assert env.get("AUTOMERGE_OUTCOME") == "${{ steps.automerge.outcome }}"
+
+    def test_sticky_comment_exposes_app_token_configured(self) -> None:
+        """Regression guard for issue #428.
+
+        The sticky comment step must expose ``APP_TOKEN_CONFIGURED`` so the
+        inline script can distinguish the "App not configured → Merge Gate
+        will not re-run" case from the ordinary "merge call failed" case.
+        Without this flag the user would get a generic failure message and
+        would not know to remove and re-add the label manually.
+        """
+        steps = _enable_automerge_steps()
+        env = steps[3].get("env", {})
+        assert env.get("APP_TOKEN_CONFIGURED") == "${{ steps.app-token.outputs.token != '' }}"
+
+    def test_sticky_comment_branches_on_outcome(self) -> None:
+        """The inline script should branch on ``AUTOMERGE_OUTCOME``.
+
+        Branching lets the script emit either the success copy or the
+        failure copy depending on whether the merge call succeeded.
+        """
+        steps = _enable_automerge_steps()
+        script: str = steps[3]["with"]["script"]
+        assert "AUTOMERGE_OUTCOME" in script, (
+            "sticky comment script must reference AUTOMERGE_OUTCOME so it can "
+            "produce a success vs failure body"
+        )
+
+    def test_sticky_comment_branches_on_app_token_configured(self) -> None:
+        """Regression guard for issue #428.
+
+        The inline script must reference ``APP_TOKEN_CONFIGURED`` so it can
+        emit the third-state message (App not configured, Merge Gate will
+        not re-run, manual relabel required). Dropping this branch would
+        leave the user guessing about the correct fallback path.
+        """
+        steps = _enable_automerge_steps()
+        script: str = steps[3]["with"]["script"]
+        assert "APP_TOKEN_CONFIGURED" in script, (
+            "sticky comment script must reference APP_TOKEN_CONFIGURED so it "
+            "can emit the App-not-configured copy (issue #428)"
+        )
+
+    def test_sticky_comment_retains_dedupe_marker(self) -> None:
+        """The sticky-comment dedupe marker must survive the refactor."""
+        steps = _enable_automerge_steps()
+        script: str = steps[3]["with"]["script"]
+        assert "<!-- dependabot-automerge:status -->" in script
+
+    def test_sticky_comment_deletes_prior_bot_marker_comments(self) -> None:
+        """The dedupe logic (list + delete prior marker comments) must remain."""
+        steps = _enable_automerge_steps()
+        script: str = steps[3]["with"]["script"]
+        assert "deleteComment" in script
+        assert "listComments" in script
+
+
+class TestOnTriggers:
+    """Trigger configuration: the ``labeled`` event is handled elsewhere.
+
+    Issue #424 moved label-driven handling to ``dependabot-blocked-label.yml``.
+    Leaving ``labeled`` in the trigger list here would re-introduce the
+    duplicate-run problem on dependabot PRs (each auto-applied label fires a
+    separate workflow run).
+    """
+
+    def test_labeled_not_in_pull_request_target_types(self) -> None:
+        """The ``labeled`` event type must NOT appear in ``pull_request_target.types``.
+
+        This is the core regression guard for issue #424.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        types = triggers["pull_request_target"]["types"]
+        assert "labeled" not in types, (
+            f"'labeled' must not be in pull_request_target.types; got {types}. "
+            "Label-driven handling is in dependabot-blocked-label.yml (issue #424)."
+        )
+
+    def test_pull_request_target_types_cover_core_lifecycle(self) -> None:
+        """The PR trigger must still cover the core lifecycle events so the
+        main evaluate/enable-automerge flow still runs on every open/sync."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request_target"]["types"]
+        for required in ("opened", "reopened", "synchronize", "ready_for_review"):
+            assert required in types, f"pull_request_target.types missing '{required}': {types}"
+
+    def test_schedule_and_workflow_dispatch_retained(self) -> None:
+        """``schedule`` and ``workflow_dispatch`` drive the rebase-requester job,
+        so they must remain triggers on this workflow."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        assert "schedule" in triggers
+        assert "workflow_dispatch" in triggers
+
+
+class TestConcurrency:
+    """Workflow-level concurrency block dedupes in-flight runs per PR.
+
+    The concurrency block is only safe to add after the ``labeled`` trigger
+    split in issue #424: prior to the split, a labeled event arriving shortly
+    after an ``opened`` event would cancel the in-flight ``evaluate`` job
+    mid-run. With label events routed to ``dependabot-blocked-label.yml``,
+    cancelling stale runs on this workflow is safe.
+    """
+
+    def test_concurrency_block_exists(self) -> None:
+        """The workflow must declare a top-level ``concurrency`` block."""
+        workflow = _load_workflow()
+        assert "concurrency" in workflow, "workflow must declare a concurrency block"
+
+    def test_concurrency_group_keyed_on_pr_number_or_ref(self) -> None:
+        """The group key must reference ``pull_request.number`` and ``github.ref``.
+
+        ``pull_request.number`` isolates PR runs from each other;
+        ``github.ref`` is the fallback for schedule/workflow_dispatch runs
+        that have no PR context.
+        """
+        workflow = _load_workflow()
+        group: str = workflow["concurrency"]["group"]
+        assert "pull_request.number" in group or "github.event.pull_request.number" in group
+        assert "github.ref" in group
+
+    def test_concurrency_cancel_in_progress(self) -> None:
+        """``cancel-in-progress: true`` supersedes stale runs on a new PR push."""
+        workflow = _load_workflow()
+        assert workflow["concurrency"]["cancel-in-progress"] is True

--- a/tests/test_dependabot_blocked_label_workflow.py
+++ b/tests/test_dependabot_blocked_label_workflow.py
@@ -1,0 +1,208 @@
+"""Tests for the dependabot blocked-label GitHub Actions workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow -- they only verify its shape. This workflow was split out from
+``dependabot-automerge.yml`` in issue #424 so that the ``labeled`` trigger no
+longer fires the main auto-merge workflow on every auto-applied dependabot
+label (see the Context section of that issue's plan for the motivation).
+
+The central regression guards here are:
+
+1. The workflow triggers on ``pull_request_target: labeled`` only -- no other
+   event types. Adding ``opened`` or ``synchronize`` would defeat the whole
+   purpose of the split.
+2. The ``handle-blocked-label`` job preserves the exact ``if:`` conditions and
+   step sequence from the original job (disable auto-merge -> remove
+   ``ready-to-merge`` label -> post sticky comment). The sticky-comment marker
+   must survive intact so that the dedupe logic in ``dependabot-automerge.yml``
+   and this workflow share a single comment slot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).parent.parent / ".github" / "workflows" / "dependabot-blocked-label.yml"
+)
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the dependabot blocked-label workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
+    non-ASCII content in the workflow file (lesson from issue #430).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _handle_blocked_label_steps() -> list[dict[str, Any]]:
+    """Return the list of steps in the ``handle-blocked-label`` job."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["handle-blocked-label"]
+    steps: list[dict[str, Any]] = job["steps"]
+    return steps
+
+
+class TestWorkflowFile:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The dependabot blocked-label workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML with a jobs dict."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_workflow_name(self) -> None:
+        """The workflow name is the user-facing check-run label."""
+        workflow = _load_workflow()
+        assert workflow.get("name") == "Dependabot Blocked Label"
+
+
+class TestTriggers:
+    """Trigger configuration: ``labeled`` only, no other event types."""
+
+    def test_only_trigger_is_pull_request_target(self) -> None:
+        """The workflow should have exactly one trigger: ``pull_request_target``."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        assert list(triggers.keys()) == ["pull_request_target"], (
+            "workflow should trigger on pull_request_target only; other triggers "
+            "would defeat the split from dependabot-automerge.yml (issue #424)"
+        )
+
+    def test_pull_request_target_types_is_labeled_only(self) -> None:
+        """The only event type should be ``labeled``.
+
+        This is the core regression guard for issue #424: the whole point of
+        this workflow is to absorb the ``labeled`` event so the main
+        auto-merge workflow no longer runs on every auto-applied label.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request_target"]["types"]
+        assert types == ["labeled"], f"expected types: [labeled], got {types}"
+
+
+class TestPermissions:
+    """Top-level permissions follow the principle of least privilege."""
+
+    def test_permissions_pull_requests_write(self) -> None:
+        """The job edits labels and toggles auto-merge, so it needs PR write access."""
+        workflow = _load_workflow()
+        assert workflow["permissions"]["pull-requests"] == "write"
+
+    def test_permissions_contents_read(self) -> None:
+        """``contents: read`` is the baseline; this workflow does not write to the repo.
+
+        Notably we do NOT copy ``contents: write`` from the parent
+        ``dependabot-automerge.yml``. That permission was there for the
+        ``request-rebase`` job, which stays in the parent workflow. This
+        workflow only needs to edit PR labels and comments.
+        """
+        workflow = _load_workflow()
+        assert workflow["permissions"]["contents"] == "read"
+
+
+class TestHandleBlockedLabelJob:
+    """The ``handle-blocked-label`` job preserves the shape of the original job."""
+
+    def test_job_exists(self) -> None:
+        """Workflow should define the ``handle-blocked-label`` job."""
+        workflow = _load_workflow()
+        assert "handle-blocked-label" in workflow["jobs"]
+
+    def test_job_name(self) -> None:
+        """The user-facing job name should be ``Handle blocking label``."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["handle-blocked-label"]
+        assert job["name"] == "Handle blocking label"
+
+    def test_job_if_guards_dependabot_and_blocking_labels(self) -> None:
+        """The ``if:`` guard must match the original from ``dependabot-automerge.yml``.
+
+        The guard has four parts:
+
+        1. ``github.event_name == 'pull_request_target'`` -- sanity check.
+        2. ``github.event.action == 'labeled'`` -- explicit action filter.
+        3. ``github.event.pull_request.user.login == 'dependabot[bot]'`` --
+           only act on dependabot PRs.
+        4. label name is ``automerge-blocked`` or ``do-not-merge``.
+
+        Any of these going missing is a behavior change the test must catch.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["handle-blocked-label"]
+        guard: str = job["if"]
+        assert "github.event_name == 'pull_request_target'" in guard
+        assert "github.event.action == 'labeled'" in guard
+        assert "github.event.pull_request.user.login == 'dependabot[bot]'" in guard
+        assert "github.event.label.name == 'automerge-blocked'" in guard
+        assert "github.event.label.name == 'do-not-merge'" in guard
+
+    def test_job_env_exposes_pr_number_and_label_name(self) -> None:
+        """The job exposes ``PR_NUMBER`` and ``LABEL_NAME`` via ``env`` so the
+        subsequent steps can read them as shell variables (the secure pattern
+        that avoids direct ``${{ ... }}`` interpolation in ``run``).
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["handle-blocked-label"]
+        env = job["env"]
+        assert env["PR_NUMBER"] == "${{ github.event.pull_request.number }}"
+        assert env["LABEL_NAME"] == "${{ github.event.label.name }}"
+        assert env["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+
+
+class TestHandleBlockedLabelSteps:
+    """Step ordering mirrors the original job: disable -> unlabel -> comment."""
+
+    def test_has_three_steps(self) -> None:
+        """The job should have exactly three steps, matching the original."""
+        steps = _handle_blocked_label_steps()
+        assert len(steps) == 3, f"expected 3 steps, got {len(steps)}: {steps}"
+
+    def test_first_step_disables_auto_merge(self) -> None:
+        """Step 1 disables GitHub auto-merge via ``gh pr merge --disable-auto``."""
+        steps = _handle_blocked_label_steps()
+        assert steps[0]["name"] == "Disable auto-merge"
+        assert "gh pr merge --disable-auto" in steps[0]["run"]
+
+    def test_second_step_removes_ready_to_merge_label(self) -> None:
+        """Step 2 removes the ``ready-to-merge`` label so the Merge Gate blocks the PR."""
+        steps = _handle_blocked_label_steps()
+        assert steps[1]["name"] == "Remove ready-to-merge label"
+        assert "--remove-label ready-to-merge" in steps[1]["run"]
+
+    def test_third_step_posts_sticky_blocked_comment(self) -> None:
+        """Step 3 posts the sticky blocked comment via ``actions/github-script``."""
+        steps = _handle_blocked_label_steps()
+        assert steps[2]["name"] == "Post sticky blocked comment"
+        assert steps[2]["uses"] == "actions/github-script@v9"
+
+    def test_sticky_comment_retains_dedupe_marker(self) -> None:
+        """The sticky-comment dedupe marker must match the parent workflow's marker
+        so both workflows share a single comment slot on the PR."""
+        steps = _handle_blocked_label_steps()
+        script: str = steps[2]["with"]["script"]
+        assert "<!-- dependabot-automerge:status -->" in script
+
+    def test_sticky_comment_deletes_prior_bot_marker_comments(self) -> None:
+        """The dedupe logic (list + delete prior marker comments) must remain."""
+        steps = _handle_blocked_label_steps()
+        script: str = steps[2]["with"]["script"]
+        assert "deleteComment" in script
+        assert "listComments" in script


### PR DESCRIPTION
## Description

Phase A of the pyproject-template sync tracked by #673. Adopts the
upstream dependabot auto-merge pipeline and the labels it depends on,
all of which are net-new additions — no existing workflow is modified.
One upstream file pair (`ci-full-matrix.yml` + its test) is deferred to
Phase E because upstream's dispatcher calls `./.github/workflows/ci.yml`
with a `workflow_call` input (`full_matrix`) our `ci.yml` does not yet
declare; adopting it now would create a broken CI reference.

### Phase context

- Parent tracker: #673 (pyproject-template sync, covers phases A–F).
- Phase F (divergence-doc scaffold, #679) already merged via PR #680.
  This PR appends Section 4 "Temporarily deferred files" to that doc.
- Phases B–E remain to be filed.

### Per-file adopt / defer decisions

Every file listed in the issue's "Proposed Changes" section is
accounted for. Files marked **adopt** land in this PR byte-for-byte
from `tmp/extracted/pyproject-template-main/`; files marked **defer**
are documented in the divergence doc for a future phase.

| File | Decision | Rationale |
| :--- | :--- | :--- |
| `.github/workflows/dependabot-automerge.yml` | adopt | Net-new. Automerges eligible dependabot PRs (patch+minor, not in sensitive-deps blocklist). App-token fallback to `GITHUB_TOKEN` with a clear sticky-comment warning when no app is configured. |
| `.github/workflows/dependabot-blocked-label.yml` | adopt | Net-new. Circuit breaker: when `automerge-blocked` or `do-not-merge` is applied to a dependabot PR, disables auto-merge and removes `ready-to-merge`. |
| `.github/automerge-config.json` | adopt | Upstream defaults are sensible: blocks `crypt*/*ssl*/*security*/auth*/*jwt*/*oauth*`, allows only patch+minor, treats `do-not-merge`/`automerge-blocked` as blockers. Can be tuned per-repo later without another sync. |
| `.github/hooks/copilot-hooks.json` | adopt | Copilot-only — points `preToolUse` at our existing `tools/hooks/ai/block-dangerous-commands.py`. No effect on Claude, Gemini, or humans. |
| `.github/labels.yml` | adopt | Declarative label set the new workflows depend on (`ready-to-merge`, `automerge-blocked`, `do-not-merge`, `full-matrix`, plus the conventional `enhancement`/`bug`/`documentation`/…). File-only in this PR — no `doit labels_sync` task exists yet; that ships in Phase C. Labels currently on GitHub are unchanged until the user runs a manual sync or Phase C lands. |
| `tests/test_dependabot_automerge_workflow.py` | adopt | Structural assertions against workflow #1 (triggers, permissions, job conditions, env plumbing). |
| `tests/test_dependabot_blocked_label_workflow.py` | adopt | Structural assertions against workflow #2. |
| `.github/workflows/ci-full-matrix.yml` | **defer to Phase E** | Calls `./.github/workflows/ci.yml` with `with: full_matrix: true`, but our `ci.yml` does not declare the `full_matrix` `workflow_call` input. Adopting now would break the CI dispatcher. Phase E will add the input and flip the label-check logic, then this file and its test come in together. |
| `tests/test_ci_full_matrix_workflow.py` | **defer to Phase E** | Paired with the workflow above. |

The deferrals are recorded in
`docs/development/pyproject-template-divergences.md` Section 4 so a
reviewer opening that doc after this merges knows they are temporary.

### Docs touched

- `docs/development/pyproject-template-divergences.md` — added
  Section 4 naming the two deferred files.
- `AGENTS.md` — the existing "Dependabot PRs" section now opens with a
  short paragraph clarifying that the manual `@dependabot rebase →
  doit pr_merge` flow applies only to major bumps or blocked PRs;
  patch+minor flow is automated.
- `.github/CONTRIBUTING.md` — added a "Dependabot PRs" note in the
  Merge Gate section pointing at `.github/automerge-config.json` and
  the `automerge-blocked` / `do-not-merge` opt-outs.

## Related Issue

Addresses #674

## Type of Change

<!-- Mark with an 'x' all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [x] Other: CI/CD configuration (sync from pyproject-template)

## Changes Made

- Adopt upstream dependabot auto-merge workflow pair + config (7 new files).
- Append Section 4 to the pyproject-template divergence doc, recording the `ci-full-matrix.yml` deferral for Phase E.
- Cross-reference the new automation from `AGENTS.md` and `.github/CONTRIBUTING.md` so contributors hit the right flow for dependabot PRs.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (51 tests added across the two new workflow test files)
- [ ] Manually tested the changes *(workflows cannot be exercised until they ship to `main`; structural tests cover the shape)*

### Local validation

- `doit check` — all checks pass (format, lint, lint_blueprints, type_check, security, spell_check, test).
- `doit docs_build` — clean (divergence doc still renders).

### Runtime observations expected after merge

- The `dependabot-automerge.yml` workflow will trigger on existing and future dependabot PRs. Without `allow_auto_merge` enabled on the repo, the `gh pr merge --auto` step will fail and the workflow posts its "Auto-merge could not be enabled" sticky comment — no harm, but the automation is a no-op until the user flips the setting.
- The `dependabot-blocked-label.yml` workflow is inert unless `automerge-blocked` or `do-not-merge` is applied to a dependabot PR.
- The `.github/labels.yml` file is inert until `doit labels_sync` ships in Phase C or a maintainer syncs manually.

## Post-merge follow-ups (manual actions for the user)

These are **required** for the new automation to actually do anything — the workflows ship in this PR but sit idle until these steps land:

1. **Enable repo-level auto-merge** — Settings → General → Pull Requests → check "Allow auto-merge". Without this, `gh pr merge --auto` fails and every dependabot PR gets the fallback "auto-merge could not be enabled" sticky comment.
2. **(Optional) Provision the release app token** — create the `RELEASE_APP_ID` repo variable and `RELEASE_APP_PRIVATE_KEY` secret so `ready-to-merge` is applied with an app token (which re-triggers the Merge Gate). Without this, the workflow falls back to `GITHUB_TOKEN`, and the label is applied but Merge Gate won't re-run automatically — the PR will need a manual re-label or an admin merge. The workflow's own warning comment explains this.
3. **Sync labels to GitHub** — `.github/labels.yml` is only a source of truth in the filesystem until Phase C ships `doit labels_sync`. Until then, any missing labels (notably `automerge-blocked` and `ready-to-merge` if not already present) need to be created manually or the workflows that depend on them will silently no-op.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md *(CHANGELOG is auto-generated from conventional commits at release time)*
- [x] My changes generate no new warnings

## Additional Notes

- No `needs-adr` label on #674. The decision here (adopt upstream CI automation verbatim) is operational rather than architectural, so no new ADR. No existing ADR covers CI/automerge strategy, so none to update.
- `Closes`/`Fixes` syntax intentionally not used — auto-close is disabled on this repo; the issue will be closed manually after merge.
