### PR TITLE
chore: sync AI agent config, commands, and docs from pyproject-template

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,7 +37,7 @@ When creating new code (functions, modules, commands, features), Claude MUST use
 - Any task involving writing new Python code
 
 **Example todo list for "create new CLI command":**
-- [ ] Create src/package_name/cli.py
+- [ ] Create src/__PACKAGE_NAME__/cli.py
 - [ ] Create tests/test_cli.py with comprehensive tests
 - [ ] Update pyproject.toml (if needed)
 - [ ] Run doit check to verify all tests pass

--- a/.claude/agents/implement-worker.md
+++ b/.claude/agents/implement-worker.md
@@ -1,0 +1,67 @@
+---
+name: implement-worker
+description: >-
+  Performs the implementation step of the /implement workflow after the
+  plan comment exists and the branch is created. Reads project rules,
+  fetches the plan, edits files, writes tests, and runs `doit check`.
+  Do NOT invoke directly — /implement drives this subagent.
+tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
+permissionMode: default
+---
+
+You implement a GitHub issue's approved plan on an already-created branch. The parent `/implement` command has verified preconditions and created the branch; your job is to read the rules, fetch the plan, edit files, write tests, run `doit check`, and return a summary.
+
+## Inputs from the parent
+
+The parent prompt will provide:
+
+- The **issue number** (so you can fetch the plan).
+- The **branch name** (for context only — you will not switch branches).
+- Any **issue-specific notes** or scope clarifications.
+
+## Steps
+
+### 1. Read the project rules
+
+- Read `AGENTS.md` — understand workflow, conventions, code style, and testing guidelines.
+- Read `.claude/CLAUDE.md` — understand TodoWrite requirements.
+
+### 2. Fetch the implementation plan
+
+Retrieve all comments and find the one whose body has a heading line starting with `Implementation Plan for`:
+
+```bash
+gh api repos/{owner}/{repo}/issues/<issue-number>/comments --jq '.[] | select(.body | test("^#+ Implementation Plan for"; "m")) | .body'
+```
+
+- If multiple plan comments exist, use the most recent one.
+- Parse the plan to extract the file list and test plan.
+
+### 3. Implement the plan
+
+- Follow the plan step by step.
+- Create implementation files.
+- Create test files — this is MANDATORY per AGENTS.md. Never skip tests when there is Python code to test.
+- Follow existing code patterns and conventions.
+- All new code must be type-annotated (mypy strict).
+
+### 4. Run validation
+
+- Run: `doit check`
+- If checks fail, fix the issues and re-run.
+- Do NOT give up after the first failure — investigate and fix.
+
+### 5. Return a summary
+
+Report to the parent:
+
+- Files created/modified with brief descriptions.
+- Test results (pass/fail counts).
+- Any deviations from the plan and why.
+
+## Constraints
+
+- **Do NOT switch branches.** The parent `/implement` command has already created and checked out the correct branch.
+- **Do NOT commit.** Committing is handled by the parent's `/finalize` step, not by you.
+- **Do NOT enter plan mode.** Do not call `EnterPlanMode`. You run with `permissionMode: default` so you can edit files directly.
+- **All new code must be type-annotated** (mypy strict mode is enforced by `doit check`).

--- a/.claude/commands/finalize.md
+++ b/.claude/commands/finalize.md
@@ -59,7 +59,8 @@ Use the Task tool with `subagent_type: "general-purpose"` and provide it with th
 
 5. **Draft the PR description** and write it to a temp file:
    - Read `.github/pull_request_template.md` for structure
-   - Write the PR body to `/tmp/pr-body.md`
+   - Run `mkdir -p tmp/agents/claude` to ensure the directory exists
+   - Write the PR body to `tmp/agents/claude/pr-body-issue-<n>.md`
    - The body MUST include `Addresses #<issue-number>`
 
 6. **Return** a summary of:
@@ -67,7 +68,7 @@ Use the Task tool with `subagent_type: "general-purpose"` and provide it with th
    - ADR changes made (if any)
    - Suggested commit message following conventional format: `<type>: <subject>`
    - Suggested PR title following conventional format: `<type>: <subject>`
-   - Path to the PR body file (`/tmp/pr-body.md`)
+   - Path to the PR body file (`tmp/agents/claude/pr-body-issue-<n>.md`)
 
 ### Step 3: Commit and create PR
 
@@ -78,7 +79,8 @@ After the agent returns, in the main context:
 3. **Only after user confirms:**
    - Stage files: `git add <specific files>` (include all changed files from implementation and review/fix cycle)
    - Commit with the approved message
-   - Create PR: `doit pr --title="<type>: <subject>" --body-file=/tmp/pr-body.md`
+   - Create PR: `doit pr --title="<type>: <subject>" --body-file=tmp/agents/claude/pr-body-issue-<n>.md`
+   - Delete the temp file: `rm tmp/agents/claude/pr-body-issue-<n>.md`
 4. **Report** the PR URL to the user
 
 **IMPORTANT:** Do NOT commit or create the PR without explicit user confirmation.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -4,9 +4,9 @@ Implement the plan for GitHub issue #$ARGUMENTS.
 
 ## Instructions
 
-**CRITICAL: Do NOT enter plan mode. Do NOT use EnterPlanMode. This command executes code directly — plan mode will block the implementation agent from writing files.**
+The implementation is delegated to a sub-agent (Task tool) so raw tool output stays out of the main conversation context. The agent does the coding; you receive the summary for user review.
 
-You MUST delegate the implementation to an agent (Task tool) to keep the main conversation context clean. The agent does all the coding. You receive the summary for user review.
+**Plan-mode trap:** parent plan-mode state propagates to the spawned sub-agent mid-execution and freezes it after its first non-readonly action (typically the first `Write`). Check your Claude Code status line before running — if it shows "plan mode", exit before invoking.
 
 ### Step 1: Validate preconditions
 
@@ -19,7 +19,7 @@ You MUST delegate the implementation to an agent (Task tool) to keep the main co
 2. **Verify a plan comment exists:**
    Fetch all comments and search for the plan header:
    ```bash
-   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[].body' | grep "## Implementation Plan for"
+   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
    ```
    - If no plan comment is found, tell the user:
      > "No implementation plan found for issue #$ARGUMENTS. Run `/plan-issue $ARGUMENTS` first."
@@ -57,37 +57,15 @@ Only if not already on the correct branch:
    git checkout -b <type>/$ARGUMENTS-<short-description>
    ```
 
-### Step 3: Spawn an implementation agent
+### Step 3: Spawn the implementation subagent
 
-Use the Task tool with `subagent_type: "general-purpose"` and provide it with the issue number and branch name. The agent should:
+Use the Task tool with `subagent_type: "implement-worker"`. In the prompt, pass:
 
-1. **Read the project rules:**
-   - Read `AGENTS.md` — understand workflow, conventions, code style, testing guidelines
-   - Read `.claude/CLAUDE.md` — understand TodoWrite requirements
+- The issue number (so the subagent can fetch the plan).
+- The branch name (for context; the subagent will not switch branches).
+- Any issue-specific notes or scope clarifications.
 
-2. **Fetch the implementation plan:**
-   Retrieve all comments and find the one containing `## Implementation Plan for`:
-   ```bash
-   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[] | select(.body | contains("## Implementation Plan for")) | .body'
-   ```
-   - If multiple plan comments exist, use the most recent one
-   - Parse the plan to extract the file list and test plan
-
-3. **Implement the plan:**
-   - Follow the plan step by step
-   - Create implementation files
-   - Create test files — this is MANDATORY, never skip tests
-   - Follow existing code patterns and conventions
-
-4. **Run validation:**
-   - Run: `doit check`
-   - If checks fail, fix the issues and re-run
-   - Do NOT give up after first failure — investigate and fix
-
-5. **Return a summary** of all changes made:
-   - Files created/modified with brief descriptions
-   - Test results (pass/fail counts)
-   - Any deviations from the plan and why
+The subagent carries its own system prompt covering project rules, plan fetch, implementation, and validation — this command does not repeat them. The subagent has `permissionMode: default`, which (per Claude Code's sub-agent precedence rules) should override parent plan mode for operations inside the subagent's context.
 
 ### Step 4: Present changes to user
 

--- a/.claude/commands/plan-both.md
+++ b/.claude/commands/plan-both.md
@@ -18,7 +18,7 @@ gh issue view $ARGUMENTS --json number,title,state,labels
 ### Step 2: Check for existing plans
 
 ```bash
-gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -l "## Implementation Plan for"
+gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -lE "^#+ Implementation Plan for"
 ```
 
 - If plan comments already exist, warn the user:

--- a/.claude/commands/plan-issue.md
+++ b/.claude/commands/plan-issue.md
@@ -19,7 +19,7 @@ This command runs in the main conversation context (NOT in a subagent) so the us
 
 2. **Check for an existing plan comment:**
    ```bash
-   gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -l "## Implementation Plan for"
+   gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -lE "^#+ Implementation Plan for"
    ```
    - If a plan comment already exists, warn the user:
      > "Issue #$ARGUMENTS already has an implementation plan comment. Continuing will post a new one. Proceed?"

--- a/.claude/commands/where-am-i.md
+++ b/.claude/commands/where-am-i.md
@@ -30,7 +30,7 @@ Based on the branch name, determine the workflow state:
    ```
 3. Check for a plan comment:
    ```bash
-   gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[].body' | grep "## Implementation Plan for"
+   gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
    ```
 4. Check for uncommitted changes:
    ```bash

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,7 +10,17 @@
 default_policy = "untrusted"  # Prompt before running untrusted commands
 
 # =============================================================================
-# BLOCKED COMMANDS - These bypass security controls
+# PRE-TOOL-USE HOOK — Primary defense
+# =============================================================================
+# The shared hook script provides context-aware blocking (shlex tokenization,
+# protected-branch detection, chained-command scanning). The approval_policy
+# deny rules below act as a secondary (belt-and-suspenders) defense layer in
+# case the hook fails to load or Codex evaluates policies before hooks.
+[hooks]
+pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+
+# =============================================================================
+# BLOCKED COMMANDS - Secondary defense (approval_policy deny rules)
 # =============================================================================
 
 # Block --admin flag (bypasses branch protection)

--- a/.copilot/README.md
+++ b/.copilot/README.md
@@ -1,0 +1,33 @@
+# Copilot CLI Configuration
+
+This directory is the GitHub Copilot CLI configuration directory for this repository, parallel to `.claude/`, `.gemini/`, and `.codex/`.
+
+## Workflow Skills
+
+Copilot CLI automatically discovers project skills from `.claude/commands/`. No separate Copilot command files are needed — the full workflow (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) is available out of the box.
+
+## Dangerous Command Hook
+
+The dangerous command hook is wired in `.github/hooks/copilot-hooks.json`. It blocks shell commands identified as dangerous before they execute:
+
+```
+.github/hooks/copilot-hooks.json → tools/hooks/ai/block-dangerous-commands.py
+```
+
+No changes to this hook are needed when adding new slash commands.
+
+## Subagent / Implement Worker
+
+The `implement-worker` subagent used by `/implement` is defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when spawning the subagent.
+
+## Temporary Files
+
+Agents must write temporary files to `tmp/agents/copilot/` (not `/tmp/`). Include a context identifier (issue number, PR number, or task ID) in the filename to avoid collisions.
+
+## See Also
+
+- `.claude/commands/` — slash command definitions (auto-discovered by Copilot CLI)
+- `.claude/agents/implement-worker.md` — implement-worker subagent definition
+- `.github/hooks/copilot-hooks.json` — dangerous command hook wiring
+- `docs/development/ai/slash-commands.md` — full workflow and command reference
+- `docs/development/ai/command-blocking.md` — hook documentation

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -1,0 +1,423 @@
+---
+title: AI Agent Setup Guide
+description: Configure Claude, Gemini, Copilot, and Codex for this project
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - setup
+  - configuration
+---
+
+# AI Agent Setup Guide
+
+This template is designed primarily for **Claude Code**, which is the only agent that ships the full slash-command workflow and acts as the orchestrator in single-agent and dual-agent flows. **Gemini CLI** is supported in a narrower role (second-opinion planner/reviewer inside Claude-orchestrated commands). **GitHub Copilot CLI** is supported as a standalone alternative that auto-discovers the full slash-command workflow from `.claude/commands/`. **Codex CLI** is supported as a standalone alternative without slash commands. See the comparison table below for the per-agent breakdown.
+
+> **New here?** Start with the [First 5 Minutes walkthrough](ai/first-5-minutes.md) for a narrative tour of the AI agent workflow. This page is the configuration reference.
+
+## Supported AI Agents
+
+### Agent comparison
+
+| Agent | Permission model | Hooks support | Slash commands | LSP | Dual-agent role |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Codex CLI** | TOML approval policies (`.codex/config.toml`) | Project-level `tools/hooks/ai/` apply via shell | None shipped | Not documented | Standalone alternative (not part of dual-agent flow) |
+| **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 2 output-only (`/plan-issue`, `/review-pr`) | Not documented | Second-opinion reviewer / planner in dual-agent flow |
+| **GitHub Copilot CLI** | JSON hook config (`.github/hooks/copilot-hooks.json`) | Project-level hooks apply; Copilot `preToolUse` hook wired | Auto-discovers from `.claude/commands/` | Not documented | Standalone alternative (auto-discovers Claude commands) |
+| **Claude Code** | Layered permissions (`.claude/settings.local.json` + `.claude/settings.json` PreToolUse hooks) | Project-level hooks plus Claude PreToolUse hooks | 8 (`plan-issue`, `implement`, `finalize`, `close-issue`, `plan-both`, `review-both`, `gemini-review`, `where-am-i`) | Supported | Primary orchestrator in single-agent and dual-agent flows |
+
+The project-level dangerous-command hooks under `tools/hooks/ai/` apply to all four agents regardless of per-agent config and cannot be bypassed by editing `.claude/settings.local.json`, `.codex/config.toml`, `.gemini/settings.json`, or `.github/hooks/copilot-hooks.json`. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+
+### 1. Codex CLI (OpenAI)
+
+**Configuration:** `.codex/config.toml`
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+
+Codex CLI directly reads `AGENTS.md` from the project root. The configuration file whitelists common development commands.
+
+**Whitelisted commands:**
+- `git` - All git operations
+- `gh` - GitHub CLI
+- `uv` - UV package manager
+- `doit` - Task automation
+- File operations: `ls`, `cat`, `tree`, `find`, `grep`, `wc`, `mkdir`
+
+**Setup:**
+```bash
+# Codex CLI will automatically use .codex/config.toml if present
+# Or copy to global config:
+cp .codex/config.toml ~/.codex/config.toml
+
+# Initialize or regenerate AGENTS.md with Codex:
+codex
+/init
+```
+
+**Documentation:**
+- [Codex CLI Documentation](https://developers.openai.com/codex/cli/)
+- [Configuring Codex](https://developers.openai.com/codex/local-config/)
+- [Codex Security Guide](https://developers.openai.com/codex/security/)
+
+**Codex parity status:** Codex ships no slash commands in this template — `.codex/` contains only `config.toml`. LSP integration is not documented for Codex here. Codex is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer the OpenAI CLI. The project-level hooks under `tools/hooks/ai/` still apply to Codex — see [Command Blocking](ai/command-blocking.md). For the broader slash-command and dual-agent picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+
+### 2. Gemini CLI (Google)
+
+**Configuration:** `.gemini/settings.json`
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+
+Gemini CLI can read `AGENTS.md` (or `GEMINI.md`) from the project root. The configuration file uses allowlists for tools and shell commands, and configures lifecycle hooks.
+
+**Allowlisted commands:**
+- `git`, `gh`, `uv`, `doit` - Development tools
+- `python`, `pytest`, `ruff`, `mypy` - Python tools
+- File operations: `ls`, `cat`, `tree`, `find`, `grep`, `wc`, `mkdir`
+
+**Core tools enabled:**
+- `ShellTool` - Execute shell commands
+- `ReadFileTool`, `WriteFileTool` - File operations
+- `LSTool`, `GrepTool` - File exploration
+
+**Setup:**
+```bash
+# Gemini CLI automatically uses .gemini/settings.json if present
+# Or copy to global config:
+cp .gemini/settings.json ~/.gemini/settings.json
+
+# Ensure hooks are enabled in settings.json:
+# {
+#   "hooks": { "enabled" : true }
+# }
+
+# Use YOLO mode to skip all permission prompts (use with caution):
+gemini --yolo
+# Or toggle auto-approve with Ctrl+Y during a session
+```
+
+**Documentation:**
+- [Gemini CLI Configuration](https://geminicli.com/docs/get-started/configuration/)
+- [Gemini CLI Hooks](https://geminicli.com/docs/hooks/)
+- [Provide Context with GEMINI.md Files](https://google-gemini.github.io/gemini-cli/docs/cli/gemini-md.html)
+- [Sandboxing in Gemini CLI](https://geminicli.com/docs/cli/sandbox/)
+- [Gemini CLI Settings](https://geminicli.com/docs/cli/settings/)
+
+### 3. Claude Code (Anthropic)
+
+**Configuration:** `.claude/` directory
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+
+Claude Code uses a reference file (`.claude/claude.md`) that imports `AGENTS.md`.
+
+**Whitelisted commands:**
+- `git:*` - All git commands
+- `gh:*` - All GitHub CLI commands
+- `uv:*` - All uv commands
+- `doit:*` - All doit commands
+- File operations: `ls`, `cat`, `tree`, `find`, `grep`, `wc`, `mkdir`
+
+**Setup:**
+```bash
+# Claude Code automatically detects .claude/ directory
+# No additional setup needed
+```
+
+**Files:**
+- `.claude/claude.md` - Imports AGENTS.md
+- `.claude/settings.local.json` - Command permissions
+- `.claude/settings.json` - Status line and PreToolUse hooks
+
+**LSP Support (Recommended):**
+
+Claude Code supports Language Server Protocol for enhanced code intelligence:
+- Document symbols (functions, classes, variables)
+- Go to definition / find references
+- Hover information and type checking
+- Call hierarchy navigation
+
+**Quick LSP Setup:**
+```bash
+# 1. Install the LSP plugin from marketplace
+/install-plugin @anthropic-ai/claude-code-lsp
+
+# 2. Install development dependencies (includes language server)
+doit install_dev
+
+# 3. Enable LSP tool in .envrc.local
+echo 'export ENABLE_LSP_TOOL=1' >> .envrc.local
+direnv allow
+
+# 4. Start Claude Code
+claude
+```
+
+For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` in the repository root.
+
+### 4. GitHub Copilot CLI
+
+**Configuration:** `.copilot/` directory
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+
+GitHub Copilot CLI reads `AGENTS.md` directly and auto-discovers project skills from `.claude/commands/`, so the full slash-command workflow (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) is available in Copilot sessions without any parallel command files. The `implement-worker` subagent used by `/implement` is shared with Claude (defined in `.claude/agents/implement-worker.md`).
+
+**Hook wiring:**
+
+The dangerous-command hook is wired in `.github/hooks/copilot-hooks.json`:
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+```
+
+**Setup:**
+```bash
+# Copilot CLI automatically picks up .github/hooks/copilot-hooks.json
+# and reads AGENTS.md; no additional setup needed.
+copilot
+```
+
+**Files:**
+- `.copilot/README.md` - Description of the Copilot CLI config directory
+- `.github/hooks/copilot-hooks.json` - `preToolUse` hook wiring
+- `.claude/commands/*.md` - Slash commands (auto-discovered by Copilot CLI)
+- `.claude/agents/implement-worker.md` - Shared subagent definition
+
+**Documentation:**
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Copilot CLI Hooks](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-in-the-cli)
+
+**Copilot parity status:** Copilot CLI ships no parallel command or agent files — it auto-discovers from `.claude/commands/` and `.claude/agents/`, so every Claude slash command works unchanged in Copilot sessions. Copilot is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer GitHub Copilot. The project-level hooks under `tools/hooks/ai/` apply to Copilot via `.github/hooks/copilot-hooks.json` — see [Command Blocking](ai/command-blocking.md). For the broader slash-command picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+
+### 5. Other AI Tools
+
+The `AGENTS.md` file serves as general-purpose documentation for any AI coding assistant:
+
+- **Cursor**: Reference in `.cursorrules`
+- **Codeium**: Reference in project settings
+- **Tabnine**: Reference in configuration
+
+> **Note**: For the slash commands and dual-agent workflow this template ships with, see [Slash Commands and Workflows](ai/slash-commands.md).
+
+## AGENTS.md - Universal Context File
+
+The `AGENTS.md` file provides comprehensive project context including:
+
+- Repository structure and architecture
+- Development workflows and commands
+- Code style and conventions
+- Testing expectations
+- CI/CD workflows
+- Troubleshooting guides
+
+This file is:
+- **Read directly** by Codex CLI, Gemini CLI, and GitHub Copilot CLI
+- **Imported** by Claude Code via `.claude/claude.md`
+- **Referenceable** by other AI tools
+
+## Context files and precedence
+
+This template ships several files that influence agent behavior. They fall into two categories: **context/instruction files** (markdown) and **settings/config files** (JSON or TOML). Knowing which is which — and which one wins on conflict — matters when adapting the template for a new project.
+
+**File inventory:**
+
+- **`AGENTS.md`** (project root, ~20 KB) — universal source of truth for architecture, workflow, tooling hierarchy, and security rules. Read directly by Codex CLI, Gemini CLI, and GitHub Copilot CLI; imported by Claude Code via `@../AGENTS.md` in `.claude/CLAUDE.md`.
+- **`.claude/CLAUDE.md`** (~2 KB) — Claude-specific complement. First line is `@../AGENTS.md`, which imports the universal rules; the rest adds Claude-specific layers (token-efficiency guidance, the mandatory TodoWrite plan-test-code loop, the development workflow reminder, and the commit workflow reminder).
+- **`GEMINI.md`** (project root, ~1 KB) — Gemini-specific complement. Covers Gemini's stdout-only collaboration mode (so Claude handles GitHub writes), the output signing footer, and Gemini's tool-usage rules. Read alongside `AGENTS.md` by Gemini CLI, not instead of it.
+- **`.copilot/README.md`** — describes the Copilot CLI config directory. Copilot CLI reads `AGENTS.md` directly and auto-discovers slash commands from `.claude/commands/`; no Copilot-specific context markdown is required.
+- **`.codex/config.toml`** — Codex approval policy file (TOML). Not a context file; configures permissions only. Codex reads `AGENTS.md` directly for instructions.
+- **`.claude/settings.json`** — Claude PreToolUse hooks and statusline configuration. Committed.
+- **`.claude/settings.local.json`** — local Claude permissions overlay. Not committed.
+- **`.gemini/settings.json`** — Gemini tool allowlists and lifecycle hook configuration.
+- **`.github/hooks/copilot-hooks.json`** — Copilot CLI `preToolUse` hook wiring that routes shell commands through `tools/hooks/ai/block-dangerous-commands.py`.
+
+**Precedence rules:**
+
+- All four agents treat `AGENTS.md` as the architectural and workflow source of truth.
+- Agent-specific markdown files (`.claude/CLAUDE.md`, `GEMINI.md`) **complement** `AGENTS.md` — they cover behaviors specific to that agent's interaction model and do not override the universal rules.
+- Settings/config files (`.codex/config.toml`, `.gemini/settings.json`, `.claude/settings*.json`, `.github/hooks/copilot-hooks.json`) configure **permissions and tooling**, not workflow rules. They cannot grant an agent permission to do something `AGENTS.md` forbids.
+- Project-level hooks under `tools/hooks/ai/` apply to all agents and cannot be bypassed by per-agent config. This is the strongest layer.
+
+**Conflict resolution:** if an agent-specific file conflicts with `AGENTS.md`, `AGENTS.md` wins for cross-cutting concerns (workflow, architecture, security). An agent-specific file may further restrict its own agent's behavior, but it should not loosen a universal rule.
+
+## Customization
+
+### For Your Project
+
+When using this template for a new project:
+
+1. **Update AGENTS.md**: Customize project-specific details
+2. **Adjust permissions**: Modify `.codex/config.toml` and `.claude/settings.local.json` as needed
+3. **Add project commands**: Include any custom scripts or tools
+
+### Adding New Commands
+
+**Codex CLI** (`.codex/config.toml`):
+```toml
+[[approval_policy]]
+type = "command"
+pattern = "^your-command\\b"
+action = "allow"
+reason = "Description of command"
+```
+
+**Gemini CLI** (`.gemini/settings.json`):
+```json
+{
+  "tools": {
+    "allowed": [
+      "run_shell_command(your-command)"
+    ]
+  }
+}
+```
+
+**Claude Code** (`.claude/settings.local.json`):
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(your-command:*)"
+    ]
+  }
+}
+```
+
+**GitHub Copilot CLI** (`.github/hooks/copilot-hooks.json`):
+
+Copilot CLI does not use a per-command allowlist — the dangerous-command hook blocks unsafe patterns; everything else is allowed. To adjust what is blocked, edit the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (which applies to Claude, Gemini, and Copilot alike). New slash commands added under `.claude/commands/<name>.md` are automatically discovered by Copilot CLI — no additional configuration is needed.
+
+## Security Considerations
+
+All configuration files are set up with security in mind.
+
+> **Note**: This template enforces security rules in code and settings, not just instructions. See [AI Enforcement Principles](ai/enforcement-principles.md) for details.
+
+> **Note**: For the architectural rules AI agents must follow when generating code, see [Architectural Conventions](ai/architectural-conventions.md).
+
+**Whitelisted Operations:**
+- Read-only file operations
+- Safe git operations (status, diff, log, add, commit, push, pull)
+- Package management (uv)
+- Testing and linting (pytest, ruff, mypy)
+- Task automation (doit)
+
+**Protected Information:**
+- API keys and tokens are excluded from environment variables
+- No dangerous operations (rm -rf, format, etc.) are pre-approved
+- Network operations require approval in some modes
+
+## Troubleshooting
+
+### Codex CLI
+
+**Commands still prompt for approval:**
+```bash
+# Check current config
+cat ~/.codex/config.toml
+
+# Copy project config to global
+cp .codex/config.toml ~/.codex/config.toml
+
+# Or use project-specific config
+codex --config .codex/config.toml
+```
+
+**Regenerate AGENTS.md:**
+```bash
+codex
+/init
+```
+
+### Claude Code
+
+**Permissions not working:**
+- Ensure `.claude/settings.local.json` exists
+- Check file is valid JSON
+- Restart Claude Code
+
+**Context not loading:**
+- Verify `.claude/claude.md` contains `@AGENTS.md`
+- Check `AGENTS.md` exists in project root
+
+### Gemini CLI
+
+**Commands still prompt for approval:**
+```bash
+# Check current config
+cat ~/.gemini/settings.json
+
+# Copy project config to global
+cp .gemini/settings.json ~/.gemini/settings.json
+
+# Or use YOLO mode (auto-approve all)
+gemini --yolo
+
+# Or toggle auto-approve during session
+# Press Ctrl+Y
+```
+
+**Context not loading:**
+- Ensure `AGENTS.md` or `GEMINI.md` exists in project root
+- Check `.gemini/settings.json` has `"context": {"files": ["AGENTS.md"]}`
+- Verify settings.json is valid JSON
+
+### Copilot CLI
+
+**Hook not firing (dangerous commands going through):**
+- Verify `.github/hooks/copilot-hooks.json` exists and is valid JSON
+- The hook uses a relative `bash` path (`python3 ../../tools/hooks/ai/block-dangerous-commands.py`) and a `cwd` of `.github/hooks`; both must match your layout
+- Run `python3 tools/hooks/ai/test_hook.py` to confirm the shared hook script still passes its test suite
+
+**Slash commands not appearing:**
+- Copilot CLI auto-discovers skills from `.claude/commands/` — make sure that directory exists and contains `.md` files with the CLI file format (no YAML frontmatter; leading `# Title` and `## Instructions` sections)
+- Restart the Copilot CLI session after adding new command files
+
+**`.copilot/` auto-detection:**
+- The `.copilot/` directory exists primarily to document Copilot-specific wiring; Copilot CLI does not require any config files there
+- If you move the repository, Copilot CLI still loads `AGENTS.md` from the repo root and the hook from `.github/hooks/copilot-hooks.json`
+
+## Resources
+
+### Codex CLI
+- [Codex CLI](https://developers.openai.com/codex/cli/)
+- [Codex Configuration](https://developers.openai.com/codex/local-config/)
+- [Codex Security Guide](https://developers.openai.com/codex/security/)
+- [Codex CLI Reference](https://developers.openai.com/codex/cli/reference/)
+
+### Gemini CLI
+- [Gemini CLI Documentation](https://geminicli.com/docs/get-started/configuration/)
+- [Gemini CLI Hooks](https://geminicli.com/docs/hooks/)
+- [GEMINI.md Context Files](https://google-gemini.github.io/gemini-cli/docs/cli/gemini-md.html)
+- [Sandboxing in Gemini CLI](https://geminicli.com/docs/cli/sandbox/)
+- [Gemini CLI Settings](https://geminicli.com/docs/cli/settings/)
+- [Gemini CLI GitHub](https://github.com/google-gemini/gemini-cli)
+
+### Claude Code
+- [Claude Code Documentation](https://claude.com/claude-code)
+- [Claude Agent SDK](https://github.com/anthropics/claude-code)
+
+### GitHub Copilot CLI
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Using Copilot in the CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-in-the-cli)
+- [GitHub Copilot](https://github.com/features/copilot)
+
+### General AI Coding
+- [Cursor](https://cursor.sh/)
+- [Codeium](https://codeium.com/)
+
+---
+
+**Note**: The `.codex/`, `.gemini/`, `.claude/`, and `.copilot/` directories should be committed to version control to share consistent AI assistant configuration across the team. .local files should not be committed.

--- a/docs/development/ai/architectural-conventions.md
+++ b/docs/development/ai/architectural-conventions.md
@@ -1,0 +1,87 @@
+---
+title: AI Architectural Conventions
+description: Imperative-form architectural rules AI agents must follow when generating code
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - architecture
+---
+
+# AI Architectural Conventions
+
+## Purpose
+
+This page is the imperative-form rulebook AI agents must follow when generating code in this template. It complements [Tooling Roles and Architectural Boundaries](../tooling-roles.md), which explains *why* the layering exists and is written for human readers. This page restates those rules as short directives plus concrete anti-patterns AI agents frequently hit. Do not duplicate the rationale here — read `tooling-roles.md` when you need the reasoning.
+
+## Rules
+
+**DO:**
+
+- DO put runtime application code under `src/__PACKAGE_NAME__/`.
+- DO put development tooling, scaffolding, install scripts, and doit task definitions under `tools/`.
+- DO expose the application's user-facing command-line interface as a console script declared in `[project.scripts]` in `pyproject.toml`, backed by a module under `src/__PACKAGE_NAME__/`.
+- DO keep `[project] dependencies` minimal. Every entry ships to every end user of the package.
+- DO use `doit <task>` for development workflows (test, lint, type-check, build, release, issue and PR creation).
+- DO add heavy libraries used only by tests or tooling to `[dependency-groups] dev`, not `[project] dependencies`.
+
+**DO NOT:**
+
+- DO NOT import from `tools/` or `dodo.py` in any module under `src/__PACKAGE_NAME__/`. Runtime code must be installable and runnable without any dev tooling present.
+- DO NOT use `doit` tasks to expose application functionality to end users. `doit` is a dev surface, not a runtime surface.
+- DO NOT add a runtime dependency without asking the user first. See the "Ask First" policy in `.github/CONTRIBUTING.md`.
+- DO NOT conflate the development CLI (`doit`) with the application's runtime CLI (console script) in code, PR descriptions, or docs.
+
+## Common failure modes
+
+Concrete anti-patterns AI agents hit in this template, with the correct framing for each.
+
+### 1. Adding a new user-facing feature as a doit task
+
+**Wrong:** User asks for a "greet" command. Agent adds `def task_greet()` under `tools/doit/` so the user runs `doit greet`.
+
+**Right:** Add a module under `src/__PACKAGE_NAME__/` that implements `greet`, register a console script in `[project.scripts]` (e.g. `greet = "__PACKAGE_NAME__.greet:main"`), and test it as runtime code under `tests/`. End users install the package and run `greet` directly — they should never need `doit` installed.
+
+### 2. Importing a helper from `tools/` into `src/__PACKAGE_NAME__/`
+
+**Wrong:** Runtime module does `from tools.doit.helpers import something` because the helper "already exists and does what I need."
+
+**Right:** If the helper is needed by runtime code, move it into `src/__PACKAGE_NAME__/` and test it as runtime code. If it is only needed by dev tooling, duplicate the small bit of logic or keep it in `tools/` — `src/__PACKAGE_NAME__/` never imports from `tools/` or `dodo.py`.
+
+### 3. Adding a heavy library to `[project] dependencies` for tests or tooling
+
+**Wrong:** Test needs `hypothesis`, so agent runs `uv add hypothesis`, which adds it to `[project] dependencies`. Every downstream user of the package now pulls `hypothesis` at install time.
+
+**Right:** Add test-only and tooling-only libraries to `[dependency-groups] dev`. Runtime dependencies ship to every user of the package and must stay minimal. New runtime deps require explicit user approval (do not run `uv add` on your own — that command is blocked for AI agents).
+
+### 4. Proposing `doit run_app` as the user entry point
+
+**Wrong:** Agent drafts a README section telling end users to `pip install __PACKAGE_NAME__ && doit run_app` to launch the application.
+
+**Right:** End users run the console script declared in `[project.scripts]`. They install the package and invoke the entry point by name. `doit` is not in the runtime dependency surface for end users and must not be presented as a runtime entry point.
+
+### 5. Conflating the dev CLI with the runtime CLI
+
+**Wrong:** PR description says "adds `doit foo` command for users." Docs under `docs/usage/` reference `doit` tasks as the way to use the package.
+
+**Right:** Keep the two surfaces distinct in both code and prose. `doit` tasks live in contributor-facing docs (`docs/development/`). The application's user-facing commands live in end-user docs (`docs/usage/`, `docs/getting-started/`) and are invoked via the console script, not `doit`.
+
+## Before generating code
+
+Short checklist to run through before writing any new code:
+
+1. Read [Tooling Roles and Architectural Boundaries](../tooling-roles.md) for the layering rationale.
+2. Identify the layer the change belongs in: runtime (`src/__PACKAGE_NAME__/`), dev tooling (`tools/`), or dev entry point (`dodo.py`).
+3. Confirm imports respect the boundary: nothing under `src/__PACKAGE_NAME__/` imports from `tools/` or `dodo.py`.
+4. If the change adds a user-facing command, plan it as a console script under `[project.scripts]`, not a `doit` task.
+5. If the change needs a new runtime dependency, stop and ask the user first.
+
+## See also
+
+- [Tooling Roles and Architectural Boundaries](../tooling-roles.md) — the human-facing rationale for the layering
+- [ADR-9002: Use doit for task automation](../../decisions/9002-use-doit-for-task-automation.md)
+- [ADR-9005: AI agent command restrictions](../../decisions/9005-ai-agent-command-restrictions.md)
+- [AI Enforcement Principles](enforcement-principles.md)
+- [AI Command Blocking](command-blocking.md)
+- [`AGENTS.md`](../../../AGENTS.md) — imperative tool reference and workflow rules

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -12,7 +12,7 @@ tags:
 
 # AI CLI Hooks
 
-The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI).
+The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI, Copilot CLI, Codex CLI).
 
 ## Block Dangerous Commands
 
@@ -42,6 +42,20 @@ The hook uses Python's `shlex` module to properly parse shell quoting:
 6. **Check** for merge commits on protected branches (linear history)
 7. **Block** (exit code 2) or **Allow** (exit code 0)
 
+#### Key Feature: Chained Command Detection
+
+The hook scans all token positions, so chained commands using `&&` or `;` are caught:
+
+```bash
+# BLOCKED - dangerous command after safe one
+git status; git push --force origin main
+cd /path && doit release
+
+# ALLOWED - all commands in the chain are safe
+cd /path && doit check
+git status; git push origin feat/branch
+```
+
 #### Key Feature: Quote-Aware Parsing
 
 The hook correctly distinguishes between:
@@ -64,7 +78,7 @@ EOF
 
 | File | Description |
 |------|-------------|
-| [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
+| [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude, Gemini, Copilot, and Codex) |
 | [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
 
 ### Configuration
@@ -96,6 +110,7 @@ EOF
 ```json
 {
   "hooks": {
+    "enabled" : true,
     "BeforeTool": [
       {
         "matcher": "run_shell_command",
@@ -111,9 +126,34 @@ EOF
 }
 ```
 
+#### Copilot CLI
+
+`.github/hooks/copilot-hooks.json`:
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+```
+
 #### Codex CLI
 
-Codex uses approval policies instead of hooks. See `.codex/config.toml` for deny rules.
+`.codex/config.toml`:
+```toml
+[hooks]
+pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+```
+
+Codex also keeps `approval_policy` deny rules as a secondary defense layer. See `.codex/config.toml` for the full configuration.
 
 ### Testing
 

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -164,26 +164,26 @@ reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
 
 > **Note**: GitHub settings require repository admin access to configure. See Settings → Rules → Rulesets.
 
-### By AI Agent Enforcement (Claude, Gemini, Codex)
+### By AI Agent Enforcement (Claude, Gemini, Copilot, Codex)
 
-These patterns are blocked across all AI agents. Claude and Gemini use the shared hook at `tools/hooks/ai/block-dangerous-commands.py`. Codex uses approval policies in `.codex/config.toml` (no hook support).
+These patterns are blocked across all AI agents. Claude, Gemini, and Copilot all use the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (wired via `.claude/settings.json`, `.gemini/settings.json`, and `.github/hooks/copilot-hooks.json` respectively). Codex uses approval policies in `.codex/config.toml` (no hook support).
 
-| Pattern | Command | Claude | Gemini | Codex |
-|---------|---------|--------|--------|-------|
-| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Config |
-| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Config |
-| `--hard` flag | `git reset --hard` | Hook | Hook | Config |
-| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Config |
-| `sudo rm` | Any shell | Hook | Hook | Config |
-| Force push to protected branch | `git push --force origin main` | Hook | Hook | Config |
-| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | — |
-| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | — |
-| `gh pr create` | Use `doit pr` instead | Hook | Hook | Config |
-| `gh issue create` | Use `doit issue` instead | Hook | Hook | Config |
-| `uv add` | User runs manually | Hook | Hook | Config |
-| `doit release*` | User runs manually | Hook | Hook | Config |
+| Pattern | Command | Claude | Gemini | Copilot | Codex |
+|---------|---------|--------|--------|---------|-------|
+| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Hook | Config |
+| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Hook | Config |
+| `--hard` flag | `git reset --hard` | Hook | Hook | Hook | Config |
+| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Hook | Config |
+| `sudo rm` | Any shell | Hook | Hook | Hook | Config |
+| Force push to protected branch | `git push --force origin main` | Hook | Hook | Hook | Config |
+| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | Hook | — |
+| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | Hook | — |
+| `gh pr create` | Use `doit pr` instead | Hook | Hook | Hook | Config |
+| `gh issue create` | Use `doit issue` instead | Hook | Hook | Hook | Config |
+| `uv add` | User runs manually | Hook | Hook | Hook | Config |
+| `doit release*` | User runs manually | Hook | Hook | Hook | Config |
 
-> **Note**: "Hook" = `block-dangerous-commands.py`, "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
+> **Note**: "Hook" = `block-dangerous-commands.py` (shared across Claude, Gemini, and Copilot), "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
 
 ### By Pre-commit Hooks (All Developers and Agents)
 
@@ -199,6 +199,7 @@ These patterns are blocked across all AI agents. Claude and Gemini use the share
 | Type checking | `mypy` | Blocks commits with type errors |
 | Security scan | `bandit` | Blocks commits with security issues |
 | Spelling | `codespell` | Blocks commits with spelling errors |
+| GitHub Actions linting | `actionlint` | Blocks commits with invalid workflow syntax |
 | Private key detection | `detect-private-key` | Blocks commits containing secrets |
 | Large file prevention | `check-added-large-files` | Blocks commits with large files |
 

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -1,0 +1,150 @@
+---
+title: First 5 Minutes with an AI Agent
+description: Narrative walkthrough of the AI agent workflow from issue to merge
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - onboarding
+  - walkthrough
+---
+
+# First 5 Minutes with an AI Agent
+
+## Purpose
+
+This page is a narrative walkthrough of the AI agent workflow this template ships with. It is aimed at a new adopter who has Claude Code installed, has opened the repository for the first time, and wants to see what a full issue-to-merge cycle looks like before diving into the reference material. It is intentionally not a reference — the command-by-command reference lives in [Slash Commands and Workflows](slash-commands.md). Read this page once, then use the reference when you need the details.
+
+## Prerequisites
+
+- Claude Code installed and authenticated. See [AI Agent Setup](../AI_SETUP.md) for installation and per-agent configuration.
+- The [GitHub CLI](https://cli.github.com/) (`gh`) installed and logged in. The slash commands shell out to `gh` for issue and PR operations.
+- Optionally, the [Gemini CLI](https://github.com/google-gemini/gemini-cli) if you want to run the dual-agent review commands. The single-agent flow described below does not require it.
+- Alternatively, the [GitHub Copilot CLI](https://github.com/github/copilot-cli) can be used in place of Claude Code for the single-agent flow — it auto-discovers the same slash commands from `.claude/commands/`. See [AI Agent Setup § 4. GitHub Copilot CLI](../AI_SETUP.md#4-github-copilot-cli) for the wiring.
+
+The rest of this page assumes you have these working.
+
+## The walkthrough
+
+### 1. Open Claude Code in the repo
+
+Launch Claude Code from the repository root. On startup Claude automatically loads `AGENTS.md` (workflow and conventions), `.claude/CLAUDE.md` (Claude-specific rules on top of `AGENTS.md`), and the project hooks under `tools/hooks/ai/` (which block dangerous commands for every agent, not just Claude). You do not need to paste any context — the template is designed so a fresh session already knows the rules.
+
+If you are not sure what state you are in, run `/where-am-i` at any time. It inspects the branch, issue state, plan comments, uncommitted changes, unpushed commits, and open PRs, then reports a summary and suggests the next command. It is read-only and safe to run whenever you are unsure.
+
+### 2. Pick an issue
+
+Every change starts from an issue. Either list the open backlog with `gh issue list` and pick one, or create a new issue with `doit issue --type=<type>` (types are `feature`, `bug`, `refactor`, `docs`, `chore`). The template enforces Issue → Branch → Commit → PR → Merge; there is no supported path that skips the issue.
+
+For the rest of this walkthrough assume you have picked issue number `42`.
+
+### 3. `/plan-issue 42`
+
+Run `/plan-issue 42` in the main conversation. Claude enters plan mode, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the issue, explores the codebase, and drafts a plan. Plan mode is interactive: Claude will ask questions and iterate with you until you approve the plan. Only on approval does it exit plan mode and post the plan as a comment on the issue with the header `## Implementation Plan for #42: <title>`. That posted comment is the artifact the next command reads.
+
+What you'll see (illustrative — your plan will look different):
+
+```markdown
+## Implementation Plan for #42: feat: add caching layer to provider
+
+### Context
+The provider module currently makes a network call on every lookup...
+
+### Files to create
+- `src/__PACKAGE_NAME__/cache.py` — new LRU cache wrapper
+- `tests/test_cache.py` — unit tests for hit, miss, eviction
+
+### Files to modify
+- `src/__PACKAGE_NAME__/provider.py` — wrap lookups in the cache
+
+### Test plan
+- Unit tests for cache hit, cache miss, eviction ordering
+- Provider tests updated to assert the cache is consulted
+
+### Validation
+- `doit check` passes
+```
+
+Read the comment, discuss revisions in chat if anything is off, and re-run `/plan-issue 42` if you need a fresh pass.
+
+### 4. `/implement 42`
+
+Once the plan comment exists, run `/implement 42`. Claude checks out `main`, pulls, and creates a branch whose type is derived from the issue's labels — for example, a `feature` issue becomes `feat/42-add-caching-layer`. Claude then spawns a subagent via the Task tool. The subagent does the heavy work: re-reads `AGENTS.md`, fetches the plan via `gh api`, creates files, writes tests, and runs `doit check`, fixing failures rather than giving up. The main conversation context receives only the subagent's summary, which keeps your scrollback clean and your context window small.
+
+The artifact at the end of this step is an uncommitted working tree on the feature branch. Nothing has been committed yet — that is deliberate.
+
+### 5. (Optional) `/gemini-review`
+
+If you have the Gemini CLI installed and want a second opinion on the changes, you can run `/gemini-review` at this point (after a PR exists) or use `/review-both` for a parallel Claude + Gemini review. The template invokes Gemini in an isolated context, captures its stdout, and posts it as a comment on the PR. Gemini never writes to GitHub directly — the orchestrating Claude agent does the posting. Skip this step if you are running single-agent.
+
+### 6. `/finalize`
+
+Run `/finalize` when you are satisfied with the changes. Claude detects the branch and issue number, spawns a finalization subagent that reviews changed files for doc/ADR updates, runs `doit check` one more time, and drafts both a commit message and a PR body. The main conversation then presents the drafts to you and **waits for explicit approval** before staging files, committing, and running `doit pr`. Nothing gets committed without your go-ahead.
+
+What you'll see (illustrative — your drafts will look different):
+
+```markdown
+Proposed commit message:
+
+  feat: add LRU cache to provider lookups
+
+  Wraps provider.lookup() in a bounded LRU cache to eliminate
+  repeated network calls for the same key within a session.
+
+  Addresses #42
+
+Proposed PR body:
+
+  ## Summary
+  Adds a small LRU cache in front of the provider network calls.
+
+  ## Changes
+  - New `cache.py` with an LRU wrapper
+  - Provider updated to consult the cache
+  - Unit tests for hit, miss, eviction
+
+  ## Validation
+  - `doit check` passes locally
+
+  Addresses #42
+
+Approve and commit? (yes / edit / no)
+```
+
+Approve, and Claude stages the files, commits, and opens the PR via `doit pr`. The artifact is an open PR referencing `Addresses #42`.
+
+### 7. Merge
+
+Merging is never automated. Review the PR yourself, wait for CI to go green, add the `ready-to-merge` label, and merge via `doit pr_merge` (or the GitHub web UI). The `ready-to-merge` label and the Merge Gate action are designed to be a human checkpoint — do not let an agent add that label for you.
+
+### 8. `/close-issue 42`
+
+After the PR merges, run `/close-issue 42`. Claude verifies a merged PR references `#42`, updates the task checkboxes in the issue body, posts the closing comment `Addressed in PR #<pr-number>`, and closes the issue. It then scans the PR body and comments for related-issue references (`Addresses`, `Part of`, `Closes`, bare `#N`, and so on) and asks you, one at a time, whether to close each open related issue. It never closes a related issue without per-issue confirmation.
+
+That is the full loop.
+
+## What each command produces
+
+Every step in the flow produces a specific artifact the next step expects:
+
+- `/plan-issue <n>` → a plan comment on the issue with the header `## Implementation Plan for #<n>`
+- `/implement <n>` → a feature branch with an uncommitted working tree
+- `/finalize` → a staged commit plus an open PR referencing `Addresses #<n>`
+- Merge → a merged commit on `main` and a closed PR
+- `/close-issue <n>` → a closed issue with updated checkboxes and a closing comment
+
+Knowing the artifact chain is the fastest way to figure out where you are if you get interrupted mid-flow.
+
+## If you get lost
+
+Run `/where-am-i`. It is read-only, has no side effects, and will tell you the current branch, issue state, plan comment status, uncommitted changes, unpushed commits, open PRs, and the suggested next command. Run it any time you are unsure. For the full command-by-command reference and the dual-agent variants, see [Slash Commands and Workflows](slash-commands.md).
+
+## See also
+
+- [Slash Commands and Workflows](slash-commands.md) — full command reference and dual-agent workflow.
+- [AI Agent Setup](../AI_SETUP.md) — per-CLI configuration, permissions, and hooks.
+- [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
+- [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.
+- <!-- TODO: wire this link up properly when #342 lands -->
+  For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).

--- a/docs/development/ai/ruff-fix-hook.md
+++ b/docs/development/ai/ruff-fix-hook.md
@@ -1,0 +1,86 @@
+---
+title: Ruff Auto-Fix on Edit Hook
+description: PostToolUse hook that runs ruff --fix on edited Python files
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - hooks
+  - ruff
+---
+
+# Ruff Auto-Fix on Edit
+
+A Claude Code `PostToolUse` hook that runs `ruff --fix` plus `ruff format` on a Python file immediately after an AI agent edits it. Cuts the feedback loop on trivial issues (unused imports, unused variables, import ordering) from "discovered at `doit check` many turns later" to "fixed before the next tool call".
+
+## What It Does
+
+After every `Edit`, `Write`, or `MultiEdit` call, the hook:
+
+1. Reads the tool payload from stdin and extracts `tool_input.file_path`.
+2. Skips the file unless it's a tracked Python source path (see scope below).
+3. Runs `uv run ruff check --fix --select F401,F841,I --quiet <path>`.
+4. Runs `uv run ruff format --quiet <path>`.
+5. Always exits 0. Hook errors must never block tool calls.
+
+The hook is best-effort — timeouts, missing `ruff`, malformed payloads, and ruff non-zero exits are all swallowed silently. The next `doit check` will surface anything genuine.
+
+## Scope
+
+| Path pattern | Auto-fixed? |
+|---|---|
+| `src/**/*.py` | yes |
+| `tests/**/*.py` | yes |
+| `tools/**/*.py` | yes |
+| `bootstrap.py` | yes |
+| Anything else (including `scripts/*.py`, `*.md`, `*.toml`, etc.) | no |
+
+This mirrors the scope `doit format` and `doit lint` already target.
+
+## Rules Fixed
+
+Only deterministic, judgment-free rules are selected:
+
+| Rule | Description |
+|---|---|
+| `F401` | Unused imports |
+| `F841` | Unused local variables |
+| `I` | Import sorting (`isort`-compatible) |
+
+All other ruff rules (`E`, `W`, `B`, `RUF`, etc.) are intentionally **not** enabled by the hook — they require human judgment. They still run as part of `doit lint` / `doit check`.
+
+## Disabling Locally
+
+Override the hook entry in `.claude/settings.local.json` (gitignored):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": []
+  }
+}
+```
+
+Restart Claude Code for the change to take effect.
+
+## Known Limitation: Stale `old_string` After Reorder
+
+If you make two consecutive `Edit` calls on the same file and the first edit's ruff pass reorders imports or removes a line you were about to target, the second `Edit`'s `old_string` may no longer match. Mitigations:
+
+- Use `Write` for large rewrites that touch many lines.
+- Re-`Read` the file between consecutive `Edit` calls on imports or unused-variable-adjacent code.
+
+The friction is intentional — silencing the noise on every other turn is worth the occasional re-read.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`tools/hooks/ai/ruff-fix-on-edit.py`](../../../tools/hooks/ai/ruff-fix-on-edit.py) | The hook script |
+| [`tests/test_hook_ruff_fix.py`](../../../tests/test_hook_ruff_fix.py) | Pytest coverage |
+| [`.claude/settings.json`](../../../.claude/settings.json) | Wires the hook into `PostToolUse` |
+
+## Related
+
+- [AI Command Blocking](command-blocking.md) — sibling `PreToolUse` hook for dangerous commands

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -1,0 +1,144 @@
+---
+title: Slash Commands and Workflows
+description: Reference for the slash commands and dual-agent workflow this template ships with
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - workflow
+  - slash-commands
+---
+
+# Slash Commands and Workflows
+
+## Purpose
+
+This page documents the slash commands this template ships under `.claude/commands/` and `.gemini/commands/`, and the single-agent and dual-agent workflows built on top of them. It is written for contributors who want to understand or extend the workflow, and for AI agents that need to know which command to run at each stage of the issue lifecycle.
+
+## Workflows
+
+### Single-agent workflow
+
+The default Claude flow takes an issue from unplanned to closed. Each step produces an artifact the next step expects.
+
+1. **`/plan-issue <n>`** — Claude enters plan mode in the main conversation, reads project rules, explores the codebase, drafts a plan, and iterates with the user until approved. On approval the plan is posted as a comment on issue `#n` with the header `## Implementation Plan for #<n>: <title>`. The next step expects this comment to exist.
+2. **User review of the plan** — read the comment, discuss revisions in chat, re-run `/plan-issue` if needed.
+3. **`/implement <n>`** — Claude verifies the plan comment exists, creates a branch (`<type>/<n>-<short-description>`) off fresh `main`, then spawns a subagent (Task tool) that reads `AGENTS.md`, fetches the plan, implements files and tests, and runs `doit check`. The main context receives only the summary. The artifact is an uncommitted working tree on the feature branch.
+4. **User review of the changes** — inspect the diff and discuss fixes directly in chat; no command is needed for fix-ups.
+5. **`/finalize`** — Claude detects the branch and issue, spawns a finalization subagent that updates docs/ADRs as needed, runs `doit check`, and drafts a commit message and PR body. The main context presents the drafts and waits for explicit user approval before staging, committing, and creating the PR via `doit pr`. The artifact is an open PR referencing `Addresses #<n>`.
+6. **User-driven merge** — the user reviews the PR, adds the `ready-to-merge` label, and merges via `doit pr_merge` (or the web UI). This step is never automated.
+7. **`/close-issue <n>`** — Claude verifies a merged PR addresses `#n`, updates task checkboxes in the issue body, posts `Addressed in PR #<pr>`, closes the issue, and scans the PR for related issues to optionally close as well.
+
+### Dual-agent workflow
+
+The dual-agent flow replaces the planning and (optionally) review steps with orchestrated calls that spawn Claude and Gemini in **isolated contexts**. The design intent is that neither agent can bias the other: each generates its output without seeing the other's work, and the orchestrating Claude agent in the main conversation posts both raw outputs plus a synthesis.
+
+Gemini commands under `.gemini/commands/` are **output-only**: Gemini does not post to GitHub itself. The orchestrating Claude agent captures Gemini's stdout and posts it via `gh`.
+
+1. **`/plan-both <n>`** — replaces `/plan-issue`. Claude validates the issue, then in parallel (a) spawns a general-purpose subagent to produce a Claude plan and (b) invokes `gemini -p "/plan-issue <n>" --yolo` to produce a Gemini plan. Both are posted as separate comments on the issue, Claude synthesizes a combined plan, reviews it with the user, and posts the approved synthesized plan.
+2. **`/implement <n>`** — same as the single-agent flow. The synthesized plan comment is the input.
+3. **`/review-both`** — runs after a PR exists. In parallel spawns a Claude review subagent and invokes `gemini -p "/review-pr" --yolo`, posts both reviews as PR comments, and posts a combined synthesis listing consensus findings, agent-specific findings, and a combined verdict. Alternatively, **`/gemini-review`** runs only the Gemini review and posts it (useful when the user wants a second opinion without a full Claude review).
+4. **`/finalize`**, merge, and **`/close-issue <n>`** — same as the single-agent flow.
+
+### Diagnostic command
+
+**`/where-am-i`** can be invoked at any point. It inspects the current branch, issue state, plan comment, uncommitted changes, unpushed commits, and open PRs, then reports a status summary and the suggested next command. It has no side effects.
+
+## Command reference
+
+Entries are alphabetical. Each one names the command, its arguments, what it does, its position in the workflow, and any design note worth knowing.
+
+### `/close-issue <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/close-issue.md`.
+
+Verifies a merged PR references `#n`, updates task checkboxes in the issue body, posts the closing comment `Addressed in PR #<pr-number>`, closes the issue via `gh issue close`, then scans the PR body and comments for related issue references (`Addresses`, `Part of`, `Related to`, `Closes`, `Fixes`, `References`, bare `#N`) and asks the user individually whether to close each open related issue. **Workflow position:** last step of both single-agent and dual-agent flows. **Design note:** never closes an issue without a merged PR unless the user explicitly confirms; never closes related issues without per-issue confirmation.
+
+### `/finalize`
+
+**Args:** none. **Source:** `.claude/commands/finalize.md`.
+
+Operates on the current feature branch, assuming implementation and review are complete. In the main context it detects the branch, extracts the issue number from the branch name, fetches issue details, and checks for uncommitted changes. It then spawns a general-purpose subagent that reads `AGENTS.md`, `.github/CONTRIBUTING.md`, and `.github/pull_request_template.md`, reviews changed files for doc/ADR updates, runs `doit check`, and drafts a commit message plus a PR body written to a temp file. The main context then presents the drafts to the user, waits for explicit approval, stages files, commits, and creates the PR via `doit pr --title=... --body-file=...`. **Workflow position:** after implementation and review. **Design note:** will not commit or create the PR without explicit user confirmation; stops if run on `main`.
+
+### `/gemini-review`
+
+**Args:** none. **Source:** `.claude/commands/gemini-review.md`.
+
+Runs in the main conversation context. Verifies a PR exists for the current branch, invokes `gemini -p "/review-pr" --yolo` to get a Gemini-authored review as stdout markdown, and posts the output as a comment on the PR via `gh pr comment`, then reports a brief summary to the user. **Workflow position:** optional second-opinion review on an open PR. **Design note:** Gemini does not post to GitHub itself — the orchestrating Claude agent posts the captured stdout.
+
+### `/implement <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/implement.md`.
+
+Validates that the issue is open and that a plan comment exists (otherwise instructs the user to run `/plan-issue <n>` first). Checks the current branch: if already on `<type>/<n>-*` it resumes work on that branch, otherwise it checks out `main`, pulls, and creates a new branch whose type is derived from the issue's labels (`enhancement`→`feat`, `bug`→`fix`, `refactor`→`refactor`, `documentation`→`docs`, `chore`→`chore`, else `issue`). It then spawns the custom `implement-worker` subagent (defined in `.claude/agents/implement-worker.md`) that reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the plan via `gh api`, implements files and tests, and runs `doit check`, fixing failures rather than giving up. The main context receives only the summary. **Workflow position:** after plan exists, before `/finalize`. **Design note:** the subagent pattern keeps the main conversation context clean. The command now spawns `implement-worker` rather than the built-in `general-purpose` subagent. The custom subagent has `permissionMode: default` in its YAML frontmatter — per Claude Code's documented sub-agent precedence rules, this should escape parent plan mode because plan mode is not in the parent-overrides-child list. The status-line preamble warning (telling the user to check for "plan mode" before running) is retained as belt-and-suspenders while the override is empirically validated; it can be removed in a follow-up once confirmed on the shipping Claude Code version.
+
+
+### `/plan-both <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/plan-both.md`.
+
+Dual-agent replacement for `/plan-issue`. Validates the issue, warns if plan comments already exist, then generates two plans in isolated contexts — a Claude plan via a spawned subagent and a Gemini plan via `gemini -p "/plan-issue <n>" --yolo` — posts both as separate issue comments, synthesizes a combined plan that highlights agreements and divergences, reviews the synthesis with the user, and only posts the synthesized plan after explicit approval. **Workflow position:** first step of the dual-agent workflow. **Design note:** isolated contexts are mandatory so neither agent can see the other's output while drafting; Claude is the orchestrator and the only agent that writes to GitHub.
+
+### `/plan-issue <n>`
+
+**Args:** issue number. **Source:** `.claude/commands/plan-issue.md`.
+
+Runs in the main conversation context (not a subagent) so the user can ask questions and refine the plan interactively. Enters plan mode, validates the issue, warns if a plan comment already exists, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches issue details, explores the codebase, and drafts a plan with the standard sections (Overview, Files to Create/Modify, Test Plan, Documentation, Validation). It iterates inside plan mode with `AskUserQuestion` until the user approves, then exits plan mode and posts the approved plan as an issue comment. **Workflow position:** first step of the single-agent workflow. **Design note:** plan mode is preserved throughout iteration; exiting plan mode means "post the approved plan", nothing more.
+
+### `/review-both`
+
+**Args:** none. **Source:** `.claude/commands/review-both.md`.
+
+Dual-agent PR review. Verifies a PR exists for the current branch, then in parallel spawns a general-purpose Claude review subagent and invokes `gemini -p "/review-pr" --yolo`, posts both reviews as separate PR comments, and posts a synthesis listing consensus findings (both agents flagged), Claude-only findings, Gemini-only findings, and a combined verdict. **Workflow position:** after `/implement`, before `/finalize`, in the dual-agent workflow. **Design note:** same isolation guarantee as `/plan-both` — neither reviewer sees the other's output; the synthesis is posted after both raw reviews so readers can audit the synthesis against the sources.
+
+### `/where-am-i`
+
+**Args:** none. **Source:** `.claude/commands/where-am-i.md`.
+
+Inspects the current git state (branch, uncommitted changes, recent log), extracts the issue number from the branch name if on a feature branch, checks for a plan comment, unpushed commits, and open PRs, then reports a status summary and suggests the next command to run. **Workflow position:** any time. **Design note:** read-only and side-effect-free — safe to run whenever the user is unsure where they are in the lifecycle.
+
+### `/plan-issue <n>` (Gemini)
+
+**Args:** issue number. **Source:** `.gemini/commands/plan-issue.md`.
+
+Invoked by Claude's `/plan-both` orchestration command via `gemini -p "/plan-issue <n>" --yolo`. Fetches the issue, reads `AGENTS.md`, explores the codebase, and outputs a plan in the standard format to stdout, signed `*Plan by: Gemini*`. **Workflow position:** called indirectly from `/plan-both`. **Design note:** output-only — the command explicitly instructs Gemini not to post to GitHub; the orchestrating Claude agent captures stdout and posts it.
+
+### `/review-pr` (Gemini)
+
+**Args:** none. **Source:** `.gemini/commands/review-pr.md`.
+
+Invoked by Claude's `/review-both` and `/gemini-review` commands via `gemini -p "/review-pr" --yolo`. Identifies the current branch's PR, scans for `Addresses #XXX` to find the issue, reads `AGENTS.md` and `.github/CONTRIBUTING.md`, runs `gh pr diff`, reviews the changes for correctness, style, testing, security, documentation, architecture, and breaking changes, and outputs a review in the standard format to stdout, signed `*Review by: Gemini*`. **Workflow position:** called indirectly from `/review-both` or `/gemini-review`. **Design note:** output-only for the same reason as the Gemini plan command.
+
+## Codex
+
+The `.codex/` directory contains only `config.toml`, which configures command approval policies for the Codex CLI. No slash commands ship for Codex. The dual-agent workflow in this template targets Claude and Gemini.
+
+## Copilot
+
+GitHub Copilot CLI automatically discovers project skills from `.claude/commands/`. All workflow commands (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) are available in Copilot sessions without any additional files.
+
+**Config directory:** `.copilot/` — established as the Copilot CLI config directory for this repo, parallel to `.claude/`, `.gemini/`, and `.codex/`.
+
+**Dangerous command hook:** Already wired in `.github/hooks/copilot-hooks.json`. It invokes `tools/hooks/ai/block-dangerous-commands.py` as a `preToolUse` hook, blocking dangerous shell commands before they execute. See [AI Command Blocking](command-blocking.md) for details.
+
+**Implement-worker subagent:** Shared with Claude — defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when `/implement` spawns the subagent.
+
+**No parallel command files needed:** Because Copilot CLI discovers skills from `.claude/commands/` directly, you do not need to maintain a separate `.copilot/commands/` directory unless you need to override Claude-specific behavior for Copilot sessions.
+
+## Adding a new slash command
+
+1. **Pick the location.** Claude commands live in `.claude/commands/<name>.md` and become `/<name>` in Claude Code. Gemini commands live in `.gemini/commands/<name>.md` and become `/<name>` in Gemini CLI. Copilot CLI auto-discovers skills from `.claude/commands/` — no separate `.copilot/commands/<name>.md` is needed unless you want to override Claude-specific behaviour for Copilot sessions.
+2. **Use the CLI file format** — not the `docs/` frontmatter format. Start with a top-level `# Title` heading, follow with a one-line description (which may include the `$ARGUMENTS` placeholder if the command takes arguments), then a `## Instructions` section containing the step-by-step body. **Do not add YAML frontmatter.** The CLIs expect plain markdown; frontmatter would appear verbatim in the rendered prompt.
+3. **Use `$ARGUMENTS` for inputs.** When the user invokes `/<command> foo bar`, every `$ARGUMENTS` occurrence in the file is substituted with `foo bar` before the command body is sent to the model. For commands that take no arguments (like `/finalize` or `/where-am-i`), omit the placeholder.
+4. **Decide: subagent or main context?** Delegate to a general-purpose subagent via the Task tool when the command does heavy codebase exploration, writes files, or runs long commands whose output would bloat the main conversation — `.claude/commands/implement.md` is the canonical example. Run in the main context when the user needs to interact step by step (plan mode, iteration, explicit approvals) — `.claude/commands/plan-issue.md` is the canonical example.
+5. **Update this document** when you add or remove a command. The command reference section should list every file under `.claude/commands/` and `.gemini/commands/`.
+
+## See also
+
+- [First 5 Minutes with an AI Agent](first-5-minutes.md) — narrative onboarding walkthrough showing the workflow end to end.
+- [AI Agent Setup Guide](../AI_SETUP.md) — per-CLI configuration and whitelists.
+- [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
+- [AI Enforcement Principles](enforcement-principles.md) — how this template enforces rules in code, not just instructions.
+- [AI Command Blocking](command-blocking.md) — tool-level hooks that block dangerous commands.
+- [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,15 @@ nav:
     - Coding Standards: development/coding-standards.md
     - CI/CD Testing: development/ci-cd-testing.md
     - Release & Automation: development/release-and-automation.md
+    - AI:
+        - First 5 Minutes: development/ai/first-5-minutes.md
+        - Setup: development/AI_SETUP.md
+        - Slash Commands: development/ai/slash-commands.md
+        - Architectural Conventions: development/ai/architectural-conventions.md
+        - Enforcement Principles: development/ai/enforcement-principles.md
+        - Command Blocking: development/ai/command-blocking.md
+        - Ruff-fix Hook: development/ai/ruff-fix-hook.md
+        - Statusline: development/ai/statusline.md
     - pyproject-template Divergences: development/pyproject-template-divergences.md
     - Implementing Secret Providers: development/implementing-secret-providers.md
     - Secrets Handling: development/security/secrets-handling.md


### PR DESCRIPTION
## Description

Phase D of the pyproject-template sync (tracker #673). This phase adopts upstream AI
agent configuration, slash commands, and AI-development documentation. The plan
flagged this as the heaviest hand-merge phase (risk of clobbering infrafoundry
customizations), but per-file diffing showed most files were already close to
upstream — the actual footprint is 7 git-new files and 10 modifications, almost
all purely additive.

The one meaningful behavioral change is the `/implement` slash-command refactor:
the inline general-purpose-subagent instructions move out of `.claude/commands/implement.md`
into a dedicated `.claude/agents/implement-worker.md` subagent. This mirrors the
upstream pattern and makes the worker reusable across CLIs (Copilot auto-discovers
subagents in `.claude/agents/`). Note: **the refactor takes effect on the NEXT
`/implement` call**, not this PR — Phase D itself was executed under the pre-refactor
`implement.md`.

Phases F (#680), A (#681), B (#682), and C (#684) are already merged. Phase E
(#678) — the dense AGENTS.md hand-merge — is still outstanding.

## Related Issue

Addresses #677

## Type of Change

- [x] Documentation update
- [x] Code refactoring

## Changes Made

### Modified (10 files)

| File | Nature of change |
| :--- | :--- |
| `.claude/CLAUDE.md` | 1-line placeholder fix: `src/package_name/cli.py` → `src/__PACKAGE_NAME__/cli.py` |
| `.claude/commands/finalize.md` | Temp-path update `/tmp/pr-body.md` → `tmp/agents/claude/pr-body-issue-<n>.md` + cleanup `rm` step |
| `.claude/commands/implement.md` | 103 → 81 lines; refactored to delegate to new `implement-worker` subagent |
| `.claude/commands/plan-both.md` | 4-line trivial diff from upstream |
| `.claude/commands/plan-issue.md` | 4-line trivial diff from upstream |
| `.claude/commands/where-am-i.md` | 4-line trivial diff from upstream |
| `.codex/config.toml` | Adds `[hooks]` section wiring shared `block-dangerous-commands.py` as primary defense |
| `docs/development/ai/command-blocking.md` | +46 lines additive — quote-aware parsing, chained-command detection, per-CLI config examples |
| `docs/development/ai/enforcement-principles.md` | +41 lines additive — decision framework GitHub > pre-commit > AI hooks > config > instructions |
| `mkdocs.yml` | Adds `AI:` sub-section under `Development:` with 8 entries |

### New directories (2)

| Path | Contents |
| :--- | :--- |
| `.claude/agents/` | `implement-worker.md` — dedicated subagent for `/implement` (pairs with the `implement.md` refactor; auto-discovered by Copilot as well) |
| `.copilot/` | `README.md` — Copilot-specific guidance |

### New files under `docs/development/` (5)

| File | Purpose |
| :--- | :--- |
| `docs/development/AI_SETUP.md` | Per-CLI setup guide covering Codex / Gemini / Claude / Copilot |
| `docs/development/ai/architectural-conventions.md` | Architectural conventions for AI-authored code |
| `docs/development/ai/first-5-minutes.md` | Fast-path onboarding for AI agents |
| `docs/development/ai/ruff-fix-hook.md` | Documents the PostToolUse ruff-fix hook adopted in Phase C |
| `docs/development/ai/slash-commands.md` | Canonical slash-command reference |

### Documentation navigation

- `mkdocs.yml` — new `AI:` sub-section under `Development:` exposing the 8 AI docs (5 new + 3 pre-existing).

## Behavioral changes

Only two items change runtime behavior. Everything else is documentation or
internal cleanup.

1. **`.codex/config.toml` now wires the shared command-blocking hook.**
   Codex previously ran without the `tools/hooks/ai/block-dangerous-commands.py`
   hook that Claude and Gemini already use as their primary defense. The new
   `[hooks]` block brings Codex in line with the other CLIs.

2. **`/implement` delegates to a dedicated subagent.**
   `.claude/commands/implement.md` shrank from 103 to 81 lines; the
   general-purpose-subagent block moved into `.claude/agents/implement-worker.md`.
   Reusable across CLIs that auto-discover `.claude/agents/` (notably Copilot).
   **Takes effect on the next `/implement` invocation** — this PR was finalized
   under the Phase C version of `implement.md`.

## Testing

- [x] All existing tests pass — `doit check` green across all 8 gates
- [x] `.codex/config.toml` parses as valid TOML (verified with `tomllib`)
- [x] `.claude/settings.json` parses as valid JSON (verified; byte-identical to upstream, no change this phase)
- [x] `doit docs_build` succeeds (see Known issues below)

No new unit tests — this PR is documentation and configuration adoption only.

## Known issues

**`doit docs_build` emits ~17 new warnings on top of the Phase C baseline.**
All are from adopted upstream doc files linking to upstream-only paths:

- `AGENTS.md` at a different relative location (our layout moved it)
- `tooling-roles.md` — doesn't exist locally
- Skeleton docs that Phase F's divergence note explicitly marks as "never adopt"

This is consistent with how Phase B and Phase C handled warnings on adopted
content: the plan guardrails explicitly say **don't edit adopted content**
inside a sync PR. A broader doc-link cleanup is filed as post-sync follow-up.

## Accounting note

The Phase D plan listed 8 new files to adopt. `.claude/lsp-setup.md` turned out
to be byte-identical to upstream already (present from an earlier sync predating
tracker #673); `cp` was a no-op and git tracks no change. Content is correct —
there's simply no tracked diff for it. Net: **7 git-new files + 10 modifications
= 17 tracked changes**, not 18.

## Deferred items

- **`AGENTS.md` edits** — category-3 hand-merge file, deferred to Phase E (#678)
  per the divergence note.
- **Optional divergence-doc one-liner** — adding `.claude/commands/*.md` and
  `docs/development/ai/*` to the divergence doc's category-3 cluster. Skipped for
  this PR; nice-to-have follow-up.
- **Broader doc-link cleanup** — addresses the new `doit docs_build` warnings
  from adopted upstream files. Tracked as post-sync work.

## ADR impact

No new ADR; no `needs-adr` label. Adoption is consistent with existing
template-meta ADRs 9005 (AI agent command restrictions) and 9009 (pre-commit
hooks). No existing ADR needs its Related-Issues section touched for this
purely-additive documentation phase.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (docs + config adoption)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A (chore)
- [ ] My changes generate no new warnings — ~17 new `doit docs_build` warnings on adopted upstream content, documented above

## Additional Notes

Phase E (#678) is the remaining template-sync work: the dense AGENTS.md
hand-merge. After Phase E merges, tracker #673 can be closed.
