### PR TITLE
fix: drop stale mypy suppressions in opnsense api_client

### DIFF
--- a/src/infrafoundry/providers/opnsense/api_client.py
+++ b/src/infrafoundry/providers/opnsense/api_client.py
@@ -5,7 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
-from opnsense_openapi import OPNsenseClient as OpenAPIOPNsenseClient  # type: ignore[import-untyped]
+from opnsense_openapi import OPNsenseClient as OpenAPIOPNsenseClient
 
 if TYPE_CHECKING:  # pragma: no cover
     # opnsense-openapi lacks stubs; this keeps mypy satisfied without affecting runtime.
@@ -55,7 +55,7 @@ class OPNsenseClient:
             else:
                 response = self.client.post(module, controller, command, *extra, json=data or {})
 
-            return cast(dict[str, Any], response)
+            return response
 
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code if e.response else None


### PR DESCRIPTION
## Description

`opnsense-openapi` 0.3.0 ships type information, so the `# type: ignore[import-untyped]` on the import and the `cast(dict[str, Any], ...)` on the request return in `src/infrafoundry/providers/opnsense/api_client.py` are now no-ops. mypy reports `unused-ignore` and `redundant-cast` under `doit check`, blocking CI on every branch off `main` since PR #697.

This PR drops the two stale suppressions. The remaining `cast(list[dict[str, Any]], ...)` later in the same file stays — mypy did not flag it.

## Related Issue

Addresses #702

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Removed `# type: ignore[import-untyped]` from the `from opnsense_openapi import OPNsenseClient as OpenAPIOPNsenseClient` line.
- Replaced `return cast(dict[str, Any], response)` with `return response` in `OPNsenseClient.request`.

## Testing

- [x] All existing tests pass (`doit check` green locally — format_check, lint, lint_blueprints, type_check, security, spell_check, test).
- [x] Manually verified the diff is the minimal change needed to satisfy mypy.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

The vestigial `if TYPE_CHECKING: pass` block on lines 10–12 of `api_client.py` is unrelated and out of scope for this fix. It can be cleaned up separately if desired.
