### PR TITLE
chore: sync new pyproject_template tooling modules and ruff-fix hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/ruff-fix-on-edit.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+bootstrap.py - Single-command setup for pyproject-template
+
+This script provides two modes of operation:
+
+1. Default (no flags): Downloads setup tools to a temp directory and runs the
+   repository setup wizard for creating new projects.
+
+2. --sync: Downloads the template management suite permanently to
+   tools/pyproject_template/ for existing projects that want to use manage.py
+   for ongoing template synchronization.
+
+Usage:
+    # New project setup (default)
+    curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py \
+        | python3
+
+    # Install management suite for existing project
+    curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py \
+        | python3 - --sync
+"""
+
+import argparse
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
+# Base URL for raw files
+REPO_OWNER = "endavis"
+REPO_NAME = "pyproject-template"
+BRANCH = "main"
+BASE_URL = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/{BRANCH}"
+
+# Files needed for new project setup (downloaded to temp dir, runs wizard)
+SETUP_FILES = [
+    "tools/pyproject_template/__init__.py",
+    "tools/pyproject_template/utils.py",
+    "tools/pyproject_template/setup_repo.py",
+    "tools/pyproject_template/configure.py",
+]
+
+# Files needed for template sync management (installed permanently)
+SYNC_FILES = [
+    "tools/pyproject_template/__init__.py",
+    "tools/pyproject_template/utils.py",
+    "tools/pyproject_template/settings.py",
+    "tools/pyproject_template/check_template_updates.py",
+    "tools/pyproject_template/manage.py",
+    "tools/pyproject_template/configure.py",
+    "tools/pyproject_template/cleanup.py",
+]
+
+
+def download_file(url: str, dest: Path) -> None:
+    """Download a file from a URL to a local path."""
+    try:
+        with urllib.request.urlopen(url) as response:  # nosec B310
+            content = response.read().decode("utf-8")
+            dest.write_text(content, encoding="utf-8")
+    except Exception as e:
+        print(f"Error downloading {url}: {e}")
+        sys.exit(1)
+
+
+def detect_project_settings(project_root: Path) -> dict[str, str]:
+    """Detect project settings from pyproject.toml if it exists.
+
+    Returns a dict with keys matching settings.toml [project] fields.
+    """
+    settings: dict[str, str] = {}
+    pyproject_path = project_root / "pyproject.toml"
+    if not pyproject_path.exists():
+        return settings
+
+    try:
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            import tomli as tomllib  # type: ignore[no-redef]
+
+        with pyproject_path.open("rb") as f:
+            data = tomllib.load(f)
+
+        project = data.get("project", {})
+
+        name = project.get("name", "")
+        if name:
+            settings["project_name"] = name
+            settings["package_name"] = name.lower().replace("-", "_")
+            settings["pypi_name"] = name.lower().replace("_", "-")
+
+        description = project.get("description", "")
+        if description:
+            settings["description"] = description
+
+        authors = project.get("authors", [])
+        if authors:
+            first = authors[0]
+            if "name" in first:
+                settings["author_name"] = first["name"]
+            if "email" in first:
+                settings["author_email"] = first["email"]
+
+        repo_url = project.get("urls", {}).get("Repository", "")
+        if repo_url:
+            parsed = urlparse(repo_url)
+            if parsed.netloc == "github.com" or parsed.netloc.endswith(".github.com"):
+                segments = parsed.path.strip("/").split("/")
+                if len(segments) >= 2:
+                    settings["github_user"] = segments[0]
+                    settings["github_repo"] = segments[1].removesuffix(".git")
+
+    except Exception as e:
+        print(f"  Warning: Could not parse pyproject.toml: {e}")
+
+    return settings
+
+
+def create_settings_file(project_root: Path, settings: dict[str, str]) -> Path:
+    """Create .config/pyproject_template/settings.toml with detected settings.
+
+    Returns the path to the created file.
+    """
+    settings_dir = project_root / ".config" / "pyproject_template"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.toml"
+
+    lines = ["[project]"]
+    for key in (
+        "project_name",
+        "package_name",
+        "pypi_name",
+        "description",
+        "author_name",
+        "author_email",
+        "github_user",
+        "github_repo",
+    ):
+        value = settings.get(key, "")
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        lines.append(f'{key} = "{escaped}"')
+
+    lines.append("")
+    lines.append("[template]")
+    lines.append('commit = ""')
+    lines.append('commit_date = ""')
+    lines.append("")
+
+    settings_path.write_text("\n".join(lines), encoding="utf-8")
+    return settings_path
+
+
+def run_sync(project_root: Path) -> None:
+    """Install the template management suite for an existing project."""
+    print(f"Installing {REPO_NAME} management suite...")
+    print()
+
+    pkg_dir = project_root / "tools" / "pyproject_template"
+
+    # Check if already installed
+    if pkg_dir.exists() and (pkg_dir / "manage.py").exists():
+        print("  tools/pyproject_template/ already exists.")
+        response = input("  Overwrite with latest versions? [y/N] ").strip().lower()
+        if response not in ("y", "yes"):
+            print("  Cancelled.")
+            sys.exit(0)
+        print()
+
+    # Create directory structure
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+
+    # Download sync files
+    for file_path in SYNC_FILES:
+        filename = Path(file_path).name
+        url = f"{BASE_URL}/{file_path}"
+        dest = pkg_dir / filename
+        print(f"  Downloading {filename}...")
+        download_file(url, dest)
+
+    print()
+
+    # Detect and create settings
+    print("  Detecting project settings from pyproject.toml...")
+    settings = detect_project_settings(project_root)
+    settings_path = create_settings_file(project_root, settings)
+    print(f"  Created {settings_path.relative_to(project_root)}")
+
+    if settings:
+        print()
+        print("  Detected:")
+        for key, value in settings.items():
+            print(f"    {key}: {value}")
+
+    print()
+
+    # Verify installation
+    print("  Verifying installation...")
+    try:
+        import subprocess  # nosec B404
+
+        result = subprocess.run(
+            [sys.executable, str(pkg_dir / "manage.py"), "--dry-run", "check"],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+        if result.returncode == 0:
+            print("  Verification passed.")
+        else:
+            print(f"  Warning: Verification returned non-zero exit code ({result.returncode})")
+            if result.stderr:
+                print(f"  stderr: {result.stderr.strip()}")
+    except Exception as e:
+        print(f"  Warning: Could not verify installation: {e}")
+
+    print()
+    print("Installation complete!")
+    print()
+    print("Next steps:")
+    print("  1. Review .config/pyproject_template/settings.toml")
+    print("  2. Run: python tools/pyproject_template/manage.py check")
+    print("  3. Apply relevant template updates")
+    print("  4. Run: python tools/pyproject_template/manage.py sync")
+
+
+def run_setup() -> None:
+    """Run the new project setup wizard (original behavior)."""
+    print(f"Bootstrapping {REPO_NAME} setup...")
+
+    # Create temp directory
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root_path = Path(temp_dir)
+
+        # Recreate the package structure: tools/pyproject_template/
+        pkg_dir = root_path / "tools" / "pyproject_template"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+
+        # Download files
+        for file_path in SETUP_FILES:
+            url = f"{BASE_URL}/{file_path}"
+            dest = pkg_dir / Path(file_path).name
+            print(f"  Downloading {Path(file_path).name}...")
+            download_file(url, dest)
+
+        print("\nStarting setup wizard...\n")
+
+        # Add the temp root to sys.path so 'tools.pyproject_template' can be imported
+        sys.path.insert(0, str(root_path))
+
+        # Import and run the setup module
+        try:
+            from tools.pyproject_template.setup_repo import main as setup_main
+
+            setup_main()
+        except ImportError as e:
+            print(f"Error importing setup script: {e}")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Setup failed: {e}")
+            sys.exit(1)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        prog="bootstrap.py",
+        description="Bootstrap pyproject-template for new or existing projects.",
+    )
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="Install template management suite for an existing project "
+        "(downloads to tools/pyproject_template/)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Main entry point."""
+    args = parse_args(argv)
+
+    if args.sync:
+        project_root = Path.cwd()
+        run_sync(project_root)
+    else:
+        run_setup()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nCancelled.")
+        sys.exit(1)

--- a/tests/template/test_bootstrap.py
+++ b/tests/template/test_bootstrap.py
@@ -1,0 +1,440 @@
+"""Tests for bootstrap.py setup and sync functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bootstrap import (
+    SETUP_FILES,
+    SYNC_FILES,
+    create_settings_file,
+    detect_project_settings,
+    download_file,
+    parse_args,
+)
+
+
+class TestConstants:
+    """Tests for file list constants."""
+
+    def test_setup_files_contains_required_modules(self) -> None:
+        """Test that SETUP_FILES contains all required setup modules."""
+        filenames = [Path(f).name for f in SETUP_FILES]
+        assert "__init__.py" in filenames
+        assert "utils.py" in filenames
+        assert "setup_repo.py" in filenames
+        assert "configure.py" in filenames
+
+    def test_sync_files_contains_required_modules(self) -> None:
+        """Test that SYNC_FILES contains all required management modules."""
+        filenames = [Path(f).name for f in SYNC_FILES]
+        assert "__init__.py" in filenames
+        assert "utils.py" in filenames
+        assert "settings.py" in filenames
+        assert "check_template_updates.py" in filenames
+        assert "manage.py" in filenames
+        assert "configure.py" in filenames
+        assert "cleanup.py" in filenames
+
+    def test_sync_files_does_not_contain_setup_only_modules(self) -> None:
+        """Test that SYNC_FILES excludes setup-only modules."""
+        filenames = [Path(f).name for f in SYNC_FILES]
+        assert "setup_repo.py" not in filenames
+        assert "repo_settings.py" not in filenames
+        assert "migrate_existing_project.py" not in filenames
+
+    def test_setup_files_does_not_contain_sync_only_modules(self) -> None:
+        """Test that SETUP_FILES excludes sync-only modules."""
+        filenames = [Path(f).name for f in SETUP_FILES]
+        assert "settings.py" not in filenames
+        assert "check_template_updates.py" not in filenames
+        assert "manage.py" not in filenames
+
+
+class TestParseArgs:
+    """Tests for argument parsing."""
+
+    def test_no_args_defaults_to_setup_mode(self) -> None:
+        """Test that no arguments means sync=False (setup mode)."""
+        args = parse_args([])
+        assert args.sync is False
+
+    def test_sync_flag(self) -> None:
+        """Test that --sync flag is parsed correctly."""
+        args = parse_args(["--sync"])
+        assert args.sync is True
+
+
+class TestDownloadFile:
+    """Tests for download_file function."""
+
+    def test_download_file_writes_content(self, tmp_path: Path) -> None:
+        """Test that download_file writes fetched content to disk."""
+        dest = tmp_path / "test.py"
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"print('hello')"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("bootstrap.urllib.request.urlopen", return_value=mock_response):
+            download_file("https://example.com/test.py", dest)
+
+        assert dest.read_text(encoding="utf-8") == "print('hello')"
+
+    def test_download_file_exits_on_error(self, tmp_path: Path) -> None:
+        """Test that download_file exits on network error."""
+        dest = tmp_path / "test.py"
+
+        with (
+            patch("bootstrap.urllib.request.urlopen", side_effect=Exception("Network error")),
+            pytest.raises(SystemExit),
+        ):
+            download_file("https://example.com/test.py", dest)
+
+
+class TestDetectProjectSettings:
+    """Tests for detect_project_settings function."""
+
+    def test_returns_empty_when_no_pyproject(self, tmp_path: Path) -> None:
+        """Test that missing pyproject.toml returns empty settings."""
+        result = detect_project_settings(tmp_path)
+        assert result == {}
+
+    def test_detects_project_name(self, tmp_path: Path) -> None:
+        """Test that project name is detected from pyproject.toml."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "my-cool-project"\n', encoding="utf-8")
+
+        result = detect_project_settings(tmp_path)
+        assert result["project_name"] == "my-cool-project"
+        assert result["package_name"] == "my_cool_project"
+        assert result["pypi_name"] == "my-cool-project"
+
+    def test_detects_description(self, tmp_path: Path) -> None:
+        """Test that description is detected."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\ndescription = "A test project"\n', encoding="utf-8"
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert result["description"] == "A test project"
+
+    def test_detects_author_info(self, tmp_path: Path) -> None:
+        """Test that author name and email are detected."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n'
+            '[[project.authors]]\nname = "John Doe"\nemail = "john@example.com"\n',
+            encoding="utf-8",
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert result["author_name"] == "John Doe"
+        assert result["author_email"] == "john@example.com"
+
+    def test_detects_github_from_urls(self, tmp_path: Path) -> None:
+        """Test that GitHub user/repo are parsed from repository URL."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n'
+            '[project.urls]\nRepository = "https://github.com/myuser/myrepo"\n',
+            encoding="utf-8",
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert result["github_user"] == "myuser"
+        assert result["github_repo"] == "myrepo"
+
+    def test_strips_git_suffix_from_repo_url(self, tmp_path: Path) -> None:
+        """Test that .git suffix is removed from repository URL."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n'
+            '[project.urls]\nRepository = "https://github.com/user/repo.git"\n',
+            encoding="utf-8",
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert result["github_repo"] == "repo"
+
+    def test_handles_malformed_pyproject(self, tmp_path: Path) -> None:
+        """Test that malformed pyproject.toml doesn't crash."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("this is not valid toml [[[", encoding="utf-8")
+
+        result = detect_project_settings(tmp_path)
+        assert result == {}
+
+    def test_handles_empty_project_section(self, tmp_path: Path) -> None:
+        """Test that empty [project] section returns empty settings."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\n", encoding="utf-8")
+
+        result = detect_project_settings(tmp_path)
+        assert result == {}
+
+    def test_rejects_non_github_url_with_github_in_path(self, tmp_path: Path) -> None:
+        """Test that URLs with github.com in path (not host) are rejected."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n'
+            '[project.urls]\nRepository = "https://evil.com/github.com/user/repo"\n',
+            encoding="utf-8",
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert "github_user" not in result
+        assert "github_repo" not in result
+
+    def test_accepts_github_subdomain(self, tmp_path: Path) -> None:
+        """Test that GitHub subdomain URLs are accepted."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n'
+            '[project.urls]\nRepository = "https://www.github.com/myuser/myrepo"\n',
+            encoding="utf-8",
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert result["github_user"] == "myuser"
+        assert result["github_repo"] == "myrepo"
+
+    def test_underscore_name_converted_to_hyphen_for_pypi(self, tmp_path: Path) -> None:
+        """Test that underscores in name become hyphens for pypi_name."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "my_project"\n', encoding="utf-8")
+
+        result = detect_project_settings(tmp_path)
+        assert result["pypi_name"] == "my-project"
+        assert result["package_name"] == "my_project"
+
+
+class TestCreateSettingsFile:
+    """Tests for create_settings_file function."""
+
+    def test_creates_directory_structure(self, tmp_path: Path) -> None:
+        """Test that parent directories are created."""
+        create_settings_file(tmp_path, {})
+
+        settings_dir = tmp_path / ".config" / "pyproject_template"
+        assert settings_dir.exists()
+
+    def test_creates_settings_file(self, tmp_path: Path) -> None:
+        """Test that settings.toml is created."""
+        result = create_settings_file(tmp_path, {})
+
+        assert result.exists()
+        assert result.name == "settings.toml"
+
+    def test_writes_project_section(self, tmp_path: Path) -> None:
+        """Test that [project] section is written with settings."""
+        settings = {
+            "project_name": "my-project",
+            "package_name": "my_project",
+            "github_user": "testuser",
+        }
+        result = create_settings_file(tmp_path, settings)
+
+        content = result.read_text(encoding="utf-8")
+        assert "[project]" in content
+        assert 'project_name = "my-project"' in content
+        assert 'package_name = "my_project"' in content
+        assert 'github_user = "testuser"' in content
+
+    def test_writes_template_section(self, tmp_path: Path) -> None:
+        """Test that [template] section is written with empty values."""
+        result = create_settings_file(tmp_path, {})
+
+        content = result.read_text(encoding="utf-8")
+        assert "[template]" in content
+        assert 'commit = ""' in content
+        assert 'commit_date = ""' in content
+
+    def test_empty_settings_writes_empty_strings(self, tmp_path: Path) -> None:
+        """Test that missing settings are written as empty strings."""
+        result = create_settings_file(tmp_path, {})
+
+        content = result.read_text(encoding="utf-8")
+        assert 'project_name = ""' in content
+        assert 'author_email = ""' in content
+
+    def test_escapes_special_characters(self, tmp_path: Path) -> None:
+        """Test that special characters in values are escaped."""
+        settings = {"description": 'A "quoted" project\\path'}
+        result = create_settings_file(tmp_path, settings)
+
+        content = result.read_text(encoding="utf-8")
+        assert 'description = "A \\"quoted\\" project\\\\path"' in content
+
+    def test_returns_path_to_created_file(self, tmp_path: Path) -> None:
+        """Test that the returned path points to the created file."""
+        result = create_settings_file(tmp_path, {"project_name": "test"})
+
+        expected = tmp_path / ".config" / "pyproject_template" / "settings.toml"
+        assert result == expected
+
+
+class TestRunSync:
+    """Tests for run_sync function."""
+
+    def test_creates_tools_directory(self, tmp_path: Path) -> None:
+        """Test that tools/pyproject_template/ is created."""
+        from bootstrap import run_sync
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"# file content"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("bootstrap.urllib.request.urlopen", return_value=mock_response),
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0, stderr="")
+            run_sync(tmp_path)
+
+        pkg_dir = tmp_path / "tools" / "pyproject_template"
+        assert pkg_dir.exists()
+
+    def test_downloads_all_sync_files(self, tmp_path: Path) -> None:
+        """Test that all SYNC_FILES are downloaded."""
+        from bootstrap import run_sync
+
+        downloaded_urls: list[str] = []
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"# content"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        def track_downloads(url: str) -> MagicMock:
+            downloaded_urls.append(url)
+            return mock_response
+
+        with (
+            patch("bootstrap.urllib.request.urlopen", side_effect=track_downloads),
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0, stderr="")
+            run_sync(tmp_path)
+
+        # Verify each sync file was downloaded
+        for file_path in SYNC_FILES:
+            filename = Path(file_path).name
+            expected_url_suffix = f"/{file_path}"
+            assert any(url.endswith(expected_url_suffix) for url in downloaded_urls), (
+                f"{filename} was not downloaded"
+            )
+
+    def test_prompts_if_already_installed(self, tmp_path: Path) -> None:
+        """Test that existing installation prompts for confirmation."""
+        from bootstrap import run_sync
+
+        pkg_dir = tmp_path / "tools" / "pyproject_template"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "manage.py").write_text("# existing", encoding="utf-8")
+
+        with (
+            patch("builtins.input", return_value="n"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            run_sync(tmp_path)
+
+        assert exc_info.value.code == 0
+
+    def test_overwrites_if_confirmed(self, tmp_path: Path) -> None:
+        """Test that existing installation is overwritten when confirmed."""
+        from bootstrap import run_sync
+
+        pkg_dir = tmp_path / "tools" / "pyproject_template"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "manage.py").write_text("# old", encoding="utf-8")
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"# new content"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("builtins.input", return_value="y"),
+            patch("bootstrap.urllib.request.urlopen", return_value=mock_response),
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0, stderr="")
+            run_sync(tmp_path)
+
+        assert (pkg_dir / "manage.py").read_text(encoding="utf-8") == "# new content"
+
+    def test_creates_settings_file(self, tmp_path: Path) -> None:
+        """Test that settings.toml is created during sync."""
+        from bootstrap import run_sync
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"# content"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("bootstrap.urllib.request.urlopen", return_value=mock_response),
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            mock_subprocess.return_value = MagicMock(returncode=0, stderr="")
+            run_sync(tmp_path)
+
+        settings_path = tmp_path / ".config" / "pyproject_template" / "settings.toml"
+        assert settings_path.exists()
+
+
+class TestRunSetup:
+    """Tests for run_setup function (original behavior)."""
+
+    def test_downloads_setup_files_to_temp_dir(self) -> None:
+        """Test that setup mode downloads SETUP_FILES to a temp directory."""
+        from bootstrap import run_setup
+
+        downloaded_urls: list[str] = []
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"# content"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        def track_downloads(url: str) -> MagicMock:
+            downloaded_urls.append(url)
+            return mock_response
+
+        with (
+            patch("bootstrap.urllib.request.urlopen", side_effect=track_downloads),
+            pytest.raises(SystemExit),
+        ):
+            run_setup()
+
+        # Verify setup files were downloaded
+        for file_path in SETUP_FILES:
+            assert any(url.endswith(f"/{file_path}") for url in downloaded_urls), (
+                f"{file_path} was not downloaded"
+            )
+
+
+class TestMain:
+    """Tests for main entry point."""
+
+    def test_sync_flag_calls_run_sync(self) -> None:
+        """Test that --sync flag routes to run_sync."""
+        from bootstrap import main
+
+        with patch("bootstrap.run_sync") as mock_sync:
+            main(["--sync"])
+            mock_sync.assert_called_once()
+
+    def test_no_flags_calls_run_setup(self) -> None:
+        """Test that no flags routes to run_setup."""
+        from bootstrap import main
+
+        with patch("bootstrap.run_setup") as mock_setup:
+            main([])
+            mock_setup.assert_called_once()

--- a/tests/template/test_cleanup.py
+++ b/tests/template/test_cleanup.py
@@ -1,0 +1,874 @@
+"""Tests for cleanup.py template file cleanup functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestCleanupMode:
+    """Tests for CleanupMode enum."""
+
+    def test_cleanup_mode_values(self) -> None:
+        """Test that CleanupMode has expected values."""
+        from tools.pyproject_template.cleanup import CleanupMode
+
+        assert CleanupMode.SETUP_ONLY.value == "setup"
+        assert CleanupMode.ALL.value == "all"
+
+
+class TestGetFilesToDelete:
+    """Tests for get_files_to_delete function."""
+
+    def test_get_files_setup_only(self, tmp_path: Path) -> None:
+        """Test get_files_to_delete returns setup files for SETUP_ONLY mode."""
+        from tools.pyproject_template.cleanup import CleanupMode, get_files_to_delete
+
+        # Create some setup files
+        (tmp_path / "bootstrap.py").touch()
+        tools_dir = tmp_path / "tools" / "pyproject_template"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "setup_repo.py").touch()
+        (tools_dir / "migrate_existing_project.py").touch()
+        # This one should NOT be deleted in SETUP_ONLY mode
+        (tools_dir / "manage.py").touch()
+
+        files = get_files_to_delete(CleanupMode.SETUP_ONLY, tmp_path)
+
+        file_names = [f.name for f in files]
+        assert "bootstrap.py" in file_names
+        assert "setup_repo.py" in file_names
+        assert "migrate_existing_project.py" in file_names
+        assert "manage.py" not in file_names
+
+    def test_get_files_all(self, tmp_path: Path) -> None:
+        """Test get_files_to_delete returns all template files for ALL mode."""
+        from tools.pyproject_template.cleanup import CleanupMode, get_files_to_delete
+
+        # Create template files
+        (tmp_path / "bootstrap.py").touch()
+        tools_dir = tmp_path / "tools" / "pyproject_template"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "setup_repo.py").touch()
+        (tools_dir / "manage.py").touch()
+        (tools_dir / "cleanup.py").touch()
+
+        files = get_files_to_delete(CleanupMode.ALL, tmp_path)
+
+        file_names = [f.name for f in files]
+        assert "bootstrap.py" in file_names
+        assert "setup_repo.py" in file_names
+        assert "manage.py" in file_names
+        assert "cleanup.py" in file_names
+
+    def test_get_files_nonexistent(self, tmp_path: Path) -> None:
+        """Test get_files_to_delete returns empty list when no files exist."""
+        from tools.pyproject_template.cleanup import CleanupMode, get_files_to_delete
+
+        files = get_files_to_delete(CleanupMode.SETUP_ONLY, tmp_path)
+        assert files == []
+
+
+class TestGetDirsToDelete:
+    """Tests for get_dirs_to_delete function."""
+
+    def test_get_dirs_setup_only(self, tmp_path: Path) -> None:
+        """Test get_dirs_to_delete returns empty for SETUP_ONLY mode."""
+        from tools.pyproject_template.cleanup import CleanupMode, get_dirs_to_delete
+
+        # Create directories
+        (tmp_path / "tools" / "pyproject_template").mkdir(parents=True)
+
+        dirs = get_dirs_to_delete(CleanupMode.SETUP_ONLY, tmp_path)
+        assert dirs == []
+
+    def test_get_dirs_all(self, tmp_path: Path) -> None:
+        """Test get_dirs_to_delete returns directories for ALL mode."""
+        from tools.pyproject_template.cleanup import CleanupMode, get_dirs_to_delete
+
+        # Create directories
+        (tmp_path / "tools" / "pyproject_template").mkdir(parents=True)
+        (tmp_path / "docs" / "template").mkdir(parents=True)
+        (tmp_path / ".config" / "pyproject_template").mkdir(parents=True)
+
+        dirs = get_dirs_to_delete(CleanupMode.ALL, tmp_path)
+
+        dir_names = [d.name for d in dirs]
+        assert "pyproject_template" in dir_names
+
+
+class TestUpdateMkdocsNav:
+    """Tests for update_mkdocs_nav function."""
+
+    def test_update_mkdocs_nav_removes_template_section(self, tmp_path: Path) -> None:
+        """Test that Template section is removed from mkdocs.yml."""
+        from tools.pyproject_template.cleanup import update_mkdocs_nav
+
+        mkdocs_content = """\
+nav:
+  - Home: index.md
+  - Template:
+      - Overview: template/index.md
+      - Manager: template/manage.md
+  - Development:
+      - Setup: development/setup.md
+"""
+        mkdocs_file = tmp_path / "mkdocs.yml"
+        mkdocs_file.write_text(mkdocs_content, encoding="utf-8")
+
+        result = update_mkdocs_nav(tmp_path, dry_run=False)
+
+        assert result is True
+        new_content = mkdocs_file.read_text(encoding="utf-8")
+        assert "Template:" not in new_content
+        assert "template/index.md" not in new_content
+        assert "Development:" in new_content
+
+    def test_update_mkdocs_nav_no_template_section(self, tmp_path: Path) -> None:
+        """Test update_mkdocs_nav when no Template section exists."""
+        from tools.pyproject_template.cleanup import update_mkdocs_nav
+
+        mkdocs_content = """\
+nav:
+  - Home: index.md
+  - Development:
+      - Setup: development/setup.md
+"""
+        mkdocs_file = tmp_path / "mkdocs.yml"
+        mkdocs_file.write_text(mkdocs_content, encoding="utf-8")
+
+        result = update_mkdocs_nav(tmp_path, dry_run=False)
+        assert result is False
+
+    def test_update_mkdocs_nav_dry_run(self, tmp_path: Path) -> None:
+        """Test update_mkdocs_nav dry run doesn't modify file."""
+        from tools.pyproject_template.cleanup import update_mkdocs_nav
+
+        mkdocs_content = """\
+nav:
+  - Home: index.md
+  - Template:
+      - Overview: template/index.md
+"""
+        mkdocs_file = tmp_path / "mkdocs.yml"
+        mkdocs_file.write_text(mkdocs_content, encoding="utf-8")
+
+        result = update_mkdocs_nav(tmp_path, dry_run=True)
+
+        assert result is True
+        # Content should be unchanged
+        assert mkdocs_file.read_text(encoding="utf-8") == mkdocs_content
+
+    def test_update_mkdocs_nav_no_file(self, tmp_path: Path) -> None:
+        """Test update_mkdocs_nav when mkdocs.yml doesn't exist."""
+        from tools.pyproject_template.cleanup import update_mkdocs_nav
+
+        result = update_mkdocs_nav(tmp_path, dry_run=False)
+        assert result is False
+
+
+class TestCleanupTemplateFiles:
+    """Tests for cleanup_template_files function."""
+
+    def test_cleanup_setup_only(self, tmp_path: Path) -> None:
+        """Test cleanup in SETUP_ONLY mode deletes only setup files."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        # Create files
+        (tmp_path / "bootstrap.py").touch()
+        tools_dir = tmp_path / "tools" / "pyproject_template"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "setup_repo.py").touch()
+        (tools_dir / "manage.py").touch()  # Should NOT be deleted
+
+        result = cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path)
+
+        assert not (tmp_path / "bootstrap.py").exists()
+        assert not (tools_dir / "setup_repo.py").exists()
+        assert (tools_dir / "manage.py").exists()  # Should still exist
+        assert len(result.deleted_files) >= 2
+        assert len(result.deleted_dirs) == 0
+
+    def test_cleanup_all(self, tmp_path: Path) -> None:
+        """Test cleanup in ALL mode deletes all template files and directories."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        # Create files and directories
+        (tmp_path / "bootstrap.py").touch()
+        tools_dir = tmp_path / "tools" / "pyproject_template"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "setup_repo.py").touch()
+        (tools_dir / "manage.py").touch()
+        (tools_dir / "__init__.py").touch()
+
+        # Create mkdocs.yml with Template section
+        mkdocs_content = """\
+nav:
+  - Home: index.md
+  - Template:
+      - Overview: template/index.md
+"""
+        (tmp_path / "mkdocs.yml").write_text(mkdocs_content, encoding="utf-8")
+
+        result = cleanup_template_files(CleanupMode.ALL, tmp_path)
+
+        assert not (tmp_path / "bootstrap.py").exists()
+        assert not tools_dir.exists()
+        assert result.mkdocs_updated is True
+
+    def test_cleanup_dry_run(self, tmp_path: Path) -> None:
+        """Test cleanup dry run doesn't delete files."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        # Create files
+        bootstrap = tmp_path / "bootstrap.py"
+        bootstrap.touch()
+
+        result = cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path, dry_run=True)
+
+        # File should still exist
+        assert bootstrap.exists()
+        # But should be in the list of files that would be deleted
+        assert any(f.name == "bootstrap.py" for f in result.deleted_files)
+
+    def test_cleanup_no_files(self, tmp_path: Path) -> None:
+        """Test cleanup when no template files exist."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        result = cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path)
+
+        assert result.deleted_files == []
+        assert result.deleted_dirs == []
+        assert result.failed == []
+
+
+class TestPromptCleanup:
+    """Tests for prompt_cleanup function."""
+
+    def test_prompt_cleanup_setup_only(self) -> None:
+        """Test prompt_cleanup returns SETUP_ONLY for choice 1."""
+        from tools.pyproject_template.cleanup import CleanupMode, prompt_cleanup
+
+        with patch("builtins.input", return_value="1"):
+            result = prompt_cleanup()
+            assert result == CleanupMode.SETUP_ONLY
+
+    def test_prompt_cleanup_all(self) -> None:
+        """Test prompt_cleanup returns ALL for choice 2."""
+        from tools.pyproject_template.cleanup import CleanupMode, prompt_cleanup
+
+        with patch("builtins.input", return_value="2"):
+            result = prompt_cleanup()
+            assert result == CleanupMode.ALL
+
+    def test_prompt_cleanup_keep(self) -> None:
+        """Test prompt_cleanup returns None for choice 3."""
+        from tools.pyproject_template.cleanup import prompt_cleanup
+
+        with patch("builtins.input", return_value="3"):
+            result = prompt_cleanup()
+            assert result is None
+
+    def test_prompt_cleanup_invalid_then_valid(self) -> None:
+        """Test prompt_cleanup handles invalid input then valid."""
+        from tools.pyproject_template.cleanup import CleanupMode, prompt_cleanup
+
+        with patch("builtins.input", side_effect=["invalid", "1"]):
+            result = prompt_cleanup()
+            assert result == CleanupMode.SETUP_ONLY
+
+    def test_prompt_cleanup_keyboard_interrupt(self) -> None:
+        """Test prompt_cleanup handles keyboard interrupt."""
+        from tools.pyproject_template.cleanup import prompt_cleanup
+
+        with patch("builtins.input", side_effect=KeyboardInterrupt):
+            result = prompt_cleanup()
+            assert result is None
+
+
+class TestMain:
+    """Tests for main entry point."""
+
+    def test_main_setup_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test main with --setup flag."""
+        from tools.pyproject_template.cleanup import main
+
+        monkeypatch.chdir(tmp_path)
+
+        # Create a file to delete
+        (tmp_path / "bootstrap.py").touch()
+
+        with patch("sys.argv", ["cleanup.py", "--setup"]):
+            result = main()
+            assert result == 0
+
+    def test_main_dry_run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test main with --dry-run flag."""
+        from tools.pyproject_template.cleanup import main
+
+        monkeypatch.chdir(tmp_path)
+
+        # Create a file
+        bootstrap = tmp_path / "bootstrap.py"
+        bootstrap.touch()
+
+        with patch("sys.argv", ["cleanup.py", "--setup", "--dry-run"]):
+            result = main()
+            assert result == 0
+            assert bootstrap.exists()  # Should not be deleted
+
+    def test_main_conflicting_flags(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test main with conflicting --setup and --all flags."""
+        from tools.pyproject_template.cleanup import main
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("sys.argv", ["cleanup.py", "--setup", "--all"]):
+            result = main()
+            assert result == 1
+
+
+class TestScrubTemplateReferences:
+    """Tests for ``scrub_template_references``.
+
+    Verifies each of the three target files gets cleaned up correctly and
+    that the scrubber is idempotent. Addresses issue #469.
+    """
+
+    _PYPROJECT_WITH_STANZA = """\
+[tool.mypy]
+strict = true
+
+[[tool.mypy.overrides]]
+module = "doit.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Standalone scripts using sys.path manipulation; excluded from discovery
+# but still followed via imports from bootstrap.py
+module = "tools.pyproject_template.*"
+follow_imports = "skip"
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+"""
+
+    _PYPROJECT_WITHOUT_STANZA = """\
+[tool.mypy]
+strict = true
+
+[[tool.mypy.overrides]]
+module = "doit.*"
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+"""
+
+    # Mirrors the pyproject.toml state that ``doit fmt_pyproject`` produces
+    # before the scrubber runs in the wizard: mypy overrides are normalized
+    # into an ``overrides = [...]`` inline array, and the mypy ``exclude``
+    # brackets get space-padded. Exercises every new scrub pattern added for
+    # the #469 follow-up in one realistic fixture.
+    _PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS = """\
+[tool.ruff]
+line-length = 100
+
+lint.per-file-ignores."tests/benchmarks/*.py" = [
+  "ANN401",
+]
+lint.per-file-ignores."tools/pyproject_template/*.py" = [
+  "ANN401",
+  "RUF022",
+]
+
+[tool.mypy]
+strict = true
+# tools/pyproject_template/ uses sys.path manipulation for standalone execution
+exclude = [ "tools/pyproject_template/", ".claude/", ".gemini/", ".codex/" ]
+overrides = [
+  { module = "doit.*", ignore_missing_imports = true },
+  # Standalone scripts using sys.path manipulation; excluded from discovery
+  # but still followed via imports from bootstrap.py
+  { module = "tools.pyproject_template.*", follow_imports = "skip" },
+]
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+"""
+
+    _README_WITH_TEMPLATE_SECTIONS = """\
+# My Project
+
+Intro text.
+
+## Features
+
+- feature one
+
+## Quick Setup (Automated)
+
+Stuff about bootstrap.py.
+
+## Using This Template (Manual)
+
+Manual instructions about tools/pyproject_template/configure.py.
+
+## Development Setup
+
+Dev instructions.
+"""
+
+    _README_WITHOUT_TEMPLATE_SECTIONS = """\
+# My Project
+
+Intro text.
+
+## Features
+
+- feature one
+
+## Development Setup
+
+Dev instructions.
+"""
+
+    _README_WITH_TEMPLATE_SUBSECTIONS = """\
+# My Project
+
+Intro text.
+
+## Versioning & Releases
+
+Commitizen + hatch-vcs.
+
+### Migrating an Existing Project
+
+Bring your existing Python project into this template:
+
+```bash
+python tools/pyproject_template/migrate_existing_project.py --target /path/to/your/project
+```
+
+### Keeping Up to Date
+
+Already using this template? Stay in sync with improvements:
+
+```bash
+python tools/pyproject_template/check_template_updates.py
+```
+
+### Creating a Release
+
+```bash
+doit release
+```
+"""
+
+    _DOIT_REF_WITH_TEMPLATE_CLEAN = """\
+# Doit Tasks Reference
+
+| Category | Commands | Purpose |
+| --- | --- | --- |
+| Setup | `install` | Install deps |
+| Maintenance | `cleanup`, `template_clean` | Project cleanup |
+
+## Testing Tasks
+
+### `test`
+
+Run tests.
+
+### `template_clean`
+
+Remove template-specific files after project setup.
+
+```bash
+doit template_clean --setup
+```
+
+**Setup mode (`--setup`)** removes:
+- `bootstrap.py`
+
+### `build`
+
+Build the package.
+"""
+
+    _DOIT_REF_WITHOUT_TEMPLATE_CLEAN = """\
+# Doit Tasks Reference
+
+| Category | Commands | Purpose |
+| --- | --- | --- |
+| Setup | `install` | Install deps |
+| Maintenance | `cleanup` | Project cleanup |
+
+## Testing Tasks
+
+### `test`
+
+Run tests.
+
+### `build`
+
+Build the package.
+"""
+
+    def test_scrubs_pyproject_when_stanza_present(self, tmp_path: Path) -> None:
+        """pyproject.toml stanza is removed when present."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        (tmp_path / "pyproject.toml").write_text(self._PYPROJECT_WITH_STANZA, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+        assert "tools.pyproject_template" not in new
+        # The unrelated doit.* override must survive.
+        assert 'module = "doit.*"' in new
+        assert tmp_path / "pyproject.toml" in changed
+
+    def test_pyproject_noop_when_stanza_absent(self, tmp_path: Path) -> None:
+        """Already-scrubbed pyproject.toml is left unchanged."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT_WITHOUT_STANZA, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        assert pyproject not in changed
+        assert pyproject.read_text(encoding="utf-8") == self._PYPROJECT_WITHOUT_STANZA
+
+    def test_scrubs_readme_when_sections_present(self, tmp_path: Path) -> None:
+        """Both template sections are removed; surrounding headings survive."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        readme = tmp_path / "README.md"
+        readme.write_text(self._README_WITH_TEMPLATE_SECTIONS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = readme.read_text(encoding="utf-8")
+        assert "## Quick Setup (Automated)" not in new
+        assert "## Using This Template (Manual)" not in new
+        # Surrounding headings intact.
+        assert "## Features" in new
+        assert "## Development Setup" in new
+        assert readme in changed
+
+    def test_readme_noop_when_sections_absent(self, tmp_path: Path) -> None:
+        """Already-scrubbed README.md is left unchanged."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        readme = tmp_path / "README.md"
+        readme.write_text(self._README_WITHOUT_TEMPLATE_SECTIONS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        assert readme not in changed
+        assert readme.read_text(encoding="utf-8") == self._README_WITHOUT_TEMPLATE_SECTIONS
+
+    def test_scrubs_doit_reference_section_and_toc(self, tmp_path: Path) -> None:
+        """doit-tasks-reference.md section removed and TOC row rewritten."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
+        doit_ref.parent.mkdir(parents=True)
+        doit_ref.write_text(self._DOIT_REF_WITH_TEMPLATE_CLEAN, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = doit_ref.read_text(encoding="utf-8")
+        assert "template_clean" not in new
+        # The TOC row is rewritten to list only ``cleanup``.
+        assert "| Maintenance | `cleanup` | Project cleanup |" in new
+        # The surrounding sections still exist.
+        assert "### `test`" in new
+        assert "### `build`" in new
+        assert doit_ref in changed
+
+    def test_doit_reference_noop_when_template_clean_absent(self, tmp_path: Path) -> None:
+        """Already-scrubbed doit-tasks-reference.md is left unchanged."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
+        doit_ref.parent.mkdir(parents=True)
+        doit_ref.write_text(self._DOIT_REF_WITHOUT_TEMPLATE_CLEAN, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        assert doit_ref not in changed
+        assert doit_ref.read_text(encoding="utf-8") == self._DOIT_REF_WITHOUT_TEMPLATE_CLEAN
+
+    def test_scrubs_pyproject_post_fmt_inline_overrides(self, tmp_path: Path) -> None:
+        """Post-fmt inline-array mypy override is scrubbed (#469 follow-up).
+
+        The wizard runs ``doit fmt_pyproject`` before cleanup, which rewrites
+        the template's ``[[tool.mypy.overrides]]`` stanza form into an inline
+        array entry — the original scrubber only matched the stanza form, so
+        the reference survived into spawned projects.
+        """
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        # Every mention of the template path is gone.
+        assert "tools/pyproject_template" not in new
+        assert "tools.pyproject_template" not in new
+        # Unrelated overrides and excludes survive.
+        assert 'module = "doit.*"' in new
+        assert '".claude/"' in new
+        assert '".gemini/"' in new
+        assert '".codex/"' in new
+        # The unrelated ruff per-file-ignores block survives.
+        assert 'lint.per-file-ignores."tests/benchmarks/*.py"' in new
+        assert pyproject in changed
+
+    def test_scrubs_pyproject_ruff_perfile_ignores(self, tmp_path: Path) -> None:
+        """Ruff ``per-file-ignores`` block for the template path is removed (#469 follow-up)."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            'lint.per-file-ignores."tools/pyproject_template/*.py" = [\n'
+            '  "ANN401",\n'
+            '  "RUF022",\n'
+            "]\n"
+            "\n"
+            "[tool.pytest.ini_options]\n"
+            'minversion = "8.0"\n',
+            encoding="utf-8",
+        )
+
+        changed = scrub_template_references(tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        assert 'lint.per-file-ignores."tools/pyproject_template' not in new
+        assert "[tool.pytest.ini_options]" in new
+        assert pyproject in changed
+
+    def test_scrubs_pyproject_mypy_exclude_entry_and_comment(self, tmp_path: Path) -> None:
+        """Mypy ``exclude`` entry and its comment go; other excludes stay (#469 follow-up)."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[tool.mypy]\n"
+            "strict = true\n"
+            "# tools/pyproject_template/ uses sys.path manipulation for standalone execution\n"
+            'exclude = [ "tools/pyproject_template/", ".claude/", ".gemini/", ".codex/" ]\n',
+            encoding="utf-8",
+        )
+
+        changed = scrub_template_references(tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        assert "tools/pyproject_template" not in new
+        # The comment line is gone (it was specifically about the removed entry).
+        assert "uses sys.path manipulation" not in new
+        # The remaining AI-config excludes survive intact.
+        assert '".claude/"' in new
+        assert '".gemini/"' in new
+        assert '".codex/"' in new
+        assert pyproject in changed
+
+    def test_scrubs_readme_template_subsections(self, tmp_path: Path) -> None:
+        """README's ``### Migrating``/``### Keeping Up to Date`` are removed (#469 follow-up).
+
+        Both subsections point at deleted template-management scripts; the
+        preceding ``## Versioning & Releases`` heading and the following
+        ``### Creating a Release`` subsection must survive.
+        """
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        readme = tmp_path / "README.md"
+        readme.write_text(self._README_WITH_TEMPLATE_SUBSECTIONS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = readme.read_text(encoding="utf-8")
+        assert "### Migrating an Existing Project" not in new
+        assert "### Keeping Up to Date" not in new
+        assert "migrate_existing_project.py" not in new
+        assert "check_template_updates.py" not in new
+        # Surrounding headings survive.
+        assert "## Versioning & Releases" in new
+        assert "### Creating a Release" in new
+        assert readme in changed
+
+    def test_scrub_is_idempotent(self, tmp_path: Path) -> None:
+        """Running the scrubber twice must change nothing on the second pass."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        # Use the realistic post-``fmt_pyproject`` fixture so the idempotency
+        # check exercises every new pattern introduced in the #469 follow-up.
+        (tmp_path / "pyproject.toml").write_text(
+            self._PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS, encoding="utf-8"
+        )
+        # README gets both the top-level template sections AND the subsections
+        # so the two README patterns are both exercised.
+        (tmp_path / "README.md").write_text(
+            self._README_WITH_TEMPLATE_SECTIONS + "\n" + self._README_WITH_TEMPLATE_SUBSECTIONS,
+            encoding="utf-8",
+        )
+        doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
+        doit_ref.parent.mkdir(parents=True)
+        doit_ref.write_text(self._DOIT_REF_WITH_TEMPLATE_CLEAN, encoding="utf-8")
+
+        # First pass: changes expected.
+        first_changed = scrub_template_references(tmp_path)
+        assert first_changed  # non-empty list
+
+        # Snapshot the post-first-pass file contents.
+        snapshots = {path: path.read_text(encoding="utf-8") for path in first_changed}
+
+        # Second pass: nothing should change.
+        second_changed = scrub_template_references(tmp_path)
+        assert second_changed == []
+
+        for path, original in snapshots.items():
+            assert path.read_text(encoding="utf-8") == original
+
+    def test_dry_run_does_not_write_files(self, tmp_path: Path) -> None:
+        """Under dry_run=True the files are not modified."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT_WITH_STANZA, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path, dry_run=True)
+
+        # File still has the stanza — nothing was written.
+        assert pyproject.read_text(encoding="utf-8") == self._PYPROJECT_WITH_STANZA
+        # But the change is still reported.
+        assert pyproject in changed
+
+    def test_no_target_files_returns_empty(self, tmp_path: Path) -> None:
+        """When none of the three target files exist, return an empty list."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        changed = scrub_template_references(tmp_path)
+        assert changed == []
+
+
+class TestCleanupAllDeletesTemplateCleanTask:
+    """Regression test for issue #469: ``tools/doit/template_clean.py`` goes away.
+
+    The doit task file imports the template cleanup module, which is deleted
+    under ``CleanupMode.ALL``. Leaving the task behind is misleading because
+    it would fail on invocation in a spawned repo.
+    """
+
+    def test_cleanup_all_deletes_template_clean_task(self, tmp_path: Path) -> None:
+        """template_clean.py is in ALL_TEMPLATE_FILES and gets deleted."""
+        from tools.pyproject_template.cleanup import (
+            ALL_TEMPLATE_FILES,
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        # Verify the constant itself lists the file (documents intent).
+        assert "tools/doit/template_clean.py" in ALL_TEMPLATE_FILES
+
+        # Create the file and run ALL-mode cleanup.
+        template_clean = tmp_path / "tools" / "doit" / "template_clean.py"
+        template_clean.parent.mkdir(parents=True)
+        template_clean.write_text("# placeholder", encoding="utf-8")
+
+        result = cleanup_template_files(CleanupMode.ALL, tmp_path)
+
+        assert not template_clean.exists()
+        # And the deleted_files list reflects the removal.
+        assert any(p.name == "template_clean.py" for p in result.deleted_files)
+
+    def test_cleanup_setup_only_leaves_template_clean_task(self, tmp_path: Path) -> None:
+        """Under SETUP_ONLY mode, template_clean.py survives (bug-#469 scope)."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        template_clean = tmp_path / "tools" / "doit" / "template_clean.py"
+        template_clean.parent.mkdir(parents=True)
+        template_clean.write_text("# placeholder", encoding="utf-8")
+
+        cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path)
+
+        assert template_clean.exists()
+
+
+class TestCleanupAllInvokesScrubber:
+    """``cleanup_template_files(CleanupMode.ALL)`` calls the scrubber."""
+
+    def test_all_mode_scrubs_pyproject(self, tmp_path: Path) -> None:
+        """ALL-mode cleanup removes the tools.pyproject_template mypy override."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        pyproject_content = (
+            "[tool.mypy]\n"
+            "strict = true\n"
+            "\n"
+            "[[tool.mypy.overrides]]\n"
+            "# Standalone scripts using sys.path manipulation; excluded from discovery\n"
+            "# but still followed via imports from bootstrap.py\n"
+            'module = "tools.pyproject_template.*"\n'
+            'follow_imports = "skip"\n'
+            "\n"
+            "[tool.pytest.ini_options]\n"
+            'minversion = "8.0"\n'
+        )
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(pyproject_content, encoding="utf-8")
+
+        # We need at least one deletable file so ALL-mode has work to do.
+        (tmp_path / "bootstrap.py").touch()
+
+        cleanup_template_files(CleanupMode.ALL, tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        assert "tools.pyproject_template" not in new
+
+    def test_setup_only_mode_does_not_scrub(self, tmp_path: Path) -> None:
+        """SETUP_ONLY mode leaves scrubber targets untouched."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        pyproject_content = (
+            "[[tool.mypy.overrides]]\n"
+            "# guarded\n"
+            'module = "tools.pyproject_template.*"\n'
+            'follow_imports = "skip"\n'
+            "\n"
+        )
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(pyproject_content, encoding="utf-8")
+        (tmp_path / "bootstrap.py").touch()
+
+        cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path)
+
+        # Scrubber must not run under SETUP_ONLY.
+        assert pyproject.read_text(encoding="utf-8") == pyproject_content

--- a/tests/template/test_pyproject_template_main.py
+++ b/tests/template/test_pyproject_template_main.py
@@ -1,0 +1,959 @@
+"""Tests for the unified pyproject-template management tool."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tools.pyproject_template.settings import (
+    PreflightWarning,
+    ProjectContext,
+    ProjectSettings,
+    SettingsManager,
+    TemplateState,
+    get_template_commits_since,
+    get_template_latest_commit,
+)
+
+
+class TestProjectSettings:
+    """Tests for ProjectSettings dataclass."""
+
+    def test_is_configured_with_valid_settings(self) -> None:
+        """Test that is_configured returns True for valid settings."""
+        settings = ProjectSettings(
+            project_name="My Project",
+            package_name="my_project",
+            pypi_name="my-project",
+            description="A test project",
+            author_name="Test Author",
+            author_email="test@example.com",
+            github_user="testuser",
+            github_repo="my-project",
+        )
+        assert settings.is_configured() is True
+
+    def test_is_configured_with_placeholder_name(self) -> None:
+        """Test that is_configured returns False for placeholder values."""
+        settings = ProjectSettings(
+            project_name="Package Name",  # placeholder
+            package_name="package_name",  # placeholder
+            description="A test project",
+            author_name="Your Name",  # placeholder
+            author_email="your.email@example.com",  # placeholder
+            github_user="username",  # placeholder
+        )
+        assert settings.is_configured() is False
+
+    def test_is_configured_with_empty_values(self) -> None:
+        """Test that is_configured returns False for empty values."""
+        settings = ProjectSettings()
+        assert settings.is_configured() is False
+
+    def test_has_placeholder_values_returns_fields(self) -> None:
+        """Test that has_placeholder_values returns list of placeholder fields."""
+        settings = ProjectSettings(
+            project_name="Package Name",
+            package_name="my_project",
+            author_name="Your Name",
+            author_email="test@example.com",
+            github_user="testuser",
+        )
+        placeholders = settings.has_placeholder_values()
+        assert "project_name" in placeholders
+        assert "author_name" in placeholders
+        assert "package_name" not in placeholders
+
+
+class TestProjectContext:
+    """Tests for ProjectContext dataclass."""
+
+    def test_is_fresh_clone(self) -> None:
+        """Test is_fresh_clone property."""
+        context = ProjectContext(has_git=True, has_pyproject=False)
+        assert context.is_fresh_clone is True
+
+        context = ProjectContext(has_git=True, has_pyproject=True)
+        assert context.is_fresh_clone is False
+
+    def test_is_existing_repo(self) -> None:
+        """Test is_existing_repo property."""
+        context = ProjectContext(has_git=True, has_pyproject=True)
+        assert context.is_existing_repo is True
+
+        context = ProjectContext(has_git=False, has_pyproject=True)
+        assert context.is_existing_repo is False
+
+
+class TestTemplateState:
+    """Tests for TemplateState dataclass."""
+
+    def test_is_synced_with_commit(self) -> None:
+        """Test is_synced returns True when commit is set."""
+        state = TemplateState(commit="abc123", commit_date="2025-01-15")
+        assert state.is_synced() is True
+
+    def test_is_synced_without_commit(self) -> None:
+        """Test is_synced returns False when commit is not set."""
+        state = TemplateState()
+        assert state.is_synced() is False
+
+
+class TestPreflightWarning:
+    """Tests for PreflightWarning dataclass."""
+
+    def test_warning_with_suggestion(self) -> None:
+        """Test warning creation with suggestion."""
+        warning = PreflightWarning(
+            message="GitHub CLI not authenticated",
+            suggestion="Run: gh auth login",
+        )
+        assert warning.message == "GitHub CLI not authenticated"
+        assert warning.suggestion == "Run: gh auth login"
+
+    def test_warning_without_suggestion(self) -> None:
+        """Test warning creation without suggestion."""
+        warning = PreflightWarning(message="Not a git repository")
+        assert warning.message == "Not a git repository"
+        assert warning.suggestion == ""
+
+
+class TestSettingsManager:
+    """Tests for SettingsManager class."""
+
+    def test_init_creates_default_context(self, tmp_path: Path) -> None:
+        """Test that SettingsManager initializes with detected context."""
+        # Create a minimal directory structure
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+        (tmp_path / ".git").mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            # Mock git config calls
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+
+            manager = SettingsManager(root=tmp_path)
+
+            assert manager.context.has_pyproject is True
+            assert manager.context.has_git is True
+
+    def test_load_from_pyproject(self, tmp_path: Path) -> None:
+        """Test loading settings from pyproject.toml."""
+        pyproject_content = """
+[project]
+name = "test-project"
+description = "A test project"
+authors = [{name = "Test Author", email = "test@example.com"}]
+
+[project.urls]
+Repository = "https://github.com/testuser/test-project"
+"""
+        (tmp_path / "pyproject.toml").write_text(pyproject_content, encoding="utf-8")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+
+            manager = SettingsManager(root=tmp_path)
+
+            assert manager.settings.project_name == "test-project"
+            assert manager.settings.description == "A test project"
+            assert manager.settings.author_name == "Test Author"
+            assert manager.settings.author_email == "test@example.com"
+            assert manager.settings.github_user == "testuser"
+            assert manager.settings.github_repo == "test-project"
+
+    def test_load_from_settings_file(self, tmp_path: Path) -> None:
+        """Test loading settings from settings.toml."""
+        settings_dir = tmp_path / ".config" / "pyproject_template"
+        settings_dir.mkdir(parents=True)
+
+        settings_content = """
+[project]
+name = "My Project"
+package_name = "my_project"
+pypi_name = "my-project"
+description = "A great project"
+author_name = "Author Name"
+author_email = "author@example.com"
+github_user = "authoruser"
+github_repo = "my-project"
+
+[template]
+commit = "abc123def456"
+commit_date = "2025-01-15"
+"""
+        (settings_dir / "settings.toml").write_text(settings_content, encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "other"', encoding="utf-8")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+
+            manager = SettingsManager(root=tmp_path)
+
+            # Settings file values should take precedence
+            assert manager.settings.project_name == "My Project"
+            assert manager.settings.package_name == "my_project"
+            assert manager.template_state.commit == "abc123def456"
+            assert manager.template_state.commit_date == "2025-01-15"
+
+    def test_save_creates_settings_file(self, tmp_path: Path) -> None:
+        """Test that save creates the settings file with template state."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+
+            manager = SettingsManager(root=tmp_path)
+            # save() only saves when there's template state
+            manager.template_state.commit = "abc123"
+            manager.template_state.commit_date = "2025-01-17"
+            manager.save()
+
+            settings_file = tmp_path / ".config" / "pyproject_template" / "settings.toml"
+            assert settings_file.exists()
+            content = settings_file.read_text(encoding="utf-8")
+            assert "abc123" in content
+
+    def test_update_template_state(self, tmp_path: Path) -> None:
+        """Test updating template state."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+
+            manager = SettingsManager(root=tmp_path)
+            manager.update_template_state("newcommit123", "2025-01-20")
+
+            assert manager.template_state.commit == "newcommit123"
+            assert manager.template_state.commit_date == "2025-01-20"
+
+            # Verify it was saved
+            settings_file = tmp_path / ".config" / "pyproject_template" / "settings.toml"
+            content = settings_file.read_text(encoding="utf-8")
+            assert "newcommit123" in content
+
+
+class TestGetTemplateLatestCommit:
+    """Tests for get_template_latest_commit function."""
+
+    def test_returns_commit_info_on_success(self) -> None:
+        """Test that function returns commit SHA and date on success."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"""
+{
+    "sha": "abc123def456789",
+    "commit": {
+        "committer": {
+            "date": "2025-01-15T10:30:00Z"
+        }
+    }
+}
+"""
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            result = get_template_latest_commit()
+
+            assert result is not None
+            commit_sha, commit_date = result
+            assert commit_sha == "abc123def456789"  # Full SHA for GitHub compare
+            assert commit_date == "2025-01-15"
+
+    def test_returns_none_on_error(self) -> None:
+        """Test that function returns None on network error."""
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            result = get_template_latest_commit()
+            assert result is None
+
+
+class TestGetTemplateCommitsSince:
+    """Tests for get_template_commits_since function."""
+
+    def test_returns_commits_since_sha(self) -> None:
+        """Test that function returns commits since the given SHA."""
+        mock_response = MagicMock()
+        # Use 12-char SHAs to match the truncation in the function
+        mock_response.read.return_value = b"""
+[
+    {
+        "sha": "newest123456",
+        "commit": {
+            "message": "Latest commit",
+            "committer": {"date": "2025-01-20T10:00:00Z"}
+        }
+    },
+    {
+        "sha": "middle123456",
+        "commit": {
+            "message": "Middle commit",
+            "committer": {"date": "2025-01-18T10:00:00Z"}
+        }
+    },
+    {
+        "sha": "known1234567",
+        "commit": {
+            "message": "Known commit",
+            "committer": {"date": "2025-01-15T10:00:00Z"}
+        }
+    }
+]
+"""
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            # Pass the exact truncated SHA that will match
+            result = get_template_commits_since("known1234567")
+
+            assert result is not None
+            assert len(result) == 2
+            assert result[0]["sha"] == "newest123456"
+            assert result[0]["message"] == "Latest commit"
+            assert result[1]["sha"] == "middle123456"
+
+    def test_returns_none_on_error(self) -> None:
+        """Test that function returns None on error."""
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            result = get_template_commits_since("abc123")
+            assert result is None
+
+
+class TestMainModule:
+    """Tests for the manage module."""
+
+    def test_parse_args_no_args(self) -> None:
+        """Test parsing with no arguments."""
+        from tools.pyproject_template.manage import parse_args
+
+        args = parse_args([])
+        assert args.command is None
+        assert args.yes is False
+        assert args.dry_run is False
+
+    def test_parse_args_with_command(self) -> None:
+        """Test parsing with command."""
+        from tools.pyproject_template.manage import parse_args
+
+        args = parse_args(["create"])
+        assert args.command == "create"
+
+        args = parse_args(["configure"])
+        assert args.command == "configure"
+
+        args = parse_args(["check"])
+        assert args.command == "check"
+
+        args = parse_args(["repo"])
+        assert args.command == "repo"
+
+    def test_parse_args_with_flags(self) -> None:
+        """Test parsing with flags."""
+        from tools.pyproject_template.manage import parse_args
+
+        args = parse_args(["--yes", "--dry-run"])
+        assert args.yes is True
+        assert args.dry_run is True
+
+        args = parse_args(["-y"])
+        assert args.yes is True
+
+    def test_parse_args_update_only(self) -> None:
+        """Test parsing --update-only flag."""
+        from tools.pyproject_template.manage import parse_args
+
+        args = parse_args(["--update-only"])
+        assert args.update_only is True
+
+    def test_get_recommended_action_fresh_clone(self) -> None:
+        """Test recommended action for fresh clone."""
+        from tools.pyproject_template.manage import get_recommended_action
+
+        context = ProjectContext(has_git=True, has_pyproject=False)
+        settings = ProjectSettings()
+        template_state = TemplateState()
+
+        result = get_recommended_action(context, settings, template_state, None)
+        assert result == 2  # Configure project (has placeholders)
+
+    def test_get_recommended_action_placeholder_values(self) -> None:
+        """Test recommended action when placeholders exist."""
+        from tools.pyproject_template.manage import get_recommended_action
+
+        context = ProjectContext(has_git=True, has_pyproject=True)
+        settings = ProjectSettings(
+            project_name="Package Name",  # placeholder
+            author_name="Your Name",  # placeholder
+        )
+        template_state = TemplateState()
+
+        result = get_recommended_action(context, settings, template_state, None)
+        assert result == 2  # Re-run configuration
+
+    def test_get_recommended_action_outdated_template(self) -> None:
+        """Test recommended action when template is outdated."""
+        from tools.pyproject_template.manage import get_recommended_action
+
+        context = ProjectContext(has_git=True, has_pyproject=True)
+        settings = ProjectSettings(
+            project_name="My Project",
+            package_name="my_project",
+            pypi_name="my-project",
+            author_name="Test Author",
+            author_email="test@example.com",
+            github_user="testuser",
+            github_repo="my-project",
+            description="A project",
+        )
+        template_state = TemplateState(commit="oldcommit123", commit_date="2025-01-01")
+
+        result = get_recommended_action(
+            context, settings, template_state, ("newcommit456", "2025-01-15")
+        )
+        assert result == 3  # Check for template updates
+
+    def test_get_recommended_action_up_to_date(self) -> None:
+        """Test recommended action when everything is up to date."""
+        from tools.pyproject_template.manage import get_recommended_action
+
+        context = ProjectContext(has_git=True, has_pyproject=True)
+        settings = ProjectSettings(
+            project_name="My Project",
+            package_name="my_project",
+            pypi_name="my-project",
+            author_name="Test Author",
+            author_email="test@example.com",
+            github_user="testuser",
+            github_repo="my-project",
+            description="A project",
+        )
+        template_state = TemplateState(commit="samecommit12", commit_date="2025-01-15")
+
+        result = get_recommended_action(
+            context, settings, template_state, ("samecommit12", "2025-01-15")
+        )
+        assert result is None  # No recommendation, up to date
+
+
+class TestConfigureModule:
+    """Tests for the configure module refactoring."""
+
+    def test_parse_args_accepts_argv(self) -> None:
+        """Test that parse_args accepts argv parameter."""
+        from tools.pyproject_template.configure import parse_args
+
+        args = parse_args(["--auto", "--yes"])
+        assert args.auto is True
+        assert args.yes is True
+
+    def test_parse_args_dry_run(self) -> None:
+        """Test that parse_args accepts --dry-run."""
+        from tools.pyproject_template.configure import parse_args
+
+        args = parse_args(["--dry-run"])
+        assert args.dry_run is True
+
+    def test_run_configure_replaces_owner_repo_placeholders(self, tmp_path: Path) -> None:
+        """Test that {owner} and {repo} placeholders are replaced."""
+        from tools.pyproject_template.configure import run_configure
+
+        # Create minimal project structure
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+        (tmp_path / "src" / "test_pkg").mkdir(parents=True)
+        (tmp_path / "src" / "test_pkg" / "__init__.py").write_text("", encoding="utf-8")
+
+        # Create issue template with {owner}/{repo} placeholders
+        issue_template_dir = tmp_path / ".github" / "ISSUE_TEMPLATE"
+        issue_template_dir.mkdir(parents=True)
+        config_yml = issue_template_dir / "config.yml"
+        config_yml.write_text(
+            "contact_links:\n  - url: https://github.com/{owner}/{repo}/discussions\n",
+            encoding="utf-8",
+        )
+
+        import os
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            # Mock Path.unlink to prevent configure.py self-destruct
+            with patch.object(Path, "unlink"):
+                result = run_configure(
+                    auto=True,
+                    yes=True,
+                    defaults={
+                        "project_name": "Test Project",
+                        "package_name": "test_pkg",
+                        "pypi_name": "test-pkg",
+                        "description": "A test project",
+                        "author_name": "Test Author",
+                        "author_email": "test@example.com",
+                        "github_user": "testuser",
+                    },
+                )
+            assert result == 0
+
+            # Verify {owner} and {repo} were replaced
+            content = config_yml.read_text(encoding="utf-8")
+            assert "{owner}" not in content
+            assert "{repo}" not in content
+            assert "testuser" in content
+            assert "test_pkg" in content
+        finally:
+            os.chdir(old_cwd)
+
+    def test_run_configure_replaces_security_email(self, tmp_path: Path) -> None:
+        """Test that security@example.com placeholder is replaced."""
+        from tools.pyproject_template.configure import run_configure
+
+        # Create minimal project structure
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+        (tmp_path / "src" / "test_pkg").mkdir(parents=True)
+        (tmp_path / "src" / "test_pkg" / "__init__.py").write_text("", encoding="utf-8")
+
+        # Create SECURITY.md with placeholder email
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir(parents=True)
+        security_md = github_dir / "SECURITY.md"
+        security_md.write_text("Contact: security@example.com\n", encoding="utf-8")
+
+        import os
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            # Mock Path.unlink to prevent configure.py self-destruct
+            with patch.object(Path, "unlink"):
+                result = run_configure(
+                    auto=True,
+                    yes=True,
+                    defaults={
+                        "project_name": "Test Project",
+                        "package_name": "test_pkg",
+                        "pypi_name": "test-pkg",
+                        "description": "A test project",
+                        "author_name": "Test Author",
+                        "author_email": "author@myproject.com",
+                        "github_user": "testuser",
+                    },
+                )
+            assert result == 0
+
+            # Verify security@example.com was replaced
+            content = security_md.read_text(encoding="utf-8")
+            assert "security@example.com" not in content
+            assert "author@myproject.com" in content
+        finally:
+            os.chdir(old_cwd)
+
+    def test_run_configure_replaces_insert_contact_email(self, tmp_path: Path) -> None:
+        """Test that [INSERT CONTACT EMAIL] placeholder is replaced."""
+        from tools.pyproject_template.configure import run_configure
+
+        # Create minimal project structure
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+        (tmp_path / "src" / "test_pkg").mkdir(parents=True)
+        (tmp_path / "src" / "test_pkg" / "__init__.py").write_text("", encoding="utf-8")
+
+        # Create CODE_OF_CONDUCT.md with placeholder
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir(parents=True)
+        coc_md = github_dir / "CODE_OF_CONDUCT.md"
+        coc_md.write_text("Report issues to [INSERT CONTACT EMAIL].\n", encoding="utf-8")
+
+        import os
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            # Mock Path.unlink to prevent configure.py self-destruct
+            with patch.object(Path, "unlink"):
+                result = run_configure(
+                    auto=True,
+                    yes=True,
+                    defaults={
+                        "project_name": "Test Project",
+                        "package_name": "test_pkg",
+                        "pypi_name": "test-pkg",
+                        "description": "A test project",
+                        "author_name": "Test Author",
+                        "author_email": "contact@myproject.com",
+                        "github_user": "testuser",
+                    },
+                )
+            assert result == 0
+
+            # Verify [INSERT CONTACT EMAIL] was replaced
+            content = coc_md.read_text(encoding="utf-8")
+            assert "[INSERT CONTACT EMAIL]" not in content
+            assert "contact@myproject.com" in content
+        finally:
+            os.chdir(old_cwd)
+
+    def test_run_configure_replaces_mkdocs_placeholders(self, tmp_path: Path) -> None:
+        """Test that mkdocs.yml placeholders (GitHub Pages URL, repo_name) are replaced."""
+        from tools.pyproject_template.configure import run_configure
+
+        # Create minimal project structure
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+        (tmp_path / "src" / "test_pkg").mkdir(parents=True)
+        (tmp_path / "src" / "test_pkg" / "__init__.py").write_text("", encoding="utf-8")
+
+        # Create mkdocs.yml with placeholders
+        mkdocs_yml = tmp_path / "mkdocs.yml"
+        mkdocs_yml.write_text(
+            "site_url: https://username.github.io/package_name\nrepo_name: username/package_name\n",
+            encoding="utf-8",
+        )
+
+        import os
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            # Mock Path.unlink to prevent configure.py self-destruct
+            with patch.object(Path, "unlink"):
+                result = run_configure(
+                    auto=True,
+                    yes=True,
+                    defaults={
+                        "project_name": "Test Project",
+                        "package_name": "test_pkg",
+                        "pypi_name": "test-pkg",
+                        "description": "A test project",
+                        "author_name": "Test Author",
+                        "author_email": "test@example.com",
+                        "github_user": "myuser",
+                    },
+                )
+            assert result == 0
+
+            # Verify mkdocs.yml placeholders were replaced
+            content = mkdocs_yml.read_text(encoding="utf-8")
+            assert "username.github.io" not in content
+            assert "https://myuser.github.io/test_pkg" in content
+            assert "username/package_name" not in content
+            assert "myuser/test_pkg" in content
+        finally:
+            os.chdir(old_cwd)
+
+    def test_run_configure_removes_template_tests_directory(self, tmp_path: Path) -> None:
+        """Test that tests/template/ is removed during configure."""
+        from tools.pyproject_template.configure import run_configure
+
+        # Create minimal project structure
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"', encoding="utf-8")
+        (tmp_path / "src" / "test_pkg").mkdir(parents=True)
+        (tmp_path / "src" / "test_pkg" / "__init__.py").write_text("", encoding="utf-8")
+
+        # Create template-only tests directory that should be removed
+        template_tests_dir = tmp_path / "tests" / "template"
+        template_tests_dir.mkdir(parents=True)
+        (template_tests_dir / "__init__.py").write_text("", encoding="utf-8")
+        (template_tests_dir / "test_utils.py").write_text("# test file", encoding="utf-8")
+
+        import os
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            # Mock Path.unlink to prevent configure.py self-destruct
+            with patch.object(Path, "unlink"):
+                result = run_configure(
+                    auto=True,
+                    yes=True,
+                    defaults={
+                        "project_name": "Test Project",
+                        "package_name": "test_pkg",
+                        "pypi_name": "test-pkg",
+                        "description": "A test project",
+                        "author_name": "Test Author",
+                        "author_email": "test@example.com",
+                        "github_user": "testuser",
+                    },
+                )
+            assert result == 0
+
+            # Verify template-only tests directory was removed
+            assert not template_tests_dir.exists()
+            # But tests directory itself should still exist
+            assert (tmp_path / "tests").exists()
+        finally:
+            os.chdir(old_cwd)
+
+
+class TestSeedBaselineTag:
+    """Tests for ``seed_baseline_tag`` (issue #447).
+
+    Exercises the auto-seed of ``v0.0.0`` on the bootstrap root commit. The
+    function powers the fix for the papercut introduced by the ``--prerelease``
+    guard from issue #448: without a baseline tag, cz bump refuses to compute
+    a pre-release on a fresh repo.
+    """
+
+    @staticmethod
+    def _init_repo(repo: Path) -> str:
+        """Initialize a git repo in ``repo`` with one empty root commit.
+
+        Returns the SHA of the root commit.
+        """
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+        subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "root", "--no-verify"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    @staticmethod
+    def _list_tags(repo: Path) -> list[str]:
+        result = subprocess.run(
+            ["git", "tag", "--list"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def test_no_tags_creates_v0_0_0_on_root_commit(self, tmp_path: Path) -> None:
+        """With no existing v* tags, seed_baseline_tag creates v0.0.0 on the root commit."""
+        from tools.pyproject_template.configure import seed_baseline_tag
+
+        root_sha = self._init_repo(tmp_path)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            seed_baseline_tag()
+
+            assert self._list_tags(tmp_path) == ["v0.0.0"]
+
+            # Verify the tag points at the root commit
+            tagged_sha = subprocess.run(
+                ["git", "rev-list", "-n", "1", "v0.0.0"],
+                cwd=tmp_path,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            assert tagged_sha == root_sha
+        finally:
+            os.chdir(old_cwd)
+
+    def test_existing_version_tag_is_preserved(self, tmp_path: Path) -> None:
+        """When a v* tag already exists, seed_baseline_tag is a no-op (idempotent)."""
+        from tools.pyproject_template.configure import seed_baseline_tag
+
+        self._init_repo(tmp_path)
+        subprocess.run(
+            ["git", "tag", "v0.1.0"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            seed_baseline_tag()
+
+            # v0.1.0 preserved, v0.0.0 NOT added.
+            assert self._list_tags(tmp_path) == ["v0.1.0"]
+        finally:
+            os.chdir(old_cwd)
+
+    def test_not_a_git_repo_is_safe_no_op(self, tmp_path: Path) -> None:
+        """Outside a git repo, seed_baseline_tag skips without raising."""
+        from tools.pyproject_template.configure import seed_baseline_tag
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            seed_baseline_tag()  # Must not raise.
+            # No .git, no tags, nothing to observe — just reaching this line
+            # proves the function returned cleanly.
+            assert not (tmp_path / ".git").exists()
+        finally:
+            os.chdir(old_cwd)
+
+
+class TestCheckUpdatesModule:
+    """Tests for the check_template_updates module refactoring."""
+
+    def test_parse_args_accepts_argv(self) -> None:
+        """Test that parse_args accepts argv parameter."""
+        from tools.pyproject_template.check_template_updates import parse_args
+
+        args = parse_args(["--skip-changelog", "--keep-template"])
+        assert args.skip_changelog is True
+        assert args.keep_template is True
+
+    def test_parse_args_dry_run(self) -> None:
+        """Test that parse_args accepts --dry-run."""
+        from tools.pyproject_template.check_template_updates import parse_args
+
+        args = parse_args(["--dry-run"])
+        assert args.dry_run is True
+
+
+class TestYesFlagBehavior:
+    """Tests for --yes flag threading through subcommands."""
+
+    def test_yes_flag_passed_to_run_action(self) -> None:
+        """Verify main(["--yes", "sync"]) passes yes=True through to run_action."""
+        from tools.pyproject_template.manage import main
+
+        with (
+            patch("tools.pyproject_template.manage.SettingsManager") as mock_manager_cls,
+            patch("tools.pyproject_template.manage.run_action", return_value=0) as mock_run_action,
+        ):
+            mock_manager = MagicMock()
+            mock_manager_cls.return_value = mock_manager
+
+            main(["--yes", "sync"])
+
+            mock_run_action.assert_called_once_with(
+                5, mock_manager, False, yes=True, cleanup_mode=None
+            )
+
+    def test_sync_with_yes_skips_prompt(self, tmp_path: Path) -> None:
+        """Verify action_mark_synced() with yes=True skips the confirmation prompt."""
+        from tools.pyproject_template.manage import action_mark_synced
+
+        # Set up template commit file
+        template_dir = tmp_path / "tmp" / "extracted" / "pyproject-template-main"
+        template_dir.mkdir(parents=True)
+        commit_file = template_dir / ".template_commit"
+        commit_file.write_text("abc123newcommit\n2025-06-15\n", encoding="utf-8")
+
+        mock_manager = MagicMock()
+        mock_manager.template_state.commit = "oldcommit000"
+
+        with (
+            patch("tools.pyproject_template.manage.Path") as mock_path_cls,
+            patch("tools.pyproject_template.manage.prompt") as mock_prompt,
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            # Make Path("tmp/extracted/...") resolve to our tmp_path
+            def path_side_effect(arg: str = "") -> Path:
+                if arg == "tmp/extracted/pyproject-template-main":
+                    return template_dir
+                return Path(arg)
+
+            mock_path_cls.side_effect = path_side_effect
+
+            # subprocess calls succeed
+            mock_subprocess.return_value = MagicMock(returncode=0)
+
+            action_mark_synced(mock_manager, dry_run=False, yes=True)
+
+            # prompt should NOT have been called
+            mock_prompt.assert_not_called()
+            # update_template_state should have been called
+            mock_manager.update_template_state.assert_called_once_with(
+                "abc123newcommit", "2025-06-15"
+            )
+
+    def test_cleanup_with_yes_skips_prompt(self) -> None:
+        """Verify action_template_cleanup() with yes=True skips prompt_cleanup."""
+        from tools.pyproject_template.manage import action_template_cleanup
+
+        mock_manager = MagicMock()
+
+        with patch("tools.pyproject_template.manage.prompt_cleanup") as mock_prompt_cleanup:
+            result = action_template_cleanup(mock_manager, dry_run=False, yes=True)
+
+            assert result == 0
+            mock_prompt_cleanup.assert_not_called()
+
+    def test_configure_with_yes_uses_auto_mode(self) -> None:
+        """Verify action_configure() with yes=True calls run_configure with auto=True."""
+        from tools.pyproject_template.manage import action_configure
+
+        mock_manager = MagicMock()
+        mock_manager.settings.project_name = "test"
+        mock_manager.settings.package_name = "test"
+        mock_manager.settings.pypi_name = "test"
+        mock_manager.settings.description = "test"
+        mock_manager.settings.author_name = "test"
+        mock_manager.settings.author_email = "test@test.com"
+        mock_manager.settings.github_user = "test"
+
+        with (
+            patch("tools.pyproject_template.manage.run_configure", return_value=0) as mock_run,
+            patch("tools.pyproject_template.manage.load_defaults", return_value={}),
+        ):
+            result = action_configure(mock_manager, dry_run=False, yes=True)
+
+            assert result == 0
+            mock_run.assert_called_once()
+            _, kwargs = mock_run.call_args
+            assert kwargs["auto"] is True
+            assert kwargs["yes"] is True
+
+    def test_cleanup_with_cleanup_mode_setup(self) -> None:
+        """Verify action_template_cleanup() with cleanup_mode='setup' uses that mode."""
+        from tools.pyproject_template.manage import action_template_cleanup
+
+        mock_manager = MagicMock()
+
+        with (
+            patch("tools.pyproject_template.manage.cleanup_template_files") as mock_cleanup,
+            patch("tools.pyproject_template.manage.prompt_cleanup"),
+        ):
+            mock_result = MagicMock()
+            mock_result.failed = []
+            mock_cleanup.return_value = mock_result
+
+            result = action_template_cleanup(mock_manager, dry_run=False, cleanup_mode="setup")
+
+            assert result == 0
+            mock_cleanup.assert_called_once()
+
+    def test_cleanup_with_invalid_mode_fails(self) -> None:
+        """Verify action_template_cleanup() with invalid cleanup_mode returns error."""
+        from tools.pyproject_template.manage import action_template_cleanup
+
+        mock_manager = MagicMock()
+
+        with patch("tools.pyproject_template.manage.prompt_cleanup"):
+            result = action_template_cleanup(mock_manager, dry_run=False, cleanup_mode="invalid")
+
+            assert result == 1
+
+
+class TestMigrateModule:
+    """Tests for the migrate_existing_project module refactoring."""
+
+    def test_parse_args_accepts_argv(self) -> None:
+        """Test that parse_args accepts argv parameter."""
+        from tools.pyproject_template.migrate_existing_project import parse_args
+
+        args = parse_args(["--target", "/some/path", "--download"])
+        assert args.target == Path("/some/path")
+        assert args.download is True
+
+    def test_parse_args_dry_run(self) -> None:
+        """Test that parse_args accepts --dry-run."""
+        from tools.pyproject_template.migrate_existing_project import parse_args
+
+        args = parse_args(["--target", "/some/path", "--dry-run"])
+        assert args.dry_run is True

--- a/tests/template/test_repo_settings.py
+++ b/tests/template/test_repo_settings.py
@@ -1,0 +1,272 @@
+"""Tests for repo_settings.py repository settings functionality."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+class TestConfigureRepositorySettings:
+    """Tests for configure_repository_settings function."""
+
+    def test_configure_repository_settings_success(self) -> None:
+        """Test successful repository settings configuration."""
+        from tools.pyproject_template.repo_settings import configure_repository_settings
+
+        mock_template_settings = {
+            "description": "Template description",
+            "has_issues": True,
+            "has_wiki": False,
+            "allow_squash_merge": True,
+            # Read-only fields that should be filtered
+            "id": 123,
+            "node_id": "abc",
+            "full_name": "old/name",
+        }
+
+        mock_owner_info = {"type": "User"}
+
+        with (
+            patch(
+                "tools.pyproject_template.repo_settings.GitHubCLI.api",
+                side_effect=[mock_template_settings, mock_owner_info, None],
+            ) as mock_api,
+        ):
+            result = configure_repository_settings(
+                repo_full="user/repo",
+                description="New description",
+                visibility="public",
+            )
+
+            assert result is True
+            # Verify API was called correctly
+            assert mock_api.call_count == 3
+
+    def test_configure_repository_settings_failure(self) -> None:
+        """Test repository settings configuration handles failure."""
+        from subprocess import CalledProcessError
+
+        from tools.pyproject_template.repo_settings import configure_repository_settings
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            side_effect=CalledProcessError(1, "gh", stderr="Error"),
+        ):
+            result = configure_repository_settings(
+                repo_full="user/repo",
+                description="Description",
+            )
+
+            assert result is False
+
+
+class TestConfigureBranchProtection:
+    """Tests for configure_branch_protection function."""
+
+    def test_configure_branch_protection_creates_new_ruleset(self) -> None:
+        """Test creating a new ruleset when none exists."""
+        from tools.pyproject_template.repo_settings import configure_branch_protection
+
+        mock_template_rulesets = [{"id": 1, "name": "main-protection"}]
+        mock_existing_rulesets: list[dict[str, object]] = []  # No existing rulesets
+        mock_full_ruleset = {
+            "id": 1,
+            "name": "main-protection",
+            "target": "branch",
+            "enforcement": "active",
+            "bypass_actors": [],
+            "conditions": {},
+            "rules": [],
+        }
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            side_effect=[
+                mock_template_rulesets,  # GET template rulesets
+                mock_existing_rulesets,  # GET existing rulesets in target repo
+                mock_full_ruleset,  # GET full ruleset details
+                None,  # POST new ruleset
+            ],
+        ) as mock_api:
+            result = configure_branch_protection(repo_full="user/repo")
+            assert result is True
+            # Verify POST was used (4th call)
+            assert mock_api.call_count == 4
+            last_call = mock_api.call_args_list[3]
+            assert last_call.kwargs.get("method") == "POST"
+            assert "rulesets" in last_call.args[0]
+            assert "rulesets/" not in last_call.args[0]  # No ID in URL for POST
+
+    def test_configure_branch_protection_updates_existing_ruleset(self) -> None:
+        """Test updating an existing ruleset instead of creating a duplicate."""
+        from tools.pyproject_template.repo_settings import configure_branch_protection
+
+        mock_template_rulesets = [{"id": 1, "name": "main-protection"}]
+        mock_existing_rulesets = [{"id": 99, "name": "main-protection"}]  # Already exists
+        mock_full_ruleset = {
+            "id": 1,
+            "name": "main-protection",
+            "target": "branch",
+            "enforcement": "active",
+            "bypass_actors": [],
+            "conditions": {},
+            "rules": [],
+        }
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            side_effect=[
+                mock_template_rulesets,  # GET template rulesets
+                mock_existing_rulesets,  # GET existing rulesets in target repo
+                mock_full_ruleset,  # GET full ruleset details
+                None,  # PUT existing ruleset
+            ],
+        ) as mock_api:
+            result = configure_branch_protection(repo_full="user/repo")
+            assert result is True
+            # Verify PUT was used with correct ID (4th call)
+            assert mock_api.call_count == 4
+            last_call = mock_api.call_args_list[3]
+            assert last_call.kwargs.get("method") == "PUT"
+            assert "rulesets/99" in last_call.args[0]  # Uses existing ID
+
+    def test_configure_branch_protection_no_rulesets(self) -> None:
+        """Test branch protection when template has no rulesets."""
+        from tools.pyproject_template.repo_settings import configure_branch_protection
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            return_value=[],
+        ):
+            result = configure_branch_protection(repo_full="user/repo")
+            assert result is True  # No rulesets is not a failure
+
+
+class TestReplicateLabels:
+    """Tests for replicate_labels function."""
+
+    def test_replicate_labels_success(self) -> None:
+        """Test successful label replication."""
+        from tools.pyproject_template.repo_settings import replicate_labels
+
+        mock_labels = [
+            {"name": "bug", "color": "d73a4a", "description": "Bug report"},
+            {"name": "enhancement", "color": "a2eeef", "description": "New feature"},
+        ]
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            side_effect=[mock_labels, None, None],
+        ):
+            result = replicate_labels(repo_full="user/repo")
+            assert result is True
+
+    def test_replicate_labels_empty(self) -> None:
+        """Test label replication when template has no labels."""
+        from tools.pyproject_template.repo_settings import replicate_labels
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            return_value=[],
+        ):
+            result = replicate_labels(repo_full="user/repo")
+            assert result is False
+
+
+class TestEnableGithubPages:
+    """Tests for enable_github_pages function."""
+
+    def test_enable_github_pages_success(self) -> None:
+        """Test successful GitHub Pages enablement."""
+        from tools.pyproject_template.repo_settings import enable_github_pages
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            return_value=None,
+        ):
+            result = enable_github_pages(repo_full="user/repo")
+            assert result is True
+
+    def test_enable_github_pages_no_branch(self) -> None:
+        """Test GitHub Pages when gh-pages branch doesn't exist."""
+        from subprocess import CalledProcessError
+
+        from tools.pyproject_template.repo_settings import enable_github_pages
+
+        with patch(
+            "tools.pyproject_template.repo_settings.GitHubCLI.api",
+            side_effect=CalledProcessError(1, "gh"),
+        ):
+            result = enable_github_pages(repo_full="user/repo")
+            assert result is False
+
+
+class TestUpdateAllRepoSettings:
+    """Tests for update_all_repo_settings convenience function.
+
+    CodeQL scanning is intentionally NOT part of this orchestration: it runs
+    from the committed ``.github/workflows/codeql.yml`` workflow file that
+    the template generator copies into every new repository. See issue #431
+    for the migration from the default-setup API to the workflow file.
+    """
+
+    def test_update_all_repo_settings_success(self) -> None:
+        """Test that update_all_repo_settings calls all configuration functions."""
+        from tools.pyproject_template.repo_settings import update_all_repo_settings
+
+        with (
+            patch(
+                "tools.pyproject_template.repo_settings.configure_repository_settings",
+                return_value=True,
+            ) as mock_repo,
+            patch(
+                "tools.pyproject_template.repo_settings.configure_branch_protection",
+                return_value=True,
+            ) as mock_branch,
+            patch(
+                "tools.pyproject_template.repo_settings.replicate_labels",
+                return_value=True,
+            ) as mock_labels,
+            patch(
+                "tools.pyproject_template.repo_settings.enable_github_pages",
+                return_value=True,
+            ) as mock_pages,
+        ):
+            result = update_all_repo_settings(
+                repo_full="user/repo",
+                description="Description",
+            )
+
+            assert result is True
+            mock_repo.assert_called_once()
+            mock_branch.assert_called_once()
+            mock_labels.assert_called_once()
+            mock_pages.assert_called_once()
+
+    def test_update_all_repo_settings_partial_failure(self) -> None:
+        """Test that update_all_repo_settings returns False if any step fails."""
+        from tools.pyproject_template.repo_settings import update_all_repo_settings
+
+        with (
+            patch(
+                "tools.pyproject_template.repo_settings.configure_repository_settings",
+                return_value=True,
+            ),
+            patch(
+                "tools.pyproject_template.repo_settings.configure_branch_protection",
+                return_value=False,  # This one fails
+            ),
+            patch(
+                "tools.pyproject_template.repo_settings.replicate_labels",
+                return_value=True,
+            ),
+            patch(
+                "tools.pyproject_template.repo_settings.enable_github_pages",
+                return_value=True,
+            ),
+        ):
+            result = update_all_repo_settings(
+                repo_full="user/repo",
+                description="Description",
+            )
+
+            assert result is False

--- a/tests/template/test_setup_repo.py
+++ b/tests/template/test_setup_repo.py
@@ -1,0 +1,637 @@
+"""Tests for setup_repo.py repository setup functionality."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRepositorySetup:
+    """Tests for RepositorySetup class."""
+
+    def test_init_creates_empty_config(self) -> None:
+        """Test that __init__ creates empty config dict."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+        assert setup.config == {}
+        assert setup.start_dir is not None
+
+    def test_template_full_is_set(self) -> None:
+        """Test that TEMPLATE_FULL is set from utils."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        assert RepositorySetup.TEMPLATE_FULL == "endavis/pyproject-template"
+
+    def test_print_banner_outputs_text(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test that print_banner outputs the welcome message."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+        setup.print_banner()
+
+        captured = capsys.readouterr()
+        assert "Python Project Template" in captured.out
+        assert "Repository Setup" in captured.out
+
+    def test_check_requirements_fails_without_git(self) -> None:
+        """Test that check_requirements exits if git is not installed."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.command_exists", return_value=False),
+            pytest.raises(SystemExit),
+        ):
+            setup.check_requirements()
+
+    def test_check_requirements_fails_without_gh(self) -> None:
+        """Test that check_requirements exits if gh CLI is not installed."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        def mock_command_exists(cmd: str) -> bool:
+            return cmd == "git"  # git exists, gh doesn't
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.command_exists",
+                side_effect=mock_command_exists,
+            ),
+            pytest.raises(SystemExit),
+        ):
+            setup.check_requirements()
+
+    def test_check_requirements_fails_without_gh_auth(self) -> None:
+        """Test that check_requirements exits if gh is not authenticated."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.command_exists", return_value=True),
+            patch(
+                "tools.pyproject_template.setup_repo.GitHubCLI.is_authenticated",
+                return_value=False,
+            ),
+            pytest.raises(SystemExit),
+        ):
+            setup.check_requirements()
+
+    def test_check_requirements_passes_with_all_requirements(self) -> None:
+        """Test that check_requirements passes when all requirements met."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.command_exists", return_value=True),
+            patch(
+                "tools.pyproject_template.setup_repo.GitHubCLI.is_authenticated",
+                return_value=True,
+            ),
+            patch.object(setup, "_check_token_permissions"),
+        ):
+            # Should not raise
+            setup.check_requirements()
+
+    def test_gather_inputs_with_git_config(self) -> None:
+        """Test that gather_inputs uses git config values as defaults."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        def mock_get_git_config(key: str, default: str = "") -> str:
+            configs = {
+                "user.name": "Test User",
+                "user.email": "test@example.com",
+            }
+            return configs.get(key, default)
+
+        def mock_prompt(_question: str, default: str = "") -> str:
+            # Return defaults for all prompts
+            return default if default else "test_value"
+
+        # Track calls to prompt_confirm to return appropriate values
+        confirm_calls = []
+
+        def mock_prompt_confirm(_question: str, default: bool = False) -> bool:
+            confirm_calls.append(True)
+            if len(confirm_calls) == 1:
+                return False  # "Create in organization?" -> No
+            if len(confirm_calls) == 2:
+                return True  # "Make repository public?" -> Yes
+            return True  # "Proceed with these settings?" -> Yes
+
+        mock_api_response = {"login": "testuser"}
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.get_git_config",
+                side_effect=mock_get_git_config,
+            ),
+            patch(
+                "tools.pyproject_template.setup_repo.prompt",
+                side_effect=mock_prompt,
+            ),
+            patch(
+                "tools.pyproject_template.setup_repo.prompt_confirm",
+                side_effect=mock_prompt_confirm,
+            ),
+            patch(
+                "tools.pyproject_template.setup_repo.GitHubCLI.api",
+                return_value=mock_api_response,
+            ),
+        ):
+            setup.gather_inputs()
+
+            assert setup.config["author_name"] == "Test User"
+            assert setup.config["author_email"] == "test@example.com"
+            assert setup.config["repo_owner"] == "testuser"
+
+
+class TestCleanupTemplateSuite:
+    """Tests for RepositorySetup.cleanup_template_suite().
+
+    These tests cover the auto-removal of the template management suite
+    from spawned consumer projects (issue #465). They mock
+    ``cleanup_template_files`` and ``subprocess.run`` so no real filesystem
+    or git effects occur.
+    """
+
+    def _make_cleanup_result(
+        self,
+        *,
+        deleted_files: list[Path] | None = None,
+        deleted_dirs: list[Path] | None = None,
+    ) -> MagicMock:
+        """Build a CleanupResult-compatible mock.
+
+        ``cleanup_template_files`` returns a ``CleanupResult`` (NamedTuple).
+        Only ``deleted_files`` and ``deleted_dirs`` are consulted by
+        ``cleanup_template_suite``; supplying a MagicMock with those
+        attributes is sufficient.
+        """
+        result = MagicMock()
+        result.deleted_files = deleted_files or []
+        result.deleted_dirs = deleted_dirs or []
+        result.failed = []
+        result.mkdocs_updated = False
+        return result
+
+    def test_cleanup_invokes_cleanup_template_files_with_all_mode(self) -> None:
+        """cleanup_template_suite() passes CleanupMode.ALL to cleanup_template_files."""
+        from tools.pyproject_template.setup_repo import CleanupMode, RepositorySetup
+
+        setup = RepositorySetup()
+
+        # Simulate at least one deleted file so the git path is exercised.
+        fake_result = self._make_cleanup_result(deleted_files=[Path("bootstrap.py")])
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ) as mock_cleanup,
+            patch("tools.pyproject_template.setup_repo.subprocess.run"),
+        ):
+            setup.cleanup_template_suite()
+
+        # Assert it was called exactly once with CleanupMode.ALL.
+        mock_cleanup.assert_called_once()
+        _, kwargs = mock_cleanup.call_args
+        args = mock_cleanup.call_args.args
+        assert args[0] == CleanupMode.ALL
+        # root is passed as a keyword argument.
+        assert "root" in kwargs
+
+    def test_cleanup_uses_current_working_directory_as_root(self) -> None:
+        """cleanup_template_suite() passes Path.cwd() as the root."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        fake_result = self._make_cleanup_result(deleted_files=[Path("bootstrap.py")])
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ) as mock_cleanup,
+            patch("tools.pyproject_template.setup_repo.subprocess.run"),
+        ):
+            setup.cleanup_template_suite()
+
+        _, kwargs = mock_cleanup.call_args
+        assert kwargs["root"] == Path.cwd()
+
+    def test_cleanup_commits_and_pushes_after_successful_cleanup(self) -> None:
+        """After deletions, cleanup_template_suite() stages, commits, and pushes."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        fake_result = self._make_cleanup_result(
+            deleted_files=[Path("bootstrap.py")],
+            deleted_dirs=[Path("tools/pyproject_template")],
+        )
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+        ):
+            setup.cleanup_template_suite()
+
+        # Collect the first positional argument (the command list) for each call.
+        commands = [call.args[0] for call in mock_run.call_args_list]
+
+        # Verify add -A was called.
+        assert any(cmd[:2] == ["git", "add"] and "-A" in cmd for cmd in commands), (
+            f"Expected 'git add -A' in commands, got: {commands}"
+        )
+
+        # Verify commit --no-verify was called with the expected subject.
+        commit_calls = [
+            cmd for cmd in commands if len(cmd) >= 3 and cmd[0] == "git" and cmd[1] == "commit"
+        ]
+        assert commit_calls, f"Expected 'git commit' call, got: {commands}"
+        commit_cmd = commit_calls[0]
+        assert "--no-verify" in commit_cmd
+        # The commit message is the argument after -m.
+        assert "-m" in commit_cmd
+        msg_index = commit_cmd.index("-m") + 1
+        assert "chore: remove template management suite" in commit_cmd[msg_index]
+
+        # Verify push was called.
+        assert ["git", "push"] in commands, f"Expected 'git push' in commands, got: {commands}"
+
+    def test_cleanup_skips_commit_when_nothing_was_deleted(self) -> None:
+        """cleanup_template_suite() does not commit when no files were deleted.
+
+        Guards against an empty git commit when a consumer re-runs setup on a
+        project that has already been cleaned.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        # No deletions performed.
+        fake_result = self._make_cleanup_result()
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+        ):
+            setup.cleanup_template_suite()
+
+        # No git subprocess calls should have been made.
+        assert mock_run.call_count == 0
+
+    def test_cleanup_logs_warning_and_does_not_raise_on_failure(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """cleanup_template_suite() swallows exceptions rather than re-raising.
+
+        A cleanup failure must not block the user from using their freshly
+        spawned repository, so the method must log a warning and return
+        normally.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                side_effect=OSError("permission denied"),
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run"),
+        ):
+            # Must not raise.
+            setup.cleanup_template_suite()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Warning text should surface the exception.
+        assert "Template suite cleanup failed" in combined
+        assert "permission denied" in combined
+
+    def test_cleanup_logs_warning_when_git_commit_fails(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """cleanup_template_suite() handles subprocess failures defensively."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        fake_result = self._make_cleanup_result(deleted_files=[Path("bootstrap.py")])
+
+        def mock_run(cmd: list[str], **_kwargs: object) -> object:
+            if len(cmd) >= 2 and cmd[0] == "git" and cmd[1] == "commit":
+                raise subprocess.CalledProcessError(1, cmd, b"", b"hook rejected")
+            return MagicMock(returncode=0)
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run", side_effect=mock_run),
+        ):
+            # Must not raise.
+            setup.cleanup_template_suite()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Template suite cleanup failed" in combined
+
+
+class TestRunOrder:
+    """Tests for RepositorySetup.run() ordering.
+
+    The critical ordering requirement introduced by issue #465 is that
+    ``cleanup_template_suite`` must run AFTER the development environment
+    is set up (so ``doit check`` still has the template tests available)
+    and BEFORE the manual steps are printed (so the printed summary
+    reflects the cleaned tree).
+    """
+
+    def test_run_invokes_cleanup_between_env_setup_and_manual_steps(self) -> None:
+        """run() calls cleanup_template_suite() between env-setup and manual-steps."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        # Track the order that the orchestration methods are called.
+        call_order: list[str] = []
+
+        def make_tracker(name: str) -> object:
+            def _tracked(*_args: object, **_kwargs: object) -> None:
+                call_order.append(name)
+
+            return _tracked
+
+        # Patch every orchestration step on the instance. We use
+        # ``patch.object`` so each MagicMock records on the ``setup``
+        # instance without polluting other tests.
+        with (
+            patch.object(setup, "print_banner", side_effect=make_tracker("print_banner")),
+            patch.object(
+                setup, "check_requirements", side_effect=make_tracker("check_requirements")
+            ),
+            patch.object(setup, "gather_inputs", side_effect=make_tracker("gather_inputs")),
+            patch.object(
+                setup,
+                "create_github_repository",
+                side_effect=make_tracker("create_github_repository"),
+            ),
+            patch.object(
+                setup,
+                "configure_repository_settings",
+                side_effect=make_tracker("configure_repository_settings"),
+            ),
+            patch.object(
+                setup,
+                "configure_branch_protection",
+                side_effect=make_tracker("configure_branch_protection"),
+            ),
+            patch.object(setup, "replicate_labels", side_effect=make_tracker("replicate_labels")),
+            patch.object(
+                setup, "enable_github_pages", side_effect=make_tracker("enable_github_pages")
+            ),
+            patch.object(setup, "clone_repository", side_effect=make_tracker("clone_repository")),
+            patch.object(
+                setup,
+                "configure_placeholders",
+                side_effect=make_tracker("configure_placeholders"),
+            ),
+            patch.object(
+                setup,
+                "setup_development_environment",
+                side_effect=make_tracker("setup_development_environment"),
+            ),
+            patch.object(
+                setup,
+                "cleanup_template_suite",
+                side_effect=make_tracker("cleanup_template_suite"),
+            ),
+            patch.object(
+                setup,
+                "verify_post_cleanup",
+                side_effect=make_tracker("verify_post_cleanup"),
+            ),
+            patch.object(
+                setup, "print_manual_steps", side_effect=make_tracker("print_manual_steps")
+            ),
+        ):
+            setup.run()
+
+        # cleanup_template_suite must appear after setup_development_environment
+        # and before print_manual_steps.
+        assert "setup_development_environment" in call_order
+        assert "cleanup_template_suite" in call_order
+        assert "verify_post_cleanup" in call_order
+        assert "print_manual_steps" in call_order
+
+        env_idx = call_order.index("setup_development_environment")
+        cleanup_idx = call_order.index("cleanup_template_suite")
+        verify_idx = call_order.index("verify_post_cleanup")
+        manual_idx = call_order.index("print_manual_steps")
+
+        assert env_idx < cleanup_idx < verify_idx < manual_idx, (
+            f"Expected setup_development_environment < cleanup_template_suite < "
+            f"verify_post_cleanup < print_manual_steps, got order: {call_order}"
+        )
+
+
+class TestVerifyPostCleanup:
+    """Tests for RepositorySetup.verify_post_cleanup().
+
+    Issue #469: after ``cleanup_template_suite`` removes ``bootstrap.py``
+    and the template management suite, any doit task that referenced those
+    files becomes broken. ``verify_post_cleanup`` re-runs ``doit check`` to
+    surface the failure in the spawned repo. It must be LENIENT — log a
+    diagnostic and return without raising or ``sys.exit`` — so the wizard
+    still reaches ``print_manual_steps`` and the user sees the final
+    instructions.
+    """
+
+    def test_runs_doit_check_in_current_directory(self) -> None:
+        """verify_post_cleanup invokes ``uv run doit check``."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            setup.verify_post_cleanup()
+
+        assert mock_run.call_count == 1
+        # Grab the command argument (first positional) from the call.
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["uv", "run", "doit", "check"]
+
+    def test_success_emits_success_message_and_does_not_raise(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When doit check returns 0, method returns silently with a success message."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            # Must not raise.
+            setup.verify_post_cleanup()
+
+        # Output should include the success marker but NOT the failure
+        # diagnostic.
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Post-cleanup validation checks passed" in combined
+        assert "Validation failed *after* cleanup" not in combined
+
+    def test_failure_logs_diagnostic_and_does_not_raise(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When doit check returns non-zero, method logs diagnostic and returns.
+
+        The diagnostic marker ``Validation failed *after* cleanup`` must
+        appear in the output so the user can correlate the failure with
+        the post-cleanup phase.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            # Must not raise — no SystemExit, no other exception.
+            setup.verify_post_cleanup()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Specific diagnostic marker we can assert on.
+        assert "Validation failed *after* cleanup" in combined
+
+    def test_failure_does_not_call_sys_exit(self) -> None:
+        """verify_post_cleanup must not sys.exit on failure.
+
+        Issue #469 explicitly requires lenient handling because the GitHub
+        repo has already been created and partially configured — forcing
+        an exit would leave the user stranded with no path to the manual
+        steps summary.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+            patch("tools.pyproject_template.setup_repo.sys.exit") as mock_exit,
+        ):
+            mock_run.return_value = MagicMock(returncode=1)
+            setup.verify_post_cleanup()
+
+        mock_exit.assert_not_called()
+
+    def test_filenotfounderror_handled_gracefully(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """If ``uv`` is missing from PATH, surface a diagnostic but do not raise."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch(
+            "tools.pyproject_template.setup_repo.subprocess.run",
+            side_effect=FileNotFoundError("uv not found"),
+        ):
+            # Must not raise.
+            setup.verify_post_cleanup()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Validation failed *after* cleanup" in combined
+
+
+class TestConfigurePlaceholdersTemplateTestsRemoval:
+    """Tests for RepositorySetup.configure_placeholders() template-tests removal.
+
+    Issue #463: spawned consumer projects must not ship with
+    ``tests/template/`` (the template-only test suite). This verifies that
+    ``configure_placeholders()`` removes the directory and that the removal
+    is a no-op when the directory is absent.
+    """
+
+    @staticmethod
+    def _minimum_config() -> dict[str, str]:
+        """Return the minimum config dict ``configure_placeholders()`` requires."""
+        return {
+            "repo_owner": "testuser",
+            "repo_name": "Test Project",
+            "package_name": "test_pkg",
+            "pypi_name": "test-pkg",
+            "description": "A test project",
+            "author_name": "Test Author",
+            "author_email": "test@example.com",
+        }
+
+    def test_configure_placeholders_removes_tests_template_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """configure_placeholders() removes tests/template/ when present."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        # Simulate a cloned consumer project with a tests/template/ directory.
+        template_tests_dir = tmp_path / "tests" / "template"
+        template_tests_dir.mkdir(parents=True)
+        (template_tests_dir / "__init__.py").write_text("", encoding="utf-8")
+        (template_tests_dir / "test_doit_adr.py").write_text("# template test", encoding="utf-8")
+
+        monkeypatch.chdir(tmp_path)
+
+        setup = RepositorySetup()
+        setup.config = self._minimum_config()
+
+        # Mock subprocess.run so git add/commit/push does not execute.
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            setup.configure_placeholders()
+
+        assert not template_tests_dir.exists(), (
+            "tests/template/ should have been removed by configure_placeholders()"
+        )
+        # The parent tests/ directory should still exist.
+        assert (tmp_path / "tests").exists()
+
+    def test_configure_placeholders_noop_when_tests_template_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """configure_placeholders() does not raise when tests/template/ is absent."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        # No tests/template/ directory; just an empty tests/ directory.
+        (tmp_path / "tests").mkdir()
+
+        monkeypatch.chdir(tmp_path)
+
+        setup = RepositorySetup()
+        setup.config = self._minimum_config()
+
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            # Must not raise even though tests/template/ does not exist.
+            setup.configure_placeholders()
+
+        assert (tmp_path / "tests").exists()
+        assert not (tmp_path / "tests" / "template").exists()

--- a/tests/template/test_utils.py
+++ b/tests/template/test_utils.py
@@ -1,0 +1,649 @@
+"""Tests for pyproject_template utility functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.pyproject_template.utils import (
+    FILES_TO_UPDATE,
+    Colors,
+    GitHubCLI,
+    Logger,
+    command_exists,
+    get_first_author,
+    get_git_config,
+    is_github_url,
+    load_toml_file,
+    parse_github_url,
+    update_file,
+    update_test_files,
+    validate_email,
+    validate_package_name,
+    validate_pypi_name,
+)
+
+
+class TestValidatePackageName:
+    """Tests for validate_package_name function."""
+
+    def test_lowercase_conversion(self) -> None:
+        """Test that names are converted to lowercase."""
+        assert validate_package_name("MyPackage") == "mypackage"
+
+    def test_invalid_chars_replaced(self) -> None:
+        """Test that invalid characters are replaced with underscores."""
+        assert validate_package_name("my-package") == "my_package"
+        assert validate_package_name("my.package") == "my_package"
+        assert validate_package_name("my package") == "my_package"
+
+    def test_leading_trailing_underscores_stripped(self) -> None:
+        """Test that leading/trailing underscores are stripped."""
+        assert validate_package_name("_mypackage_") == "mypackage"
+        assert validate_package_name("__my__") == "my"
+
+    def test_leading_number_prefixed(self) -> None:
+        """Test that leading numbers get underscore prefix."""
+        assert validate_package_name("123package") == "_123package"
+
+    def test_valid_name_unchanged(self) -> None:
+        """Test that valid names remain unchanged."""
+        assert validate_package_name("my_package") == "my_package"
+        assert validate_package_name("package123") == "package123"
+
+
+class TestValidatePypiName:
+    """Tests for validate_pypi_name function."""
+
+    def test_lowercase_conversion(self) -> None:
+        """Test that names are converted to lowercase."""
+        assert validate_pypi_name("MyPackage") == "mypackage"
+
+    def test_invalid_chars_replaced(self) -> None:
+        """Test that invalid characters are replaced with hyphens."""
+        assert validate_pypi_name("my_package") == "my-package"
+        assert validate_pypi_name("my.package") == "my-package"
+        assert validate_pypi_name("my package") == "my-package"
+
+    def test_leading_trailing_hyphens_stripped(self) -> None:
+        """Test that leading/trailing hyphens are stripped."""
+        assert validate_pypi_name("-mypackage-") == "mypackage"
+
+    def test_multiple_hyphens_collapsed(self) -> None:
+        """Test that multiple hyphens are collapsed to one."""
+        assert validate_pypi_name("my--package") == "my-package"
+        assert validate_pypi_name("my___package") == "my-package"
+
+    def test_valid_name_unchanged(self) -> None:
+        """Test that valid names remain unchanged."""
+        assert validate_pypi_name("my-package") == "my-package"
+
+
+class TestValidateEmail:
+    """Tests for validate_email function."""
+
+    def test_valid_emails(self) -> None:
+        """Test that valid emails pass validation."""
+        assert validate_email("user@example.com") is True
+        assert validate_email("user.name@example.com") is True
+        assert validate_email("user+tag@example.co.uk") is True
+        assert validate_email("user123@sub.domain.com") is True
+
+    def test_invalid_emails(self) -> None:
+        """Test that invalid emails fail validation."""
+        assert validate_email("notanemail") is False
+        assert validate_email("@example.com") is False
+        assert validate_email("user@") is False
+        assert validate_email("user@.com") is False
+        assert validate_email("") is False
+
+
+class TestCommandExists:
+    """Tests for command_exists function."""
+
+    def test_existing_command(self) -> None:
+        """Test that existing commands are detected."""
+        # 'which' should exist on Linux/macOS
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert command_exists("python") is True
+
+    def test_nonexistent_command(self) -> None:
+        """Test that non-existent commands return False."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            assert command_exists("nonexistent_command_xyz") is False
+
+    def test_handles_exception(self) -> None:
+        """Test that exceptions are handled gracefully."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert command_exists("anything") is False
+
+
+class TestGetGitConfig:
+    """Tests for get_git_config function."""
+
+    def test_returns_config_value(self) -> None:
+        """Test that git config values are returned."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="Test User\n")
+            result = get_git_config("user.name")
+            assert result == "Test User"
+
+    def test_returns_default_on_failure(self) -> None:
+        """Test that default is returned when config not found."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = get_git_config("nonexistent.key", "default_value")
+            assert result == "default_value"
+
+    def test_handles_exception(self) -> None:
+        """Test that exceptions return default value."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = get_git_config("user.name", "fallback")
+            assert result == "fallback"
+
+    def test_falls_back_to_global_when_unscoped_fails(self) -> None:
+        """Unscoped lookup failure triggers ``--global`` retry (#470)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stdout=""),
+                MagicMock(returncode=0, stdout="Global User\n"),
+            ]
+            result = get_git_config("user.name")
+            assert result == "Global User"
+            assert mock_run.call_count == 2
+            # Second call must include the --global flag.
+            second_call_argv = mock_run.call_args_list[1].args[0]
+            assert "--global" in second_call_argv
+
+    def test_returns_default_when_both_scopes_fail(self) -> None:
+        """Both unscoped and global lookups failing yields the default (#470)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stdout=""),
+                MagicMock(returncode=1, stdout=""),
+            ]
+            result = get_git_config("nonexistent.key", "default_value")
+            assert result == "default_value"
+            assert mock_run.call_count == 2
+
+    def test_fallback_exception_returns_default(self) -> None:
+        """Exception on the ``--global`` retry falls back to default (#470)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stdout=""),
+                FileNotFoundError,
+            ]
+            result = get_git_config("user.name", "fallback")
+            assert result == "fallback"
+            assert mock_run.call_count == 2
+
+
+class TestIsGithubUrl:
+    """Tests for is_github_url function."""
+
+    def test_valid_github_urls(self) -> None:
+        """Test that valid GitHub URLs are recognized."""
+        assert is_github_url("https://github.com/owner/repo") is True
+        assert is_github_url("https://github.com/owner/repo.git") is True
+        assert is_github_url("http://github.com/owner/repo") is True
+
+    def test_github_subdomains(self) -> None:
+        """Test that GitHub subdomains are recognized."""
+        assert is_github_url("https://raw.github.com/owner/repo/main/file") is True
+
+    def test_non_github_urls(self) -> None:
+        """Test that non-GitHub URLs are rejected."""
+        assert is_github_url("https://gitlab.com/owner/repo") is False
+        assert is_github_url("https://bitbucket.org/owner/repo") is False
+
+    def test_url_manipulation_attack(self) -> None:
+        """Test that URL manipulation attacks are rejected."""
+        # This should NOT match - github.com is in the path, not the host
+        assert is_github_url("https://evil.com/github.com/owner/repo") is False
+        assert is_github_url("https://evil.com?redirect=github.com") is False
+
+    def test_invalid_urls(self) -> None:
+        """Test that invalid URLs return False."""
+        assert is_github_url("") is False
+        assert is_github_url("not-a-url") is False
+
+
+class TestParseGithubUrl:
+    """Tests for parse_github_url function."""
+
+    def test_https_url(self) -> None:
+        """Test parsing HTTPS GitHub URL."""
+        owner, repo = parse_github_url("https://github.com/owner/repo")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_https_url_with_git_suffix(self) -> None:
+        """Test parsing HTTPS URL with .git suffix."""
+        owner, repo = parse_github_url("https://github.com/owner/repo.git")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_ssh_url(self) -> None:
+        """Test parsing SSH GitHub URL."""
+        owner, repo = parse_github_url("git@github.com:owner/repo.git")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_trailing_slash(self) -> None:
+        """Test parsing URL with trailing slash."""
+        owner, repo = parse_github_url("https://github.com/owner/repo/")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_empty_url(self) -> None:
+        """Test that empty URL returns empty tuple."""
+        owner, repo = parse_github_url("")
+        assert owner == ""
+        assert repo == ""
+
+    def test_non_github_url(self) -> None:
+        """Test that non-GitHub URL returns empty tuple."""
+        owner, repo = parse_github_url("https://gitlab.com/owner/repo")
+        assert owner == ""
+        assert repo == ""
+
+
+class TestLoadTomlFile:
+    """Tests for load_toml_file function."""
+
+    def test_loads_valid_toml(self, tmp_path: Path) -> None:
+        """Test loading a valid TOML file."""
+        toml_file = tmp_path / "test.toml"
+        toml_file.write_text('[section]\nkey = "value"\nnumber = 42', encoding="utf-8")
+
+        result = load_toml_file(toml_file)
+        assert result == {"section": {"key": "value", "number": 42}}
+
+    def test_returns_empty_dict_for_missing_file(self, tmp_path: Path) -> None:
+        """Test that missing file returns empty dict."""
+        result = load_toml_file(tmp_path / "nonexistent.toml")
+        assert result == {}
+
+    def test_returns_empty_dict_for_invalid_toml(self, tmp_path: Path) -> None:
+        """Test that invalid TOML returns empty dict."""
+        toml_file = tmp_path / "invalid.toml"
+        toml_file.write_text("this is not valid toml [[[", encoding="utf-8")
+
+        result = load_toml_file(toml_file)
+        assert result == {}
+
+
+class TestGetFirstAuthor:
+    """Tests for get_first_author function."""
+
+    def test_extracts_first_author(self) -> None:
+        """Test extracting first author from pyproject data."""
+        data = {
+            "project": {
+                "authors": [
+                    {"name": "First Author", "email": "first@example.com"},
+                    {"name": "Second Author", "email": "second@example.com"},
+                ]
+            }
+        }
+        name, email = get_first_author(data)
+        assert name == "First Author"
+        assert email == "first@example.com"
+
+    def test_returns_empty_for_no_authors(self) -> None:
+        """Test that empty tuple is returned when no authors."""
+        data: dict[str, Any] = {"project": {}}
+        name, email = get_first_author(data)
+        assert name == ""
+        assert email == ""
+
+    def test_returns_empty_for_missing_project(self) -> None:
+        """Test that empty tuple is returned when no project section."""
+        data: dict[str, Any] = {}
+        name, email = get_first_author(data)
+        assert name == ""
+        assert email == ""
+
+    def test_handles_partial_author_info(self) -> None:
+        """Test handling author with only name or email."""
+        data = {"project": {"authors": [{"name": "Only Name"}]}}
+        name, email = get_first_author(data)
+        assert name == "Only Name"
+        assert email == ""
+
+
+class TestUpdateFile:
+    """Tests for update_file function."""
+
+    def test_replaces_strings(self, tmp_path: Path) -> None:
+        """Test basic string replacement."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello old_value, goodbye old_value", encoding="utf-8")
+
+        update_file(test_file, {"old_value": "new_value"})
+
+        assert test_file.read_text(encoding="utf-8") == "Hello new_value, goodbye new_value"
+
+    def test_package_name_preserves_kwargs(self, tmp_path: Path) -> None:
+        """Test that package_name replacement preserves keyword arguments."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text(
+            'from package_name import module\nfunc(package_name="value")\n',
+            encoding="utf-8",
+        )
+
+        update_file(test_file, {"package_name": "my_pkg"})
+
+        content = test_file.read_text(encoding="utf-8")
+        assert "from my_pkg import module" in content
+        # The kwarg should be preserved
+        assert 'package_name="value"' in content
+
+    def test_package_name_preserves_toml_keys(self, tmp_path: Path) -> None:
+        """``package_name = "value"`` form is preserved inside Python source.
+
+        The ``(?!\\s*=)`` guard protects both kwargs and TOML-key forms when
+        the file is a ``.py`` module. Non-Python files receive a blind
+        replace and are covered by
+        :class:`TestUpdateFileModes` (see commit-3 additions for this fix).
+        """
+        test_file = tmp_path / "settings.py"
+        test_file.write_text('package_name = "value"\nname = "package_name"\n', encoding="utf-8")
+
+        update_file(test_file, {"package_name": "my_pkg"})
+
+        content = test_file.read_text(encoding="utf-8")
+        assert 'package_name = "value"' in content
+        assert 'name = "my_pkg"' in content
+
+    def test_skips_missing_file(self, tmp_path: Path) -> None:
+        """Test that missing files are skipped without error."""
+        update_file(tmp_path / "nonexistent.txt", {"old": "new"})
+        # Should not raise
+
+    def test_skips_binary_files(self, tmp_path: Path) -> None:
+        """Test that binary files are skipped."""
+        binary_file = tmp_path / "test.bin"
+        binary_file.write_bytes(b"\x00\x01\x02\xff\xfe")
+
+        # Should not raise
+        update_file(binary_file, {"old": "new"})
+
+
+class TestUpdateTestFiles:
+    """Tests for update_test_files function."""
+
+    def test_updates_imports(self, tmp_path: Path) -> None:
+        """Test that imports are updated in test files."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        test_file = test_dir / "test_example.py"
+        test_file.write_text("from package_name import core\n", encoding="utf-8")
+
+        update_test_files(test_dir, "my_package")
+
+        assert "from my_package import core" in test_file.read_text(encoding="utf-8")
+
+    def test_skips_missing_directory(self, tmp_path: Path) -> None:
+        """Test that missing directory is handled gracefully."""
+        update_test_files(tmp_path / "nonexistent", "my_package")
+        # Should not raise
+
+
+class TestUpdateFileModes:
+    """Tests for update_file's three replacement modes (#464).
+
+    1. Marker tokens (``__FOO__``): blind replace; collision-proof.
+    2. Identifier-like literals in ``.py`` files: word-boundary regex,
+       so ``validate_package_name`` survives replacement of ``package_name``.
+    3. Everything else: blind replace.
+    """
+
+    def test_marker_replacement_is_blind(self, tmp_path: Path) -> None:
+        """``__PACKAGE_NAME__`` marker is replaced regardless of surrounding chars."""
+        test_file = tmp_path / "readme.md"
+        test_file.write_text(
+            "Install `__PACKAGE_NAME__`. See docs at __PACKAGE_NAME__.\n",
+            encoding="utf-8",
+        )
+
+        update_file(test_file, {"__PACKAGE_NAME__": "my_pkg"})
+
+        content = test_file.read_text(encoding="utf-8")
+        assert "Install `my_pkg`" in content
+        assert "See docs at my_pkg" in content
+
+    def test_literal_in_python_code_protects_identifiers(self, tmp_path: Path) -> None:
+        """``validate_package_name`` survives replacement of the ``package_name`` literal."""
+        test_file = tmp_path / "mod.py"
+        test_file.write_text(
+            "from tools.utils import validate_package_name\nfrom package_name import core\n",
+            encoding="utf-8",
+        )
+
+        update_file(test_file, {"package_name": "my_pkg"})
+
+        content = test_file.read_text(encoding="utf-8")
+        assert "validate_package_name" in content  # identifier preserved
+        assert "from my_pkg import core" in content  # standalone replaced
+
+    def test_literal_username_in_python_code_protects_identifiers(self, tmp_path: Path) -> None:
+        """``my_username`` survives; bare ``username`` is replaced."""
+        test_file = tmp_path / "mod.py"
+        test_file.write_text(
+            "my_username = config['user']\nprint(username)\n",
+            encoding="utf-8",
+        )
+
+        update_file(test_file, {"username": "testuser"})
+
+        content = test_file.read_text(encoding="utf-8")
+        assert "my_username" in content
+        assert "print(testuser)" in content
+
+    def test_literal_in_non_python_file_is_blind(self, tmp_path: Path) -> None:
+        """Prose files still get blind replace for literal tokens (no word boundary)."""
+        test_file = tmp_path / "guide.md"
+        test_file.write_text("Run `my_package_name` to install.\n", encoding="utf-8")
+
+        update_file(test_file, {"package_name": "pyprojecttest"})
+
+        # Blind replace corrupts identifiers in non-Python files by design;
+        # callers should migrate prose files to marker tokens (see #464 commit 2).
+        content = test_file.read_text(encoding="utf-8")
+        assert "my_pyprojecttest" in content
+
+    def test_python_identifier_hyphen_case(self, tmp_path: Path) -> None:
+        """``\\b`` boundaries work around hyphen since ``-`` is non-word."""
+        test_file = tmp_path / "mod.py"
+        test_file.write_text(
+            "# doc: package-name and somepackage-name and package-nameish\n",
+            encoding="utf-8",
+        )
+
+        update_file(test_file, {"package-name": "my-pkg"})
+
+        content = test_file.read_text(encoding="utf-8")
+        assert "# doc: my-pkg and somepackage-name and package-nameish" in content
+
+    def test_marker_does_not_interfere_with_literal(self, tmp_path: Path) -> None:
+        """Marker and literal replacements for the same concept coexist cleanly."""
+        test_file = tmp_path / "mixed.md"
+        test_file.write_text(
+            "New marker: __PACKAGE_NAME__. Old literal: package_name.\n",
+            encoding="utf-8",
+        )
+
+        update_file(
+            test_file,
+            {"__PACKAGE_NAME__": "my_pkg", "package_name": "my_pkg"},
+        )
+
+        content = test_file.read_text(encoding="utf-8")
+        assert "New marker: my_pkg" in content
+        assert "Old literal: my_pkg" in content
+
+
+class TestColors:
+    """Tests for Colors class."""
+
+    def test_color_codes_defined(self) -> None:
+        """Test that all color codes are defined."""
+        assert Colors.RED.startswith("\033[")
+        assert Colors.GREEN.startswith("\033[")
+        assert Colors.YELLOW.startswith("\033[")
+        assert Colors.BLUE.startswith("\033[")
+        assert Colors.CYAN.startswith("\033[")
+        assert Colors.BOLD.startswith("\033[")
+        assert Colors.NC == "\033[0m"
+
+
+class TestLogger:
+    """Tests for Logger class."""
+
+    def test_info_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test info message output."""
+        Logger.info("Test message")
+        captured = capsys.readouterr()
+        assert "Test message" in captured.out
+        assert "i" in captured.out
+
+    def test_success_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test success message output."""
+        Logger.success("Success message")
+        captured = capsys.readouterr()
+        assert "Success message" in captured.out
+
+    def test_warning_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test warning message output."""
+        Logger.warning("Warning message")
+        captured = capsys.readouterr()
+        assert "Warning message" in captured.out
+
+    def test_error_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test error message output to stderr."""
+        Logger.error("Error message")
+        captured = capsys.readouterr()
+        assert "Error message" in captured.err
+
+    def test_step_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test step message output."""
+        Logger.step("Step message")
+        captured = capsys.readouterr()
+        assert "Step message" in captured.out
+
+    def test_header_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test header message output."""
+        Logger.header("Header message")
+        captured = capsys.readouterr()
+        assert "Header message" in captured.out
+        assert "━" in captured.out  # Check for separator line
+
+
+class TestGitHubCLI:
+    """Tests for GitHubCLI class."""
+
+    def test_run_success(self) -> None:
+        """Test successful gh command execution."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="output", stderr="")
+            result = GitHubCLI.run(["repo", "view"])
+            assert result.stdout == "output"
+            mock_run.assert_called_once()
+
+    def test_run_failure_raises(self) -> None:
+        """Test that failed gh command raises exception."""
+        import subprocess
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "gh")
+            with pytest.raises(subprocess.CalledProcessError):
+                GitHubCLI.run(["repo", "view"])
+
+    def test_is_authenticated_true(self) -> None:
+        """Test is_authenticated returns True when authenticated."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert GitHubCLI.is_authenticated() is True
+
+    def test_is_authenticated_false(self) -> None:
+        """Test is_authenticated returns False when not authenticated."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            assert GitHubCLI.is_authenticated() is False
+
+    def test_is_authenticated_no_gh(self) -> None:
+        """Test is_authenticated returns False when gh not installed."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert GitHubCLI.is_authenticated() is False
+
+
+class TestFilesToUpdate:
+    """Tests for FILES_TO_UPDATE constant."""
+
+    def test_is_tuple(self) -> None:
+        """Test that FILES_TO_UPDATE is a tuple (immutable)."""
+        assert isinstance(FILES_TO_UPDATE, tuple)
+
+    def test_contains_core_files(self) -> None:
+        """Test that essential files are included."""
+        core_files = [
+            "pyproject.toml",
+            "README.md",
+            "LICENSE",
+            "dodo.py",
+            "mkdocs.yml",
+            "AGENTS.md",
+        ]
+        for f in core_files:
+            assert f in FILES_TO_UPDATE, f"Missing core file: {f}"
+
+    def test_contains_github_workflows(self) -> None:
+        """Test that GitHub workflow files are included."""
+        workflow_files = [
+            ".github/workflows/ci.yml",
+            ".github/workflows/release.yml",
+            ".github/workflows/testpypi.yml",
+            ".github/workflows/breaking-change-detection.yml",
+        ]
+        for f in workflow_files:
+            assert f in FILES_TO_UPDATE, f"Missing workflow: {f}"
+
+    def test_contains_github_files(self) -> None:
+        """Test that GitHub config files are included."""
+        github_files = [
+            ".github/CONTRIBUTING.md",
+            ".github/SECURITY.md",
+            ".github/CODE_OF_CONDUCT.md",
+            ".github/CODEOWNERS",
+            ".github/pull_request_template.md",
+        ]
+        for f in github_files:
+            assert f in FILES_TO_UPDATE, f"Missing GitHub file: {f}"
+
+    def test_contains_claude_files(self) -> None:
+        """Test that Claude config files are included."""
+        claude_files = [
+            ".claude/CLAUDE.md",
+            ".claude/lsp-setup.md",
+        ]
+        for f in claude_files:
+            assert f in FILES_TO_UPDATE, f"Missing Claude file: {f}"
+
+    def test_contains_config_files(self) -> None:
+        """Test that config files are included."""
+        config_files = [
+            ".envrc",
+            ".pre-commit-config.yaml",
+        ]
+        for f in config_files:
+            assert f in FILES_TO_UPDATE, f"Missing config file: {f}"
+
+    def test_no_duplicates(self) -> None:
+        """Test that there are no duplicate entries."""
+        assert len(FILES_TO_UPDATE) == len(set(FILES_TO_UPDATE))

--- a/tests/test_hook_ruff_fix.py
+++ b/tests/test_hook_ruff_fix.py
@@ -1,0 +1,264 @@
+"""Tests for the ``ruff-fix-on-edit`` PostToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/ruff-fix-on-edit.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "ruff-fix-on-edit.py"
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("ruff_fix_on_edit", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook(monkeypatch: pytest.MonkeyPatch) -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["ruff_fix_on_edit"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("ruff_fix_on_edit", None)
+
+
+@pytest.fixture
+def call_log(hook: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Replace ``run_ruff`` with a recorder; return the list of received paths."""
+    calls: list[Path] = []
+
+    def _record(path: Path) -> None:
+        calls.append(path)
+
+    monkeypatch.setattr(hook, "run_ruff", _record)
+    return calls
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _payload(file_path: str) -> str:
+    """Build a minimal Edit-tool payload referencing *file_path*."""
+    return json.dumps({"tool_name": "Edit", "tool_input": {"file_path": file_path}})
+
+
+def _setup_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``CLAUDE_PROJECT_DIR`` at *tmp_path*."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+
+def _touch(tmp_path: Path, rel: str, contents: str = "x = 1\n") -> Path:
+    """Create *rel* under *tmp_path* with *contents* and return the absolute path."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(contents, encoding="utf-8")
+    return target
+
+
+def test_non_python_file_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """README.md (non-.py) should not invoke ruff."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "README.md", "# hi\n")
+    _set_stdin(monkeypatch, _payload("README.md"))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_python_file_outside_scope_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A .py file outside src/tests/tools and not bootstrap.py is skipped."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "scripts/adhoc.py")
+    _set_stdin(monkeypatch, _payload("scripts/adhoc.py"))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_python_file_in_src_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """src/foo.py triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "src/foo.py")
+    _set_stdin(monkeypatch, _payload("src/foo.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_python_file_in_tests_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """tests/test_foo.py triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "tests/test_foo.py")
+    _set_stdin(monkeypatch, _payload("tests/test_foo.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_python_file_in_tools_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """tools/doit/github.py triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "tools/doit/github.py", "pass\n")
+    _set_stdin(monkeypatch, _payload("tools/doit/github.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_bootstrap_py_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """bootstrap.py at the project root triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "bootstrap.py")
+    _set_stdin(monkeypatch, _payload("bootstrap.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_missing_file_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A path that does not exist on disk is skipped (likely a deletion)."""
+    _setup_project(tmp_path, monkeypatch)
+    # Note: we do NOT create tests/nope.py.
+    _set_stdin(monkeypatch, _payload("tests/nope.py"))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_ruff_failure_still_exits_zero(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If ``run_ruff`` raises a generic exception, main() still returns 0."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "src/foo.py")
+
+    def _boom(_path: Path) -> None:
+        raise RuntimeError("ruff exploded")
+
+    monkeypatch.setattr(hook, "run_ruff", _boom)
+    _set_stdin(monkeypatch, _payload("src/foo.py"))
+
+    assert hook.main() == 0
+
+
+def test_ruff_timeout_still_exits_zero(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If ``run_ruff`` raises ``TimeoutExpired``, main() still returns 0."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "src/foo.py")
+
+    def _timeout(_path: Path) -> None:
+        raise subprocess.TimeoutExpired(cmd="ruff", timeout=30)
+
+    monkeypatch.setattr(hook, "run_ruff", _timeout)
+    _set_stdin(monkeypatch, _payload("src/foo.py"))
+
+    assert hook.main() == 0
+
+
+def test_malformed_stdin_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid JSON on stdin returns 0 with no ruff call."""
+    _setup_project(tmp_path, monkeypatch)
+    _set_stdin(monkeypatch, "not json")
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_missing_tool_input_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """JSON without ``tool_input.file_path`` returns 0 with no ruff call."""
+    _setup_project(tmp_path, monkeypatch)
+    _set_stdin(monkeypatch, json.dumps({"tool_name": "Edit", "tool_input": {}}))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_absolute_path_inside_project(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An absolute path inside the project is normalized and fixed."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "src/foo.py")
+    _set_stdin(monkeypatch, _payload(str(target)))
+
+    assert hook.main() == 0
+    assert call_log == [target]

--- a/tools/doit/template_clean.py
+++ b/tools/doit/template_clean.py
@@ -1,0 +1,114 @@
+"""Template cleanup doit task.
+
+Provides a task to remove template-specific files from projects
+created from pyproject-template.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from doit.tools import title_with_actions
+from rich.console import Console
+
+# Add tools directory to path for imports
+_tools_dir = Path(__file__).parent.parent
+if str(_tools_dir) not in sys.path:
+    sys.path.insert(0, str(_tools_dir))
+
+
+def task_template_clean() -> dict[str, Any]:
+    """Remove template-specific files from the project.
+
+    Options:
+        --setup: Remove setup files only (keep update checking)
+        --all: Remove all template files (no future updates)
+        --dry-run: Show what would be deleted without deleting
+    """
+
+    def run_cleanup(setup: bool, all_files: bool, dry_run: bool) -> None:
+        # Import from tools directory
+        cleanup_module_path = _tools_dir / "pyproject_template" / "cleanup.py"
+        if not cleanup_module_path.exists():
+            console = Console()
+            console.print(
+                "[red]Error: cleanup.py not found. Template files may have been removed.[/red]"
+            )
+            sys.exit(1)
+
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("cleanup", cleanup_module_path)
+        if spec is None or spec.loader is None:
+            console = Console()
+            console.print("[red]Error: Could not load cleanup module.[/red]")
+            sys.exit(1)
+
+        cleanup_mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cleanup_mod)
+
+        cleanup_mode_enum = cleanup_mod.CleanupMode
+        cleanup_template_files = cleanup_mod.cleanup_template_files
+        prompt_cleanup = cleanup_mod.prompt_cleanup
+
+        console = Console()
+
+        # Determine mode
+        if setup and all_files:
+            console.print("[red]Error: Cannot specify both --setup and --all[/red]")
+            sys.exit(1)
+        elif setup:
+            mode = cleanup_mode_enum.SETUP_ONLY
+        elif all_files:
+            mode = cleanup_mode_enum.ALL
+        else:
+            # Interactive mode
+            mode = prompt_cleanup()
+            if mode is None:
+                console.print("[cyan]Keeping all template files[/cyan]")
+                return
+
+        # Perform cleanup
+        result = cleanup_template_files(mode, dry_run=dry_run)
+
+        if dry_run:
+            console.print()
+            console.print("[yellow]Dry run complete. No files were deleted.[/yellow]")
+        elif result.failed:
+            console.print()
+            console.print("[red]Some files could not be deleted.[/red]")
+            sys.exit(1)
+
+    return {
+        "actions": [run_cleanup],
+        "params": [
+            {
+                "name": "setup",
+                "short": "s",
+                "long": "setup",
+                "type": bool,
+                "default": False,
+                "help": "Remove setup files only (keep update checking)",
+            },
+            {
+                "name": "all_files",
+                "short": "a",
+                "long": "all",
+                "type": bool,
+                "default": False,
+                "help": "Remove all template files (no future updates)",
+            },
+            {
+                "name": "dry_run",
+                "short": "n",
+                "long": "dry-run",
+                "type": bool,
+                "default": False,
+                "help": "Show what would be deleted without deleting",
+            },
+        ],
+        "title": title_with_actions,
+        "verbosity": 2,
+    }

--- a/tools/hooks/ai/ruff-fix-on-edit.py
+++ b/tools/hooks/ai/ruff-fix-on-edit.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Claude Code PostToolUse hook that runs ``ruff --fix`` on edited Python files.
+
+Triggered after ``Edit``/``Write``/``MultiEdit`` tool calls. When the touched
+file is a tracked Python source path, runs a fast ``ruff check --fix`` for
+unused imports/variables and import ordering, followed by ``ruff format``.
+
+The hook is best-effort: any failure (timeout, ruff missing, malformed payload)
+is swallowed and the hook exits 0 so it never blocks a tool call. The next
+``doit check`` will surface any genuine issue.
+
+For full documentation, see: docs/development/ai/ruff-fix-hook.md
+"""
+
+import json
+import os
+import subprocess  # nosec B404 - required to invoke ruff
+import sys
+from pathlib import Path
+
+# Path roots whose Python files are eligible for the auto-fix.
+# Mirrors the scope of ``doit format`` / ``doit lint``.
+ALLOWED_ROOTS: tuple[str, ...] = ("src/", "tests/", "tools/")
+
+# Specific files at the project root that are also eligible.
+ALLOWED_FILES: tuple[str, ...] = ("bootstrap.py",)
+
+# Ruff rule selectors restricted to deterministic, judgment-free fixes:
+#   F401 - unused imports
+#   F841 - unused local variables
+#   I    - import ordering
+SELECTED_RULES = "F401,F841,I"
+
+# Per-invocation timeout for ruff (covers both ``check`` and ``format`` calls).
+RUFF_TIMEOUT_SECONDS = 30
+
+
+def _is_in_scope(rel_path: str) -> bool:
+    """Return True iff *rel_path* is a Python file inside the auto-fix scope."""
+    if not rel_path.endswith(".py"):
+        return False
+    if rel_path in ALLOWED_FILES:
+        return True
+    return any(rel_path.startswith(root) for root in ALLOWED_ROOTS)
+
+
+def run_ruff(path: Path) -> None:
+    """Run ``ruff check --fix`` then ``ruff format`` on *path*.
+
+    Best-effort: every exception is swallowed. This function must never raise.
+    """
+    try:
+        subprocess.run(  # nosec B603 B607 - trusted ruff invocation
+            [
+                "uv",
+                "run",
+                "ruff",
+                "check",
+                "--fix",
+                "--select",
+                SELECTED_RULES,
+                "--quiet",
+                str(path),
+            ],
+            capture_output=True,
+            timeout=RUFF_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    except Exception:  # nosec B110 - hook must never raise; errors would block tool calls
+        pass
+
+    try:
+        subprocess.run(  # nosec B603 B607 - trusted ruff invocation
+            ["uv", "run", "ruff", "format", "--quiet", str(path)],
+            capture_output=True,
+            timeout=RUFF_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    except Exception:  # nosec B110 - hook must never raise; errors would block tool calls
+        pass
+
+
+def _normalize_path(raw_path: str, project_dir: str) -> str | None:
+    """Return *raw_path* as a project-relative POSIX-style string.
+
+    Returns None if the path is absolute and outside the project directory
+    (we never auto-fix files we don't own).
+    """
+    path = Path(raw_path)
+    if not path.is_absolute():
+        return raw_path
+
+    if not project_dir:
+        return None
+
+    try:
+        return path.relative_to(project_dir).as_posix()
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+        if not isinstance(input_data, dict):
+            return 0
+
+        tool_input = input_data.get("tool_input")
+        if not isinstance(tool_input, dict):
+            return 0
+
+        raw_file_path = tool_input.get("file_path")
+        if not isinstance(raw_file_path, str) or not raw_file_path:
+            return 0
+
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+        rel_path = _normalize_path(raw_file_path, project_dir)
+        if rel_path is None:
+            return 0
+
+        if not _is_in_scope(rel_path):
+            return 0
+
+        # Resolve to an absolute path for the existence check and ruff call.
+        target = Path(project_dir) / rel_path if project_dir else Path(rel_path)
+        if not target.is_file():
+            return 0
+
+        run_ruff(target)
+    except Exception:  # hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pyproject_template/cleanup.py
+++ b/tools/pyproject_template/cleanup.py
@@ -74,6 +74,10 @@ ALL_TEMPLATE_FILES = [
     "tools/pyproject_template/cleanup.py",
     "tools/pyproject_template/utils.py",
     "tools/pyproject_template/__init__.py",
+    # doit task that wraps cleanup.py — useless in a spawned project because
+    # the module it imports is deleted above. Leaving it in ``doit list``
+    # would be misleading.
+    "tools/doit/template_clean.py",
     "docs/template/index.md",
     "docs/template/manage.md",
     "docs/template/updates.md",
@@ -156,7 +160,7 @@ def update_mkdocs_nav(root: Path | None = None, dry_run: bool = False) -> bool:
     if not mkdocs_file.exists():
         return False
 
-    content = mkdocs_file.read_text()
+    content = mkdocs_file.read_text(encoding="utf-8")
 
     # Pattern to match the Template section in nav
     # Matches from "  - Template:" to the next "  - " at the same indent level or end of nav
@@ -170,9 +174,202 @@ def update_mkdocs_nav(root: Path | None = None, dry_run: bool = False) -> bool:
         return True
 
     new_content = re.sub(pattern, "", content)
-    mkdocs_file.write_text(new_content)
+    mkdocs_file.write_text(new_content, encoding="utf-8")
     Logger.success("Removed Template section from mkdocs.yml")
     return True
+
+
+# Regex patterns used by scrub_template_references. Defined at module scope so
+# tests can import/inspect them if needed. The patterns are applied blindly
+# (``re.sub`` is a no-op when nothing matches), and the function detects
+# whether any scrub occurred by comparing the final content to the original.
+
+# ``pyproject.toml`` stanza for the template-only tools.pyproject_template.*
+# mypy override. Removes the ``[[tool.mypy.overrides]]`` block (including its
+# two trailing preceding comment lines and the ``follow_imports = "skip"`` row)
+# plus the single blank line that separates it from the next section. Greedy
+# comment capture is avoided by anchoring on the module line.
+#
+# Kept as a fallback because ``doit fmt_pyproject`` in the wizard rewrites the
+# stanza form into inline-array form before the scrubber runs
+# (see ``_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_INLINE_RE``); downstream users that
+# invoke the scrubber on an un-formatted file still need this pattern to hit.
+_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE = re.compile(
+    r"\[\[tool\.mypy\.overrides\]\]\n"
+    r"(?:# [^\n]*\n)*"  # optional explanatory comments
+    r'module = "tools\.pyproject_template\.\*"\n'
+    r'follow_imports = "skip"\n'
+    r"\n?",  # trailing blank line (optional so trailing-file case is tolerated)
+)
+
+# ``pyproject.toml`` inline-array form of the mypy override. ``doit
+# fmt_pyproject`` (run earlier in the wizard) rewrites the stanza form into
+# an entry inside ``overrides = [...]``. The two comment lines above the
+# dict entry are preserved by the formatter, so they're part of the match.
+_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_INLINE_RE = re.compile(
+    r"  # Standalone scripts using sys\.path manipulation; excluded from discovery\n"
+    r"  # but still followed via imports from bootstrap\.py\n"
+    r'  \{ module = "tools\.pyproject_template\.\*", follow_imports = "skip" \},\n',
+)
+
+# ``pyproject.toml`` ruff ``per-file-ignores`` block targeting
+# ``tools/pyproject_template/*.py``. Matches the whole TOML entry from the
+# ``lint.per-file-ignores."tools/pyproject_template/*.py" = [`` line through
+# the closing ``]\n``; the indented body is captured non-greedily.
+_PYPROJECT_TEMPLATE_RUFF_PERFILE_RE = re.compile(
+    r'lint\.per-file-ignores\."tools/pyproject_template/\*\.py" = \[\n'
+    r"(?:  [^\n]*\n)*?"
+    r"\]\n",
+)
+
+# ``pyproject.toml`` comment line above ``[tool.mypy]::exclude`` that
+# specifically references ``tools/pyproject_template/``. Removed alongside
+# the corresponding array entry so the remaining AI-config excludes are not
+# left dangling beneath a now-irrelevant explanatory comment.
+_PYPROJECT_TEMPLATE_MYPY_EXCLUDE_COMMENT_RE = re.compile(
+    r"# tools/pyproject_template/ uses sys\.path manipulation for standalone execution\n",
+)
+
+# ``pyproject.toml`` array entry ``"tools/pyproject_template/"`` inside
+# ``[tool.mypy]::exclude = [...]``. The trailing ``\s*`` consumes the
+# separator between array entries (comma, optional whitespace and/or
+# newline), which handles both pyproject-fmt-normalized form (``[ ... ]``
+# padded with spaces) and the raw template form.
+_PYPROJECT_TEMPLATE_MYPY_EXCLUDE_ENTRY_RE = re.compile(
+    r'"tools/pyproject_template/",\s*',
+)
+
+# README.md block containing both template-only top-level setup sections.
+# Starts at ``## Quick Setup (Automated)`` and runs up to (but not including)
+# the next top-level heading ``## Development Setup``. The non-greedy body
+# match plus explicit terminator keeps the scrubber from devouring unrelated
+# sections if the consumer has reshuffled headings.
+_README_TEMPLATE_SECTIONS_RE = re.compile(
+    r"## Quick Setup \(Automated\)\n.*?(?=## Development Setup\b)",
+    re.DOTALL,
+)
+
+# README.md ``### Migrating an Existing Project`` and ``### Keeping Up to
+# Date`` subsections (under ``## Versioning & Releases``). Both reference
+# template-management scripts that no longer exist in the consumer project
+# (``migrate_existing_project.py`` and ``check_template_updates.py``). The
+# terminator ``### Creating a Release`` is the next subsection that stays.
+_README_TEMPLATE_SUBSECTIONS_RE = re.compile(
+    r"### Migrating an Existing Project\n.*?(?=### Creating a Release\b)",
+    re.DOTALL,
+)
+
+# doit-tasks-reference.md ``### template_clean`` section. Runs from the heading
+# up to (but not including) the next ``### build`` heading. The non-greedy body
+# match guards against consuming adjacent sections.
+_DOIT_REF_TEMPLATE_CLEAN_RE = re.compile(
+    r"### `template_clean`\n.*?(?=### `build`)",
+    re.DOTALL,
+)
+
+# doit-tasks-reference.md TOC table row that lists ``template_clean`` alongside
+# ``cleanup``. Rewrites the backtick-delimited command pair so the remaining
+# task (``cleanup``) still shows up in the Maintenance row.
+_DOIT_REF_TOC_TEMPLATE_CLEAN_RE = re.compile(
+    r"`cleanup`, `template_clean`",
+)
+
+
+def scrub_template_references(root: Path | None = None, dry_run: bool = False) -> list[Path]:
+    """Remove user-visible stale references to template-only machinery.
+
+    Applies targeted regex rewrites to three files that retain documentation
+    or configuration for template-only tooling after the cleanup phase has
+    deleted the files those references point at:
+
+    * ``pyproject.toml`` — removes every ``tools/pyproject_template/``
+      artifact: the ruff ``per-file-ignores`` block, the mypy ``exclude``
+      entry (and its explanatory comment), and the mypy override (in both
+      stanza and inline-array form, because ``doit fmt_pyproject`` rewrites
+      the file before cleanup runs in the wizard).
+    * ``README.md`` — removes the ``## Quick Setup (Automated)`` and
+      ``## Using This Template (Manual)`` top-level sections plus the
+      ``### Migrating an Existing Project`` and ``### Keeping Up to Date``
+      subsections of ``## Versioning & Releases``.
+    * ``docs/development/doit-tasks-reference.md`` — removes the
+      ``### template_clean`` section and rewrites the TOC table row so the
+      remaining ``cleanup`` entry is listed alone.
+
+    Patterns are applied blindly; ``re.sub`` is a no-op when nothing matches,
+    and the function detects whether a file changed by comparing final
+    content to the original. That makes the scrubber idempotent — repeat
+    calls and already-scrubbed files record no change.
+
+    Args:
+        root: Project root directory (defaults to cwd).
+        dry_run: If True, report what would be changed but do not write files.
+
+    Returns:
+        Sorted list of paths whose contents changed (or would change, under
+        ``dry_run``). Empty list when no scrub was needed.
+    """
+    if root is None:
+        root = Path.cwd()
+
+    changed: list[Path] = []
+
+    # 1. pyproject.toml — scrub all template-only configuration fragments.
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        original = pyproject.read_text(encoding="utf-8")
+        new_content = original
+        new_content = _PYPROJECT_TEMPLATE_RUFF_PERFILE_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_EXCLUDE_COMMENT_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_EXCLUDE_ENTRY_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_INLINE_RE.sub("", new_content)
+        if new_content != original:
+            if dry_run:
+                Logger.info("Would scrub template-only references in pyproject.toml")
+            else:
+                pyproject.write_text(new_content, encoding="utf-8")
+                Logger.success("Removed template-only references from pyproject.toml")
+            changed.append(pyproject)
+
+    # 2. README.md — scrub both top-level template sections and the two
+    #    template-management subsections under "Versioning & Releases".
+    readme = root / "README.md"
+    if readme.is_file():
+        original = readme.read_text(encoding="utf-8")
+        new_content = original
+        new_content = _README_TEMPLATE_SECTIONS_RE.sub("", new_content)
+        new_content = _README_TEMPLATE_SUBSECTIONS_RE.sub("", new_content)
+        if new_content != original:
+            if dry_run:
+                Logger.info("Would scrub template-only sections in README.md")
+            else:
+                readme.write_text(new_content, encoding="utf-8")
+                Logger.success("Removed template-only sections from README.md")
+            changed.append(readme)
+
+    # 3. docs/development/doit-tasks-reference.md — remove the template_clean
+    #    section and rewrite the TOC row.
+    doit_ref = root / "docs" / "development" / "doit-tasks-reference.md"
+    if doit_ref.is_file():
+        original = doit_ref.read_text(encoding="utf-8")
+        new_content = original
+        new_content = _DOIT_REF_TEMPLATE_CLEAN_RE.sub("", new_content)
+        new_content = _DOIT_REF_TOC_TEMPLATE_CLEAN_RE.sub("`cleanup`", new_content)
+        if new_content != original:
+            if dry_run:
+                Logger.info(
+                    "Would scrub template_clean references in "
+                    "docs/development/doit-tasks-reference.md"
+                )
+            else:
+                doit_ref.write_text(new_content, encoding="utf-8")
+                Logger.success(
+                    "Removed template_clean references from "
+                    "docs/development/doit-tasks-reference.md"
+                )
+            changed.append(doit_ref)
+
+    return sorted(changed)
 
 
 def cleanup_template_files(
@@ -223,6 +420,9 @@ def cleanup_template_files(
         mkdocs_would_update = False
         if mode == CleanupMode.ALL:
             mkdocs_would_update = update_mkdocs_nav(root, dry_run=True)
+            # Also report any scrub targets; the return value is discarded
+            # here because CleanupResult has no field for it.
+            scrub_template_references(root, dry_run=True)
         return CleanupResult(files_to_delete, dirs_to_delete, [], mkdocs_would_update)
 
     # Delete files
@@ -247,6 +447,9 @@ def cleanup_template_files(
     mkdocs_updated = False
     if mode == CleanupMode.ALL:
         mkdocs_updated = update_mkdocs_nav(root, dry_run=False)
+        # Scrub user-visible references (pyproject.toml, README.md,
+        # doit-tasks-reference.md) that still point at now-deleted files.
+        scrub_template_references(root, dry_run=False)
 
     # Report results
     if deleted_files:

--- a/tools/pyproject_template/configure.py
+++ b/tools/pyproject_template/configure.py
@@ -9,6 +9,7 @@ Optional: skip final confirmation with --yes.
 
 import argparse
 import shutil
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
@@ -88,7 +89,7 @@ def guess_github_user(pyproject_data: dict[str, object]) -> str:
 def read_readme_title(readme_path: Path) -> str:
     if not readme_path.exists():
         return ""
-    for line in readme_path.read_text().splitlines():
+    for line in readme_path.read_text(encoding="utf-8").splitlines():
         if line.startswith("#"):
             return line.lstrip("#").strip()
     return ""
@@ -157,6 +158,78 @@ def require(value: str, label: str) -> str:
     raise SystemExit(
         f"❌ Missing required value for {label} (supply in pyproject.toml or via prompt)."
     )
+
+
+def _git_has_version_tag() -> bool:
+    """Return ``True`` if the current repo has at least one ``v*`` tag."""
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "tag", "--list", "v*"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
+def _git_root_commit() -> str | None:
+    """Return the root commit SHA of the current repo, or ``None`` if unavailable.
+
+    Returns ``None`` if not inside a git repo, the repo has no commits, or the
+    ``git rev-list`` call fails for any other reason.
+    """
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "rev-list", "--max-parents=0", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return lines[0] if lines else None
+
+
+def seed_baseline_tag() -> None:
+    """Seed a ``v0.0.0`` tag on the root commit if no ``v*`` tag exists.
+
+    Gives commitizen an anchor to compute pre-release versions against. Without
+    it, ``doit release --prerelease=alpha`` refuses on a tagless repo (guard
+    from issue #448). Idempotent: skips if any ``v*`` tag already exists. Skips
+    silently (with a visible message) if not inside a git repo or if there are
+    no commits yet, so the user can run ``git init && git commit`` first and
+    seed manually with ``git tag v0.0.0 <root-commit>``.
+    """
+    if not Path(".git").exists():
+        Logger.info(
+            "Skipping v0.0.0 baseline tag: not a git repo yet (run `git init` "
+            "and commit first, then seed manually: "
+            "`git tag v0.0.0 <root-commit>`)"
+        )
+        return
+
+    if _git_has_version_tag():
+        Logger.info("Skipping v0.0.0 baseline tag: a v* tag already exists")
+        return
+
+    root = _git_root_commit()
+    if root is None:
+        Logger.info(
+            "Skipping v0.0.0 baseline tag: no commits yet "
+            "(seed manually after your first commit: `git tag v0.0.0 <root-commit>`)"
+        )
+        return
+
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "tag", "v0.0.0", root],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        print(f"  ✓ Seeded baseline tag v0.0.0 on root commit {root[:7]}")
+        Logger.info("   → push with `git push origin v0.0.0` when ready")
+    else:
+        Logger.warning(f"Could not create v0.0.0 tag: {result.stderr.strip() or 'unknown error'}")
 
 
 def run_configure(
@@ -270,7 +343,22 @@ def run_configure(
     # Define replacements
     # IMPORTANT: Longer/Specific replacements must come before shorter substrings
     replacements = {
-        # URLs (Specific matches first)
+        # Marker tokens (unambiguous, used in prose files). These take
+        # priority because ``update_file()`` treats them as blind replaces
+        # regardless of surrounding context.
+        "__PACKAGE_NAME__": package_name,
+        "__PYPI_NAME__": pypi_name,
+        "__PROJECT_NAME__": project_name,
+        "__GH_OWNER__": github_user,
+        "__AUTHOR_NAME__": author_name,
+        "__AUTHOR_EMAIL__": author_email,
+        "__DESCRIPTION__": description,
+        "__REPO_URL__": f"https://github.com/{github_user}/{package_name}",
+        "__REPO_SLUG__": f"{github_user}/{package_name}",
+        # URLs (Specific matches first). Retained for runtime-critical files
+        # (pyproject.toml, workflows, LICENSE, mkdocs.yml, dodo.py, .envrc,
+        # .pre-commit-config.yaml) that keep literal placeholders, and for
+        # downstream consumer projects that have not yet migrated.
         "https://github.com/username/package_name": f"https://github.com/{github_user}/{package_name}",
         "https://github.com/original-owner/package_name": f"https://github.com/{github_user}/{package_name}",
         "https://codecov.io/gh/username/package_name": f"https://codecov.io/gh/{github_user}/{package_name}",
@@ -284,7 +372,9 @@ def run_configure(
         "package-name/": f"{pypi_name}/",
         # Repo name pattern (mkdocs.yml) - must come before general package_name
         "username/package_name": f"{github_user}/{package_name}",
-        # General Placeholders (Substrings)
+        # General Placeholders (Substrings). Python files receive
+        # word-boundary protection from ``update_file()`` so identifier
+        # substrings (e.g. ``validate_package_name``) survive.
         "package_name": package_name,
         "package-name": pypi_name,
         "Package Name": project_name,
@@ -355,11 +445,11 @@ def run_configure(
         print("  ✓ Updating test files")
         update_test_files(test_dir, package_name)
 
-    # Remove template tool tests (they're only for the template itself)
-    tool_tests_dir = Path("tests/pyproject_template")
-    if tool_tests_dir.exists():
-        print("  ✓ Removing template tool tests (tests/pyproject_template/)")
-        shutil.rmtree(tool_tests_dir)
+    # Remove template-only tests (they're only for the template itself)
+    template_tests_dir = Path("tests/template")
+    if template_tests_dir.exists():
+        print("  ✓ Removing template-only tests (tests/template/)")
+        shutil.rmtree(template_tests_dir)
 
     # Enable Dependabot if requested
     dependabot_example = Path(".github/dependabot.yml.example")
@@ -368,6 +458,11 @@ def run_configure(
         print("  ✓ Enabling Dependabot")
         shutil.copy(dependabot_example, dependabot_config)
 
+    # Seed v0.0.0 baseline tag so `doit release --prerelease=alpha` works on the
+    # first release (see issue #447). Idempotent and skipped gracefully when
+    # there is no git repo or no commits yet.
+    seed_baseline_tag()
+
     Logger.success("Configuration complete!")
     Logger.header("Next Steps")
     print("1. Review the changes: git diff")
@@ -375,7 +470,7 @@ def run_configure(
     print("3. Install dependencies: uv sync --all-extras --dev")
     print("4. Install pre-commit hooks: uv run doit pre_commit_install")
     print("5. Run tests: uv run pytest")
-    print("6. Cut a prerelease (if desired): uv run doit release_dev")
+    print("6. Cut a prerelease (if desired): uv run doit release --prerelease=alpha")
     print("7. Start coding!")
     print("━" * 60)
 

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -40,7 +40,7 @@ from settings import (  # noqa: E402
     get_template_commits_since,
     get_template_latest_commit,
 )
-from utils import Colors, Logger, prompt, prompt_confirm, validate_package_name  # noqa: E402
+from utils import Colors, Logger, prompt, validate_package_name  # noqa: E402
 
 # Import cleanup utilities (optional - may not exist if already cleaned)
 try:
@@ -307,27 +307,9 @@ def run_action(
         return 1
 
 
-def _copy_template_adrs(template_dir: Path, project_dir: Path) -> int:
-    """Copy template ADR files (9*.md) into the project's decisions directory.
-
-    Args:
-        template_dir: Path to docs/template/decisions/ in the cloned project.
-        project_dir: Path to docs/decisions/ in the cloned project.
-
-    Returns:
-        Number of files copied.
-    """
-    import shutil
-
-    copied = 0
-    for adr_file in sorted(template_dir.glob("9*.md")):
-        shutil.copy2(adr_file, project_dir / adr_file.name)
-        copied += 1
-    return copied
-
-
 def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool = False) -> int:
     """Create a new project from the template."""
+    del yes  # Kept for action_* signature uniformity; no confirmation prompts remain.
     Logger.header("Creating New Project from Template")
 
     settings = manager.settings
@@ -379,23 +361,6 @@ def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool 
         # Clone and configure locally BEFORE branch protection
         setup.clone_repository()
 
-        # Offer to copy template ADRs into project decisions
-        template_adrs_dir = Path.cwd() / "docs" / "template" / "decisions"
-        project_adrs_dir = Path.cwd() / "docs" / "decisions"
-        # When yes=True, skip prompt and default to False (don't copy ADRs)
-        should_copy_adrs = (
-            not yes
-            and template_adrs_dir.exists()
-            and project_adrs_dir.exists()
-            and prompt_confirm(
-                "Include template ADRs in project decisions directory?",
-                default=False,
-            )
-        )
-        if should_copy_adrs:
-            count = _copy_template_adrs(template_adrs_dir, project_adrs_dir)
-            Logger.info(f"Copied {count} template ADR(s) to docs/decisions/")
-
         setup.configure_placeholders()
         setup.setup_development_environment()
 
@@ -430,11 +395,12 @@ def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool 
             )
             subprocess.run(["git", "push"], cwd=project_dir, check=True)
 
-        # Now configure branch protection and other GitHub settings
+        # Now configure branch protection and other GitHub settings.
+        # CodeQL scanning is NOT set up here: it runs from the committed
+        # .github/workflows/codeql.yml workflow that was cloned with the repo.
         setup.configure_branch_protection()
         setup.replicate_labels()
         setup.enable_github_pages()
-        setup.configure_codeql()
 
         setup.print_manual_steps()
 
@@ -473,7 +439,7 @@ def action_check_updates(manager: SettingsManager, dry_run: bool) -> int:
         template_dir = Path("tmp/extracted/pyproject-template-main")
         if template_dir.exists():
             commit_file = template_dir / ".template_commit"
-            commit_file.write_text(f"{latest[0]}\n{latest[1]}\n")
+            commit_file.write_text(f"{latest[0]}\n{latest[1]}\n", encoding="utf-8")
             print()
             Logger.info("After reviewing changes, use option [5] to mark as synced.")
 
@@ -524,7 +490,6 @@ def action_repo_settings(manager: SettingsManager, dry_run: bool) -> int:
         Logger.info("  - Branch protection rulesets")
         Logger.info("  - Labels")
         Logger.info("  - GitHub Pages")
-        Logger.info("  - CodeQL code scanning")
         return 0
 
     # Import repo_settings module for repository configuration
@@ -567,7 +532,7 @@ def action_mark_synced(manager: SettingsManager, dry_run: bool, *, yes: bool = F
         return 1
 
     # Read commit info from the reviewed template
-    lines = commit_file.read_text().strip().split("\n")
+    lines = commit_file.read_text(encoding="utf-8").strip().split("\n")
     if len(lines) < 2:
         Logger.error("Invalid commit file format")
         return 1

--- a/tools/pyproject_template/migrate_existing_project.py
+++ b/tools/pyproject_template/migrate_existing_project.py
@@ -1,0 +1,261 @@
+"""
+Helper script to apply this template onto an existing repository.
+
+Usage:
+    python tools/pyproject_template/migrate_existing_project.py --target /path/to/existing/repo
+    # Optional: download the template archive (no local checkout needed)
+    python tools/pyproject_template/migrate_existing_project.py --target /path/to/repo --download
+
+What it does:
+    - Optionally downloads the template (zip/tar) into target/tmp and extracts it
+    - Backs up any files/dirs it would overwrite into a timestamped backup folder
+      (under target/tmp/)
+    - Copies core template files (tooling, docs, workflows, editor config)
+    - Prints a summary of moved/backed-up items and next steps
+
+This does NOT run the interactive configurator or move your source code. After
+copying, you still need to:
+    - Run `python configure.py` in the target repo to set project/package info
+    - Move your code into src/<package_name>/ and fix imports
+    - Merge dependencies/metadata into the new pyproject.toml
+    - Regenerate uv.lock and rerun checks
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import shutil
+import sys
+from pathlib import Path
+
+# Support running as script or as module
+_script_dir = Path(__file__).parent
+if str(_script_dir) not in sys.path:
+    sys.path.insert(0, str(_script_dir))
+
+# Import shared utilities
+from utils import TEMPLATE_URL, Logger, download_and_extract_archive  # noqa: E402
+
+DEFAULT_ARCHIVE_URL = f"{TEMPLATE_URL}/archive/refs/heads/main.zip"
+
+
+TEMPLATE_REL_PATHS: tuple[str, ...] = (
+    # Config and tooling
+    "pyproject.toml",
+    "dodo.py",
+    "tools/pyproject_template/configure.py",
+    ".envrc",
+    ".envrc.local.example",
+    ".pre-commit-config.yaml",
+    ".python-version",
+    "mkdocs.yml",
+    ".editorconfig",
+    ".gitignore",
+    "src/package_name",
+    # Docs and guides
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "docs",
+    "examples",
+    # Project scaffolding / automation
+    ".github",
+    ".devcontainer",
+    ".vscode",
+    ".claude",
+    ".codex",
+    ".gemini",
+    "tools",
+    "tmp/.gitkeep",
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Copy pyproject-template scaffolding into an existing repo with backups.",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        type=Path,
+        help="Path to the existing repository you want to update.",
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=None,
+        help="Path to the pyproject-template root (defaults to this script's "
+        "repo unless --download).",
+    )
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Download the template archive into target/tmp instead of using a local checkout.",
+    )
+    parser.add_argument(
+        "--archive-url",
+        type=str,
+        default=DEFAULT_ARCHIVE_URL,
+        help=f"URL to template archive (zip/tarball). Default: {DEFAULT_ARCHIVE_URL}",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be copied without making changes.",
+    )
+    return parser.parse_args(argv)
+
+
+def ensure_exists(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def run_migrate(
+    target: Path,
+    template: Path | None = None,
+    download: bool = False,
+    archive_url: str = DEFAULT_ARCHIVE_URL,
+    dry_run: bool = False,
+) -> int:
+    """Migrate an existing project to use pyproject-template.
+
+    Args:
+        target: Path to the existing repository to update.
+        template: Path to the pyproject-template root.
+        download: Download the template archive instead of using local checkout.
+        archive_url: URL to template archive.
+        dry_run: Show what would be done without making changes.
+
+    Returns:
+        Exit code (0 for success, non-zero for error).
+    """
+    target_root = target.resolve()
+
+    if download:
+        if dry_run:
+            Logger.info(f"Dry run: Would download template from {archive_url}")
+            template_root = Path(__file__).resolve().parent.parent.parent
+        else:
+            tmp_dir = target_root / "tmp"
+            ensure_exists(tmp_dir)
+            print(f"Downloading template archive from {archive_url} ...")
+
+            template_root = download_and_extract_archive(archive_url, tmp_dir)
+            Logger.success(f"Template downloaded to {template_root}")
+    else:
+        # Default to the root of the repo containing this script
+        # Script is at tools/pyproject_template/migrate_existing_project.py
+        # Root is ../../..
+        template_root = (template or Path(__file__).resolve().parent.parent.parent).resolve()
+
+    if not template_root.exists():
+        Logger.error(f"Template path does not exist: {template_root}")
+        return 1
+    if not target_root.exists():
+        Logger.error(f"Target path does not exist: {target_root}")
+        return 1
+
+    timestamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = target_root / "tmp" / f"template-migration-backup-{timestamp}"
+
+    backed_up: list[tuple[Path, Path]] = []
+    copied: list[Path] = []
+    skipped: list[Path] = []
+    would_backup: list[Path] = []
+
+    for rel in TEMPLATE_REL_PATHS:
+        src = template_root / rel
+        dst = target_root / rel
+
+        if not src.exists():
+            skipped.append(src)
+            continue
+
+        if dst.exists():
+            if dry_run:
+                would_backup.append(dst)
+            else:
+                backup_path = backup_root / rel
+                ensure_exists(backup_path.parent)
+                shutil.move(str(dst), str(backup_path))
+                backed_up.append((dst, backup_path))
+
+        if dry_run:
+            copied.append(dst)
+        else:
+            if src.is_dir():
+                shutil.copytree(src, dst)
+            else:
+                ensure_exists(dst.parent)
+                shutil.copy2(src, dst)
+            copied.append(dst)
+
+    print("\n=== Template Migration Helper ===")
+    print(f"Template: {template_root}")
+    print(f"Target  : {target_root}")
+    if dry_run:
+        print("Mode    : DRY RUN (no changes made)")
+    else:
+        print(f"Backup  : {backup_root}")
+    print()
+
+    if copied:
+        print("Would copy:" if dry_run else "Copied:")
+        for path in copied:
+            print(f"  - {path.relative_to(target_root)}")
+    else:
+        print("Copied: (none)")
+
+    print()
+    if dry_run and would_backup:
+        print("Would back up existing items before overwrite:")
+        for path in would_backup:
+            print(f"  - {path.relative_to(target_root)}")
+    elif backed_up:
+        print("Backed up existing items before overwrite:")
+        for original, backup in backed_up:
+            print(f"  - {original.relative_to(target_root)} -> {backup.relative_to(target_root)}")
+    else:
+        print("Backed up: (none needed)")
+
+    if skipped:
+        print()
+        print("Skipped (not present in template):")
+        for path in skipped:
+            print(f"  - {path.relative_to(template_root)}")
+
+    if dry_run:
+        print("\nDry run complete - no changes were made.")
+    else:
+        print("\nNext steps:")
+        print(" 1) Run: python tools/pyproject_template/configure.py")
+        print(" 2) Move your source code into src/<package_name>/ and fix imports")
+        print(" 3) Merge your dependencies into pyproject.toml")
+        print(" 4) Run: uv sync && doit check")
+        print(" 5) Review backed-up files and port any custom content")
+        print("\nFuture updates:")
+        print(" • Run: python tools/pyproject_template/check_template_updates.py")
+        print(" • This will show what changed in the template since migration")
+        print("\nDone.")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for CLI usage."""
+    args = parse_args(argv)
+    return run_migrate(
+        target=args.target,
+        template=args.template,
+        download=args.download,
+        archive_url=args.archive_url,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    print("This script should not be run directly.")
+    print("Please use: python manage.py")
+    sys.exit(1)

--- a/tools/pyproject_template/repo_settings.py
+++ b/tools/pyproject_template/repo_settings.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""
+repo_settings.py - GitHub repository settings configuration.
+
+This module provides functions to configure GitHub repository settings,
+branch protection, labels, and GitHub Pages. It can be used independently
+of the full setup process.
+
+CodeQL scanning is configured via the committed workflow file at
+``.github/workflows/codeql.yml`` (advanced setup) -- no API call is
+required, because the workflow is replicated by the template generator
+along with all other workflow files. See issue #431.
+
+These functions are used by both setup_repo.py (initial setup) and
+manage.py (updating existing repositories).
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+from typing import Any
+
+# Support running as script or as module
+_script_dir = Path(__file__).parent
+if str(_script_dir) not in sys.path:
+    sys.path.insert(0, str(_script_dir))
+
+from utils import TEMPLATE_REPO, GitHubCLI, Logger  # noqa: E402
+
+
+def configure_repository_settings(
+    repo_full: str,
+    description: str,
+    visibility: str | None = None,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Configure repository settings to match template.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        description: Repository description
+        visibility: Repository visibility ('public' or 'private'), used for
+                   determining which security features are available
+        template_repo: Template repository to copy settings from
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Configuring repository settings...")
+
+    try:
+        # Get ALL settings from template repository
+        template_settings = GitHubCLI.api(f"repos/{template_repo}")
+
+        # Read-only fields that should not be copied
+        readonly_fields = {
+            # URLs
+            "archive_url",
+            "assignees_url",
+            "blobs_url",
+            "branches_url",
+            "clone_url",
+            "collaborators_url",
+            "comments_url",
+            "commits_url",
+            "compare_url",
+            "contents_url",
+            "contributors_url",
+            "deployments_url",
+            "downloads_url",
+            "events_url",
+            "forks_url",
+            "git_commits_url",
+            "git_refs_url",
+            "git_tags_url",
+            "git_url",
+            "hooks_url",
+            "html_url",
+            "issue_comment_url",
+            "issue_events_url",
+            "issues_url",
+            "keys_url",
+            "labels_url",
+            "languages_url",
+            "merges_url",
+            "milestones_url",
+            "notifications_url",
+            "pulls_url",
+            "releases_url",
+            "ssh_url",
+            "stargazers_url",
+            "statuses_url",
+            "subscribers_url",
+            "subscription_url",
+            "svn_url",
+            "tags_url",
+            "teams_url",
+            "trees_url",
+            "url",
+            # IDs and metadata
+            "id",
+            "node_id",
+            "owner",
+            "full_name",
+            "name",
+            # Timestamps
+            "created_at",
+            "updated_at",
+            "pushed_at",
+            # Counts and computed values
+            "forks",
+            "forks_count",
+            "open_issues",
+            "open_issues_count",
+            "size",
+            "stargazers_count",
+            "watchers",
+            "watchers_count",
+            "subscribers_count",
+            "network_count",
+            # Other read-only
+            "fork",
+            "language",
+            "license",
+            "permissions",
+            "disabled",
+            "mirror_url",
+            "default_branch",  # Keep as main
+            "private",  # Set separately via visibility
+            "is_template",  # Don't make new repos templates
+            # Deprecated
+            "use_squash_pr_title_as_default",
+        }
+
+        # Build settings data by copying all writable fields from template
+        data: dict[str, Any] = {}
+        for key, value in template_settings.items():
+            if key not in readonly_fields and value is not None:
+                data[key] = value
+
+        # Override description with user's description
+        data["description"] = description
+
+        # Check if repository is in an organization
+        repo_owner = repo_full.split("/")[0]
+        owner_info = GitHubCLI.api(f"users/{repo_owner}")
+        is_org = owner_info.get("type") == "Organization"
+
+        # Remove allow_forking if not an org repo (only applies to orgs)
+        if not is_org and "allow_forking" in data:
+            data.pop("allow_forking")
+
+        # Remove security_and_analysis - we'll handle it separately
+        security_settings = data.pop("security_and_analysis", None)
+
+        # Apply all settings in one call
+        GitHubCLI.api(f"repos/{repo_full}", method="PATCH", data=data)
+        Logger.success("Repository settings configured")
+
+        # Configure security and analysis settings separately
+        if security_settings:
+            _configure_security_settings(repo_full, security_settings, visibility)
+
+        return True
+
+    except subprocess.CalledProcessError as e:
+        Logger.warning("Repository settings configuration failed")
+        if e.stderr:
+            print(f"  Error: {e.stderr.strip()}")
+        Logger.info("You can configure settings manually at:")
+        Logger.info(f"  https://github.com/{repo_full}/settings")
+        return False
+
+
+def _configure_security_settings(
+    repo_full: str,
+    security_settings: dict[str, Any],
+    visibility: str | None = None,
+) -> None:
+    """Configure security and analysis settings.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        security_settings: Security settings from template
+        visibility: Repository visibility for determining feature availability
+    """
+    if not security_settings:
+        return
+
+    # Enable secret scanning if template has it
+    if security_settings.get("secret_scanning", {}).get("status") == "enabled":
+        try:
+            GitHubCLI.api(
+                f"repos/{repo_full}/secret-scanning",
+                method="PATCH",
+                data={"status": "enabled"},
+            )
+            Logger.success("Secret scanning enabled")
+        except subprocess.CalledProcessError as e:
+            # 404 is expected for free/private repos that don't support this
+            if "404" in str(e.stderr):
+                if visibility == "public":
+                    Logger.success("Secret scanning enabled (default for public repos)")
+                else:
+                    Logger.info("Secret scanning not available (requires GHAS or public repo)")
+            else:
+                Logger.warning("Secret scanning configuration failed")
+                if e.stderr:
+                    print(f"  Error: {e.stderr.strip()}")
+
+    # Enable secret scanning push protection if template has it
+    if security_settings.get("secret_scanning_push_protection", {}).get("status") == "enabled":
+        try:
+            GitHubCLI.api(
+                f"repos/{repo_full}/secret-scanning/push-protection",
+                method="PATCH",
+                data={"status": "enabled"},
+            )
+            Logger.success("Secret scanning push protection enabled")
+        except subprocess.CalledProcessError as e:
+            if "404" in str(e.stderr):
+                if visibility == "public":
+                    Logger.success(
+                        "Secret scanning push protection enabled (default for public repos)"
+                    )
+                else:
+                    Logger.info("Secret scanning push protection not available for this repository")
+            else:
+                Logger.warning("Secret scanning push protection configuration failed")
+                if e.stderr:
+                    print(f"  Error: {e.stderr.strip()}")
+
+    # Enable Dependabot security updates if template has it
+    if security_settings.get("dependabot_security_updates", {}).get("status") == "enabled":
+        try:
+            GitHubCLI.api(
+                f"repos/{repo_full}/automated-security-fixes",
+                method="PUT",
+            )
+            Logger.success("Dependabot security updates enabled")
+        except subprocess.CalledProcessError as e:
+            Logger.warning("Dependabot security updates configuration failed")
+            if e.stderr:
+                print(f"  Error: {e.stderr.strip()}")
+
+
+def configure_branch_protection(
+    repo_full: str,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Configure branch protection using rulesets.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        template_repo: Template repository to copy rulesets from
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Configuring branch protection rulesets...")
+
+    try:
+        # Get rulesets from template
+        template_rulesets = GitHubCLI.api(f"repos/{template_repo}/rulesets")
+
+        if not template_rulesets:
+            Logger.warning("No rulesets found in template repository")
+            return True  # Not a failure, just nothing to do
+
+        # Get existing rulesets from target repository to check for duplicates
+        existing_rulesets = GitHubCLI.api(f"repos/{repo_full}/rulesets")
+        existing_by_name: dict[str, int] = {
+            ruleset["name"]: ruleset["id"] for ruleset in existing_rulesets
+        }
+
+        # Replicate each ruleset
+        for template_ruleset in template_rulesets:
+            # Get full ruleset details
+            ruleset_id = template_ruleset["id"]
+            full_ruleset = GitHubCLI.api(f"repos/{template_repo}/rulesets/{ruleset_id}")
+
+            # Prepare ruleset data (remove read-only fields)
+            ruleset_data = {
+                "name": full_ruleset["name"],
+                "target": full_ruleset["target"],
+                "enforcement": full_ruleset["enforcement"],
+                "bypass_actors": full_ruleset.get("bypass_actors", []),
+                "conditions": full_ruleset.get("conditions", {}),
+                "rules": full_ruleset.get("rules", []),
+            }
+
+            ruleset_name = full_ruleset["name"]
+
+            # Check if ruleset already exists
+            if ruleset_name in existing_by_name:
+                # Update existing ruleset
+                existing_id = existing_by_name[ruleset_name]
+                GitHubCLI.api(
+                    f"repos/{repo_full}/rulesets/{existing_id}",
+                    method="PUT",
+                    data=ruleset_data,
+                )
+                Logger.success(f"Ruleset '{ruleset_name}' updated")
+            else:
+                # Create new ruleset
+                GitHubCLI.api(
+                    f"repos/{repo_full}/rulesets",
+                    method="POST",
+                    data=ruleset_data,
+                )
+                Logger.success(f"Ruleset '{ruleset_name}' created")
+
+        return True
+
+    except subprocess.CalledProcessError as e:
+        Logger.warning("Branch protection ruleset configuration failed")
+        if e.stderr:
+            print(f"  Error: {e.stderr.strip()}")
+        Logger.info("You can configure rulesets manually at:")
+        Logger.info(f"  https://github.com/{repo_full}/settings/rules")
+        return False
+
+
+def replicate_labels(
+    repo_full: str,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Replicate labels from template.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        template_repo: Template repository to copy labels from
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Replicating labels from template...")
+
+    try:
+        # Get labels from template
+        labels = GitHubCLI.api(f"repos/{template_repo}/labels")
+
+        if not labels:
+            Logger.warning("Could not retrieve labels from template")
+            return False
+
+        # Create each label
+        for label in labels:
+            try:
+                label_data = {
+                    "name": label["name"],
+                    "color": label["color"],
+                    "description": label.get("description", ""),
+                }
+                GitHubCLI.api(
+                    f"repos/{repo_full}/labels",
+                    method="POST",
+                    data=label_data,
+                )
+            except subprocess.CalledProcessError:
+                # Label might already exist, skip
+                pass
+
+        Logger.success("Labels replicated")
+        return True
+
+    except subprocess.CalledProcessError as e:
+        Logger.warning("Failed to retrieve labels from template")
+        if e.stderr:
+            print(f"  Error: {e.stderr.strip()}")
+        return False
+
+
+def enable_github_pages(repo_full: str) -> bool:
+    """Enable GitHub Pages.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Enabling GitHub Pages...")
+
+    try:
+        data = {
+            "source": {
+                "branch": "gh-pages",
+                "path": "/",
+            }
+        }
+        GitHubCLI.api(f"repos/{repo_full}/pages", method="POST", data=data)
+        Logger.success("GitHub Pages enabled")
+        return True
+    except subprocess.CalledProcessError:
+        Logger.warning("GitHub Pages not enabled (gh-pages branch doesn't exist yet)")
+        Logger.info("Pages will be enabled automatically after first docs deployment")
+        return False
+
+
+def update_all_repo_settings(
+    repo_full: str,
+    description: str,
+    visibility: str | None = None,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Update all repository settings to match template.
+
+    This is a convenience function that runs all configuration steps.
+
+    Note: CodeQL scanning is NOT configured here -- it is driven by the
+    committed ``.github/workflows/codeql.yml`` workflow file, which the
+    template generator copies into new repositories alongside every other
+    workflow. No API call is required. See issue #431.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        description: Repository description
+        visibility: Repository visibility ('public' or 'private')
+        template_repo: Template repository to copy settings from
+
+    Returns:
+        True if all steps successful, False if any failed
+    """
+    results = [
+        configure_repository_settings(repo_full, description, visibility, template_repo),
+        configure_branch_protection(repo_full, template_repo),
+        replicate_labels(repo_full, template_repo),
+        enable_github_pages(repo_full),
+    ]
+    return all(results)

--- a/tools/pyproject_template/settings.py
+++ b/tools/pyproject_template/settings.py
@@ -391,7 +391,7 @@ class SettingsManager:
         }
 
         settings_path = self.root / SETTINGS_FILE
-        with settings_path.open("w") as f:
+        with settings_path.open("w", encoding="utf-8") as f:
             f.write(_toml_serialize(data))
 
         Logger.success(f"Settings saved to {SETTINGS_FILE}")

--- a/tools/pyproject_template/setup_repo.py
+++ b/tools/pyproject_template/setup_repo.py
@@ -1,0 +1,898 @@
+#!/usr/bin/env python3
+"""
+setup-repo.py - Automated GitHub Repository Setup from pyproject-template
+
+This script automates the creation and configuration of a new GitHub repository
+based on the pyproject-template. It handles repository creation, settings
+configuration, branch protection, and placeholder replacement.
+
+Usage:
+    python3 setup-repo.py
+    curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py \
+        | python3
+
+Requirements:
+    - GitHub CLI (gh) installed and authenticated
+    - Git installed
+    - Python 3.12+
+
+Author: Generated from pyproject-template
+License: MIT
+"""
+
+import os
+import shutil
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+from typing import Any
+
+# Support running as script or as module
+_script_dir = Path(__file__).parent
+if str(_script_dir) not in sys.path:
+    sys.path.insert(0, str(_script_dir))
+
+# isort: off
+# Import cleanup helpers (used after development environment setup to
+# remove the template management suite from the spawned consumer project).
+from cleanup import (  # noqa: E402
+    CleanupMode,
+    cleanup_template_files,
+)
+
+# Import repo settings functions (aliased to avoid shadowing class methods)
+from repo_settings import (  # noqa: E402
+    configure_branch_protection as _configure_branch_protection,
+    configure_repository_settings as _configure_repository_settings,
+    enable_github_pages as _enable_github_pages,
+    replicate_labels as _replicate_labels,
+)
+
+# Import shared utilities
+from utils import (  # noqa: E402
+    FILES_TO_UPDATE,
+    TEMPLATE_REPO,
+    Colors,
+    GitHubCLI,
+    Logger,
+    command_exists,
+    get_git_config,
+    prompt,
+    prompt_confirm,
+    update_file,
+    update_test_files,
+)
+# isort: on
+
+
+class RepositorySetup:
+    """Main class for repository setup orchestration."""
+
+    # Use TEMPLATE_REPO from utils.py as the single source of truth
+    TEMPLATE_FULL = TEMPLATE_REPO
+
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {}
+        self.start_dir = os.getcwd()
+
+    def print_banner(self) -> None:
+        """Print welcome banner."""
+        print()
+        print(
+            f"{Colors.CYAN}╔═══════════════════════════════════════════════════════════╗{Colors.NC}"
+        )
+        print(
+            f"{Colors.CYAN}║                                                           ║{Colors.NC}"
+        )
+        print(
+            f"{Colors.CYAN}║     Python Project Template - Repository Setup            ║{Colors.NC}"
+        )
+        print(
+            f"{Colors.CYAN}║                                                           ║{Colors.NC}"
+        )
+        print(
+            f"{Colors.CYAN}╚═══════════════════════════════════════════════════════════╝{Colors.NC}"
+        )
+        print()
+
+    def check_requirements(self) -> None:
+        """Check that all required tools are installed."""
+        Logger.step("Checking requirements...")
+
+        # Check for gh CLI
+        if not command_exists("gh"):
+            Logger.error("GitHub CLI (gh) is not installed")
+            print("  Install from: https://cli.github.com/")
+            sys.exit(1)
+
+        gh_version = subprocess.run(
+            ["gh", "--version"],
+            capture_output=True,
+            text=True,
+        ).stdout.split("\n")[0]
+        Logger.success(f"GitHub CLI found: {gh_version}")
+
+        # Check gh authentication
+        if not GitHubCLI.is_authenticated():
+            Logger.error("GitHub CLI is not authenticated")
+            print("  Run: gh auth login")
+            sys.exit(1)
+        Logger.success("GitHub CLI authenticated")
+
+        # Check token type and permissions
+        self._check_token_permissions()
+
+        # Check for git
+        if not command_exists("git"):
+            Logger.error("Git is not installed")
+            print("  Install from: https://git-scm.com/downloads")
+            sys.exit(1)
+
+        git_version = subprocess.run(
+            ["git", "--version"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        Logger.success(f"Git found: {git_version}")
+
+        # Check for uv
+        if not command_exists("uv"):
+            Logger.error("uv is not installed")
+            print("  Install from: https://docs.astral.sh/uv/getting-started/installation/")
+            sys.exit(1)
+
+        uv_version = subprocess.run(
+            ["uv", "--version"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        Logger.success(f"uv found: {uv_version}")
+
+    def _check_token_permissions(self) -> None:
+        """Check GitHub token type and permissions."""
+        Logger.info("Checking GitHub token permissions...")
+
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+        )
+        auth_info = result.stderr + result.stdout
+
+        if "github_pat_" in auth_info or "gho_" in auth_info:
+            Logger.warning("You're using a Personal Access Token (PAT)")
+            print()
+            print(f"  {Colors.YELLOW}Required permissions for fine-grained PAT:{Colors.NC}")
+            print("  - Repository permissions:")
+            print("    • Administration: Read and write")
+            print("    • Contents: Read and write")
+            print("    • Metadata: Read")
+            print()
+            print(f"  {Colors.YELLOW}To create/update your PAT:{Colors.NC}")
+            print("  1. Go to: https://github.com/settings/tokens?type=beta")
+            print("  2. Create new token or edit existing")
+            print("  3. Select 'All repositories' or specific repos")
+            print("  4. Add the permissions listed above")
+            print("  5. Generate token and run: gh auth login")
+            print()
+
+            if not prompt_confirm("Do you have the required permissions configured?", default=True):
+                Logger.error("Please configure your PAT with required permissions first")
+                sys.exit(1)
+        else:
+            Logger.success("Token type appears to be OAuth (recommended)")
+
+    def gather_inputs(self) -> None:
+        """Gather repository configuration from user."""
+        Logger.step("Gathering repository information...")
+        print()
+
+        # Repository name
+        self.config["repo_name"] = prompt("Repository name")
+
+        # Organization (optional)
+        if prompt_confirm("Create in an organization?"):
+            self.config["repo_owner"] = prompt("Organization name")
+        else:
+            # Get current user
+            user_info = GitHubCLI.api("user")
+            self.config["repo_owner"] = user_info["login"]
+
+        self.config["repo_full"] = f"{self.config['repo_owner']}/{self.config['repo_name']}"
+
+        # Visibility
+        self.config["visibility"] = (
+            "public" if prompt_confirm("Make repository public?", default=True) else "private"
+        )
+
+        # Package configuration
+        print()
+        Logger.info("Package configuration (used for placeholder replacement)")
+
+        default_package = self.config["repo_name"].replace("-", "_")
+        self.config["package_name"] = prompt(
+            "Python package name (import name)", default=default_package
+        )
+        self.config["pypi_name"] = prompt("PyPI package name", default=self.config["repo_name"])
+        self.config["description"] = prompt(
+            "Package description",
+            default="A Python project based on pyproject-template",
+        )
+
+        # Get git config for defaults
+        git_name = get_git_config("user.name", "")
+        git_email = get_git_config("user.email", "")
+
+        self.config["author_name"] = prompt("Author name", default=git_name)
+        self.config["author_email"] = prompt("Author email", default=git_email)
+
+        # Confirmation
+        print()
+        Logger.step("Configuration summary:")
+        print(f"  Repository: {self.config['repo_full']}")
+        print(f"  Visibility: {self.config['visibility']}")
+        print(f"  Package name: {self.config['package_name']}")
+        print(f"  PyPI name: {self.config['pypi_name']}")
+        print(f"  Description: {self.config['description']}")
+        print(f"  Author: {self.config['author_name']} <{self.config['author_email']}>")
+        print()
+
+        if not prompt_confirm("Proceed with these settings?", default=True):
+            Logger.warning("Setup cancelled by user")
+            sys.exit(0)
+
+    def create_github_repository(self) -> None:
+        """Create repository on GitHub from template (without cloning)."""
+        Logger.step("Creating repository on GitHub from template...")
+
+        try:
+            # Use REST API to create from template
+            data = {
+                "owner": self.config["repo_owner"],
+                "name": self.config["repo_name"],
+                "description": self.config["description"],
+                "private": self.config["visibility"] == "private",
+                "include_all_branches": False,
+            }
+
+            GitHubCLI.api(f"repos/{self.TEMPLATE_FULL}/generate", method="POST", data=data)
+            Logger.success(f"Repository created: https://github.com/{self.config['repo_full']}")
+
+        except subprocess.CalledProcessError as e:
+            Logger.error("Failed to create repository from template")
+            print()
+
+            # Always show the actual error message
+            if e.stderr:
+                print(f"{Colors.RED}Error details:{Colors.NC}")
+                print(f"  {e.stderr.strip()}")
+                print()
+
+            # Provide specific help for known errors
+            if e.stderr and "Resource not accessible by personal access token" in e.stderr:
+                print(f"{Colors.YELLOW}Solution:{Colors.NC}")
+                print()
+                print(f"1. {Colors.CYAN}Re-authenticate with OAuth (recommended):{Colors.NC}")
+                print("   gh auth logout")
+                print("   gh auth login")
+                print("   # Choose: GitHub.com → HTTPS → Login with browser")
+                print()
+                print(f"2. {Colors.CYAN}Or update your fine-grained PAT:{Colors.NC}")
+                print("   https://github.com/settings/tokens?type=beta")
+                print("   Required permissions:")
+                print("   - Administration: Read and write")
+                print("   - Contents: Read and write")
+                print("   - Metadata: Read")
+                print()
+            elif e.stderr and "name already exists" in e.stderr.lower():
+                print(f"{Colors.YELLOW}Solution:{Colors.NC}")
+                print(f"  A repository named '{self.config['repo_name']}' already exists.")
+                print("  Choose a different name or delete the existing repository at:")
+                print(f"  https://github.com/{self.config['repo_full']}/settings")
+                print()
+
+            sys.exit(1)
+
+        # Wait a moment for repo to be fully ready
+        import time
+
+        time.sleep(2)
+
+    def clone_repository(self) -> None:
+        """Clone the repository locally and change to its directory."""
+        Logger.step("Cloning repository locally...")
+
+        try:
+            GitHubCLI.run(
+                ["repo", "clone", self.config["repo_full"], self.config["repo_name"]], capture=False
+            )
+            Logger.success("Repository cloned locally")
+        except subprocess.CalledProcessError:
+            Logger.error("Failed to clone repository")
+            print(f"  You can try cloning manually: gh repo clone {self.config['repo_full']}")
+            sys.exit(1)
+
+        # Change to repo directory
+        os.chdir(self.config["repo_name"])
+
+    def configure_placeholders(self) -> None:
+        """Configure project placeholders by replacing template strings."""
+        Logger.step("Configuring project placeholders...")
+
+        try:
+            # Define replacements
+            owner = self.config["repo_owner"]
+            pkg = self.config["package_name"]
+            replacements = {
+                # Marker tokens (unambiguous, used in prose files). These take
+                # priority because ``update_file()`` treats them as blind
+                # replaces regardless of surrounding context.
+                "__PACKAGE_NAME__": self.config["package_name"],
+                "__PYPI_NAME__": self.config["pypi_name"],
+                "__PROJECT_NAME__": self.config["repo_name"],
+                "__GH_OWNER__": owner,
+                "__AUTHOR_NAME__": self.config["author_name"],
+                "__AUTHOR_EMAIL__": self.config["author_email"],
+                "__DESCRIPTION__": self.config["description"],
+                "__REPO_URL__": f"https://github.com/{owner}/{pkg}",
+                "__REPO_SLUG__": f"{owner}/{pkg}",
+                # URLs — kept for runtime-critical files (pyproject.toml,
+                # workflows, LICENSE, mkdocs.yml, dodo.py, .envrc,
+                # .pre-commit-config.yaml) that retain literal placeholders,
+                # and for downstream consumer projects that have not yet
+                # migrated to marker tokens.
+                "https://github.com/username/package_name": (f"https://github.com/{owner}/{pkg}"),
+                f"https://github.com/username/{pkg}": (f"https://github.com/{owner}/{pkg}"),
+                "gh username/package_name": f"gh {owner}/{pkg}",
+                "username/package_name": f"{owner}/{pkg}",
+                "username": owner,
+                # Package names (literal forms; Python files receive
+                # word-boundary protection from ``update_file()``).
+                "package_name": self.config["package_name"],
+                "package-name": self.config["pypi_name"],
+                "Package Name": self.config["repo_name"],
+                # Metadata
+                "A short description of your package": self.config["description"],
+                "Your Name": self.config["author_name"],
+                "your.email@example.com": self.config["author_email"],
+            }
+
+            # Update main configuration files (using shared constant from utils.py)
+            for file_path in FILES_TO_UPDATE:
+                path = Path(file_path)
+                if path.exists():
+                    update_file(path, replacements)
+
+            # Update documentation files
+            docs_dir = Path("docs")
+            if docs_dir.exists():
+                for doc_file in docs_dir.rglob("*.md"):
+                    update_file(doc_file, replacements)
+
+            # Update test files (limited replacements to preserve test data)
+            tests_dir = Path("tests")
+            if tests_dir.exists():
+                update_test_files(tests_dir, self.config["package_name"])
+
+            # Remove template-only tests (they're only for the template itself)
+            template_tests_dir = Path("tests/template")
+            if template_tests_dir.exists():
+                shutil.rmtree(template_tests_dir)
+                Logger.info("Removed template-only tests (tests/template/)")
+
+            # Update source files
+            src_dir = Path("src")
+            if src_dir.exists():
+                for src_file in src_dir.rglob("*.py"):
+                    update_file(src_file, replacements)
+
+            # Update issue templates
+            issue_templates_dir = Path(".github/ISSUE_TEMPLATE")
+            if issue_templates_dir.exists():
+                for template_file in issue_templates_dir.glob("*.md"):
+                    update_file(template_file, replacements)
+                # Also update config.yml if it exists
+                config_file = issue_templates_dir / "config.yml"
+                if config_file.exists():
+                    update_file(config_file, replacements)
+
+            # Update example files
+            examples_dir = Path("examples")
+            if examples_dir.exists():
+                for example_file in examples_dir.rglob("*"):
+                    if example_file.is_file():
+                        update_file(example_file, replacements)
+
+            # Rename package directory
+            old_package_dir = Path("src/package_name")
+            new_package_dir = Path(f"src/{self.config['package_name']}")
+            if old_package_dir.exists() and old_package_dir != new_package_dir:
+                shutil.move(str(old_package_dir), str(new_package_dir))
+                Logger.success(f"Renamed package directory to src/{self.config['package_name']}")
+
+            Logger.success("Placeholders configured")
+
+            # Commit the changes
+            subprocess.run(["git", "add", "."], check=True, capture_output=True)
+            commit_msg = f"""
+chore: configure project from template
+
+- Set project name to {self.config["repo_name"]}
+- Configure package as {self.config["package_name"]}
+- Set author to {self.config["author_name"]}
+
+🤖 Generated with setup-repo.py"""
+
+            # Use --no-verify to bypass pre-commit hooks (like no-commit-to-main)
+            # This is necessary because we are initializing the repo on main
+            subprocess.run(
+                ["git", "commit", "-m", commit_msg, "--no-verify"], check=True, capture_output=True
+            )
+            subprocess.run(["git", "push"], check=True, capture_output=True)
+            Logger.success("Changes committed and pushed")
+
+        except Exception as e:
+            Logger.warning(f"Placeholder configuration failed: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+    def setup_development_environment(self) -> None:
+        """Set up the development environment with dependencies and pre-commit hooks."""
+        Logger.step("Setting up development environment...")
+
+        try:
+            # Install dependencies
+            Logger.info("Installing dependencies with uv sync --all-extras...")
+            result = subprocess.run(
+                ["uv", "sync", "--all-extras"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                Logger.warning("Failed to install dependencies")
+                Logger.info("You can install manually with: uv sync --all-extras")
+                return
+
+            Logger.success("Dependencies installed")
+
+            # Install pre-commit hooks
+            Logger.info("Installing pre-commit hooks...")
+            result = subprocess.run(
+                ["uv", "run", "pre-commit", "install"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                Logger.success("Pre-commit hooks installed")
+                # Install post-merge and post-checkout hooks for auto uv sync
+                for hook_type in ["post-merge", "post-checkout"]:
+                    subprocess.run(
+                        ["uv", "run", "pre-commit", "install", "--hook-type", hook_type],
+                        capture_output=True,
+                        text=True,
+                    )
+            else:
+                Logger.warning("Failed to install pre-commit hooks")
+                Logger.info("You can install manually with: uv run pre-commit install")
+
+            # Fix linting issues (including import ordering)
+            # Note: We run ruff directly with --fix because doit lint only checks,
+            # doesn't auto-fix. This fixes import ordering (I001) and other auto-fixable issues.
+            Logger.info("Fixing linting issues with ruff...")
+            subprocess.run(
+                ["uv", "run", "ruff", "check", "--fix", "."],
+                capture_output=True,
+                text=True,
+            )
+
+            # Format pyproject.toml using doit task
+            Logger.info("Formatting pyproject.toml...")
+            subprocess.run(
+                ["uv", "run", "doit", "fmt_pyproject"],
+                capture_output=True,
+                text=True,
+            )
+
+            # Format code using doit task
+            Logger.info("Formatting code with ruff...")
+            subprocess.run(
+                ["uv", "run", "doit", "format"],
+                capture_output=True,
+                text=True,
+            )
+
+            # Run validation checks BEFORE committing
+            Logger.info("Running validation checks (doit check)...")
+            check_result = subprocess.run(
+                ["uv", "run", "doit", "check"],
+                capture_output=False,
+                text=True,
+            )
+
+            if check_result.returncode != 0:
+                Logger.error("Validation checks failed")
+                print()
+                print(f"{Colors.YELLOW}Please fix the issues above before continuing.{Colors.NC}")
+                print("The formatting changes have been applied but not committed.")
+                print()
+                print("After fixing issues, you can commit with:")
+                print("  git add .")
+                print("  git commit -m 'chore: apply code formatting'")
+                print("  git push")
+                print()
+                return
+
+            Logger.success("All validation checks passed")
+
+            # Check if there are any formatting changes to commit
+            result = subprocess.run(
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+            )
+
+            if result.stdout.strip():
+                Logger.info("Committing formatting changes...")
+                subprocess.run(["git", "add", "."], check=True, capture_output=True)
+                commit_msg = """
+chore: apply code formatting
+
+- Fix linting issues with ruff
+- Format pyproject.toml with pyproject-fmt
+- Format code with ruff
+
+🤖 Generated with setup-repo.py"""
+                commit_result = subprocess.run(
+                    ["git", "commit", "-m", commit_msg, "--no-verify"],
+                    capture_output=True,
+                    text=True,
+                )
+                if commit_result.returncode != 0:
+                    Logger.error("Failed to commit formatting changes")
+                    print()
+                    print(f"{Colors.RED}Git commit error:{Colors.NC}")
+                    if commit_result.stderr:
+                        print(f"  {commit_result.stderr.strip()}")
+                    if commit_result.stdout:
+                        print(f"  {commit_result.stdout.strip()}")
+                    print()
+                    print(f"{Colors.YELLOW}Possible solutions:{Colors.NC}")
+                    print("  1. Check pre-commit hook output above for specific issues")
+                    print("  2. Fix any failing pre-commit checks manually")
+                    print("  3. Run: git status")
+                    print("  4. Review changes and commit manually")
+                    print()
+                    return
+
+                push_result = subprocess.run(
+                    ["git", "push"],
+                    capture_output=True,
+                    text=True,
+                )
+                if push_result.returncode != 0:
+                    Logger.error("Failed to push formatting changes")
+                    if push_result.stderr:
+                        print(f"  Error: {push_result.stderr.strip()}")
+                    print("  You can push manually later with: git push")
+                else:
+                    Logger.success("Formatting changes committed and pushed")
+            else:
+                Logger.success("No formatting changes needed")
+
+        except subprocess.CalledProcessError as e:
+            Logger.error("Development environment setup failed")
+            print()
+            print(f"{Colors.RED}Error details:{Colors.NC}")
+            if e.stderr:
+                print(f"  {e.stderr.strip()}")
+            if e.stdout:
+                print(f"  {e.stdout.strip()}")
+            print()
+            print(f"{Colors.YELLOW}You can complete setup manually with:{Colors.NC}")
+            print("  cd", self.config["repo_name"])
+            print("  uv sync --all-extras")
+            print("  uv run pre-commit install")
+            print("  uv run doit check")
+            print()
+        except Exception as e:
+            Logger.error(f"Development environment setup failed: {e}")
+            print()
+            import traceback
+
+            print(f"{Colors.RED}Full error:{Colors.NC}")
+            traceback.print_exc()
+            print()
+            print(f"{Colors.YELLOW}You can complete setup manually with:{Colors.NC}")
+            print("  cd", self.config["repo_name"])
+            print("  uv sync --all-extras")
+            print("  uv run pre-commit install")
+            print("  uv run doit check")
+            print()
+
+    def cleanup_template_suite(self) -> None:
+        """Remove the template management suite from the spawned consumer project.
+
+        Consumer projects do not use or maintain the template's own tooling
+        (``tools/pyproject_template/``, ``docs/template/``, ``bootstrap.py``).
+        This step invokes :func:`cleanup_template_files` with
+        :attr:`CleanupMode.ALL` to delete the suite, then stages, commits, and
+        pushes the deletions so the consumer's default branch reflects a clean
+        tree.
+
+        Consumers who later want the template-sync suite back can re-install
+        it with ``curl -sSL .../bootstrap.py | python3 - --sync``.
+
+        This method is defensive: any failure is logged as a warning and
+        execution continues, so a cleanup failure does not block the user from
+        using their freshly-spawned repository.
+        """
+        Logger.step("Removing template management suite from spawned project...")
+
+        try:
+            result = cleanup_template_files(CleanupMode.ALL, root=Path.cwd())
+
+            # If nothing was deleted, there's nothing to commit.
+            if not result.deleted_files and not result.deleted_dirs:
+                Logger.info("No template files found to clean up")
+                return
+
+            # Stage deletions, commit, and push. --no-verify mirrors the
+            # pattern used in configure_placeholders(); the no-commit-to-main
+            # pre-commit hook would otherwise reject the commit on a freshly
+            # spawned repo whose only branch is main.
+            subprocess.run(["git", "add", "-A"], check=True, capture_output=True)
+            commit_msg = """
+chore: remove template management suite
+
+Auto-removed by setup_repo.py to keep the consumer project free of
+template-only tooling:
+
+- tools/pyproject_template/ (manage.py, setup_repo.py, configure.py,
+  cleanup.py, check_template_updates.py, migrate_existing_project.py,
+  settings.py, repo_settings.py, utils.py, __init__.py)
+- docs/template/
+- bootstrap.py
+- Template nav section in mkdocs.yml
+
+To reinstall the template-sync suite later, run:
+  curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py \\
+      | python3 - --sync
+
+🤖 Generated with setup-repo.py"""
+
+            subprocess.run(
+                ["git", "commit", "-m", commit_msg, "--no-verify"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(["git", "push"], check=True, capture_output=True)
+            Logger.success("Template management suite removed, committed, and pushed")
+
+        except Exception as e:
+            Logger.warning(f"Template suite cleanup failed: {e}")
+            Logger.info(
+                "You can remove the template suite manually later by running "
+                "`python tools/pyproject_template/cleanup.py --all` from the project root."
+            )
+            import traceback
+
+            traceback.print_exc()
+
+    def verify_post_cleanup(self) -> None:
+        """Run ``doit check`` after template suite cleanup; log on failure.
+
+        The wizard already runs ``doit check`` inside
+        :meth:`setup_development_environment`, but that runs *before*
+        :meth:`cleanup_template_suite` removes ``bootstrap.py`` and the
+        template management suite. Any task command that references files
+        which cleanup just deleted would slip through undetected.
+
+        This method re-runs ``uv run doit check`` in the cloned project
+        directory after cleanup. Failure is treated leniently — matching the
+        pattern in :meth:`setup_development_environment`: the wizard prints
+        a clear diagnostic and continues to :meth:`print_manual_steps`. It
+        does **not** ``sys.exit``, because the GitHub repo has already been
+        created and partially configured; forcing an exit here would leave
+        the user with a half-set-up remote and no friendly path forward.
+        """
+        Logger.step("Verifying project after cleanup (doit check)...")
+
+        try:
+            check_result = subprocess.run(
+                ["uv", "run", "doit", "check"],
+                capture_output=False,
+                text=True,
+            )
+        except FileNotFoundError as e:
+            # uv not on PATH in this shell; surface the diagnostic but
+            # do not raise — the user can re-run manually.
+            Logger.warning(f"Post-cleanup validation could not run: {e}")
+            Logger.info(
+                "Validation failed *after* cleanup — the repo was created but "
+                "`doit check` currently fails; see output above"
+            )
+            return
+
+        if check_result.returncode != 0:
+            Logger.warning(
+                f"Post-cleanup `doit check` returned non-zero exit status {check_result.returncode}"
+            )
+            Logger.info(
+                "Validation failed *after* cleanup — the repo was created but "
+                "`doit check` currently fails; see output above"
+            )
+            return
+
+        Logger.success("Post-cleanup validation checks passed")
+
+    def configure_repository_settings(self) -> None:
+        """Configure repository settings to match template."""
+        _configure_repository_settings(
+            repo_full=self.config["repo_full"],
+            description=self.config["description"],
+            visibility=self.config.get("visibility"),
+            template_repo=self.TEMPLATE_FULL,
+        )
+
+    def configure_branch_protection(self) -> None:
+        """Configure branch protection using rulesets."""
+        _configure_branch_protection(
+            repo_full=self.config["repo_full"],
+            template_repo=self.TEMPLATE_FULL,
+        )
+
+    def replicate_labels(self) -> None:
+        """Replicate labels from template."""
+        _replicate_labels(
+            repo_full=self.config["repo_full"],
+            template_repo=self.TEMPLATE_FULL,
+        )
+
+    def enable_github_pages(self) -> None:
+        """Enable GitHub Pages."""
+        _enable_github_pages(repo_full=self.config["repo_full"])
+
+    def print_manual_steps(self) -> None:
+        """Print manual steps that need to be completed."""
+        print()
+        print(
+            f"{Colors.CYAN}╔═══════════════════════════════════════════════════════════╗{Colors.NC}"
+        )
+        print(
+            f"{Colors.CYAN}║                  Setup Complete! 🎉                       ║{Colors.NC}"
+        )
+        print(
+            f"{Colors.CYAN}╚═══════════════════════════════════════════════════════════╝{Colors.NC}"
+        )
+        print()
+        Logger.success(
+            f"Repository created and configured: https://github.com/{self.config['repo_full']}"
+        )
+        print()
+
+        Logger.step("Manual steps required:")
+        print()
+        print(f"  {Colors.YELLOW}[ ]{Colors.NC} Add PyPI token to repository secrets:")
+        print(f"      gh secret set PYPI_TOKEN --repo {self.config['repo_full']}")
+        print()
+        print(
+            f"  {Colors.YELLOW}[ ]{Colors.NC} Add TestPyPI token to repository secrets (optional):"
+        )
+        print(f"      gh secret set TEST_PYPI_TOKEN --repo {self.config['repo_full']}")
+        print()
+        print(
+            f"  {Colors.YELLOW}[ ]{Colors.NC} Add Codecov token to repository secrets (optional):"
+        )
+        print(f"      gh secret set CODECOV_TOKEN --repo {self.config['repo_full']}")
+        print()
+        print(f"  {Colors.YELLOW}[ ]{Colors.NC} Review and adjust repository settings:")
+        print(f"      https://github.com/{self.config['repo_full']}/settings")
+        print()
+        print(f"  {Colors.YELLOW}[ ]{Colors.NC} Review branch protection rulesets:")
+        print(f"      https://github.com/{self.config['repo_full']}/settings/rules")
+        print()
+        print(f"  {Colors.YELLOW}[ ]{Colors.NC} Invite collaborators (if needed):")
+        print(f"      https://github.com/{self.config['repo_full']}/settings/access")
+        print()
+
+        Logger.info(
+            "Template tooling was auto-removed. To reinstall the template-sync "
+            "suite later, run: curl -sSL "
+            "https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py "
+            "| python3 - --sync"
+        )
+        print()
+
+        Logger.step("You're all set!")
+        print()
+        repo_path = os.path.join(self.start_dir, self.config["repo_name"])
+        print(f"  {Colors.GREEN}✓{Colors.NC} Repository cloned to: {repo_path}")
+        print(f"  {Colors.GREEN}✓{Colors.NC} Dependencies installed")
+        print(f"  {Colors.GREEN}✓{Colors.NC} Pre-commit hooks configured")
+        print(f"  {Colors.GREEN}✓{Colors.NC} Code formatted and validated")
+        print()
+        print("  Navigate to your repository and start developing:")
+        print(f"     cd {self.config['repo_name']}")
+        print()
+
+        Logger.info(
+            f"Documentation: https://github.com/{self.config['repo_full']}/blob/main/README.md"
+        )
+        print()
+
+    def run(self) -> None:
+        """Run the complete setup process.
+
+        Order of operations:
+        1. Create GitHub repository (fail fast if there are auth/permission issues)
+        2. Configure all GitHub settings (before cloning to avoid partial setup)
+        3. Clone repository locally
+        4. Configure local files and development environment
+        5. Remove template management suite from the consumer project
+        6. Re-run ``doit check`` to confirm the post-cleanup tree is valid
+        """
+        self.print_banner()
+        self.check_requirements()
+        self.gather_inputs()
+
+        # Create repository on GitHub and configure all GitHub settings
+        # BEFORE cloning to avoid partial setup if GitHub operations fail.
+        # CodeQL scanning is NOT set up here: it runs from the committed
+        # .github/workflows/codeql.yml workflow that the template generator
+        # copies into the new repo automatically.
+        self.create_github_repository()
+        self.configure_repository_settings()
+        self.configure_branch_protection()
+        self.replicate_labels()
+        self.enable_github_pages()
+
+        # Now clone and configure locally
+        self.clone_repository()
+        self.configure_placeholders()
+        self.setup_development_environment()
+
+        # Remove the template management suite from the spawned project.
+        # Consumers don't use or maintain the template's own tooling; they
+        # can re-install it later with `bootstrap.py --sync` if desired.
+        self.cleanup_template_suite()
+
+        # Re-run `doit check` after cleanup to catch any stale references
+        # that survived the template-suite removal. Lenient — logs a
+        # diagnostic and continues on failure so the wizard still reaches
+        # print_manual_steps.
+        self.verify_post_cleanup()
+
+        self.print_manual_steps()
+
+
+def main() -> None:
+    """Main entry point."""
+    try:
+        setup = RepositorySetup()
+        setup.run()
+    except KeyboardInterrupt:
+        print()
+        Logger.warning("Setup cancelled by user")
+        sys.exit(1)
+    except Exception as e:
+        print()
+        Logger.error(f"Setup failed with unexpected error: {e}")
+        print()
+        print("This is likely a bug in the setup script.")
+        print("Please report this issue with the error details above at:")
+        print("  https://github.com/endavis/pyproject-template/issues")
+        print()
+
+        # Show traceback for debugging
+        import traceback
+
+        print("Full traceback:")
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    print("This script should not be run directly.")
+    print("Please use: python manage.py")
+    sys.exit(1)

--- a/tools/pyproject_template/utils.py
+++ b/tools/pyproject_template/utils.py
@@ -171,6 +171,18 @@ def get_git_config(key: str, default: str = "") -> str:
 
     Returns:
         The config value if found, otherwise the default value.
+
+    Notes:
+        The unscoped ``git config <key>`` lookup merges system, global, and
+        local config — but only when the current working directory is inside
+        a git repository. When called from outside any repo (e.g. the
+        bootstrap wizard running from ``~/src`` before the project checkout
+        exists), the unscoped call exits non-zero even for keys that are set
+        in ``~/.gitconfig``. This function retries with ``--global`` on
+        failure so that ``user.name`` and ``user.email`` resolve from the
+        user's global identity regardless of CWD (see #470). Keys that only
+        exist locally (e.g. ``remote.origin.url``) fail both calls and fall
+        through to ``default``, which is the correct behavior.
     """
     try:
         result = subprocess.run(
@@ -178,7 +190,19 @@ def get_git_config(key: str, default: str = "") -> str:
             capture_output=True,
             text=True,
         )
-        return result.stdout.strip() if result.returncode == 0 else default
+        if result.returncode == 0:
+            return result.stdout.strip()
+        # Unscoped lookup failed — retry with --global so that globally
+        # configured values (user.name, user.email) resolve even when the
+        # CWD is not inside a git repository.
+        global_result = subprocess.run(
+            ["git", "config", "--global", key],
+            capture_output=True,
+            text=True,
+        )
+        if global_result.returncode == 0:
+            return global_result.stdout.strip()
+        return default
     except (subprocess.SubprocessError, FileNotFoundError):
         return default
 
@@ -272,25 +296,75 @@ def get_first_author(pyproject_data: dict[str, Any]) -> tuple[str, str]:
     return author.get("name", ""), author.get("email", "")
 
 
+# Marker tokens follow the ``__FOO__`` convention used in prose files
+# (README, CHANGELOG, docs, .github prose, .claude/CLAUDE.md). They are always
+# replaced via a blind string substitution because the surrounding double
+# underscores make collisions with real code/prose structurally impossible.
+_MARKER_TOKENS: frozenset[str] = frozenset(
+    {
+        "__PACKAGE_NAME__",
+        "__PYPI_NAME__",
+        "__PROJECT_NAME__",
+        "__GH_OWNER__",
+        "__AUTHOR_NAME__",
+        "__AUTHOR_EMAIL__",
+        "__DESCRIPTION__",
+        "__REPO_URL__",
+        "__REPO_SLUG__",
+    }
+)
+
+# Literal placeholder tokens that must use word-boundary regex when applied to
+# Python source so that identifier substrings (e.g. ``validate_package_name``,
+# ``my_username``) are not accidentally rewritten. These are the tokens that
+# collide with natural identifier-like substrings. Multi-word tokens such as
+# ``Your Name`` do not need this guard because they cannot appear inside a
+# Python identifier.
+_IDENTIFIER_LITERALS: frozenset[str] = frozenset(
+    {
+        "package_name",
+        "package-name",
+        "username",
+    }
+)
+
+
 def update_file(filepath: Path, replacements: dict[str, str]) -> None:
     """Update file with string replacements.
 
-    Special handling for 'package_name': only replaces when NOT followed by
-    optional whitespace and '=' to preserve:
-    - Python keyword arguments: package_name="value"
-    - TOML keys: package_name = "value"
+    Three replacement modes are applied per ``(old, new)`` pair:
+
+    1. **Marker tokens** (``__FOO__``): blind string replace. Markers cannot
+       collide with real identifiers or prose, so no guarding is required.
+    2. **Identifier-like literals in Python source** (``.py`` files only):
+       word-boundary regex replace so that ``validate_package_name`` and
+       similar identifier substrings survive. The ``package_name`` literal
+       additionally preserves keyword-argument and TOML-key forms via the
+       ``(?!\\s*=)`` lookahead.
+    3. **Everything else**: blind string replace (current default behaviour).
+
+    Binary files are skipped silently.
     """
     if not filepath.exists():
         return
     try:
         content = filepath.read_text(encoding="utf-8")
+        is_python = filepath.suffix == ".py"
         for old, new in replacements.items():
-            if old == "package_name":
-                # Use regex to replace 'package_name' only when NOT followed by
-                # optional whitespace and '='. This preserves:
-                # - Python kwargs: package_name="value"
-                # - TOML keys: package_name = "value"
-                content = re.sub(r"package_name(?!\s*=)", new, content)
+            if old in _MARKER_TOKENS:
+                # Markers are unambiguous; blind replace.
+                content = content.replace(old, new)
+            elif is_python and old in _IDENTIFIER_LITERALS:
+                # Word-boundary regex protects identifier substrings such as
+                # ``validate_package_name`` or ``my_username`` from being
+                # rewritten when the bare token appears elsewhere.
+                if old == "package_name":
+                    # Additional guard preserves kwargs/TOML-keys:
+                    # ``package_name="value"`` and ``package_name = "value"``.
+                    pattern = r"\bpackage_name\b(?!\s*=)"
+                else:
+                    pattern = rf"\b{re.escape(old)}\b"
+                content = re.sub(pattern, new, content)
             else:
                 content = content.replace(old, new)
         filepath.write_text(content, encoding="utf-8")


### PR DESCRIPTION
## Description

Phase C of the pyproject-template sync tracker (#673): adopt new tooling modules,
overwrite a handful of existing template-owned modules with their upstream
HEAD versions, wire up the new ruff-fix-on-edit AI hook, and bring in the
tests that upstream ships alongside these modules.

The only behavior-visible change in the framework repo is the `.claude/settings.json`
wiring for the new `PostToolUse` hook (`ruff-fix-on-edit.py`); it runs ruff
--fix on any `.py` file under `src/`, `tests/`, `tools/`, or `bootstrap.py`
after the assistant edits it. This sits alongside the existing `PreToolUse`
dangerous-command hook and is layered additively. Everything else in this
PR is template-owned code/tests that developers do not interact with at
runtime.

All 18 adopted files (6 module overwrites + 11 net-new + 1 `__init__.py`) are
byte-for-byte with upstream; no local customization has been introduced.

## Related Issue

Addresses #676

## Phase Context

This is Phase C of sync tracker #673. The status of sibling phases:

- **Phase F (#680)** — `.gitignore` / meta-config — **merged**
- **Phase A (#681)** — `.github/labels.yml` + dependabot automerge workflow — **merged**
- **Phase B (#682)** — 16 new 9xxx ADRs — **merged**
- **Phase C (#676)** — **this PR** — new tooling modules + tests
- **Phase D (#677)** — AI agent config (pending)
- **Phase E (#678)** — dense-merge + pin bump (pending, closes the tracker)

## Pin vs. HEAD Transparency

Our upstream pin in `.config/pyproject_template/settings.toml` is
`75cbe9b3... / 2026-04-02`. All content adopted in this PR is from upstream
HEAD (`4e405b0`, later than the pin). **This is not scope drift** — it is
how every phase in tracker #673 has operated:

- At pin `75cbe9b3`, the 16 9xxx ADRs adopted in Phase B did **not exist**
  upstream. They were only present at HEAD.
- At pin `75cbe9b3`, the dependabot automerge workflow and `.github/labels.yml`
  adopted in Phase A also did **not exist**. Same situation.
- The tracker operates against upstream HEAD at analysis time, not the pin.
- Phase E (`pin bump + dense-merge`) will advance the pin at the end of the
  tracker so it catches up to the HEAD we've been integrating from.

Additionally, `tools/pyproject_template/check_template_updates.py` downloads
only from `main` HEAD or tagged releases — it cannot fetch a specific commit
SHA. So even if we wanted to pin-sync precisely, the tool wouldn't support it
today. A follow-up tooling chore is tracked in issue #683.

## Follow-up Issue #683

A full `diff -rq pin HEAD` audit run as part of this phase surfaced 142
file-level changes in upstream. Of those:

- ~46 are covered by merged phases F / A / B plus this Phase C
- ~25 are expected in Phases D (#677) and E (#678)
- ~20 are correctly skipped (category-1 "never adopt" skeleton files per
  `docs/development/pyproject-template-divergences.md` — e.g. `docs/template/*`,
  `docs/examples/*`, `src/package_name/*`, `examples/*`)
- ~25 are **not covered by any planned phase**

The uncovered changes have been captured in new issue **#683**
("chore: sync from pyproject-template phase C2 (remaining tooling + test cleanup)"),
grouped into four buckets:

- **(A)** 11 `tools/doit/*.py` task module updates
- **(B)** 2 `tools/hooks/ai/*.py` hook script updates
- **(C)** 8 stale tests to remove + 4 new workflow tests to add
- **(D)** `check_template_updates.py` SHA-support tooling note

#683 is queued behind this PR so Phase C stays focused.

## Type of Change

- [x] Code refactoring  (mechanical upstream sync of template-owned code)
- [x] Test improvement   (adopting upstream tests for the new modules)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement

## Changes Made

### New modules (7 new source paths, 1 package init file)

| Path | Purpose |
| :--- | :--- |
| `bootstrap.py` | Standalone project setup / sync entry point at repo root |
| `tools/pyproject_template/migrate_existing_project.py` | Migrate existing projects into the template |
| `tools/pyproject_template/repo_settings.py` | GitHub repo settings helper |
| `tools/pyproject_template/setup_repo.py` | New-project orchestrator |
| `tools/doit/template_clean.py` | Adds `doit template_clean` task (auto-discovered) |
| `tools/hooks/ai/ruff-fix-on-edit.py` | PostToolUse hook invoked by `.claude/settings.json` |
| `tests/template/__init__.py` | Empty; required for pytest collection of the `tests/template` package |

### New test modules (7 files)

| Path |
| :--- |
| `tests/template/test_bootstrap.py` |
| `tests/template/test_setup_repo.py` |
| `tests/template/test_repo_settings.py` |
| `tests/template/test_cleanup.py` |
| `tests/template/test_utils.py` |
| `tests/template/test_pyproject_template_main.py` |
| `tests/test_hook_ruff_fix.py` |

### Overwritten modules (5 files; zero local customization pre-check confirmed)

| Path | Notable change upstream |
| :--- | :--- |
| `tools/pyproject_template/cleanup.py` | Expanded cleanup logic |
| `tools/pyproject_template/configure.py` | Expanded configure logic |
| `tools/pyproject_template/manage.py` | Now subcommand-driven; interactive-menu path preserved |
| `tools/pyproject_template/settings.py` | Minor refinements |
| `tools/pyproject_template/utils.py` | Adds `GitHubCLI`, `Logger`, `Colors`, prompt helpers, validators |

### Hook wiring (1 file)

- `.claude/settings.json` — adds `PostToolUse` block matching `Edit|Write|MultiEdit`
  that shells out to `python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/ruff-fix-on-edit.py`.
  This is the only behavior-changing item in the PR.

## Testing

- `doit check` — all 8 gates green (format_check, lint, lint_blueprints,
  type_check, security, spell_check, test, check).
- Adopted tests only: `uv run pytest tests/template/ tests/test_hook_ruff_fix.py -v`
  → **236 passed**.
- Task discovery: `doit list | grep template_clean` → new task visible.
- Smoke checks (already run during implementation): `bootstrap.py --help`,
  `manage.py --help`, `ruff-fix-on-edit.py` stdin handling — all OK.

- [x] All existing tests pass
- [x] Added new tests for new functionality (adopted from upstream)
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (N/A — tooling sync, no user-facing behavior docs)
- [ ] I have updated the CHANGELOG.md (N/A — template-sync chore)
- [x] My changes generate no new warnings

## Additional Notes

- **No new ADR required.** The three template-meta ADRs that cover this
  phase's decisions already exist:
  - ADR 9003 — ruff for linting/formatting (covers the ruff-fix hook)
  - ADR 9004 — auto-discover doit tasks (covers `template_clean.py`)
  - ADR 9005 — AI agent command restrictions / hooks (covers the
    `PostToolUse` hook wiring)
- **Divergence doc** (`docs/development/pyproject-template-divergences.md`)
  does not need an update: all 11 modules are "adopt verbatim by omission"
  from the skip list (they're not template-skeleton files).
- **Session-local file** `.claude/scheduled_tasks.lock` was intentionally
  excluded from this commit.
