### PR TITLE
chore: complete pyproject-template sync with phase E dense-merge

### DIFF
--- a/.config/pyproject_template/settings.toml
+++ b/.config/pyproject_template/settings.toml
@@ -1,3 +1,3 @@
 [template]
-commit = "75cbe9b37181359365d57b4e54cb59b8a47507fb"
-commit_date = "2026-04-02"
+commit = "7a13c9384b1b94446836eabaa20ca0800d185369"
+commit_date = "2026-04-23"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Package Name
+# Contributing to InfraFoundry
 
 Thank you for your interest in contributing to this project! We welcome contributions from everyone.
 
@@ -42,8 +42,8 @@ This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDU
 
 ```bash
 # Clone your fork
-git clone https://github.com/YOUR_USERNAME/package_name.git
-cd package_name
+git clone https://github.com/YOUR_USERNAME/infrafoundry.git
+cd infrafoundry
 
 # Set up direnv
 direnv allow
@@ -104,6 +104,12 @@ We welcome many types of contributions:
 - **Docstrings:** Google-style for all public APIs
 - **Type hints:** Required for all public functions/methods
 - **Naming:** `snake_case` for functions/variables, `PascalCase` for classes
+- **File I/O:** Always pass `encoding="utf-8"` to `Path.read_text()`,
+  `Path.write_text()`, text-mode `open()`, and `tempfile.NamedTemporaryFile()`.
+  Omitting the kwarg falls back to `locale.getpreferredencoding()`, which is
+  `cp1252` on Windows and breaks silently on non-ASCII content. Binary-mode
+  calls (`"rb"`, `"wb"`, `"ab"`) and `tarfile.open(...)` do not take an
+  encoding kwarg. Enforced by ruff's `PLW1514` rule.
 
 ### Type Hints
 
@@ -170,7 +176,7 @@ import click
 import pytest
 
 # Local
-from package_name import module
+from infrafoundry import module
 ```
 
 ## Testing Guidelines
@@ -366,10 +372,6 @@ If your repository requires PR approvals (branch protection → "Require approva
 
 The label and approval are independent checks - both must pass. The label serves as an explicit final confirmation after review and CI are complete.
 
-**Dependabot PRs:**
-
-Patch- and minor-bump dependabot PRs are auto-labeled `ready-to-merge` and have GitHub auto-merge enabled by the `dependabot-automerge.yml` workflow (subject to the sensitive-dependency blocklist and blocking labels in `.github/automerge-config.json`). The manual flow above only applies to major-version bumps or PRs labeled `automerge-blocked` / `do-not-merge`.
-
 ### After Merge
 
 - Delete your branch
@@ -388,7 +390,7 @@ This project uses **semantic versioning** derived automatically from git tags vi
 
 - **No manual version editing** - Version is determined by git tags
 - **Tag format:** `v<major>.<minor>.<patch>` (e.g., `v1.2.3`)
-- **Pre-release format:** `v<version>-<type><n>` (e.g., `v1.2.3-alpha0`, `v1.2.3-beta1`, `v1.2.3-rc0`)
+- **Pre-release format:** PEP440 `v<version><type><n>` (e.g., `v1.2.3a0`, `v1.2.3b1`, `v1.2.3rc0`, `v1.2.3.dev0`) — emitted by commitizen via `doit release --prerelease=...`
 
 Version bumping is handled by [commitizen](https://commitizen-tools.github.io/commitizen/) based on conventional commit history:
 
@@ -398,110 +400,78 @@ Version bumping is handled by [commitizen](https://commitizen-tools.github.io/co
 | `feat:` | Minor (1.0.0 → 1.1.0) |
 | `BREAKING CHANGE:` | Major (1.0.0 → 2.0.0) |
 
-### Pre-Release Workflow (TestPyPI)
+### Release Workflow
 
-Use pre-releases to test packages before official release:
-
-```bash
-# Create alpha release (default)
-doit release_dev
-
-# Create beta release
-doit release_dev --type=beta
-
-# Create release candidate
-doit release_dev --type=rc
-```
-
-**What `doit release_dev` does:**
-
-1. Verifies you're on the `main` branch
-2. Checks for uncommitted changes
-3. Pulls latest changes from remote
-4. Runs all checks (`doit check`)
-5. Bumps version with commitizen (e.g., `1.0.0` → `1.0.1-alpha0`)
-6. Updates CHANGELOG.md
-7. Creates git tag and pushes to GitHub
-8. **Triggers:** `.github/workflows/testpypi.yml`
-9. **Publishes to:** [TestPyPI](https://test.pypi.org/)
-
-**Testing from TestPyPI:**
+All releases — production and pre-release — go through a pull request.
+`doit release` opens the release PR; a reviewer merges it; `doit release_tag`
+then tags `main` and triggers the publish workflow. Direct-to-`main` release
+commands are not supported.
 
 ```bash
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ package-name
+# Step 1: open a release PR
+doit release                       # auto-detect next version from commits
+doit release --increment=major     # force MAJOR (1.0.0 → 2.0.0)
+doit release --increment=minor     # force MINOR
+doit release --increment=patch     # force PATCH
+doit release --prerelease=alpha    # open a pre-release PR (1.0.0 → 1.0.1a0)
+doit release --prerelease=beta
+doit release --prerelease=rc
+
+# --> reviewer merges the PR --
+
+# Step 2: tag main and trigger publish
+git checkout main
+git pull
+doit release_tag
 ```
 
-### Production Release Workflow (PyPI)
-
-There are two ways to release: **direct** (requires bypass permissions) or **PR-based** (works with branch protection).
-
-#### Option A: Direct Release (requires bypass permissions)
-
-```bash
-# Auto-detect version bump from commits
-doit release
-
-# Force a specific version bump
-doit release --increment=major    # 1.0.0 → 2.0.0
-doit release --increment=minor    # 1.0.0 → 1.1.0
-doit release --increment=patch    # 1.0.0 → 1.0.1
-```
+`--increment` and `--prerelease` can be combined to force a pre-release of a
+specific bump type (e.g. `--prerelease=alpha --increment=minor` → `1.1.0a0`).
+See [issue #475](https://github.com/endavis/pyproject-template/issues/475).
 
 **What `doit release` does:**
 
-1. Verifies you're on the `main` branch
-2. Checks for uncommitted changes
+1. Verifies you're on `main` with a clean working tree
+2. Validates `--prerelease` (must be empty, `alpha`, `beta`, or `rc`)
 3. Pulls latest changes from remote
 4. Validates merge commit format (governance check)
 5. Validates issue links in commits
 6. Runs all checks (`doit check`)
-7. Bumps version with commitizen (merges pre-releases into final version)
-8. Updates CHANGELOG.md (consolidates pre-release entries)
-9. Creates git tag and pushes to GitHub
-10. **Triggers:** `.github/workflows/release.yml`
-11. **Publishes to:** TestPyPI first, then PyPI
-
-> **Note:** This method pushes directly to `main` and requires bypass permissions. See [Setting Up Release Permissions](#setting-up-release-permissions).
-
-#### Option B: PR-Based Release (works with branch protection)
-
-```bash
-# Step 1: Create release PR (auto-detect version)
-doit release_pr
-
-# Or force a specific version bump
-doit release_pr --increment=major
-
-# Step 2: After PR is merged, create the tag
-doit release_tag
-```
-
-**What `doit release_pr` does:**
-
-1. Verifies you're on the `main` branch
-2. Determines next version using commitizen (`cz bump --get-next`)
-3. Creates a `release/vX.Y.Z` branch
-4. Updates CHANGELOG.md
-5. Commits and pushes the branch
-6. Creates a pull request
+7. Determines the next version using commitizen (`cz bump --get-next`)
+8. Creates a `release/vX.Y.Z` branch and updates `CHANGELOG.md`
+9. Commits the changelog, pushes the branch, and opens PR `release: vX.Y.Z`
 
 **What `doit release_tag` does:**
 
-1. Finds the most recently merged release PR
-2. Extracts the version from the PR title
-3. Creates a git tag on `main`
-4. Pushes the tag (triggers release workflow)
+1. Verifies you're on `main`, pulls latest changes
+2. Finds the most recently merged `release: vX.Y.Z` PR
+3. Extracts the version from the PR title (falls back to the branch name)
+4. Creates the git tag `vX.Y.Z` on `main`
+5. Pushes the tag
+6. **Triggers:** `.github/workflows/release.yml` (production) or
+   `.github/workflows/testpypi.yml` (pre-release)
+7. **Publishes to:** TestPyPI first, then PyPI for production tags; TestPyPI
+   only for pre-release tags
+
+**Testing a pre-release from TestPyPI:**
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ infrafoundry==1.0.1a0
+```
 
 ### Workflow Triggers
 
 | Workflow | Trigger | Destination |
 |----------|---------|-------------|
-| `testpypi.yml` | Tag matching `v*-[a-zA-Z]*` (e.g., `v1.0.0-alpha0`) | TestPyPI only |
+| `testpypi.yml` | PEP440 pre-release tags: `v*a[0-9]*`, `v*b[0-9]*`, `v*rc[0-9]*`, `v*.dev[0-9]*` (e.g., `v1.0.0a0`) | TestPyPI only |
 | `release.yml` | Tag matching `v[0-9]+.[0-9]+.[0-9]+` (e.g., `v1.0.0`) | TestPyPI → PyPI |
 
 ### Setting Up Release Permissions
 
-The release commands (`doit release`, `doit release_dev`) commit directly to `main` and push tags. If your repository has branch protection rules requiring pull requests, you'll need to configure a bypass for automated releases.
+`doit release_tag` pushes the version tag directly to `main`. If your branch
+protection rules cover tag pushes, configure a bypass for the tagging step.
+The release PR itself is reviewed and merged through the normal PR flow, so
+no bypass is required for the commit and changelog changes.
 
 #### Organization Repositories: GitHub App (Recommended)
 
@@ -518,6 +488,9 @@ Create a dedicated GitHub App that can bypass branch protection:
 4. Set **Repository Permissions:**
    - **Contents:** Read and write (to push commits/tags)
    - **Metadata:** Read-only (required)
+   - **Pull requests:** Write (required for the dependabot auto-merge
+     workflow to apply the `ready-to-merge` label via the App — see
+     [Dependabot Auto-merge → Required GitHub App configuration](../docs/development/dependabot-automerge.md#required-github-app-configuration))
 5. Click **Create GitHub App**
 6. Note the **App ID** displayed on the app page
 7. Scroll down → **Generate a private key** → saves a `.pem` file
@@ -548,7 +521,7 @@ In your repo **Settings** → **Secrets and variables** → **Actions**:
 ```yaml
 - name: Generate release token
   id: app-token
-  uses: actions/create-github-app-token@v1
+  uses: actions/create-github-app-token@v3
   with:
     app-id: ${{ vars.RELEASE_APP_ID }}
     private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -606,35 +579,30 @@ In your repo **Settings** → **Secrets and variables** → **Actions**:
     fetch-depth: 0
 ```
 
-#### Alternative: Release via Pull Request
-
-If you prefer not to configure bypass permissions, use the PR-based release workflow described in [Option B: PR-Based Release](#option-b-pr-based-release-works-with-branch-protection):
-
-```bash
-# Step 1: Create release PR
-doit release_pr
-
-# Step 2: After PR is merged, create the tag
-doit release_tag
-```
-
 ### Release Checklist
 
-Before running a release:
+Before opening a release PR:
 
 - [ ] All CI checks pass on `main`
 - [ ] CHANGELOG.md is up to date (or will be auto-generated)
-- [ ] No uncommitted changes
+- [ ] No uncommitted changes on your working tree
 - [ ] You have push access to the repository
 - [ ] PyPI/TestPyPI environments are configured in GitHub
+
+After the release PR is merged:
+
+- [ ] `git checkout main && git pull`
+- [ ] `doit release_tag`
+- [ ] Monitor the publish workflow in GitHub Actions
+- [ ] Verify the new version on TestPyPI (pre-release) or PyPI (production)
 
 ### Typical Release Cycle
 
 1. **Development:** Features merged to `main` via PRs
-2. **Alpha testing:** `doit release_dev --type=alpha` → Test on TestPyPI
-3. **Beta testing:** `doit release_dev --type=beta` → Wider testing
-4. **Release candidate:** `doit release_dev --type=rc` → Final testing
-5. **Production:** `doit release` → Publish to PyPI
+2. **Alpha testing:** `doit release --prerelease=alpha` → merge PR → `doit release_tag` → Test on TestPyPI
+3. **Beta testing:** `doit release --prerelease=beta` → merge PR → `doit release_tag` → Wider testing
+4. **Release candidate:** `doit release --prerelease=rc` → merge PR → `doit release_tag` → Final testing
+5. **Production:** `doit release` → merge PR → `doit release_tag` → Publish to PyPI
 
 ### Troubleshooting
 
@@ -706,12 +674,12 @@ Every code change must be linked to a GitHub Issue. This ensures:
 doit issue --type=feature    # For new features
 doit issue --type=bug        # For bugs and defects
 doit issue --type=refactor   # For code refactoring
-doit issue --type=doc        # For documentation
+doit issue --type=docs       # For documentation
 doit issue --type=chore      # For maintenance tasks
 
 # Non-interactive: For AI agents or scripts
 doit issue --type=feature --title="Add export" --body-file=issue.md
-doit issue --type=doc --title="Add guide" --body="## Description\n..."
+doit issue --type=docs --title="Add guide" --body="## Description\n..."
 ```
 
 **Or use gh CLI directly:**
@@ -723,7 +691,7 @@ gh issue create --title "<description>" --label "enhancement" --body "..."
 - `feature` → `enhancement, needs-triage`
 - `bug` → `bug, needs-triage`
 - `refactor` → `refactor, needs-triage`
-- `doc` → `documentation, needs-triage`
+- `docs` → `documentation, needs-triage`
 - `chore` → `chore, needs-triage`
 
 **Required fields ensure complete information** - Fill all fields to provide context.
@@ -801,11 +769,6 @@ Features:
 **Merge commit format:**
 ```
 <type>: <subject> (merges PR #XX, addresses #YY)
-```
-
-**When PR is docs-only or doesn't complete the issue:**
-```
-<type>: <subject> (merges PR #XX)
 ```
 
 **Examples - Correct:**
@@ -917,7 +880,7 @@ ADRs provide context for why decisions were made, helping future contributors un
 
 ```bash
 # Add upstream remote (one-time setup)
-git remote add upstream https://github.com/original-owner/package_name.git
+git remote add upstream https://github.com/original-owner/infrafoundry.git
 
 # Fetch and merge upstream changes
 git checkout main
@@ -931,7 +894,7 @@ git push origin main
 If you have questions:
 
 1. Check the [README.md](README.md) and [AGENTS.md](AGENTS.md)
-2. Search existing [Issues](https://github.com/username/package_name/issues)
+2. Search existing [Issues](https://github.com/endavis/infrafoundry/issues)
 3. Open a new issue with the "question" label
 4. Join our discussions (if available)
 

--- a/.github/actions/python-versions/action.yml
+++ b/.github/actions/python-versions/action.yml
@@ -1,0 +1,25 @@
+# Reusable composite action that reads .github/python-versions.json and exposes
+# the oldest and newest supported Python versions as outputs. Callers should
+# check out the repository (so .github/python-versions.json is on disk) before
+# invoking this action. Centralizing the jq parsing here keeps every workflow
+# that picks a Python version in sync with a single source of truth.
+name: Python Versions
+description: Read oldest and newest supported Python versions from .github/python-versions.json
+outputs:
+  oldest:
+    description: Oldest supported Python version (e.g., "3.12")
+    value: ${{ steps.read.outputs.oldest }}
+  newest:
+    description: Newest supported Python version (e.g., "3.14")
+    value: ${{ steps.read.outputs.newest }}
+runs:
+  using: composite
+  steps:
+    - name: Read python-versions.json
+      id: read
+      shell: bash
+      run: |
+        oldest=$(jq -r '.oldest' .github/python-versions.json)
+        newest=$(jq -r '.newest' .github/python-versions.json)
+        echo "oldest=$oldest" >> "$GITHUB_OUTPUT"
+        echo "newest=$newest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,15 +20,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for benchmark tests
+        id: check-benchmarks
+        run: |
+          if [ -d "tests/benchmarks" ] && find tests/benchmarks -name 'test_*.py' -print -quit | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No benchmark tests found at tests/benchmarks/; skipping benchmark workflow."
+          fi
+
       - uses: actions/setup-python@v6
+        if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           python-version: "3.14"
 
       - uses: astral-sh/setup-uv@v7
+        if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           version: "latest"
 
       - name: Cache uv dependencies
+        if: steps.check-benchmarks.outputs.exists == 'true'
         uses: actions/cache@v5
         with:
           path: ${{ env.UV_CACHE_DIR }}
@@ -37,9 +50,11 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Install dependencies
+        if: steps.check-benchmarks.outputs.exists == 'true'
         run: uv sync --all-extras --dev
 
       - name: Run benchmarks
+        if: steps.check-benchmarks.outputs.exists == 'true'
         run: |
           mkdir -p tmp
           uv run pytest tests/benchmarks/ \
@@ -47,6 +62,7 @@ jobs:
             --benchmark-json=tmp/benchmark-results.json -v
 
       - name: Check for benchmark data branch
+        if: steps.check-benchmarks.outputs.exists == 'true'
         id: check-bench-branch
         run: |
           if git ls-remote --exit-code origin gh-benchmarks >/dev/null 2>&1; then
@@ -56,7 +72,7 @@ jobs:
           fi
 
       - name: Create benchmark data branch
-        if: steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
+        if: steps.check-benchmarks.outputs.exists == 'true' && steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -66,7 +82,7 @@ jobs:
           git checkout ${{ github.sha }}
 
       - name: Store benchmark results
-        if: github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true'
+        if: steps.check-benchmarks.outputs.exists == 'true' && (github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true')
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'pytest'
@@ -80,7 +96,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload benchmark results
-        if: always()
+        if: always() && steps.check-benchmarks.outputs.exists == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results

--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -16,14 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # Need full history for comparison
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }}
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - name: Install griffe
         run: pip install griffe

--- a/.github/workflows/ci-full-matrix.yml
+++ b/.github/workflows/ci-full-matrix.yml
@@ -1,0 +1,18 @@
+name: CI (full matrix)
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch full-matrix CI
+    if: github.event.label.name == 'full-matrix'
+    uses: ./.github/workflows/ci.yml
+    with:
+      full_matrix: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,37 +3,54 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   workflow_call:
+    inputs:
+      full_matrix:
+        description: 'Run the full Python-version matrix (middle versions) instead of the bookend versions.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
-    # Skip CI if triggered by a label event that isn't 'full-matrix'
-    if: github.event.action != 'labeled' || github.event.label.name == 'full-matrix'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      oldest: ${{ steps.pv.outputs.oldest }}
+      newest: ${{ steps.pv.outputs.newest }}
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/python-versions.json
+          sparse-checkout: |
+            .github/python-versions.json
+            .github/actions/python-versions
           sparse-checkout-cone-mode: false
 
-      - name: Set matrix based on config and label
+      - id: pv
+        uses: ./.github/actions/python-versions
+
+      - name: Set matrix based on config and input
         id: set-matrix
+        env:
+          OLDEST: ${{ steps.pv.outputs.oldest }}
+          NEWEST: ${{ steps.pv.outputs.newest }}
         run: |
-          # Read config
-          oldest=$(jq -r '.oldest' .github/python-versions.json)
-          newest=$(jq -r '.newest' .github/python-versions.json)
+          oldest="$OLDEST"
+          newest="$NEWEST"
 
           oldest_minor=${oldest#3.}
           newest_minor=${newest#3.}
 
-          if [[ "${{ github.event.label.name }}" == "full-matrix" ]]; then
+          if [[ "${{ inputs.full_matrix }}" == "true" ]]; then
             # Middle versions only (bookends already tested)
             versions=""
             for ((i=oldest_minor+1; i<newest_minor; i++)); do
@@ -135,29 +152,62 @@ jobs:
         run: uv run pytest --cov=infrafoundry --cov-report=xml:tmp/coverage.xml --cov-report=term -v
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == needs.setup.outputs.newest
         uses: codecov/codecov-action@v6
         with:
-          file: ./tmp/coverage.xml
+          files: ./tmp/coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  docs:
+    needs: setup
+    if: ${{ needs.setup.outputs.matrix != '{"include":[]}' }}
+    runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ needs.setup.outputs.newest }}
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Build documentation
+        run: uv run doit docs_build
+
   ci-complete:
-    # Always run unless this is a non-full-matrix label event
-    if: always() && (github.event.action != 'labeled' || github.event.label.name == 'full-matrix')
-    needs: [setup, test]
+    if: always()
+    needs: [setup, test, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI status
         run: |
           setup_result="${{ needs.setup.result }}"
           test_result="${{ needs.test.result }}"
+          docs_result="${{ needs.docs.result }}"
 
           echo "Setup result: $setup_result"
           echo "Test result: $test_result"
+          echo "Docs result: $docs_result"
 
           # Setup must succeed
           if [[ "$setup_result" != "success" ]]; then
@@ -168,6 +218,12 @@ jobs:
           # Test must succeed or be skipped (skipped = no middle versions)
           if [[ "$test_result" != "success" && "$test_result" != "skipped" ]]; then
             echo "Test job failed"
+            exit 1
+          fi
+
+          # Docs must succeed or be skipped (skipped = no middle versions)
+          if [[ "$docs_result" != "success" && "$docs_result" != "skipped" ]]; then
+            echo "Docs job failed"
             exit 1
           fi
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -17,9 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -76,6 +76,11 @@ jobs:
               return;
             }
 
+            if (pr.user.login === 'dependabot[bot]') {
+              console.log('✅ Dependabot PR - issue link not required');
+              return;
+            }
+
             // Check for issue reference in PR body or title
             const issuePatterns = [
               /addresses\s+#\d+/i,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -50,10 +53,24 @@ jobs:
       - name: Generate SBOM (XML)
         run: uv run cyclonedx-py environment --of XML -o dist/sbom.xml
 
+      # Split into two artifacts: ``dist`` for twine (wheels + sdist only)
+      # and ``sbom`` for the GitHub release. Mixing SBOM files into the
+      # publish artifact makes twine abort with InvalidDistribution. See
+      # pyproject-template#665.
       - uses: actions/upload-artifact@v7
         with:
           name: dist
-          path: dist
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: |
+            dist/sbom.json
+            dist/sbom.xml
           if-no-files-found: error
 
   publish-testpypi:
@@ -116,7 +133,7 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: dist
+          name: sbom
           path: dist
 
       - name: Upload SBOM assets to GitHub release

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -2,9 +2,14 @@ name: Publish to TestPyPI
 
 on:
   workflow_dispatch:
+  # PEP440 pre-release tag patterns. commitizen (used by doit release) emits
+  # these forms, not semver-style v*-alpha.* tags. See pyproject-template#659.
   push:
     tags:
-      - "v*-[a-zA-Z]*"
+      - "v*a[0-9]*"       # alpha: v0.1.0a0
+      - "v*b[0-9]*"       # beta: v0.1.0b1
+      - "v*rc[0-9]*"      # rc: v0.1.0rc0
+      - "v*.dev[0-9]*"    # dev: v0.1.0.dev2
 
 permissions:
   contents: read
@@ -23,9 +28,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ MANIFEST
 htmlcov/
 .mypy_cache/
 .ruff_cache/
+.pytype/
+.pyre/
+.dmypy.json
+dmypy.json
 .tox/
 .hypothesis/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
         stages: [commit-msg]
         args: [--strict]
 
+  # GitHub Actions workflow linting
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   # Local hooks using project's installed tools via uv
   # This ensures version consistency with pyproject.toml
   - repo: local

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,8 @@
 
     // Code Quality & Formatting
     "charliermarsh.ruff",
+    "ms-python.mypy-type-checker",
+    "tamasfe.even-better-toml",
 
     // Testing
     "ms-python.pytest",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,9 @@
   "ruff.enable": true,
   "ruff.organizeImports": true,
   "ruff.fixAll": true,
+  "ruff.lint.args": ["--config=pyproject.toml"],
+  "ruff.format.args": ["--config=pyproject.toml"],
+  "mypy-type-checker.args": ["--config-file=pyproject.toml"],
 
   // YAML Configuration
   "[yaml]": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 - **NEVER implement based on a question.** Wait for explicit "Do it" or "Proceed".
 - **Stop & Verify:** If the user says "Stop", "Wait", "Hold on", "Cancel", "Wrong", or "No", immediately halt and ask for clarification.
 - **Summary Before Commit:** At the end of any implementation (docs, fix, feature, chore, etc.), summarize what was changed for the user before committing and wait for the user's explicit instruction to commit the changes.
+- **Failing Tests:** Never modify a test to make it pass. Stop, explain *why* the test broke (what behavior changed, what the test was asserting), and discuss with the user whether the code or the test should change. A failing test is a signal, not a problem to silence.
 
 ### 2. Task Planning Protocol
 - **Plan First:** Before writing code, you MUST present a checklist:
@@ -58,6 +59,7 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 | **Committing** | `.github/CONTRIBUTING.md` (Commit Guidelines) | `<type>: <subject>` format. |
 | **New Dependency** | `.github/CONTRIBUTING.md` (Dependencies) | "Ask First" policy. |
 | **Creating Code** | `.claude/CLAUDE.md` (TodoWrite) | Plan -> Test -> Code loop. |
+| **Generating new code** | `docs/development/ai/architectural-conventions.md` | Layering rules and anti-patterns to avoid before writing code. |
 | **Architectural Decision** | `docs/decisions/README.md` | Check for related ADRs to update. |
 
 ### 6. Decision Framework
@@ -108,6 +110,9 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 | **Issue Templates** | `.github/ISSUE_TEMPLATE/*.yml` | Required fields for issues. |
 | **PR Template** | `.github/pull_request_template.md` | Required PR structure. |
 | **Claude Instructions** | `.claude/CLAUDE.md` | TodoWrite usage, workflows. |
+| **Architecture & Layering** | `docs/development/ai/architectural-conventions.md` | Imperative-form rules for AI agents. |
+| **Slash Commands & Workflows** | `docs/development/ai/slash-commands.md` | Reference for /plan-issue, /implement, /finalize, dual-agent workflow. |
+| **AI Agent Walkthrough** | `docs/development/ai/first-5-minutes.md` | Narrative onboarding for the AI agent workflow (plan → implement → review → PR → merge). |
 
 ## Repository & Architecture
 
@@ -318,6 +323,7 @@ The tool hierarchy (prefer higher over lower):
 | Create PRs | `doit pr` | `gh pr create` |
 | Merge PRs | `doit pr_merge` | `gh pr merge` |
 | Create ADRs | `doit adr` | Manual file creation |
+| Sync GitHub labels | `doit labels_sync` | `gh label create` / `gh label edit` manually |
 | Commit (interactive) | `doit commit` | `git commit` without format |
 | Install/add packages | `uv add <pkg>` | `pip install` |
 | Sync dependencies | `uv sync` | `pip install -r` |
@@ -327,8 +333,8 @@ The tool hierarchy (prefer higher over lower):
 | GitHub API queries | `gh api` | `curl` to GitHub API |
 | Build docs | `doit docs_build` | `mkdocs build` directly |
 | Serve docs locally | `doit docs_serve` | `mkdocs serve` directly |
-| Release (production) | `doit release` | Manual tag + push |
-| Release (pre-release) | `doit release_dev` | Manual tag + push |
+| Release | `doit release` | Manual changelog + PR |
+| Tag after release PR merge | `doit release_tag` | Manual tag + push |
 | Mutation testing | `doit mutate` | `mutmut` directly |
 | Generate SBOM | `doit sbom` | `cyclonedx-py` directly |
 
@@ -365,12 +371,7 @@ gh pr list --state open
 
 ### Dependabot PRs
 
-Patch- and minor-bump dependabot PRs are handled automatically by the
-`dependabot-automerge.yml` workflow (enables GitHub auto-merge and adds
-`ready-to-merge` once eligibility checks pass). The manual flow below
-applies only to PRs the workflow skips — major-version bumps, PRs the
-workflow labels with `automerge-blocked`, or sensitive-dependency
-updates listed in `.github/automerge-config.json`.
+Dependabot PRs that pass CI are now auto-merged by `.github/workflows/dependabot-automerge.yml`. The manual workflow below applies only to PRs the bot skips (major bumps, sensitive deps, or PRs labeled `automerge-blocked`). See [docs/development/dependabot-automerge.md](docs/development/dependabot-automerge.md) for details.
 
 When merging dependabot PRs that are behind `main`, **never** use the GitHub API `update-branch` endpoint or local rebase to update the branch. This strips the verified commit signatures from dependabot commits, which are required by branch protection rules.
 
@@ -384,6 +385,8 @@ Dependabot will rebase the branch and re-sign the commits, preserving verified s
 
 #### Dependabot PR merge workflow
 
+When merging dependabot PRs that are behind `main`, use this procedure:
+
 1. **Request rebase** via dependabot's own action (preserves signed commits):
    ```bash
    gh pr comment <number> --body "@dependabot rebase"
@@ -391,7 +394,10 @@ Dependabot will rebase the branch and re-sign the commits, preserving verified s
 
 2. **Wait for force-push** — poll until the PR's commit parent matches current `main` HEAD:
    ```bash
+   # Get current main HEAD
    main_sha=$(gh api repos/{owner}/{repo}/git/ref/heads/main --jq '.object.sha[0:7]')
+
+   # Poll PR commit parent until it matches
    gh api repos/{owner}/{repo}/pulls/<number>/commits --jq '.[0].parents[0].sha[0:7]'
    ```
    This takes 1–3 minutes. **Do not** request a second rebase until the first one lands.
@@ -420,6 +426,19 @@ AI agents with native file tools (Read, Grep, Glob, Edit, Write) **must** prefer
 
 Native tools provide better visibility, review capabilities, and error handling for the user.
 
+### AI Config Directories
+
+Each supported AI CLI has a dedicated config directory at the repo root:
+
+| CLI | Config Directory | Notes |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/` | Commands, agents, settings. Primary source of slash commands. |
+| Gemini CLI | `.gemini/` | Commands and settings. Output-only commands (orchestrated by Claude). |
+| GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
+| Codex CLI | `.codex/` | `config.toml` only (command approval policies). No slash commands. |
+
+Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/plan-issue`, `/implement`, `/finalize`, etc.) works out of the box.
+
 ### Temporary Files
 
 AI agents **must never** write temporary files to generic locations like `/tmp/`. Instead, use the project-scoped directory:
@@ -445,7 +464,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **No Speculation:** Don't read files you don't need.
 
 ## Critical Reminders
-- **Flow:** Issue (`doit issue`) -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main.
+- **Flow:** Issue (`doit issue`) -> **`git checkout main && git pull`** -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main. Pull `main` before branching — local `main` may be behind the remote (e.g., after dependabot PRs merged via the web UI). `doit pr` enforces this by aborting if the branch is behind `origin/main`; pass `--no-update-check` to override.
 - **Scope:** Never mix refactoring, features, and docs in one PR. Create separate branches.
 - **Verify:** Check file paths (`ls`) and branch (`git status`) before assuming they exist.
 - **Security:** NEVER bypass security checks (e.g., `--no-verify`, ignoring secrets).
@@ -453,13 +472,13 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **Integrity:** Respect architectural patterns (modularity) over "quick fixes".
 - **Local State:** Protect user config (e.g., `.envrc.local`, settings). Do not revert/delete without backup.
 - **Version:** Source of truth is Git tags. Never edit `pyproject.toml` version.
-- **Tests:** Creating code = Creating tests. No exceptions.
+- **Tests:** Creating code = Creating tests. No exceptions. Never modify a failing test to make it pass — stop, explain why it broke, and discuss with the user whether the code or the test should change.
 - **Commits:** One logical change per commit. Use conventional commits.
 - **Releases:** Never run `doit release` without explicit command.
-- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed.
-- **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation.
-- **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
-- **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
+- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed — pass `--auto-close` to `doit pr_merge` to close linked issues in one step.
+- **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation. Exception: the dependabot auto-merge workflow (`.github/workflows/dependabot-automerge.yml`) applies the `ready-to-merge` label to qualifying dependabot PRs only.
+- **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, docs, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
+- **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Docs and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
 
 ## Development Workflow
 
@@ -513,9 +532,9 @@ doit issue --type=bug --title="bug: crash on empty config" \
 doit issue --type=refactor --title="refactor: extract validation" \
   --body="## Current Code Issue\nDuplicated logic\n\n## Proposed Improvement\nExtract to mixin"
 
-# Documentation (requires: Documentation Type, Description)
-doit issue --type=doc --title="doc: add provider guide" \
-  --body="## Documentation Type\nNew guide or tutorial\n\n## Description\nAdd guide for creating custom providers"
+# Documentation (requires: Description)
+doit issue --type=docs --title="docs: add provider guide" \
+  --body="## Description\nAdd guide for creating custom providers"
 
 # Chore (requires: Description)
 doit issue --type=chore --title="chore: update dependencies" \
@@ -528,10 +547,13 @@ doit pr --title="feat: add caching" --body="## Summary\nAdded caching support\n\
 doit pr --title="fix: handle null" --body-file=pr.md
 ```
 
+`doit pr` auto-pushes the current branch to `origin` if it has no upstream. Pass `--no-push` to skip the auto-push (the task aborts instead).
+
 #### PR Merge
 ```bash
-doit pr_merge                    # Merge PR for current branch
-doit pr_merge --pr=123           # Merge specific PR
+doit pr_merge                        # Merge PR for current branch
+doit pr_merge --pr=123               # Merge specific PR
+doit pr_merge --pr=123 --auto-close  # Also close linked issues after merge
 ```
 
 #### ADR Creation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # InfraFoundry
 
-## Overview
+[![CI](https://github.com/endavis/infrafoundry/actions/workflows/ci.yml/badge.svg)](https://github.com/endavis/infrafoundry/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/endavis/infrafoundry/branch/main/graph/badge.svg)](https://codecov.io/gh/endavis/infrafoundry)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 
 A pluggable infrastructure code generator and orchestration framework that turns YAML into Terraform/Ansible, with optional execution, state tracking, policies, and notifications.
 
@@ -15,18 +17,6 @@ A pluggable infrastructure code generator and orchestration framework that turns
 - You need reproducible, policy-enforced plans/applies with state/history and notifications.
 - You prefer separating framework and configuration repositories.
 
-## Quick Start
-
-```bash
-git clone https://github.com/yourusername/infrafoundry.git
-cd infrafoundry
-./scripts/setup-dependencies.sh
-./scripts/setup-config.sh
-infra validate --env dev --check-api --check-refs
-infra plan --env dev
-infra apply --env dev
-```
-
 ## Features
 
 - Pluggable providers (Proxmox, OPNsense, Kubernetes; extensible)
@@ -35,22 +25,277 @@ infra apply --env dev
 - Separate config repos; CI/CD-ready with GitHub/GitLab examples
 - State/history tracking (SQLite/PostgreSQL)
 - Event system + notifications; policy enforcement; drift detection; dependency graphing
+- Modern tooling: `uv` for deps, `ruff` for format/lint, `mypy` in strict mode
+- CI/CD ready: GitHub Actions for checks, coverage upload, and releases
+- Release automation: hatch-vcs + commitizen-driven tagging and changelog
+
+## Quick Start
+
+```bash
+git clone https://github.com/endavis/infrafoundry.git
+cd infrafoundry
+./scripts/setup-dependencies.sh
+./scripts/setup-config.sh
+foundry doctor
+foundry infra plan --env dev
+foundry infra apply --env dev
+```
 
 ## Documentation
 
-For a comprehensive overview of all documentation, including getting started guides, configuration details, architectural insights, development practices, and more, please refer to the [Table of Contents](docs/TABLE_OF_CONTENTS.md).
+Full documentation is available in the [docs/](docs/) directory.
+
+Build and view locally:
+
+```bash
+doit docs_serve  # Opens at http://127.0.0.1:8000
+```
+
+For a comprehensive overview of all documentation, including getting started guides, configuration details, architectural insights, development practices, and more, please refer to the [documentation index](docs/index.md).
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.12+
+- [uv](https://github.com/astral-sh/uv) — Fast Python package installer
+- [direnv](https://direnv.net/) — Automatic environment variable loading (optional but recommended)
+
+### Initial Setup
+
+```bash
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone repository
+git clone https://github.com/endavis/infrafoundry.git
+cd infrafoundry
+
+# Create virtual environment and install dependencies
+uv sync --all-extras --dev
+
+# Install pre-commit hooks
+doit pre_commit_install
+
+# Optional: install direnv via the doit helper on Linux
+doit install_direnv
+
+# Hook direnv into your shell (one-time setup)
+# Bash:
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+# Zsh:
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+
+# Allow direnv to load .envrc
+direnv allow
+
+# Optional: create .envrc.local for personal overrides
+cp .envrc.local.example .envrc.local
+```
+
+## Versioning & Releases
+
+This project uses automated versioning and releases powered by `commitizen` and `hatch-vcs`.
+
+- **Single Source of Truth:** The Git tag is the definitive version. `pyproject.toml` and `_version.py` are generated at build time from tags (no manual edits).
+- **Versioning Scheme:**
+    - **Production:** Standard SemVer (e.g., `v1.0.0`).
+    - **Development:** PEP440 pre-release tags (e.g., `v1.0.0a0`, `v1.0.0b0`, `v1.0.0rc0`, `v1.0.0.dev0`).
+
+### Creating a Release
+
+All releases go through a pull request. `doit release` opens the release PR; after a reviewer merges it, `doit release_tag` tags `main` and triggers the publish workflow.
+
+```bash
+# Step 1: open a release PR
+doit release                     # auto-detect next version from commits
+doit release --increment=major   # force MAJOR
+doit release --increment=minor   # force MINOR
+doit release --increment=patch   # force PATCH
+doit release --prerelease=alpha  # pre-release (1.0.0 → 1.0.1a0)
+
+# Step 2 (after PR is merged):
+git checkout main && git pull
+doit release_tag                  # tags main and triggers the publish workflow
+```
+
+See [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md#release-process) for the full release process including workflow triggers, bypass-permission setup, and troubleshooting.
+
+### Environment Variables
+
+This project uses direnv for automatic environment management. After setup:
+
+- `.envrc` (committed) contains project defaults and is loaded automatically
+- `.envrc.local` (git-ignored) is for personal overrides and credentials
+- Environment variables are set automatically when you enter the project directory
+- Virtual environment is activated automatically
+
+### Manual Setup (without direnv)
+
+```bash
+# Create virtual environment and activate it
+uv venv
+source .venv/bin/activate
+
+# Set environment variables manually
+export UV_CACHE_DIR="$(pwd)/tmp/.uv_cache"
+
+# Install dependencies
+uv sync --all-extras --dev
+```
+
+## Available Tasks
+
+View all available tasks:
+
+```bash
+doit list
+```
+
+### Quick Commands
+
+```bash
+# Testing
+doit test          # Run tests (parallel execution with pytest-xdist)
+doit coverage      # Run tests with coverage report
+
+# Code Quality
+doit format        # Format code with ruff
+doit lint          # Run linting
+doit type_check    # Run type checking with mypy
+doit check         # Run ALL checks (format, lint, type check, test)
+
+# Security
+doit security      # Run security scan with bandit
+doit audit         # Run dependency vulnerability audit
+doit spell_check   # Check for typos with codespell
+doit licenses      # Check licenses of dependencies
+
+# Version Management
+doit commit        # Interactive commit with conventional format
+doit release       # Open release PR (commitizen-driven)
+doit release_tag   # Tag main after release PR merges
+
+# Documentation
+doit docs_serve    # Serve docs locally with live reload
+doit docs_build    # Build documentation site
+doit docs_deploy   # Deploy docs to GitHub Pages
+
+# Maintenance
+doit cleanup       # Clean build artifacts and caches
+doit update_deps   # Update dependencies and run tests
+```
+
+## Running Tests
+
+```bash
+# Run all tests (parallel execution)
+doit test
+
+# Run with coverage
+doit coverage
+
+# View coverage report
+open tmp/htmlcov/index.html
+
+# Run a specific test
+uv run pytest tests/test_example.py::test_version -v
+```
+
+## Code Quality
+
+This project includes comprehensive tooling:
+
+### Core Tools
+
+- **uv** — Fast Python package installer and dependency manager
+- **ruff** — Extremely fast Python linter and formatter
+- **mypy** — Static type checker with strict mode
+- **pytest** — Testing framework with parallel execution (pytest-xdist)
+
+### Quality & Security
+
+- **bandit** — Security vulnerability scanner
+- **codespell** — Spell checker for code and documentation
+- **pip-audit** — Dependency vulnerability auditor
+- **pip-licenses** — License compliance checker
+- **pre-commit** — Git hooks for automated quality checks
+- **pyproject-fmt** — Keep pyproject.toml formatted and organized
+- **commitizen** — Enforce conventional commit message standards
+
+### Documentation
+
+- **MkDocs** — Documentation site generator
+- **mkdocs-material** — Material Design theme for MkDocs
+
+Run all quality checks:
+
+```bash
+doit check
+```
+
+### Pre-commit Hooks
+
+Install hooks to run checks automatically before each commit:
+
+```bash
+doit pre_commit_install
+```
+
+Hooks include:
+
+- Code formatting (ruff)
+- Type checking (mypy)
+- Security scanning (bandit)
+- Spell checking (codespell)
+- YAML/TOML validation
+- Trailing whitespace removal
+- Private key detection
+- Branch-naming enforcement
+- Blueprint linter (InfraFoundry-specific)
+
+## AI Agent Support
+
+InfraFoundry is designed primarily for **Claude Code**, which ships the full slash-command workflow (plan → implement → finalize → close-issue). **Gemini CLI** is supported as a second-opinion planner/reviewer inside Claude-orchestrated dual-agent commands, and **Codex CLI** is supported as a standalone alternative without slash commands.
+
+### Requirements
+
+> **Important:** [GitHub CLI (`gh`)](https://cli.github.com/) is **required** for AI-assisted workflows.
+>
+> Many `doit` tasks use `gh` for issue creation, PR management, and repository operations.
+> Install and authenticate before using AI agents:
+>
+> ```bash
+> # Install (macOS)
+> brew install gh
+>
+> # Install (Linux) — see https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+>
+> # Authenticate
+> gh auth login
+> ```
+
+### Features
+
+- **AGENTS.md** — Instructions and protocols for AI agents
+- **Dangerous command blocking** — Hooks prevent destructive operations (force push to main, branch deletion, etc.)
+- **Workflow automation** — `doit issue` and `doit pr` for GitHub operations
+
+See [AGENTS.md](AGENTS.md) and [docs/development/](docs/development/) for more details.
 
 ## Contributing
 
 - Use Conventional Commits; maintain ≥69% coverage.
-- Run locally: `doit format && doit lint && uv run pytest` (or `doit coverage`).
-- See [docs/development/ci-cd-testing.md](docs/development/ci-cd-testing.md) and [docs/development/coding-standards.md](docs/development/coding-standards.md).
+- Run locally: `doit check` (runs format, lint, type-check, tests).
+- See [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for the full workflow.
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Support
 
-- Issues/Discussions: project GitHub
-- Docs: [docs/](docs/TABLE_OF_CONTENTS.md) in repo
+- Issues/Discussions: [github.com/endavis/infrafoundry](https://github.com/endavis/infrafoundry)
+- Docs: [docs/](docs/index.md) in repo
 
----
+## License
 
-Last updated: 2025-11-29 14:27 GMT
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -26,8 +26,8 @@ doit <task_name>
 | [Security](#security-tasks) | `security`, `audit`, `licenses`, `sbom` | Security scanning and SBOM |
 | [Documentation](#documentation-tasks) | `docs_serve`, `docs_build`, `docs_deploy`, `docs_toc` | Documentation management |
 | [Dependencies](#dependency-tasks) | `install`, `install_dev`, `update_deps` | Package management |
-| [GitHub Workflow](#github-workflow-tasks) | `issue`, `pr`, `pr_merge`, `adr` | Issue and PR management |
-| [Release](#release-tasks) | `release`, `release_dev` | Version and release management |
+| [GitHub Workflow](#github-workflow-tasks) | `issue`, `pr`, `pr_merge`, `adr`, `labels_sync`, `env_create`, `env_list`, `publish_setup` | Issue, PR, and environment management |
+| [Release](#release-tasks) | `release`, `release_tag`, `publish` | Version and release management |
 | [Setup](#setup-tasks) | `pre_commit_install`, `completions`, `install_direnv` | Development environment |
 | [Maintenance](#maintenance-tasks) | `cleanup` | Project cleanup |
 
@@ -327,7 +327,14 @@ Create an Architecture Decision Record.
 
 ```bash
 doit adr --title="Use Redis for caching" --body="## Status\nAccepted\n..."
+doit adr --title="Template-meta ADR" --template  # Creates a 9XXX-series template ADR
 ```
+
+**Options:**
+- `--title`: ADR title (required)
+- `--body`: ADR body (non-interactive)
+- `--body-file`: File containing ADR body
+- `--template`: Create a template-meta ADR (9XXX series) instead of a project-level ADR
 
 ---
 
@@ -341,14 +348,64 @@ Create a production release with full governance validation.
 doit release
 ```
 
-### `release_dev`
+### `release_tag`
 
-Create a pre-release for TestPyPI testing.
+Tag `main` after a release PR is merged.
 
 ```bash
-doit release_dev              # Alpha (default)
-doit release_dev --type=beta  # Beta
-doit release_dev --type=rc    # Release candidate
+doit release_tag
+```
+
+**What it does:**
+1. Verifies you are on `main` and pulls the latest changes.
+2. Finds the most recently merged `release: vX.Y.Z` PR.
+3. Extracts the version from the PR title (falls back to the branch name).
+4. Creates the git tag `vX.Y.Z` on `main` and pushes it.
+5. The tag push triggers `.github/workflows/release.yml` (production) or
+   `.github/workflows/testpypi.yml` (pre-release).
+
+**Pre-releases:** Open a pre-release PR with `doit release --prerelease=alpha`
+(or `beta` / `rc`). After merge, run `doit release_tag` — the PEP440 tag format
+(`v1.2.3a0`, `v1.2.3b0`, `v1.2.3rc0`, `v1.2.3.dev0`) is picked up by
+`testpypi.yml` and publishes to TestPyPI only.
+
+---
+
+## GitHub Environments
+
+### `labels_sync`
+
+Reconcile GitHub labels with `.github/labels.yml` (idempotent).
+
+```bash
+doit labels_sync --dry-run      # Preview changes
+doit labels_sync                # Create missing / update drift
+doit labels_sync --prune        # Also delete labels absent from the file
+```
+
+### `env_create`
+
+Create a GitHub environment by name (idempotent).
+
+```bash
+doit env_create --name=pypi
+doit env_create --name=testpypi
+```
+
+### `env_list`
+
+List GitHub environments for the current repository.
+
+```bash
+doit env_list
+```
+
+### `publish_setup`
+
+Bootstrap GitHub environments (`testpypi`, `pypi`) for PyPI trusted publishing.
+
+```bash
+doit publish_setup
 ```
 
 ---

--- a/docs/development/pyproject-template-divergences.md
+++ b/docs/development/pyproject-template-divergences.md
@@ -136,27 +136,6 @@ proposed change, the merge lost it — push back and ask for a rework.
 ## 4. Temporarily deferred files
 
 Unlike the categories above, these files **will** be adopted — just not in the
-current sync phase. They are listed here so a reviewer opening this doc after
-Phase A does not assume they were skipped permanently. Remove each entry once
-the referenced follow-up phase lands.
-
-- `.github/workflows/ci-full-matrix.yml` and
-  `tests/test_ci_full_matrix_workflow.py` — deferred from Phase A to Phase E
-  of sync tracker #673. Upstream `ci-full-matrix.yml` calls
-  `./.github/workflows/ci.yml` with `with: full_matrix: true`, but our
-  `ci.yml` does not declare that `workflow_call` input. Phase E will add the
-  input (and switch the label-check logic to read from it), at which point
-  these two files can be adopted verbatim. Remove this note once Phase E
-  lands.
-- `tests/test_ci_workflow.py`, `tests/test_release_workflow.py`,
-  `tests/test_testpypi_workflow.py` — deferred from Phase C2 to Phase E of
-  sync tracker #673. These structural workflow tests were written upstream
-  against upstream's evolved workflow shapes: `ci.yml` with a `concurrency`
-  block and `workflow_call.inputs.full_matrix`; `release.yml` with a
-  separate `sbom` artifact upload; `testpypi.yml` with PEP440 tag-glob
-  triggers (`v*a[0-9]*` / `v*b[0-9]*` / `v*rc[0-9]*` / `v*.dev[0-9]*`
-  instead of `v*-[a-zA-Z]*`, fixing upstream #659). Our workflows still
-  carry the pre-divergence shapes; adopting the tests now fails 14 assertions.
-  Phase E will update the three workflow files to match upstream, at which
-  point these tests can be adopted verbatim. Remove this note once Phase E
-  lands.
+current sync phase. Sync-tracker #673 completed in Phase E (issue #678); no
+files are currently deferred. Future deferrals should be logged here with a
+pointer to the follow-up issue.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,20 @@ theme:
 
 plugins:
   - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_signature_annotations: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            merge_init_into_class: true
+            show_root_heading: true
+            show_root_full_path: false
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ env = "infrafoundry.secrets.backends.env:register"
 file = "infrafoundry.secrets.backends.file:register"
 
 [build-system]
-requires = ["hatchling>=1.29.0", "hatch-vcs>=0.4"]
+requires = ["hatchling>=1.29.0", "hatch-vcs>=0.5.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
@@ -90,6 +90,13 @@ target-version = "py312"
 extend-exclude = ["**/_version.py"]
 
 [tool.ruff.lint]
+# Enable preview mode but require rules to be listed by exact code so we can
+# opt into specific preview rules without pulling in every unstable preview
+# rule. (PLW1514, the UTF-8 file-I/O rule, is NOT enabled yet — enabling it
+# would flag 180+ existing call sites. Schedule a separate refactor to
+# encoding= every text-mode open/read_text/write_text call before opting in.)
+preview = true
+explicit-preview-rules = true
 select = [
     "E",    # pycodestyle errors
     "F",    # pyflakes
@@ -125,6 +132,9 @@ ignore = [
 "tools/pyproject_template/*.py" = [
     "ANN401",   # Any return type for dynamic GitHub API responses
     "RUF022",   # __all__ intentionally grouped by category, not sorted
+]
+"tests/benchmarks/*.py" = [
+    "ANN401",   # benchmark fixture has no py.typed
 ]
 
 [tool.ruff.format]

--- a/tests/test_ci_full_matrix_workflow.py
+++ b/tests/test_ci_full_matrix_workflow.py
@@ -1,0 +1,141 @@
+"""Tests for the CI (full matrix) dispatch workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow -- they only verify its shape.
+
+This workflow exists to preserve the ``full-matrix`` label UX (adding the
+label on a PR triggers a run across the middle Python versions) while keeping
+the ``labeled`` event off the main ``ci.yml`` trigger list (see
+pyproject-template#424). The dispatch job is a thin wrapper: a single ``if:``
+guard checks the label name, then delegates to ``ci.yml`` via
+``workflow_call`` with ``full_matrix: true``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "ci-full-matrix.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the CI full-matrix workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
+    non-ASCII content in the workflow file (lesson from pyproject-template#430).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+class TestWorkflowFile:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The CI full-matrix workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML with a jobs dict."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_workflow_name(self) -> None:
+        """The workflow name is the user-facing check-run label."""
+        workflow = _load_workflow()
+        assert workflow.get("name") == "CI (full matrix)"
+
+
+class TestTriggers:
+    """Trigger configuration: pull_request ``labeled`` only."""
+
+    def test_only_trigger_is_pull_request(self) -> None:
+        """The workflow should have exactly one trigger: ``pull_request``.
+
+        Adding other triggers would break the isolation that
+        pyproject-template#424 establishes between label-driven runs and
+        push-driven runs.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        assert list(triggers.keys()) == ["pull_request"], (
+            "workflow should trigger on pull_request only so label-driven "
+            "full-matrix runs stay isolated (pyproject-template#424)"
+        )
+
+    def test_pull_request_types_is_labeled_only(self) -> None:
+        """The only event type should be ``labeled``.
+
+        This is the core regression guard for pyproject-template#424: the
+        whole point of this workflow is to absorb the ``labeled`` trigger so
+        the main ``ci.yml`` no longer fires on every label event.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request"]["types"]
+        assert types == ["labeled"], f"expected types: [labeled], got {types}"
+
+    def test_pull_request_branches_is_main(self) -> None:
+        """The workflow targets PRs to ``main``, matching ``ci.yml``'s scope."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        branches = triggers["pull_request"]["branches"]
+        assert branches == ["main"]
+
+
+class TestDispatchJob:
+    """The ``dispatch`` job delegates to ``ci.yml`` via ``workflow_call``."""
+
+    def test_dispatch_job_exists(self) -> None:
+        """Workflow should define the ``dispatch`` job."""
+        workflow = _load_workflow()
+        assert "dispatch" in workflow["jobs"]
+
+    def test_dispatch_if_filters_on_full_matrix_label(self) -> None:
+        """The job's ``if:`` must filter on the ``full-matrix`` label.
+
+        Without this guard, *any* label applied to a PR would dispatch a
+        full-matrix CI run -- a massive waste of minutes.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job["if"] == "github.event.label.name == 'full-matrix'"
+
+    def test_dispatch_uses_local_ci_workflow(self) -> None:
+        """The job must call ``./.github/workflows/ci.yml`` via ``workflow_call``.
+
+        The local path (``./...``) is important: using a remote reference
+        would run a possibly-different version of the reusable workflow.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job["uses"] == "./.github/workflows/ci.yml"
+
+    def test_dispatch_passes_full_matrix_true(self) -> None:
+        """The job must pass ``full_matrix: true`` to the reusable workflow.
+
+        This is what actually flips the matrix from bookend versions to
+        middle versions. If the input is omitted or passed as ``false``,
+        the full-matrix label will silently not do anything.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job["with"]["full_matrix"] is True
+
+    def test_dispatch_inherits_secrets(self) -> None:
+        """``secrets: inherit`` so the reusable workflow can reach secrets
+        like ``CODECOV_TOKEN``."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job.get("secrets") == "inherit"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,168 @@
+"""Tests for the CI GitHub Actions workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow -- they only verify its shape.
+
+Scope is intentionally minimal: we guard the three invariants that matter for
+pyproject-template#424:
+
+1. ``labeled`` is NOT in the ``pull_request`` event type list. Keeping it
+   there would cause every auto-applied label on a dependabot PR to spawn a
+   duplicate CI run (the motivation for the split introduced in #424).
+2. A workflow-level ``concurrency`` block exists with ``cancel-in-progress:
+   true`` and a key that includes ``github.head_ref || github.ref``. This
+   ensures a new push to a PR cancels the in-flight run on the prior commit.
+3. The ``workflow_call`` trigger exposes a ``full_matrix`` boolean input
+   (default ``false``) so the sibling ``ci-full-matrix.yml`` workflow can
+   dispatch the full-matrix run via ``uses: ./.github/workflows/ci.yml``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "ci.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the CI workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
+    non-ASCII content in the workflow file (lesson from pyproject-template#430).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+class TestWorkflowFile:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The CI workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML with a jobs dict."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_workflow_name(self) -> None:
+        """The workflow name is ``CI`` -- the required check-run in branch
+        protection and the name referenced by ``ci-full-matrix.yml``."""
+        workflow = _load_workflow()
+        assert workflow.get("name") == "CI"
+
+
+class TestPullRequestTriggerHasNoLabeledType:
+    """The main CI workflow should no longer fire on label events.
+
+    Label-driven full-matrix runs are handled by ``ci-full-matrix.yml``, which
+    calls this workflow via ``workflow_call``. Leaving ``labeled`` in the
+    trigger list here would re-introduce the duplicate-run problem
+    (pyproject-template#424).
+    """
+
+    def test_labeled_not_in_pull_request_types(self) -> None:
+        """The ``labeled`` event type must NOT appear in ``pull_request.types``."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        pr = triggers["pull_request"]
+        types = pr["types"]
+        assert "labeled" not in types, (
+            f"'labeled' must not be in pull_request.types; got {types}. "
+            "Label-driven runs are handled by ci-full-matrix.yml "
+            "(pyproject-template#424)."
+        )
+
+    def test_pull_request_types_cover_core_lifecycle(self) -> None:
+        """The PR trigger must still cover the core lifecycle events.
+
+        We keep ``opened``, ``synchronize``, and ``reopened`` so that CI runs
+        on every push and on reopened PRs. Removing any of these would leave
+        a PR without CI coverage.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request"]["types"]
+        for required in ("opened", "synchronize", "reopened"):
+            assert required in types, f"pull_request.types missing '{required}': {types}"
+
+
+class TestConcurrency:
+    """Workflow-level concurrency block cancels stale runs on new pushes."""
+
+    def test_concurrency_block_exists(self) -> None:
+        """The workflow must declare a top-level ``concurrency`` block."""
+        workflow = _load_workflow()
+        assert "concurrency" in workflow, "workflow must declare a concurrency block"
+
+    def test_concurrency_group_keyed_on_ref(self) -> None:
+        """The group key must reference ``head_ref || ref``.
+
+        ``head_ref`` is only set for PR events and points at the PR's source
+        branch; ``ref`` is the fallback for push/schedule/dispatch events.
+        Using the pair gives each PR its own concurrency lane while still
+        scoping main-branch runs to ``refs/heads/main``.
+        """
+        workflow = _load_workflow()
+        group: str = workflow["concurrency"]["group"]
+        assert "github.head_ref" in group
+        assert "github.ref" in group
+
+    def test_concurrency_cancel_in_progress(self) -> None:
+        """``cancel-in-progress: true`` supersedes stale runs on a new push."""
+        workflow = _load_workflow()
+        assert workflow["concurrency"]["cancel-in-progress"] is True
+
+
+class TestWorkflowCallInputs:
+    """``workflow_call`` exposes a ``full_matrix`` boolean input."""
+
+    def test_workflow_call_present(self) -> None:
+        """The workflow must be callable as a reusable workflow.
+
+        ``ci-full-matrix.yml`` invokes this workflow via
+        ``uses: ./.github/workflows/ci.yml``; removing ``workflow_call``
+        here breaks the full-matrix dispatch path.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        assert "workflow_call" in triggers
+
+    def test_workflow_call_has_full_matrix_input(self) -> None:
+        """``workflow_call.inputs.full_matrix`` must be declared."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        wc = triggers["workflow_call"]
+        assert wc is not None, "workflow_call must declare an inputs block"
+        assert "inputs" in wc
+        assert "full_matrix" in wc["inputs"]
+
+    def test_full_matrix_input_is_boolean(self) -> None:
+        """The ``full_matrix`` input must be declared as a boolean."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        fm = triggers["workflow_call"]["inputs"]["full_matrix"]
+        assert fm["type"] == "boolean"
+
+    def test_full_matrix_input_defaults_false(self) -> None:
+        """The default must be ``false`` so plain ``workflow_call`` runs
+        the bookend matrix, matching the pre-#424 behavior."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        fm = triggers["workflow_call"]["inputs"]["full_matrix"]
+        assert fm["default"] is False

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,77 @@
+"""Tests for the production Release publish workflow.
+
+Structural asserts on `.github/workflows/release.yml`. The central regression
+guard is the artifact split: SBOM files (`sbom.json`, `sbom.xml`) must live
+in a separate `sbom` artifact from the wheels/sdist `dist` artifact, because
+twine (called by the publish jobs) inspects every file in `packages-dir` and
+rejects anything that isn't a `.whl` or `.tar.gz` with `InvalidDistribution`
+(see pyproject-template#665).
+
+These tests do not execute the workflow — they only verify its shape. Sibling
+file: `tests/test_testpypi_workflow.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "release.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the Release workflow YAML.
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is ``cp1252``.
+    """
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data: dict[Any, Any] = yaml.safe_load(content)
+    return data
+
+
+def _upload_steps_for_job(job_name: str) -> list[dict[Any, Any]]:
+    """Return all upload-artifact steps for the named job."""
+    wf = _load_workflow()
+    jobs = wf.get("jobs")
+    assert isinstance(jobs, dict), "workflow must have a 'jobs' mapping"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"workflow must define job '{job_name}'"
+    steps = job.get("steps")
+    assert isinstance(steps, list), f"'{job_name}' must have a 'steps' list"
+    return [s for s in steps if isinstance(s, dict) and "upload-artifact" in str(s.get("uses", ""))]
+
+
+class TestBuildArtifactsSeparation:
+    """SBOMs must not be in the dist artifact (pyproject-template#665)."""
+
+    def test_dist_and_sbom_are_separate_uploads(self) -> None:
+        """build job must have two upload-artifact steps: 'dist' and 'sbom'."""
+        uploads = _upload_steps_for_job("build")
+        names = sorted(str(s.get("with", {}).get("name", "")) for s in uploads)
+        assert names == ["dist", "sbom"], (
+            f"build job must upload exactly 'dist' and 'sbom' artifacts; got {names}"
+        )
+
+    def test_dist_artifact_excludes_sbom(self) -> None:
+        """The 'dist' artifact's path must not include 'sbom' patterns.
+
+        Twine reads every file in dist/ and rejects sbom.json / sbom.xml
+        with InvalidDistribution, breaking publish-testpypi and publish.
+        """
+        uploads = _upload_steps_for_job("build")
+        dist_step = next(s for s in uploads if s.get("with", {}).get("name") == "dist")
+        path_value = str(dist_step["with"].get("path", ""))
+        assert "sbom" not in path_value.lower(), (
+            f"'dist' artifact path must not include sbom files; got {path_value!r}"
+        )
+
+    def test_sbom_artifact_includes_sbom_files(self) -> None:
+        """The 'sbom' artifact path must include sbom.json and sbom.xml."""
+        uploads = _upload_steps_for_job("build")
+        sbom_step = next(s for s in uploads if s.get("with", {}).get("name") == "sbom")
+        path_value = str(sbom_step["with"].get("path", ""))
+        assert "sbom.json" in path_value
+        assert "sbom.xml" in path_value

--- a/tests/test_testpypi_workflow.py
+++ b/tests/test_testpypi_workflow.py
@@ -1,0 +1,75 @@
+"""Tests for the TestPyPI publish workflow.
+
+Structural asserts on `.github/workflows/testpypi.yml`. The central regression
+guard is the `on.push.tags` glob list: it must cover the four PEP440
+pre-release shapes that `commitizen` (used by `doit release --prerelease=...`)
+actually emits, and it must NOT use the old semver-only pattern that missed
+every PEP440 tag this project produces (pyproject-template#659).
+
+These tests do not execute the workflow — they only verify its shape. See
+`tests/test_codeql_workflow.py` for the sibling pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "testpypi.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the TestPyPI workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because PyYAML
+    parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is ``cp1252`` and chokes on any
+    non-ASCII content — see the sibling test file for pyproject-template#430
+    context.
+    """
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data: dict[Any, Any] = yaml.safe_load(content)
+    return data
+
+
+class TestPushTagTriggers:
+    """The PEP440 pre-release tag patterns must be present; semver-only absent."""
+
+    def _tag_patterns(self) -> list[str]:
+        wf = _load_workflow()
+        # PyYAML parses bare 'on' as the boolean True.
+        on_section = wf.get("on") or wf.get(True)
+        assert isinstance(on_section, dict), "workflow must have an 'on' mapping"
+        push_section = on_section.get("push")
+        assert isinstance(push_section, dict), "workflow must have an 'on.push' mapping"
+        tags = push_section.get("tags")
+        assert isinstance(tags, list), "workflow must have an 'on.push.tags' list"
+        return [str(t) for t in tags]
+
+    def test_alpha_pattern_present(self) -> None:
+        """PEP440 alpha tags (e.g. v0.1.0a0) must trigger the workflow."""
+        assert "v*a[0-9]*" in self._tag_patterns()
+
+    def test_beta_pattern_present(self) -> None:
+        """PEP440 beta tags (e.g. v0.1.0b1) must trigger the workflow."""
+        assert "v*b[0-9]*" in self._tag_patterns()
+
+    def test_rc_pattern_present(self) -> None:
+        """PEP440 rc tags (e.g. v0.1.0rc0) must trigger the workflow."""
+        assert "v*rc[0-9]*" in self._tag_patterns()
+
+    def test_dev_pattern_present(self) -> None:
+        """PEP440 dev tags (e.g. v0.1.0.dev2) must trigger the workflow."""
+        assert "v*.dev[0-9]*" in self._tag_patterns()
+
+    def test_semver_only_pattern_absent(self) -> None:
+        """The old semver-style glob that missed all PEP440 tags must be gone."""
+        assert "v*-[a-zA-Z]*" not in self._tag_patterns(), (
+            "The old semver-only glob did not match commitizen's PEP440 pre-release "
+            "tags (e.g. v0.1.0a0) and must stay out to avoid regressing "
+            "pyproject-template#659."
+        )

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tools package for InfraFoundry."""

--- a/tools/doit/quality.py
+++ b/tools/doit/quality.py
@@ -4,13 +4,13 @@ from typing import Any
 
 from doit.tools import title_with_actions
 
-from .base import success_message
+from .base import optional_root_files, success_message
 
 
 def task_lint() -> dict[str, Any]:
     """Run ruff linting."""
     return {
-        "actions": ["uv run ruff check src/ tests/ tools/"],
+        "actions": ["uv run ruff check src/ tests/ tools/" + optional_root_files("bootstrap.py")],
         "title": title_with_actions,
         "verbosity": 0,
     }
@@ -18,10 +18,11 @@ def task_lint() -> dict[str, Any]:
 
 def task_format() -> dict[str, Any]:
     """Format code with ruff."""
+    extras = optional_root_files("bootstrap.py")
     return {
         "actions": [
-            "uv run ruff format src/ tests/ tools/",
-            "uv run ruff check --fix src/ tests/ tools/",
+            "uv run ruff format src/ tests/ tools/" + extras,
+            "uv run ruff check --fix src/ tests/ tools/" + extras,
         ],
         "title": title_with_actions,
     }
@@ -30,7 +31,9 @@ def task_format() -> dict[str, Any]:
 def task_format_check() -> dict[str, Any]:
     """Check code formatting without modifying files."""
     return {
-        "actions": ["uv run ruff format --check src/ tests/ tools/"],
+        "actions": [
+            "uv run ruff format --check src/ tests/ tools/" + optional_root_files("bootstrap.py")
+        ],
         "title": title_with_actions,
         "verbosity": 0,
     }
@@ -39,7 +42,7 @@ def task_format_check() -> dict[str, Any]:
 def task_type_check() -> dict[str, Any]:
     """Run mypy type checking (uses pyproject.toml configuration)."""
     return {
-        "actions": ["uv run mypy src/"],
+        "actions": ["uv run mypy src/" + optional_root_files("bootstrap.py")],
         "title": title_with_actions,
         "verbosity": 0,
     }

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -57,8 +57,6 @@ BLOCKED_WORKFLOW_COMMANDS = {
         "AI can help prepare (update changelog, verify CI) but not execute releases."
     ),
     ("doit", "release_tag"): "Releases must be run manually by the user, not by AI agents.",
-    ("doit", "release_dev"): "Releases must be run manually by the user, not by AI agents.",
-    ("doit", "release_pr"): "Releases must be run manually by the user, not by AI agents.",
 }
 
 # Governance labels that require human approval - AI should never add these


### PR DESCRIPTION
## Description

Phase E of the pyproject-template sync (tracker #673) — the **dense-merge phase** that covers the files we customize most heavily. Landing this PR closes out the full six-phase sync series and advances the template pin to the most recent upstream commit.

This phase does three things that previous phases deliberately deferred:

1. **Bumps the template pin** from `75cbe9b3` (2026-04-02) to `7a13c9384b1b94446836eabaa20ca0800d185369` (2026-04-23). This is one commit ahead of the `0cdab3e3` pin mentioned in the original issue body — that reference was stale by the time Phase E started, and bumping to current `main` was user-approved.
2. **Adopts the 5 workflow-file tests deferred from earlier phases** (Phase A’s `ci-full-matrix.yml` test, Phase C2’s `ci`/`release`/`testpypi` workflow tests). All 31 newly-added workflow-test cases pass.
3. **Hand-merges the densely-customized files** — `AGENTS.md`, `README.md`, `.github/CONTRIBUTING.md`, `pyproject.toml`, the eight CI workflows, the `.vscode/` configs, `mkdocs.yml`, and `tools/doit/quality.py` — preserving all infrafoundry-specific customizations.

After this PR merges, both #678 and tracker #673 can close.

## Related Issue

Addresses #678

Tracker #673 can also close after this merges (phases A–D already landed).

## Phase Context

All six phases of the sync are now complete:

| Phase | PR | Issue | Scope |
| :--- | :--- | :--- | :--- |
| F (divergence note) | #680 | #679 | Document repo-specific template divergences. |
| A (dependabot automerge) | #681 | #674 | Adopt upstream dependabot automerge + label sync. |
| B (ADR unify) | #682 | #675, #670 | Unify ADRs under `docs/decisions/`. |
| C (tooling modules) | #684 | #676 | Add new `tools/pyproject_template/*` modules + ruff-fix hook. |
| D (AI config) | #685 | #677 | Sync AI agent config, commands, and docs. |
| C2 (doit tooling) | #686 | #683 | Sync remaining doit tooling and AI hook updates. |
| **E (this PR)** | — | **#678** | **Dense-merge + pin bump; closes #673.** |

## Type of Change

- [x] Documentation update
- [x] Code refactoring (tooling/config only — no behavior change in product code)

## Changes Made

### Headline milestones

- Template pin bumped `75cbe9b3` → `7a13c93` (closes the sync with upstream `main`).
- All 5 previously-deferred files now land together; their 31 new workflow-test cases pass.
- Three CI-workflow restructures adopted: `ci.yml` (`workflow_call.inputs.full_matrix` + `concurrency` + standalone `docs` job), `release.yml` (SBOM artifact split fixes twine `InvalidDistribution`), `testpypi.yml` (PEP440-correct tag globs).
- `docs/development/pyproject-template-divergences.md` Category 4 transformed from an active-deferrals list to meta-documentation ("tracker #673 completed in Phase E; no files currently deferred").
- `task_lint_blueprints()` preserved in `tools/doit/quality.py` alongside the adopted `optional_root_files` import from `.base`.
- `foundry` CLI entry points intact; full CLI group tree (`config`, `infra`, `state`, `secrets`, `policy`) unchanged.

### Modified files (22)

| # | File | Rationale |
| :-: | :--- | :--- |
| 1 | `.config/pyproject_template/settings.toml` | Pin bump → `7a13c93` (2026-04-23). |
| 2 | `.github/CONTRIBUTING.md` | Placeholder replacement + upstream enhancements; repo-specific workflow rules remain in `AGENTS.md`. |
| 3 | `.github/workflows/benchmark.yml` | Conditional benchmark-existence check; hardcoded Python 3.14 preserved. |
| 4 | `.github/workflows/breaking-change-detection.yml` | Use the new python-versions composite action; `griffe check infrafoundry` preserved. |
| 5 | `.github/workflows/ci.yml` | **Major restructure:** `workflow_call.inputs.full_matrix`, `concurrency` block, python-versions composite action, standalone `docs` job; Ubuntu-only gate + Terraform/OpenTofu/age/sops installs + `INFRAFOUNDRY_SKIP_SOPS_CHECK` + `--cov=infrafoundry` preserved. |
| 6 | `.github/workflows/mutation.yml` | python-versions composite action; Terraform/age/sops setup preserved. |
| 7 | `.github/workflows/pr-checks.yml` | Dependabot PR exemption; `release` conventional-commit type skipped (intentional divergence). |
| 8 | `.github/workflows/release.yml` | **SBOM artifact split:** `dist` (wheels+sdist) and `sbom` (SBOM files) uploaded separately — fixes twine `InvalidDistribution`. Smoke test `import infrafoundry` preserved. |
| 9 | `.github/workflows/testpypi.yml` | **PEP440 tag globs** replace the broken `v*-[a-zA-Z]*` pattern. Smoke test `import infrafoundry` preserved. |
| 10 | `.gitignore` | Added `.pytype/`, `.pyre/`, `.dmypy.json`, `dmypy.json`; all infra-specific entries preserved. |
| 11 | `.pre-commit-config.yaml` | Added `rhysd/actionlint@v1.7.12`; all infra hooks preserved. |
| 12 | `.vscode/extensions.json` | Added `ms-python.mypy-type-checker`, `tamasfe.even-better-toml`. |
| 13 | `.vscode/settings.json` | Added `ruff.lint.args`, `ruff.format.args`, `mypy-type-checker.args`. |
| 14 | `AGENTS.md` | **Major rewrite:** Failing-Tests rule, new Pre-Action-Checks entries, `labels_sync` in Tool Reference, `release_tag` replacing `release_dev`, AI Config Directories section, dependabot rebase workflow, `--auto-close`/`--no-push` flags, main-pull reminder, `docs` (not `doc`) issue type. All infra CLI groups, architecture sections, state/data flow, config/secrets, and patterns preserved. |
| 15 | `README.md` | **Mostly rewrite:** added badges (CI/codecov/Python 3.12+), upstream tooling overview, AI agent support section, versioning/release sections. InfraFoundry description, features, and `foundry` CLI quickstart preserved. |
| 16 | `docs/development/doit-tasks-reference.md` | `release_dev` → `release_tag`; added GitHub Environments section (`labels_sync`, `env_create`, `env_list`, `publish_setup`); added `--template` flag for `adr`. |
| 17 | `docs/development/pyproject-template-divergences.md` | Category 4 converted from "active deferrals" to meta-doc ("tracker #673 completed in Phase E; no files currently deferred"). |
| 18 | `mkdocs.yml` | Cherry-picked `mkdocstrings[python]` plugin config (already in dev deps); nav tree preserved. |
| 19 | `pyproject.toml` | Adopted `hatch-vcs>=0.5.0`, ruff `preview=true`, `explicit-preview-rules=true`, `tests/benchmarks/*` ANN401 ignore. **PLW1514 deferred** with a comment noting follow-up issue #687. All infra deps, entry-points, and overrides preserved. |
| 20 | `tools/__init__.py` | Added module docstring (was empty). |
| 21 | `tools/doit/quality.py` | Imported `optional_root_files` from `.base`; applied to lint/format/format_check/type_check actions. **`task_lint_blueprints()` and its `task_check.task_dep` reference preserved.** |
| 22 | `tools/hooks/ai/block-dangerous-commands.py` | Dropped obsolete `release_dev`/`release_pr` entries; `release_tag` kept. |

### New files (6 files + 1 dir)

| # | File | Rationale |
| :-: | :--- | :--- |
| 23 | `.github/actions/python-versions/action.yml` | New composite action reading `.github/python-versions.json`; referenced by 5 of the 8 workflows. |
| 24 | `.github/workflows/ci-full-matrix.yml` | **Deferred from Phase A**, now adopted. |
| 25 | `tests/test_ci_full_matrix_workflow.py` | **Deferred from Phase A** — 11 tests, all passing. |
| 26 | `tests/test_ci_workflow.py` | **Deferred from Phase C2** — 12 tests, all passing. |
| 27 | `tests/test_release_workflow.py` | **Deferred from Phase C2** — 3 tests, all passing. |
| 28 | `tests/test_testpypi_workflow.py` | **Deferred from Phase C2** — 5 tests, all passing. |

## Known Deviation

**Ruff rule `PLW1514` deferred to follow-up issue #687.**

Upstream adopted `PLW1514` (require explicit `encoding=` on text-mode file opens) as part of its preview-rule set. Adopting it wholesale in this PR would flag 180+ existing call sites needing an `encoding="utf-8"` refactor — out of scope for a template-sync chore PR.

The enabling infrastructure (`preview=true`, `explicit-preview-rules=true`) has been adopted; only the `PLW1514` rule itself is omitted from the `select` list, with an in-line comment in `pyproject.toml` pointing at issue #687. That issue is already filed and remains open.

## Tracker Closure

This PR completes the final phase of tracker #673. After merge, please close both:

- **#678** — "Fixed in PR #<this PR number>"
- **#673** — "Sync completed through Phase E (all six phases A–F + C2 landed)"

Issue #687 (PLW1514 follow-up) remains open and will be addressed in a separate PR.

## Testing

- [x] `doit check` passes — all 8 gates green (`format_check`, `lint`, `lint_blueprints`, `type_check`, `security`, `spell_check`, `test`, `check`).
- [x] Full test suite: **3361 tests pass** under `uv run pytest -n auto`.
- [x] 5 previously-deferred workflow-file tests (31 cases) now all green.
- [x] `foundry --help` works; all five command groups load.
- [x] `uv sync` clean with the adopted `hatch-vcs>=0.5.0` and ruff preview config.
- [x] No CLI public API changes; no BaseManager, provider plugin, state schema, or event-enum changes.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works (adopted the 5 deferred workflow-file tests)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (`doit-tasks-reference.md`, `pyproject-template-divergences.md`, `AGENTS.md`, `README.md`, `.github/CONTRIBUTING.md`)
- [ ] I have updated the CHANGELOG.md (handled by commitizen at release time — not edited directly)
- [x] My changes generate no new warnings

## Additional Notes

- **ADRs:** No `needs-adr` label on #678. Template-meta ADRs 9001–9016 already cover upstream-sync adoption policy; no new ADR required.
- **Scope discipline:** This PR is strictly the dense-merge phase of the sync. The PLW1514 refactor (and anything else that would expand scope) is split to #687.
- **Review focus areas:** The three major workflow restructures (`ci.yml`, `release.yml`, `testpypi.yml`), the `AGENTS.md`/`README.md` rewrites, and the `tools/doit/quality.py` hand-merge that preserves `task_lint_blueprints`.
