### PR TITLE
chore: scope OPNsense full-IaC migration with ADR-0013 and resource-coverage doc

### DIFF
--- a/docs/decisions/0013-opnsense-full-iac-migration.md
+++ b/docs/decisions/0013-opnsense-full-iac-migration.md
@@ -47,15 +47,24 @@ ISC DHCP (`<dhcpd>`/`<dhcpdv6>`) is also out of scope going forward — Kea is t
 - **The deferred items are deliberately small and stable.** HA sync, OpenVPN, ACME, certs, and physical layer constructs (LAGG/bridge/GRE/etc.) change infrequently and are well-served by OPNsense's selective `config.xml` import. Putting them under IaC is a future option, not a prerequisite.
 - **The scope is bounded and incremental.** Each gap is its own component with a clear contract (template + validator + manager + tests + `config migrate` extractor). Issues can ship independently and the migration runbook absorbs each one as it lands.
 
-## Data model
+## Data model and apply mechanism
 
-YAML resource schemas mirror the [browningluke/opnsense](https://registry.terraform.io/providers/browningluke/opnsense/latest/docs) Terraform provider's resource arguments. New components follow the existing pattern: a Pydantic config model whose fields match the corresponding `opnsense_*` Terraform resource, rendered to `.tf` via Jinja2 (see `templates/opnsense/vlans.tf.j2` for the established shape).
+The apply mechanism is intentionally **not** decided in this ADR. The current OPNsense provider mixes paths:
 
-`config migrate` extractors read live state from the OPNsense REST API via the `opnsense_openapi` client and write YAML in that same schema. The round-trip property `extract → apply` must converge: dumping a configured box and applying the dump back produces no drift.
+- VLANs / aliases / firewall rules go through Terraform (the [browningluke/opnsense](https://registry.terraform.io/providers/browningluke/opnsense/latest/docs) provider) plus an Ansible playbook for the post-apply service reload (`templates/opnsense/playbook.yml.j2`).
+- Kea DHCP goes through a Python service calling the OPNsense REST API via the `opnsense_openapi` client — using bare `.request(method, endpoint, ...)` rather than the typed methods the package exposes.
 
-The XML `config.xml` format is not part of either path. It is used only for one-shot scoping (e.g., the inventory in [docs/development/opnsense-resource-coverage.md](../development/opnsense-resource-coverage.md)) and as a fallback discovery aid for resource types where no stable API endpoint exists. When XML is required for a fallback, that decision is made per-component and recorded in the component's issue.
+Both paths converge on the OPNsense REST API; neither uses XML `config.xml`. Whether new components extend the Terraform pattern, switch to a direct-API pattern that uses `opnsense_openapi`'s typed surface (Pydantic models generated from OPNsense's OpenAPI spec, no terraform/ansible binaries), or unify under a third pattern is a separate architectural choice with downstream effects on schema source, runner integration (`BaseRunner` vs. provider-internal apply), dependency footprint, and test surface.
+
+**Deferred to ADR-0014**, to be informed by a single-component spike. VLANs are the candidate: smallest existing surface (`device`, `tag`, `description`, `priority`), already partly implemented under the Terraform pattern, suitable for side-by-side comparison.
+
+The coverage list, out-of-scope list, and implementation order in this ADR stand independent of that decision — they describe **what** to manage, not **how**.
+
+The XML `config.xml` format is not part of any apply or migrate path. It is used only for one-shot scoping (as in [docs/development/opnsense-resource-coverage.md](../development/opnsense-resource-coverage.md)) and remains a per-component fallback only if no stable API endpoint exists for a resource type. That decision would be made per-component and recorded in its issue.
 
 ## Implementation order
+
+The apply mechanism each step uses follows ADR-0014. The first component built under that mechanism is the spike (VLANs) that informs ADR-0014; once that ADR lands, the remaining components ship under the chosen pattern in the order below.
 
 1. `interface_assignments` — gates everything that depends on physical NIC mapping.
 2. `nat_rules`.

--- a/docs/decisions/0013-opnsense-full-iac-migration.md
+++ b/docs/decisions/0013-opnsense-full-iac-migration.md
@@ -1,0 +1,77 @@
+# ADR-0013: OPNsense Full-IaC Migration Coverage
+
+**Date:** 2026-04-30
+**Status:** Accepted
+**Issue:** [#701](https://github.com/endavis/infrafoundry/issues/701)
+
+## Context
+
+The OPNsense provider currently manages a subset of `config.xml`: VLANs, aliases, firewall rules, Kea DHCP (v4/v6 subnets and reservations), Unbound host overrides, and legacy ISC DHCP static maps. Everything else — interface assignments, NAT, gateways, static routes, virtual IPs, the rest of Unbound (domain override, host alias, forward) — lives only in the running box's `config.xml` and cannot be reproduced by `foundry infra apply` against a fresh box.
+
+A planned cutover (replace one OPNsense host with same-spec successors) surfaced this as a blocker: the operator wants to dump current state to YAML, change the endpoint, and re-apply on the new box. With today's coverage, that workflow recreates only DHCP and Unbound host overrides; everything else has to be hand-built or imported from `config.xml` on the new box, which defeats the goal of a repeatable IaC migration.
+
+## Decision
+
+We will close the IaC gap so OPNsense box-to-box migration is achievable through `foundry infra apply`, with a clearly bounded set of items deliberately left to manual `config.xml` import.
+
+**In scope (new components, one feature issue per row):**
+
+| Resource type | Reason |
+| --- | --- |
+| `interface_assignments` | The remap point when physical NIC names differ between boxes; blocks placement of VLANs and firewall rules. |
+| `nat_rules` | Outbound + port forward + 1:1 — required for any non-trivial WAN setup. |
+| `gateways` | Required for multi-WAN, policy routing, and gateway groups. |
+| `static_routes` | Needed when downstream networks aren't reachable via the default route. |
+| `virtual_ips` | Required for CARP, NAT outbound source addresses, and IP aliases. |
+| Unbound `domain_override`, `host_alias`, `forward` | Existing `unbound_host_override` is incomplete — host aliases and conditional forwarders are common in real deployments. |
+
+**Tooling work:**
+
+- `config migrate` extractors for every supported and newly-added resource type, extending the pattern that today exists only for Kea DHCP. Without these, dumping state from a live box requires writing API queries by hand.
+
+**Out of scope (manual `config.xml` selective import on the target box):**
+
+| Section | Reason |
+| --- | --- |
+| `<hasync>` | Set-once HA pairing config. |
+| `<openvpn>`, `<OPNsense>/OpenVPN` | Typically one or two clients/servers per box; pinning structure into IaC is high cost, low value. |
+| `<ca>`, `<cert>`, `<OPNsense>/AcmeClient` | Certificate material; importing is faster and safer than re-issuing through IaC. |
+| `<gres>`, `<gifs>`, `<laggs>`, `<bridges>`, `<ppps>`, `<wireless>` | Each typically a single record per box; not worth a component. |
+
+ISC DHCP (`<dhcpd>`/`<dhcpdv6>`) is also out of scope going forward — Kea is the supported path and the existing ISC→Kea helper covers the migration when needed.
+
+## Rationale
+
+- **Drop-in replacement is the operator's stated goal.** The current Kea-only coverage doesn't get there.
+- **Interface assignment is the lever that makes hardware swaps repeatable.** Without it, every cutover requires hand-editing `config.xml` interface mappings on the target. With it, hardware-identical successor boxes are a "change endpoint, re-apply" operation.
+- **The deferred items are deliberately small and stable.** HA sync, OpenVPN, ACME, certs, and physical layer constructs (LAGG/bridge/GRE/etc.) change infrequently and are well-served by OPNsense's selective `config.xml` import. Putting them under IaC is a future option, not a prerequisite.
+- **The scope is bounded and incremental.** Each gap is its own component with a clear contract (template + validator + manager + tests + `config migrate` extractor). Issues can ship independently and the migration runbook absorbs each one as it lands.
+
+## Data model
+
+YAML resource schemas mirror the [browningluke/opnsense](https://registry.terraform.io/providers/browningluke/opnsense/latest/docs) Terraform provider's resource arguments. New components follow the existing pattern: a Pydantic config model whose fields match the corresponding `opnsense_*` Terraform resource, rendered to `.tf` via Jinja2 (see `templates/opnsense/vlans.tf.j2` for the established shape).
+
+`config migrate` extractors read live state from the OPNsense REST API via the `opnsense_openapi` client and write YAML in that same schema. The round-trip property `extract → apply` must converge: dumping a configured box and applying the dump back produces no drift.
+
+The XML `config.xml` format is not part of either path. It is used only for one-shot scoping (e.g., the inventory in [docs/development/opnsense-resource-coverage.md](../development/opnsense-resource-coverage.md)) and as a fallback discovery aid for resource types where no stable API endpoint exists. When XML is required for a fallback, that decision is made per-component and recorded in the component's issue.
+
+## Implementation order
+
+1. `interface_assignments` — gates everything that depends on physical NIC mapping.
+2. `nat_rules`.
+3. `gateways` and `static_routes`.
+4. `virtual_ips`.
+5. Unbound extensions (`domain_override`, `host_alias`, `forward`).
+6. `config migrate` extractors for the full set, in any order once each component lands.
+7. Migration cutover (operator-facing): run extractors against the current box, remap NICs in YAML, switch endpoint, plan, apply.
+
+Each step above is a separate feature issue. Issue numbers will be added to this ADR's **Related Issues** list as they're filed.
+
+## Related Issues
+
+- Issue [#701](https://github.com/endavis/infrafoundry/issues/701): Scope OPNsense full-IaC migration (this ADR)
+
+## Related Documentation
+
+- [OPNsense Provider Resource Coverage](../development/opnsense-resource-coverage.md) — current support matrix, gap list, and the box-to-box migration runbook template.
+- [Implementing Providers](../development/implementing-providers.md) — pattern guide each new component will follow.

--- a/docs/decisions/0013-opnsense-full-iac-migration.md
+++ b/docs/decisions/0013-opnsense-full-iac-migration.md
@@ -49,22 +49,15 @@ ISC DHCP (`<dhcpd>`/`<dhcpdv6>`) is also out of scope going forward — Kea is t
 
 ## Data model and apply mechanism
 
-The apply mechanism is intentionally **not** decided in this ADR. The current OPNsense provider mixes paths:
+Decided in [ADR-0014](0014-opnsense-direct-api-apply-mechanism.md): direct-API via `opnsense_openapi`. New components ship under that pattern; existing Terraform-based paths (`vlans`, `aliases`, `firewall_rules`, `unbound_host_override`, `kea_*`, `dhcp_static_maps`) migrate per-component in the order below, retiring the `templates/opnsense/playbook.yml.j2` Ansible service-reload step with the last one.
 
-- VLANs / aliases / firewall rules go through Terraform (the [browningluke/opnsense](https://registry.terraform.io/providers/browningluke/opnsense/latest/docs) provider) plus an Ansible playbook for the post-apply service reload (`templates/opnsense/playbook.yml.j2`).
-- Kea DHCP goes through a Python service calling the OPNsense REST API via the `opnsense_openapi` client — using bare `.request(method, endpoint, ...)` rather than the typed methods the package exposes.
-
-Both paths converge on the OPNsense REST API; neither uses XML `config.xml`. Whether new components extend the Terraform pattern, switch to a direct-API pattern that uses `opnsense_openapi`'s typed surface (Pydantic models generated from OPNsense's OpenAPI spec, no terraform/ansible binaries), or unify under a third pattern is a separate architectural choice with downstream effects on schema source, runner integration (`BaseRunner` vs. provider-internal apply), dependency footprint, and test surface.
-
-**Deferred to ADR-0014**, to be informed by a single-component spike. VLANs are the candidate: smallest existing surface (`device`, `tag`, `description`, `priority`), already partly implemented under the Terraform pattern, suitable for side-by-side comparison.
-
-The coverage list, out-of-scope list, and implementation order in this ADR stand independent of that decision — they describe **what** to manage, not **how**.
+ADR-0014 takes positions on schema source, client surface, runner integration (a new `OPNsenseDirectRunner(BaseRunner)` implementing the [ADR-0010](0010-protocol-based-runner-interfaces.md) protocols), default semantics (fully-managed with `--add-only` opt-in), the `lock: true` resource-level safety annotation, and plan-time validation of interface references. Refer to that ADR for the rationale and the open follow-ups.
 
 The XML `config.xml` format is not part of any apply or migrate path. It is used only for one-shot scoping (as in [docs/development/opnsense-resource-coverage.md](../development/opnsense-resource-coverage.md)) and remains a per-component fallback only if no stable API endpoint exists for a resource type. That decision would be made per-component and recorded in its issue.
 
 ## Implementation order
 
-The apply mechanism each step uses follows ADR-0014. The first component built under that mechanism is the spike (VLANs) that informs ADR-0014; once that ADR lands, the remaining components ship under the chosen pattern in the order below.
+Each step ships under the direct-API pattern codified in [ADR-0014](0014-opnsense-direct-api-apply-mechanism.md). The VLAN spike (PR [#706](https://github.com/endavis/infrafoundry/pull/706), merged) seeds the VLAN component migration.
 
 1. `interface_assignments` — gates everything that depends on physical NIC mapping.
 2. `nat_rules`.
@@ -78,9 +71,13 @@ Each step above is a separate feature issue. Issue numbers will be added to this
 
 ## Related Issues
 
-- Issue [#701](https://github.com/endavis/infrafoundry/issues/701): Scope OPNsense full-IaC migration (this ADR)
+- Issue [#701](https://github.com/endavis/infrafoundry/issues/701): Scope OPNsense full-IaC migration (this ADR).
+- Issue [#705](https://github.com/endavis/infrafoundry/issues/705): VLAN direct-API spike that informed ADR-0014 (closed; PR [#706](https://github.com/endavis/infrafoundry/pull/706) merged).
+- Issue [#707](https://github.com/endavis/infrafoundry/issues/707): ADR-0014 (closed; PR [#708](https://github.com/endavis/infrafoundry/pull/708) merged).
 
 ## Related Documentation
 
+- [ADR-0014: OPNsense Direct-API Apply Mechanism](0014-opnsense-direct-api-apply-mechanism.md) — codifies the apply mechanism this ADR's implementation phase uses.
 - [OPNsense Provider Resource Coverage](../development/opnsense-resource-coverage.md) — current support matrix, gap list, and the box-to-box migration runbook template.
+- [OPNsense Direct-API VLAN Spike Findings](../development/opnsense-spike-vlan-findings.md) — load-bearing evidence ADR-0014 cites.
 - [Implementing Providers](../development/implementing-providers.md) — pattern guide each new component will follow.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,6 +13,7 @@ This section provides comprehensive guides for developing and extending InfraFou
 ### Core Extension Points
 
 - **[Implementing Providers](implementing-providers.md)** - Guide for creating new infrastructure providers (Proxmox, OPNsense, etc.)
+- **[OPNsense Provider Resource Coverage](opnsense-resource-coverage.md)** - Which OPNsense resource types are managed by the provider, known gaps, and the box-to-box migration runbook template
 - **[Implementing Runners](implementing-runners.md)** - Comprehensive guide for creating custom infrastructure tool runners (Terraform, Ansible, etc.)
 - **[Implementing Secret Providers](implementing-secret-providers.md)** - Guide to adding new secret storage backends (Vaultwarden, AWS, Azure, etc.)
 

--- a/docs/development/opnsense-resource-coverage.md
+++ b/docs/development/opnsense-resource-coverage.md
@@ -1,0 +1,70 @@
+# OPNsense Provider Resource Coverage
+
+This document tracks which OPNsense resource types are managed by the InfraFoundry provider today, which are known gaps, and how to plan a box-to-box migration when the provider doesn't yet cover every section of `config.xml`.
+
+It exists to support the decision in [ADR-0013](../decisions/0013-opnsense-full-iac-migration.md): **drop-in OPNsense replacement should be achievable by re-applying YAML against a new endpoint.** Closing the gaps below is a prerequisite for that to work end-to-end.
+
+## Coverage matrix
+
+Source of truth for "supported": `OPNsenseProvider.get_resource_types()` in `src/infrafoundry/providers/opnsense/__init__.py`.
+
+| Section in `config.xml` | InfraFoundry resource type | Status |
+| --- | --- | --- |
+| `<vlans>` | `vlans` | Supported |
+| `<OPNsense>/Firewall/Alias` | `aliases` | Supported |
+| `<filter>/rule` | `firewall_rules` | Supported |
+| `<OPNsense>/Kea` (DHCPv4 subnets) | `kea_subnet` | Supported |
+| `<OPNsense>/Kea` (DHCPv4 reservations) | `kea_reservation` | Supported |
+| `<OPNsense>/Kea` (DHCPv6 subnets) | `kea_dhcp6_subnet` | Supported |
+| `<OPNsense>/Kea` (DHCPv6 reservations) | `kea_dhcp6_reservation` | Supported |
+| `<OPNsense>/unboundplus/hosts/host` | `unbound_host_override` | Supported |
+| `<dhcpd>` (legacy ISC) | `dhcp_static_maps` | Supported (legacy; new deployments should use Kea) |
+| `<interfaces>` | — | **Gap** (needs new component) |
+| `<nat>/rule` and `<nat>/outbound/rule` | — | **Gap** |
+| `<OPNsense>/Gateways` | — | **Gap** |
+| `<staticroutes>/route` | — | **Gap** |
+| `<virtualip>/vip` | — | **Gap** |
+| `<OPNsense>/unboundplus/hosts/host/alias` | — | **Gap** (Unbound host alias) |
+| `<OPNsense>/unboundplus/domains/domain` | — | **Gap** (Unbound domain override) |
+| `<OPNsense>/unboundplus/forwarding/host` | — | **Gap** (Unbound forward) |
+
+Sections intentionally **out of IaC scope** (per ADR-0013): `<hasync>`, `<openvpn>`/`<OPNsense>/OpenVPN`, `<ca>`/`<cert>`, `<OPNsense>/AcmeClient`, `<gres>`, `<gifs>`, `<laggs>`, `<bridges>`, `<ppps>`, `<wireless>`. These are set-once items and are migrated via selective `config.xml` import on the target box.
+
+## Box-to-box migration runbook (template)
+
+This template assumes you are cutting over a current box (`OLD`) to a new box (`NEW`) and want the result to be a drop-in replacement, with subsequent migrations between same-spec boxes being trivial.
+
+### Prerequisites
+
+1. The OPNsense provider supports every resource type your `OLD` config uses (see matrix above; close any gaps first).
+2. Both boxes are reachable on the network and admin credentials work.
+3. You have downloaded `OLD`'s `config.xml` (System → Configuration → Backups → Download).
+4. You have the `NEW` box installed with a base interface accessible from your management network.
+
+### Steps
+
+1. **Extract**: run `foundry config migrate --env <env> --provider opnsense --component <type>` for every supported resource type on `OLD` to dump live state into YAML under `envs/<env>/opnsense/`.
+2. **Edit interface map**: in the YAML, remap physical NIC names (`igc0` → `ixl0`, etc.) and any VLAN parent interface references. This is the only manual edit if the new box has different NICs.
+3. **Out-of-IaC import**: on `NEW`, System → Configuration → Backups → Restore, choose "Restore area" and import only the sections from "out of IaC scope" above. **Do not** restore VLANs, interfaces, filter, NAT, or DHCP — those come from IaC.
+4. **Switch endpoint**: update `provider_settings.opnsense.api_url` in `envs/<env>/settings.yaml` to point at `NEW`.
+5. **Plan**: `foundry infra plan --env <env>` and review the diff. Expect a clean apply against the (mostly empty) `NEW` box.
+6. **Apply**: `foundry infra apply --env <env>`.
+7. **Verify**: confirm interfaces, VLAN trunks, and firewall connectivity. Roll DNS / Tailscale / WAN cutover as appropriate to your environment.
+8. **Decommission `OLD`**: power off after a soak period.
+
+### Same-spec follow-on migration
+
+If `NEW2` has identical NICs to `NEW`, step 2 (interface remap) is skipped. The full migration is: change endpoint → plan → apply.
+
+## Closing the gaps
+
+Each gap row in the matrix above corresponds to a planned feature issue. The implementation order in [ADR-0013](../decisions/0013-opnsense-full-iac-migration.md) is:
+
+1. `interface_assignments` (the NIC remap point — blocks every VLAN/firewall placement)
+2. `nat_rules`
+3. `gateways`, `static_routes`
+4. `virtual_ips`
+5. Unbound extensions (`domain_override`, `host_alias`, `forward`)
+6. `config migrate` extractors for every supported and newly-added resource type
+
+The follow-up issues will be filed against the InfraFoundry repo and linked from ADR-0013 as they're created.


### PR DESCRIPTION
> **Status: ready for review.** ADR-0014 has landed (PR #708, merge commit `2036694`); the latest commit on this branch (`62be5db`) replaces the "deferred to ADR-0014" prose with a forward-link to the now-landed decision and adds cross-references in Related Issues / Related Documentation.

## Description

Replacing the production OPNsense host with a same-spec successor surfaced that only Kea DHCP is currently managed by the InfraFoundry OPNsense provider. Interface assignments, NAT, gateways, static routes, virtual IPs, and most of Unbound have no IaC coverage today, so every box-to-box migration requires hand-editing `config.xml` on the target.

This PR is the **scoping/architecture step** for closing that gap. There is no provider code in this PR — only the ADR, a coverage doc, and a navigation link. Each component identified here will be filed as its own follow-up feature issue.

Key decisions captured in ADR-0013:

- **In scope:** new components for `interface_assignments`, `nat_rules`, `gateways`, `static_routes`, `virtual_ips`, plus Unbound `domain_override` / `host_alias` / `forward`. Plus `config migrate` extractors for the full set.
- **Out of scope (deliberate):** HA sync, OpenVPN, certificates / ACME, and physical-layer one-offs (GRE / GIF / LAGG / bridge / PPP / wireless). These are migrated via selective `config.xml` import on the target box.
- **Apply mechanism:** decided in ADR-0014 (PR #708, merged). Direct-API via `opnsense_openapi`. New components ship under that pattern; existing Terraform-based paths migrate per-component in priority order, retiring the Ansible service-reload step with the last one. ADR-0013's "Data model and apply mechanism" section now references ADR-0014 for the rationale and the open follow-ups.
- **`config.xml` is not in any apply or migrate path.** It is used only for one-shot scoping (this PR's coverage doc) and as a per-component fallback if no stable API endpoint exists for a resource type.

## Related Issue

Addresses #701

Related chain:

- **PR #706** (merged) — VLAN direct-API spike that produced the load-bearing evidence ADR-0014 cites.
- **PR #708** (merged) — ADR-0014 itself.
- **This PR (#704)** — ADR-0013 + provider coverage doc; comes off hold now that ADR-0014 has landed.
- **Follow-ups (not filed)** — per-component implementation issues from ADR-0013's order list (`interface_assignments` first, then `nat_rules`, `gateways`+`static_routes`, `virtual_ips`, Unbound extensions, then migration of existing Terraform paths starting with VLANs).

## Type of Change

- [x] Documentation update

## Changes Made

- Add `docs/decisions/0013-opnsense-full-iac-migration.md` — ADR-0013, status Accepted. The latest commit replaces the "deferred to ADR-0014" data-model section with a forward-link summary and tightens the implementation order intro to past tense; the scope and out-of-scope sets are unchanged.
- Add `docs/development/opnsense-resource-coverage.md` — provider coverage matrix and a generic box-to-box migration runbook template.
- Add a navigation link to the new coverage doc under "Core Extension Points" in `docs/development/README.md`.

## Testing

- [x] All existing tests pass (`doit check` green locally — format_check, lint, lint_blueprints, type_check, security, spell_check, test).
- [x] Manually verified ADR cross-links resolve (links to issue #701, issue #705, issue #707, ADR-0014, the spike findings doc, and the coverage doc).
- [x] Coverage doc does not include private homelab data — provider-focused only.
- [x] Branch was rebased on current `main` (which now includes ADR-0014 and the merged spike); rebased commit SHAs (`5a1622c`, `ee9881d`, `62be5db`) replaced the original two-commit history.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

The history on this branch is now `5a1622c` (initial scoping ADR + coverage doc) → `ee9881d` (defer apply mechanism — superseded but kept as historical artifact) → `62be5db` (take off hold; reference ADR-0014). Squash-merge collapses these to one commit with the title's conventional format; the body should mention that the spike (PR #706) and ADR-0014 (PR #708) gating decisions both landed before merge.
