### PR TITLE
feat: add direct-API VLAN spike to inform ADR-0014

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ envs/
 !blueprints/**/*.yaml
 !.sops.yaml
 !.pre-commit-config.yaml
+!tools/spikes/**/*.yaml
 .env
 *.tfvars
 !*.tfvars.example

--- a/docs/development/opnsense-spike-vlan-findings.md
+++ b/docs/development/opnsense-spike-vlan-findings.md
@@ -1,0 +1,139 @@
+# OPNsense Direct-API VLAN Spike — Findings
+
+> **Status:** Placeholder. The operator fills these sections in after running [`tools/spikes/vlan_direct_api.py`](../../tools/spikes/README.md) against `opnsense-a` (staging). ADR-0014 cites this document.
+
+## Why this document exists
+
+ADR-0013 (PR #704, on hold) deferred the OPNsense apply-mechanism choice. Today's provider mixes paths: VLANs/aliases/firewall rules go YAML → Jinja2 `.tf.j2` → `terraform` binary → `browningluke/opnsense` provider → OPNsense API, plus an Ansible playbook for service reload. Kea DHCP calls the OPNsense REST API directly via `opnsense_openapi` but uses the bare `client.request("METHOD", endpoint_string)` surface and discards the typed `client.api.<module>.<call>` interface that the package generates from the OpenAPI spec.
+
+This spike is the proof. It builds the smallest sufficient direct-API path for **VLANs** so we can produce evidence — code we can read, run, and measure — that ADR-0014 cites. The spike is intentionally not integrated into the provider/runner; it lives under `tools/spikes/` so it can ship or be deleted on its own merits.
+
+## Setup
+
+| Item                              | Value                       |
+| --------------------------------- | --------------------------- |
+| Spike script                      | `tools/spikes/vlan_direct_api.py` |
+| Example YAML                      | `tools/spikes/example-vlans.yaml` |
+| Target box                        | `opnsense-a` (staging)      |
+| Detected OPNsense version         | _TBD — fill from `inspect`_ |
+| Matched spec version              | _TBD — from `find_best_matching_spec`_ |
+| `opnsense_openapi` version        | _TBD — `python -c "import opnsense_openapi; print(opnsense_openapi.__version__)"`_ |
+| Run date                          | _TBD_                       |
+
+## Run log
+
+Capture the raw command output. Verbatim is fine — this is evidence, not prose.
+
+### `inspect`
+
+```text
+$ uv run python tools/spikes/vlan_direct_api.py inspect
+# (paste output)
+```
+
+### `list` (before)
+
+```text
+$ uv run python tools/spikes/vlan_direct_api.py list
+# (paste output — should match what the OPNsense UI shows)
+```
+
+### `plan` (cold, against empty staging)
+
+```text
+$ uv run python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.yaml
+# (paste output — expect N adds where N = entries in example-vlans.yaml)
+```
+
+### `apply --confirm`
+
+```text
+$ uv run python tools/spikes/vlan_direct_api.py apply tools/spikes/example-vlans.yaml --confirm
+# (paste output)
+```
+
+### Round-trip — `plan` immediately after `apply`
+
+```text
+$ uv run python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.yaml
+# (paste output — MUST be "No changes." for the spike to be considered a success)
+```
+
+### Delete cycle
+
+Remove one VLAN from `example-vlans.yaml`, re-run `plan` (expect 1 delete), `apply --confirm`, re-run `plan` (expect "No changes.").
+
+```text
+# (paste output for each step)
+```
+
+## Round-trip property
+
+| Question                                                     | Result   |
+| ------------------------------------------------------------ | -------- |
+| `plan` after `apply --confirm` returns "No changes."?        | _TBD_    |
+| `plan` after delete-cycle apply returns "No changes."?       | _TBD_    |
+| Any field round-trips lossy (description with quotes, etc.)? | _TBD_    |
+
+If round-trip ever fails, paste the diff verbatim here. This is the load-bearing acceptance criterion for the direct-API pattern.
+
+## Friction points
+
+> Inline notes captured while wiring up the spike — pre-run observations, kept here so they travel with the run results.
+
+- **`opnsense_openapi.OPNsenseClient` already defaults `auto_detect_version=True`.** Production wrapper at `src/infrafoundry/providers/opnsense/api_client.py:36` explicitly sets it to `False`. Why we set the default explicitly anyway: the spike has to be readable on its own without the reader chasing why detection works.
+- **Typed `.api` surface is lazy-imported, not lazy-typed.** The `GeneratedAPI` proxy resolves `__getattr__` for *every* attribute access — there's no compile-time signal that a function exists. The error only surfaces at `sync()` time as `AttributeError: API function 'interfaces.vlansettings_search_item' not found...`. The spike catches this and falls back; ADR-0014 should weigh whether this is acceptable for production code.
+- **`searchItem` is a POST, not a GET, despite the verb.** Easy to miss if you're skimming the spec. The spike's fallback uses `client.post(...)`.
+- **First-use generation cost.** The package's `generated/` ships almost empty in the wheel — clients are auto-generated on first `client.api` access. Expect ~2 minutes of "where did my CLI go?" the first time the spike runs against a new version.
+- **Spec resolution may pick a higher patch.** `find_best_matching_spec` selects the closest *available* spec and may resolve to a higher patch version than the running box. If the running box is `25.7.5` and the package only ships `25.7.6`, the typed surface is generated against `25.7.6`'s schema. Confirm `inspect` output shows version + matched-spec on the same line so future-us can tell at a glance.
+- _TBD: anything else discovered during the live run._
+
+### Items to forward upstream to `endavis/opnsense-openapi`
+
+- _TBD: any missing `operationId` in the spec that forced a fallback._
+- _TBD: any naming inconsistencies between OpenAPI tag names and generated module paths._
+- _TBD: a `find_best_matching_spec` "closest-floor" mode (today it picks the closest, which can be higher than the running box and silently misalign schemas)._
+
+## Lines of code per concern
+
+Run `wc -l` against the spike script and split by section.
+
+| Concern                                  | LoC  | File location                      |
+| ---------------------------------------- | ---- | ---------------------------------- |
+| Config model (`VlanConfig`, `LiveVlan`)  | _TBD_ | `tools/spikes/vlan_direct_api.py` |
+| Diff engine (`compute_diff`)             | _TBD_ | `tools/spikes/vlan_direct_api.py` |
+| Apply loop (`cmd_apply`, mutators)       | _TBD_ | `tools/spikes/vlan_direct_api.py` |
+| Error handling                           | _TBD_ | `tools/spikes/vlan_direct_api.py` |
+| CLI plumbing (argparse + main)           | _TBD_ | `tools/spikes/vlan_direct_api.py` |
+| **Total spike script**                   | _TBD_ | `tools/spikes/vlan_direct_api.py` |
+| Production VLAN path (Terraform + provider) | _TBD_ | `src/infrafoundry/providers/opnsense/` (vlan validator, vlan template, terraform glue) |
+
+The comparison is rough — the production path also handles things the spike doesn't (CLI-wide flags, multi-component reconciliation, drift detection, state DB). Note the discrepancy explicitly when filling this in.
+
+## Apply timing
+
+| Operation                          | Time elapsed |
+| ---------------------------------- | ------------ |
+| 3 VLAN adds + reconfigure          | _TBD_        |
+| 1 VLAN delete + reconfigure        | _TBD_        |
+| Cold first-run client generation   | _TBD_        |
+
+## Typed-surface coverage
+
+| Function                              | Generated? | Worked first try? | Fallback used? | Notes |
+| ------------------------------------- | ---------- | ----------------- | -------------- | ----- |
+| `vlansettings_search_item`            | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
+| `vlansettings_add_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
+| `vlansettings_get_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
+| `vlansettings_set_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
+| `vlansettings_del_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
+| `vlansettings_reconfigure`            | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
+
+## Recommendation
+
+> Filled in after the run. ADR-0014 codifies the choice; this section is the input it cites.
+
+- **Direct-API for VLAN mutations:** _recommend / do-not-recommend / unclear_ — _reasoning_.
+- **Use the typed `.api` surface vs. raw `client.get/post(...)`:** _recommend / do-not-recommend / unclear_ — _reasoning_.
+- **Keep Terraform for any OPNsense resource:** _yes / no / partial_ — _which resources, why_.
+- **Open questions ADR-0014 must address:** _list_.

--- a/docs/development/opnsense-spike-vlan-findings.md
+++ b/docs/development/opnsense-spike-vlan-findings.md
@@ -1,10 +1,10 @@
 # OPNsense Direct-API VLAN Spike — Findings
 
-> **Status:** Placeholder. The operator fills these sections in after running [`tools/spikes/vlan_direct_api.py`](../../tools/spikes/README.md) against `opnsense-a` (staging). ADR-0014 cites this document.
+> **Status:** Live run completed against `opnsense-a` (staging) on 2026-04-30. ADR-0014 cites this document.
 
 ## Why this document exists
 
-ADR-0013 (PR #704, on hold) deferred the OPNsense apply-mechanism choice. Today's provider mixes paths: VLANs/aliases/firewall rules go YAML → Jinja2 `.tf.j2` → `terraform` binary → `browningluke/opnsense` provider → OPNsense API, plus an Ansible playbook for service reload. Kea DHCP calls the OPNsense REST API directly via `opnsense_openapi` but uses the bare `client.request("METHOD", endpoint_string)` surface and discards the typed `client.api.<module>.<call>` interface that the package generates from the OpenAPI spec.
+ADR-0013 ([PR #704](https://github.com/endavis/infrafoundry/pull/704), on hold) deferred the OPNsense apply-mechanism choice. Today's provider mixes paths: VLANs/aliases/firewall rules go YAML → Jinja2 `.tf.j2` → `terraform` binary → `browningluke/opnsense` provider → OPNsense API, plus an Ansible playbook for service reload. Kea DHCP calls the OPNsense REST API directly via `opnsense_openapi` but uses the bare `client.request("METHOD", endpoint_string)` surface and discards the typed `client.api.<module>.<call>` interface that the package generates from the OpenAPI spec.
 
 This spike is the proof. It builds the smallest sufficient direct-API path for **VLANs** so we can produce evidence — code we can read, run, and measure — that ADR-0014 cites. The spike is intentionally not integrated into the provider/runner; it lives under `tools/spikes/` so it can ship or be deleted on its own merits.
 
@@ -14,126 +14,221 @@ This spike is the proof. It builds the smallest sufficient direct-API path for *
 | --------------------------------- | --------------------------- |
 | Spike script                      | `tools/spikes/vlan_direct_api.py` |
 | Example YAML                      | `tools/spikes/example-vlans.yaml` |
+| Lock-fixture YAML (used live)     | `tmp/agents/claude/spike-vlans-with-lock.yaml` (ad hoc; tracks WAN trunk with `lock: true`) |
 | Target box                        | `opnsense-a` (staging)      |
-| Detected OPNsense version         | _TBD — fill from `inspect`_ |
-| Matched spec version              | _TBD — from `find_best_matching_spec`_ |
-| `opnsense_openapi` version        | _TBD — `python -c "import opnsense_openapi; print(opnsense_openapi.__version__)"`_ |
-| Run date                          | _TBD_                       |
+| Detected OPNsense version         | `26.1.6_2`                  |
+| Matched spec                      | `specs/opnsense-26.1.6.json` (738 endpoints) |
+| `opnsense_openapi` version        | 0.3.0                       |
+| `openapi-python-client` installed | **No** — typed `.api` surface unavailable; spike ran entirely on the fallback `client.post(...)` path |
+| Run date                          | 2026-04-30                  |
 
 ## Run log
-
-Capture the raw command output. Verbatim is fine — this is evidence, not prose.
 
 ### `inspect`
 
 ```text
-$ uv run python tools/spikes/vlan_direct_api.py inspect
-# (paste output)
+$ python tools/spikes/vlan_direct_api.py inspect
+WARNING: openapi-python-client is not on PATH.
+  The typed .api surface cannot be generated; the spike will
+  fall back to bare client.get/post(...) for every operation.
+  Install with: uv tool install openapi-python-client
+
+openapi-python-client not found. Install it with: uv pip install openapi-python-client
+Detected OPNsense version: 26.1.6_2
+Total endpoints in matched spec: 738
+VLAN endpoints (interfaces/vlan_settings/*): 6
+  POST  /api/interfaces/vlansettings/searchItem
+  POST  /api/interfaces/vlansettings/setItem/{uuid}
+  POST  /api/interfaces/vlansettings/addItem
+  GET   /api/interfaces/vlansettings/getItem/{uuid}
+  POST  /api/interfaces/vlansettings/delItem/{uuid}
+  POST  /api/interfaces/vlansettings/reconfigure
+Typed-surface search available: False
 ```
+
+Note: the spec advertises paths under `vlansettings` (no underscore), but the live `26.1.6_2` API routes to `vlan_settings` (with underscore). See [Items to forward upstream](#items-to-forward-upstream-to-endavisopnsense-openapi).
 
 ### `list` (before)
 
 ```text
-$ uv run python tools/spikes/vlan_direct_api.py list
-# (paste output — should match what the OPNsense UI shows)
+$ python tools/spikes/vlan_direct_api.py list
+- provider: opnsense
+  type: vlan
+  name: live-ixl0-4000
+  config:
+    device: ixl0
+    tag: 4000
+    description: ''
+    priority: 0
 ```
 
-### `plan` (cold, against empty staging)
+### `plan` against the lock-fixture YAML
 
 ```text
-$ uv run python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.yaml
-# (paste output — expect N adds where N = entries in example-vlans.yaml)
+$ python tools/spikes/vlan_direct_api.py plan tmp/agents/claude/spike-vlans-with-lock.yaml
+Plan: 3 to add, 0 to update, 0 to delete, 1 locked.
+  + ixl1 tag=4001 desc='spike-test storage vlan' pcp=0
+  + ixl1 tag=4002 desc='spike-test iot vlan' pcp=3
+  + ixl1 tag=4003 desc='spike-test mgmt vlan' pcp=7
+  L ixl0 tag=4000 (locked, uuid=56db737b-590e-42d3-ab82-1b32afc140f0) — no action will be taken
 ```
 
-### `apply --confirm`
+### `apply --confirm` — add cycle
 
 ```text
-$ uv run python tools/spikes/vlan_direct_api.py apply tools/spikes/example-vlans.yaml --confirm
-# (paste output)
+$ python tools/spikes/vlan_direct_api.py apply tmp/agents/claude/spike-vlans-with-lock.yaml --confirm
+Plan: 3 to add, 0 to update, 0 to delete, 1 locked.
+  + ixl1 tag=4001 desc='spike-test storage vlan' pcp=0
+  + ixl1 tag=4002 desc='spike-test iot vlan' pcp=3
+  + ixl1 tag=4003 desc='spike-test mgmt vlan' pcp=7
+  L ixl0 tag=4000 (locked, uuid=56db737b-590e-42d3-ab82-1b32afc140f0) — no action will be taken
+
+Applying changes...
+  + add  ixl1 tag=4001  -> saved
+  + add  ixl1 tag=4002  -> saved
+  + add  ixl1 tag=4003  -> saved
+Reconfiguring service...
+  reconfigure -> ok
 ```
 
-### Round-trip — `plan` immediately after `apply`
+### Round-trip — `plan` immediately after `apply` (add cycle)
 
 ```text
-$ uv run python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.yaml
-# (paste output — MUST be "No changes." for the spike to be considered a success)
+$ python tools/spikes/vlan_direct_api.py plan tmp/agents/claude/spike-vlans-with-lock.yaml
+Plan: 0 to add, 0 to update, 0 to delete, 1 locked.
+  L ixl0 tag=4000 (locked, uuid=56db737b-590e-42d3-ab82-1b32afc140f0) — no action will be taken
 ```
+
+✅ Convergence after the add cycle.
 
 ### Delete cycle
 
-Remove one VLAN from `example-vlans.yaml`, re-run `plan` (expect 1 delete), `apply --confirm`, re-run `plan` (expect "No changes.").
+Removed all three `ixl1.400[123]` entries from the lock-fixture YAML, leaving only the locked WAN entry:
 
 ```text
-# (paste output for each step)
+$ python tools/spikes/vlan_direct_api.py plan tmp/agents/claude/spike-vlans-with-lock.yaml
+Plan: 0 to add, 0 to update, 3 to delete, 1 locked.
+  - ixl1 tag=4001 desc='spike-test storage vlan' (uuid=9b7d31cf-...)
+  - ixl1 tag=4002 desc='spike-test iot vlan' (uuid=b8fe4add-...)
+  - ixl1 tag=4003 desc='spike-test mgmt vlan' (uuid=70c18711-...)
+  L ixl0 tag=4000 (locked, uuid=56db737b-...) — no action will be taken
+
+$ python tools/spikes/vlan_direct_api.py apply tmp/agents/claude/spike-vlans-with-lock.yaml --confirm
+...
+Applying changes...
+  - del  ixl1 tag=4001  -> deleted
+  - del  ixl1 tag=4002  -> deleted
+  - del  ixl1 tag=4003  -> deleted
+Reconfiguring service...
+  reconfigure -> ok
+
+$ python tools/spikes/vlan_direct_api.py plan tmp/agents/claude/spike-vlans-with-lock.yaml
+Plan: 0 to add, 0 to update, 0 to delete, 1 locked.
 ```
+
+✅ Convergence after the delete cycle. `opnsense-a` returned to its pre-spike state (only the WAN VLAN remains).
 
 ## Round-trip property
 
 | Question                                                     | Result   |
 | ------------------------------------------------------------ | -------- |
-| `plan` after `apply --confirm` returns "No changes."?        | _TBD_    |
-| `plan` after delete-cycle apply returns "No changes."?       | _TBD_    |
-| Any field round-trips lossy (description with quotes, etc.)? | _TBD_    |
-
-If round-trip ever fails, paste the diff verbatim here. This is the load-bearing acceptance criterion for the direct-API pattern.
+| `plan` after `apply --confirm` (add cycle) returns 0/0/0?    | ✅ yes   |
+| `plan` after `apply --confirm` (delete cycle) returns 0/0/0? | ✅ yes   |
+| Any field round-trips lossy (description with quotes, etc.)? | Not exercised — descriptions in the test fixture are simple strings. Worth a follow-up test with quotes, unicode, and very long descriptions before any production lift. |
+| Lock semantics preserved across apply cycles?                | ✅ yes — WAN VLAN UUID `56db737b-...` was identified by `searchItem` on every plan and never appeared in adds/updates/deletes. |
 
 ## Friction points
 
-> Inline notes captured while wiring up the spike — pre-run observations, kept here so they travel with the run results.
+> Pre-run notes confirmed during the live run, plus new findings.
 
-- **`opnsense_openapi.OPNsenseClient` already defaults `auto_detect_version=True`.** Production wrapper at `src/infrafoundry/providers/opnsense/api_client.py:36` explicitly sets it to `False`. Why we set the default explicitly anyway: the spike has to be readable on its own without the reader chasing why detection works.
-- **Typed `.api` surface is lazy-imported, not lazy-typed.** The `GeneratedAPI` proxy resolves `__getattr__` for *every* attribute access — there's no compile-time signal that a function exists. The error only surfaces at `sync()` time as `AttributeError: API function 'interfaces.vlansettings_search_item' not found...`. The spike catches this and falls back; ADR-0014 should weigh whether this is acceptable for production code.
-- **`searchItem` is a POST, not a GET, despite the verb.** Easy to miss if you're skimming the spec. The spike's fallback uses `client.post(...)`.
-- **First-use generation cost.** The package's `generated/` ships almost empty in the wheel — clients are auto-generated on first `client.api` access. Expect ~2 minutes of "where did my CLI go?" the first time the spike runs against a new version.
-- **Spec resolution may pick a higher patch.** `find_best_matching_spec` selects the closest *available* spec and may resolve to a higher patch version than the running box. If the running box is `25.7.5` and the package only ships `25.7.6`, the typed surface is generated against `25.7.6`'s schema. Confirm `inspect` output shows version + matched-spec on the same line so future-us can tell at a glance.
-- _TBD: anything else discovered during the live run._
+- **The spec's controller name is wrong.** Bundled `26.1.6.json` advertises `interfaces/vlansettings/*` (no underscore); live `26.1.6_2` routes to `interfaces/vlan_settings/*` (with underscore). The spike works around it by hardcoding `vlan_settings` in `VLAN_CONTROLLER`. Filed as [endavis/opnsense-openapi#32](https://github.com/endavis/opnsense-openapi/issues/32). The naming is heterogeneous across modules (Kea uses `dhcpv4`/`dhcpv6` no-underscore; VlanSettings uses snake_case), so a universal converter doesn't fix it.
+- **`openapi-python-client` is an external CLI dep, not a Python dep.** Without it, `client.api.<...>` raises a misleading `RuntimeError("No OpenAPI spec found for version 26.1.6_2")` at attribute access time, even though the spec WAS found and is in active use. The spike's `_typed_call` was originally only catching `AttributeError`; the live run exposed the `RuntimeError` path. Fix is in this PR; the upstream error message could distinguish the failure modes — filed as [endavis/opnsense-openapi#33](https://github.com/endavis/opnsense-openapi/issues/33).
+- **Spec resolution can pick a higher patch than the running box.** `find_best_matching_spec` picks the highest spec in the same major.minor; a box on `25.7.5` with `25.7.7` available gets `25.7.7`'s schema. Not exercised in this run (matched exactly to `26.1.6` from `26.1.6_2`'s major.minor), but the failure mode is real. Filed alongside the patch-revision module-path issue as [endavis/opnsense-openapi#34](https://github.com/endavis/opnsense-openapi/issues/34).
+- **Plan does not validate `device:` against the live box's NICs.** An early version of the example YAML had `device: igb1` (a generic placeholder); `opnsense-a` has `ixl0`/`ixl1` only. `plan` showed three adds without flagging the bad NIC; only `apply` would have caught it via OPNsense's response. Production direct-API should weigh whether to probe `core.system.firmware.systemInformation` or similar at plan time.
+- **Fully-managed semantics + incomplete YAML = silent delete.** First live `plan` showed `1 to delete: ixl0 tag=4000` — that's the WAN trunk on staging. The spike's diff was doing exactly what its production-IaC contract dictates (anything not in YAML → DELETE). For partial migrations (which is the OPNsense cutover use case in InfraFoundry), this is a footgun. **Mitigated in this PR** with `--add-only` flag (suppresses deletes) and resource-level `lock: true` (per-resource opt-out). ADR-0014 must specify which mode is the default for production direct-API.
+- **The typed `.api` surface was never exercised.** The entire validation ran on the fallback `client.post(...)` path because `openapi-python-client` wasn't installed. **The fallback path covered every operation cleanly** — search, add, delete, reconfigure, idempotence. The typed surface's value-add is mypy/IDE help only, not a wire-protocol requirement. ADR-0014 should weigh whether mypy validation against `.api` (which the GeneratedAPI proxy can't actually deliver — see next point) is worth the dependency footprint.
+- **`.api` is a runtime proxy, not a typed surface.** `GeneratedAPI` proxies every `__getattr__` access; typo'd function names don't fail at static-check time, only at `.sync()` call time. mypy/pyright cannot validate against it. The "typed" pitch is largely about the Pydantic *payload* models, not the *call sites*.
+- **OPNsense's `auto_detect_version=True` works against a live box.** Detected `26.1.6_2` cleanly — including the `_2` security-patch suffix — without any explicit version pinning. The subsequent spec lookup resolved correctly. Auto-detect is a reasonable default for production use.
 
 ### Items to forward upstream to `endavis/opnsense-openapi`
 
-- _TBD: any missing `operationId` in the spec that forced a fallback._
-- _TBD: any naming inconsistencies between OpenAPI tag names and generated module paths._
-- _TBD: a `find_best_matching_spec` "closest-floor" mode (today it picks the closest, which can be higher than the running box and silently misalign schemas)._
+All filed:
+
+- [#32 — bug: spec generator emits wrong controller names for multi-word controllers](https://github.com/endavis/opnsense-openapi/issues/32). **Blocker** for any consumer of the typed surface or fallback against affected modules.
+- [#33 — bug: misleading "No OpenAPI spec found" error when openapi-python-client is missing](https://github.com/endavis/opnsense-openapi/issues/33).
+- [#34 — refactor: stabilize generated-client module path across patch revisions; add closest-floor spec matching](https://github.com/endavis/opnsense-openapi/issues/34).
+
+ADR-0014's recommendation depends on at least #32 landing; without it the typed surface (and the spike's fallback) require per-controller workarounds.
 
 ## Lines of code per concern
 
-Run `wc -l` against the spike script and split by section.
+| Concern                                  | LoC (approx) | File location                      |
+| ---------------------------------------- | ------------ | ---------------------------------- |
+| Constants                                | ~25          | `tools/spikes/vlan_direct_api.py` (header + spec/path bug comments) |
+| Config model (`VlanConfig`, `LiveVlan`, `Diff`) | ~95   | `tools/spikes/vlan_direct_api.py` |
+| Env / client construction / codegen warning | ~70       | `tools/spikes/vlan_direct_api.py` |
+| Typed-call wrapper (`_typed_call`)       | ~25          | `tools/spikes/vlan_direct_api.py` |
+| YAML loader                              | ~80          | `tools/spikes/vlan_direct_api.py` |
+| Diff engine (`compute_diff`)             | ~55          | `tools/spikes/vlan_direct_api.py` |
+| Subcommand handlers + `_print_diff`      | ~135         | `tools/spikes/vlan_direct_api.py` |
+| CLI plumbing (argparse + main)           | ~80          | `tools/spikes/vlan_direct_api.py` |
+| **Total spike script**                   | **736**      | `tools/spikes/vlan_direct_api.py` |
+| Production VLAN path (in-repo)           | ~80          | `templates/opnsense/vlans.tf.j2` (15) + `validators/vlan_validator.py` (50) + scattered glue in `providers/opnsense/__init__.py` (~15) |
 
-| Concern                                  | LoC  | File location                      |
-| ---------------------------------------- | ---- | ---------------------------------- |
-| Config model (`VlanConfig`, `LiveVlan`)  | _TBD_ | `tools/spikes/vlan_direct_api.py` |
-| Diff engine (`compute_diff`)             | _TBD_ | `tools/spikes/vlan_direct_api.py` |
-| Apply loop (`cmd_apply`, mutators)       | _TBD_ | `tools/spikes/vlan_direct_api.py` |
-| Error handling                           | _TBD_ | `tools/spikes/vlan_direct_api.py` |
-| CLI plumbing (argparse + main)           | _TBD_ | `tools/spikes/vlan_direct_api.py` |
-| **Total spike script**                   | _TBD_ | `tools/spikes/vlan_direct_api.py` |
-| Production VLAN path (Terraform + provider) | _TBD_ | `src/infrafoundry/providers/opnsense/` (vlan validator, vlan template, terraform glue) |
+The 736 vs. 80 line comparison is intentionally apples-to-oranges. The spike includes its **own** diff engine, idempotency, dry-run guard, lock semantics, add-only mode, error handling, and a runnable CLI. The production VLAN path delegates almost all of that to terraform + the browningluke provider + the Ansible service-reload playbook — three external tools that the spike replaces with ~600 lines of in-repo Python.
 
-The comparison is rough — the production path also handles things the spike doesn't (CLI-wide flags, multi-component reconciliation, drift detection, state DB). Note the discrepancy explicitly when filling this in.
+What the spike's 736 lines buy:
+
+- No terraform binary on the target machine.
+- No browningluke provider plugin (and its shifting compatibility window relative to upstream OPNsense).
+- No Ansible roundtrip for service reloads.
+- One stack trace, one tool dependency (`opnsense_openapi`), one schema source.
+
+What it costs:
+
+- The dependency-graph parallelism, state file, and rollback semantics that terraform gives for free.
+- Diff/apply discipline that we wrote by hand.
+- Plumbing (argparse, env loading, dry-run guards) that's table stakes in a CLI.
+
+ADR-0014 weighs this trade.
 
 ## Apply timing
 
-| Operation                          | Time elapsed |
-| ---------------------------------- | ------------ |
-| 3 VLAN adds + reconfigure          | _TBD_        |
-| 1 VLAN delete + reconfigure        | _TBD_        |
-| Cold first-run client generation   | _TBD_        |
+| Operation                             | Time elapsed (approximate) |
+| ------------------------------------- | -------------------------- |
+| `searchItem` (1 call)                 | sub-second                 |
+| `addItem` x3 + `reconfigure`          | ~1–2 seconds end-to-end    |
+| `delItem` x3 + `reconfigure`          | ~1–2 seconds end-to-end    |
+| Cold first-run client generation      | Not measured — `openapi-python-client` was not installed during this run, so codegen never ran. Upstream docs claim ~2 minutes per OPNsense version. |
+
+These are coarse — the spike doesn't time itself. Production direct-API should add structured timing for `plan`/`apply` if operators need it.
 
 ## Typed-surface coverage
 
+None. The entire validation ran on the fallback `client.post(...)` path. Filed [#32](https://github.com/endavis/opnsense-openapi/issues/32) is a precondition for the typed surface working at all against `interfaces/vlan_settings/*`; until that lands, this table is N/A.
+
 | Function                              | Generated? | Worked first try? | Fallback used? | Notes |
 | ------------------------------------- | ---------- | ----------------- | -------------- | ----- |
-| `vlansettings_search_item`            | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
-| `vlansettings_add_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
-| `vlansettings_get_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
-| `vlansettings_set_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
-| `vlansettings_del_item`               | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
-| `vlansettings_reconfigure`            | _TBD_      | _TBD_             | _TBD_          | _TBD_ |
+| `vlansettings_search_item`            | No (CLI not installed) | — | yes | Fallback works at the corrected `vlan_settings` path. |
+| `vlansettings_add_item`               | No | — | yes | 3/3 returned `result: saved`. |
+| `vlansettings_get_item`               | No | — | not exercised | Spike doesn't use `getItem` — search returns full rows. |
+| `vlansettings_set_item`               | No | — | not exercised live | Unit-tested only. |
+| `vlansettings_del_item`               | No | — | yes | 3/3 returned `result: deleted`. |
+| `vlansettings_reconfigure`            | No | — | yes | Both apply cycles, `status: ok`. |
+
+A future re-run with `openapi-python-client` installed and #32 fixed would populate this table with the typed-surface results.
 
 ## Recommendation
 
-> Filled in after the run. ADR-0014 codifies the choice; this section is the input it cites.
+The spike's evidence is strong enough to support a **conditional** recommendation that ADR-0014 should consider. Items below are starting positions for the ADR discussion, not final answers.
 
-- **Direct-API for VLAN mutations:** _recommend / do-not-recommend / unclear_ — _reasoning_.
-- **Use the typed `.api` surface vs. raw `client.get/post(...)`:** _recommend / do-not-recommend / unclear_ — _reasoning_.
-- **Keep Terraform for any OPNsense resource:** _yes / no / partial_ — _which resources, why_.
-- **Open questions ADR-0014 must address:** _list_.
+- **Direct-API for VLAN mutations: feasible and clean.** The 736-line spike covers add/update/delete + idempotence + lock semantics + add-only mode in a single readable Python file with one runtime dependency and no external binaries. The round-trip property holds. **Recommend** moving forward with direct-API for net-new components (interface assignments, NAT rules, gateways, static routes, virtual IPs from ADR-0013) once upstream blockers (#32) land.
+- **Typed `.api` surface: defer.** Without #32, it's blocked. Even with #32, the value-add is incremental (Pydantic payloads only — call sites are still a runtime proxy with no static checking). The fallback `client.get/post(...)` path is more than adequate for production. **Recommend** building production code against the fallback API by default, and revisiting whether the typed surface is worth the `openapi-python-client` dependency once #32 + #34 land.
+- **Apply semantics: lock + add-only must be in the production contract.** Pure fully-managed mode is dangerous for partial migrations (the OPNsense cutover use case). Both safety affordances developed in this spike (`lock: true` per-resource and `--add-only` per-invocation) should ship with the production direct-API. ADR-0014 should specify the default mode (suggest: fully-managed for env-root packages, add-only as an opt-in CLI flag, `lock` always available).
+- **Keep Terraform for: no clear case based on this spike.** All cited concerns (state, plan, apply, dependency ordering, parallelism) are surmountable in pure Python at the cost of ~600 lines of plumbing per provider. The browningluke compatibility lag with upstream OPNsense, plus the spec-vs-live drift caught by this spike, suggest the indirection is more cost than benefit. **Lean: migrate the existing Terraform-based VLAN/aliases/firewall_rules paths to direct-API as part of the ADR-0013 implementation phase.** ADR-0014 is the right place to commit.
+- **Open questions for ADR-0014 to address:**
+  - Does the production direct-API live in `BaseRunner` (new `OPNsenseDirectRunner`) or bypass the runner system (as Kea DHCP currently does)?
+  - Where does `lock: true` live in the production schema — top-level meta-property (as in the spike) or under a dedicated `metadata.iac.*` namespace?
+  - Should `plan` validate `device:` (and other interface refs) against the live box at plan time, or defer to apply-time errors?
+  - Does the production model support **granular** locks (`lock: { delete: true, update: false }`) or just boolean?
+  - How does direct-API integrate with `foundry config migrate`? The spike's `list` is the equivalent operation; a production version would dump *all* resource types into YAML.

--- a/tests/spikes/__init__.py
+++ b/tests/spikes/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for engineering spikes under ``tools/spikes/``."""

--- a/tests/spikes/test_vlan_direct_api.py
+++ b/tests/spikes/test_vlan_direct_api.py
@@ -217,19 +217,60 @@ class TestLoadVlansFromYaml:
         with pytest.raises(ValueError, match="non-integer"):
             spike.load_vlans_from_yaml(path)
 
+    def test_lock_field_loads_when_present(self, tmp_path: Path) -> None:
+        path = tmp_path / "locked.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: wan-trunk
+  lock: true
+  config: {device: ixl0, tag: 4000, description: "", priority: 0}
+- provider: opnsense
+  type: vlan
+  name: storage
+  config: {device: igb1, tag: 100, description: storage, priority: 0}
+""",
+            encoding="utf-8",
+        )
+        vlans = spike.load_vlans_from_yaml(path)
+        assert len(vlans) == 2
+        wan = next(v for v in vlans if v.name == "wan-trunk")
+        storage = next(v for v in vlans if v.name == "storage")
+        assert wan.lock is True
+        assert storage.lock is False  # default
+
+    def test_lock_field_must_be_boolean(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad-lock.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: v1
+  lock: "yes"
+  config: {device: igb0, tag: 10, description: a, priority: 0}
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="lock must be a boolean"):
+            spike.load_vlans_from_yaml(path)
+
 
 # ---------------------------------------------------------------------------
 # Diff engine
 # ---------------------------------------------------------------------------
 
 
-def _vlan(device: str, tag: int, desc: str = "x", pcp: int = 0) -> spike.VlanConfig:
+def _vlan(
+    device: str, tag: int, desc: str = "x", pcp: int = 0, *, lock: bool = False
+) -> spike.VlanConfig:
     return spike.VlanConfig(
         name=f"vlan-{device}-{tag}",
         device=device,
         tag=tag,
         description=desc,
         priority=pcp,
+        lock=lock,
     )
 
 
@@ -315,6 +356,85 @@ class TestComputeDiff:
         assert diff.updates[0][0].uuid == "u2"
         assert diff.deletes[0].uuid == "u3"
 
+    def test_locked_yaml_entry_with_match_skipped_from_actions(self) -> None:
+        # WAN trunk on the box; declared in YAML with lock=True so IaC stays
+        # away — exactly the opnsense-a finding that motivated this feature.
+        desired = [_vlan("ixl0", 4000, desc="", lock=True)]
+        current = [_live("u1", "ixl0", 4000, desc="")]
+        diff = spike.compute_diff(desired, current)
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+        assert len(diff.locked) == 1
+        want, have = diff.locked[0]
+        assert want.lock is True
+        assert have is not None
+        assert have.uuid == "u1"
+
+    def test_locked_yaml_entry_without_match_recorded_as_missing(self) -> None:
+        desired = [_vlan("igb0", 100, lock=True)]
+        current: list[spike.LiveVlan] = []
+        diff = spike.compute_diff(desired, current)
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+        assert len(diff.locked) == 1
+        want, have = diff.locked[0]
+        assert want.lock is True
+        assert have is None
+
+    def test_locked_entry_protects_live_resource_from_delete(self) -> None:
+        # Even in fully-managed mode, locked entries never produce deletes.
+        desired = [
+            _vlan("ixl0", 4000, lock=True),  # observed-only
+            _vlan("igb1", 100, desc="new"),  # add
+        ]
+        current = [
+            _live("u1", "ixl0", 4000),
+            _live("u2", "igb0", 99),  # not in YAML, NOT locked → delete
+        ]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.adds) == 1
+        assert diff.adds[0].tag == 100
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].uuid == "u2"
+        assert len(diff.locked) == 1
+
+    def test_add_only_suppresses_deletes(self) -> None:
+        desired = [_vlan("igb1", 100)]
+        current = [
+            _live("u1", "ixl0", 4000),  # not in YAML — would normally be deleted
+            _live("u2", "igb0", 99),  # ditto
+        ]
+        diff = spike.compute_diff(desired, current, add_only=True)
+        assert len(diff.adds) == 1
+        assert len(diff.deletes) == 0  # ← suppressed by add_only
+        # add_only is orthogonal to locked: nothing here is locked.
+        assert diff.locked == []
+        assert not diff.is_empty  # the add is real work
+
+    def test_add_only_still_emits_updates(self) -> None:
+        # add_only suppresses deletes only; updates still happen.
+        desired = [_vlan("igb0", 10, desc="new")]
+        current = [_live("u1", "igb0", 10, desc="old")]
+        diff = spike.compute_diff(desired, current, add_only=True)
+        assert len(diff.updates) == 1
+        assert len(diff.deletes) == 0
+
+    def test_add_only_combined_with_lock(self) -> None:
+        desired = [
+            _vlan("ixl0", 4000, lock=True),
+            _vlan("igb1", 100, desc="new"),
+        ]
+        current = [
+            _live("u1", "ixl0", 4000),
+            _live("u2", "igb0", 99),  # would be deleted in fully-managed mode
+        ]
+        diff = spike.compute_diff(desired, current, add_only=True)
+        assert len(diff.adds) == 1
+        assert len(diff.deletes) == 0  # add_only suppresses
+        assert len(diff.locked) == 1
+
 
 # ---------------------------------------------------------------------------
 # Typed-surface fallback
@@ -345,7 +465,7 @@ class TestSearchVlansFallback:
         assert result[0].uuid == "u1"
         assert result[0].device == "igb0"
         assert result[0].tag == 10
-        client.post.assert_called_once_with("interfaces", "vlansettings", "searchItem")
+        client.post.assert_called_once_with("interfaces", "vlan_settings", "searchItem")
 
     def test_typed_search_used_when_available(self) -> None:
         client = MagicMock()
@@ -364,6 +484,32 @@ class TestSearchVlansFallback:
         assert result[0].priority == 3
         # Fallback must not have been used.
         client.post.assert_not_called()
+
+    def test_fallback_when_client_api_raises_runtime_error(self) -> None:
+        """``client.api`` raises ``RuntimeError`` when no generated client exists.
+
+        Reproduces the live-spike-run scenario where ``opnsense-python-client``
+        is not on ``PATH``: the typed surface can't be generated, and ``client.api``
+        access raises ``RuntimeError`` rather than ``AttributeError``. The fallback
+        path must absorb it.
+        """
+        client = MagicMock()
+        # Accessing ``client.api`` raises RuntimeError — the failure mode the
+        # operator hit when openapi-python-client wasn't installed.
+        type(client).api = property(
+            fget=lambda _: (_ for _ in ()).throw(
+                RuntimeError("No OpenAPI spec found for version 26.1.6_2")
+            )
+        )
+        client.post.return_value = {
+            "rows": [{"uuid": "u3", "if": "igb0", "tag": "5", "descr": "v5", "pcp": "0"}]
+        }
+
+        result = spike.search_vlans(client)
+
+        assert len(result) == 1
+        assert result[0].uuid == "u3"
+        client.post.assert_called_once_with("interfaces", "vlan_settings", "searchItem")
 
     def test_empty_response_returns_empty_list(self) -> None:
         client = MagicMock()
@@ -534,6 +680,31 @@ class TestBuildClient:
             verify_ssl=False,
             auto_detect_version=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# Codegen-availability warning — surfaces the typed-surface gating on a CLI
+# ---------------------------------------------------------------------------
+
+
+class TestWarnIfCodegenUnavailable:
+    """The spike warns operators if ``openapi-python-client`` isn't installed."""
+
+    def test_warns_when_cli_not_on_path(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(spike.shutil, "which", return_value=None):
+            spike._warn_if_codegen_unavailable()
+        err = capsys.readouterr().err
+        assert "openapi-python-client is not on PATH" in err
+        assert "uv tool install openapi-python-client" in err
+
+    def test_silent_when_cli_present(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(
+            spike.shutil, "which", return_value="/usr/local/bin/openapi-python-client"
+        ):
+            spike._warn_if_codegen_unavailable()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/spikes/test_vlan_direct_api.py
+++ b/tests/spikes/test_vlan_direct_api.py
@@ -1,0 +1,603 @@
+"""Unit tests for the VLAN direct-API spike (``tools/spikes/vlan_direct_api.py``).
+
+These tests cover env-var loading, YAML parsing/validation, the diff engine,
+the typed-surface fallback path, and the apply-loop dry-run guard. No live
+OPNsense box is contacted — ``OPNsenseClient`` is patched at the spike
+module's import path, mirroring the inline ``unittest.mock.patch()`` pattern
+in ``tests/unit/providers/opnsense/test_dhcpv6_change_detection.py:165-167``.
+
+Live-box validation is operator-driven and recorded in
+``docs/development/opnsense-spike-vlan-findings.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The spike module lives under ``tools/spikes/`` which is already on sys.path
+# (see ``tests/unit/test_blueprint_portability_lint.py`` which imports from
+# ``tools.lint_blueprint_portability`` the same way).
+from tools.spikes import vlan_direct_api as spike
+
+# Module path used by ``patch(...)`` to substitute the OPNsense client class
+# *as imported by the spike*. Patching ``opnsense_openapi.OPNsenseClient``
+# directly would not affect the already-bound name inside the spike module.
+SPIKE_CLIENT_PATH = "tools.spikes.vlan_direct_api.OPNsenseClient"
+
+
+# ---------------------------------------------------------------------------
+# load_env_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEnvCredentials:
+    """Env var resolution into a ``Credentials`` dataclass."""
+
+    def test_happy_path_all_set(self) -> None:
+        env = {
+            "OPNSENSE_API_URL": "https://fw.example.lan",
+            "OPNSENSE_API_KEY": "key-123",
+            "OPNSENSE_API_SECRET": "secret-456",
+            "OPNSENSE_VERIFY_SSL": "true",
+        }
+        creds = spike.load_env_credentials(env)
+        assert creds.api_url == "https://fw.example.lan"
+        assert creds.api_key == "key-123"
+        assert creds.api_secret == "secret-456"
+        assert creds.verify_ssl is True
+
+    def test_missing_api_key_raises(self) -> None:
+        env = {
+            "OPNSENSE_API_URL": "https://fw",
+            "OPNSENSE_API_SECRET": "secret",
+        }
+        with pytest.raises(RuntimeError) as exc_info:
+            spike.load_env_credentials(env)
+        # Error message must name the missing var so the operator can fix it.
+        assert "OPNSENSE_API_KEY" in str(exc_info.value)
+
+    def test_missing_multiple_vars_lists_all(self) -> None:
+        env: dict[str, str] = {}
+        with pytest.raises(RuntimeError) as exc_info:
+            spike.load_env_credentials(env)
+        msg = str(exc_info.value)
+        assert "OPNSENSE_API_URL" in msg
+        assert "OPNSENSE_API_KEY" in msg
+        assert "OPNSENSE_API_SECRET" in msg
+
+    def test_empty_string_treated_as_missing(self) -> None:
+        env = {
+            "OPNSENSE_API_URL": "",
+            "OPNSENSE_API_KEY": "k",
+            "OPNSENSE_API_SECRET": "s",
+        }
+        with pytest.raises(RuntimeError) as exc_info:
+            spike.load_env_credentials(env)
+        assert "OPNSENSE_API_URL" in str(exc_info.value)
+
+    def test_verify_ssl_default_when_unset(self) -> None:
+        env = {
+            "OPNSENSE_API_URL": "https://fw",
+            "OPNSENSE_API_KEY": "k",
+            "OPNSENSE_API_SECRET": "s",
+        }
+        creds = spike.load_env_credentials(env)
+        assert creds.verify_ssl is True
+
+    @pytest.mark.parametrize("falsey", ["false", "False", "0", "no", "off", "OFF"])
+    def test_verify_ssl_falsey_values(self, falsey: str) -> None:
+        env = {
+            "OPNSENSE_API_URL": "https://fw",
+            "OPNSENSE_API_KEY": "k",
+            "OPNSENSE_API_SECRET": "s",
+            "OPNSENSE_VERIFY_SSL": falsey,
+        }
+        creds = spike.load_env_credentials(env)
+        assert creds.verify_ssl is False
+
+
+# ---------------------------------------------------------------------------
+# load_vlans_from_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestLoadVlansFromYaml:
+    """YAML parsing + per-field validation."""
+
+    def test_valid_yaml_parses(self, tmp_path: Path) -> None:
+        path = tmp_path / "vlans.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: vlan-storage
+  config:
+    device: igb1
+    tag: 100
+    description: storage
+    priority: 0
+""",
+            encoding="utf-8",
+        )
+        result = spike.load_vlans_from_yaml(path)
+        assert len(result) == 1
+        assert result[0].name == "vlan-storage"
+        assert result[0].device == "igb1"
+        assert result[0].tag == 100
+        assert result[0].description == "storage"
+        assert result[0].priority == 0
+
+    def test_non_vlan_resources_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "mixed.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: v1
+  config: {device: igb0, tag: 10, description: a, priority: 0}
+- provider: opnsense
+  type: alias
+  name: irrelevant
+  config: {}
+""",
+            encoding="utf-8",
+        )
+        result = spike.load_vlans_from_yaml(path)
+        assert len(result) == 1
+        assert result[0].name == "v1"
+
+    def test_top_level_not_list_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text("provider: opnsense\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="top-level list"):
+            spike.load_vlans_from_yaml(path)
+
+    def test_missing_required_field(self, tmp_path: Path) -> None:
+        path = tmp_path / "missing.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: v1
+  config:
+    device: igb0
+    tag: 10
+    description: a
+""",  # priority missing
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="priority"):
+            spike.load_vlans_from_yaml(path)
+
+    def test_tag_out_of_range(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad-tag.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: v1
+  config: {device: igb0, tag: 5000, description: a, priority: 0}
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="tag 5000"):
+            spike.load_vlans_from_yaml(path)
+
+    def test_priority_out_of_range(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad-pcp.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: v1
+  config: {device: igb0, tag: 10, description: a, priority: 9}
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="priority 9"):
+            spike.load_vlans_from_yaml(path)
+
+    def test_non_integer_tag(self, tmp_path: Path) -> None:
+        path = tmp_path / "non-int.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: v1
+  config: {device: igb0, tag: "not-an-int", description: a, priority: 0}
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="non-integer"):
+            spike.load_vlans_from_yaml(path)
+
+
+# ---------------------------------------------------------------------------
+# Diff engine
+# ---------------------------------------------------------------------------
+
+
+def _vlan(device: str, tag: int, desc: str = "x", pcp: int = 0) -> spike.VlanConfig:
+    return spike.VlanConfig(
+        name=f"vlan-{device}-{tag}",
+        device=device,
+        tag=tag,
+        description=desc,
+        priority=pcp,
+    )
+
+
+def _live(uuid: str, device: str, tag: int, desc: str = "x", pcp: int = 0) -> spike.LiveVlan:
+    return spike.LiveVlan(uuid=uuid, device=device, tag=tag, description=desc, priority=pcp)
+
+
+class TestComputeDiff:
+    """``compute_diff`` keyed by ``(device, tag)``."""
+
+    def test_no_changes_when_desired_matches_current(self) -> None:
+        desired = [_vlan("igb0", 10, "storage", 0)]
+        current = [_live("u1", "igb0", 10, "storage", 0)]
+        diff = spike.compute_diff(desired, current)
+        assert diff.is_empty
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+
+    def test_add_only(self) -> None:
+        desired = [_vlan("igb0", 10)]
+        current: list[spike.LiveVlan] = []
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.adds) == 1
+        assert len(diff.updates) == 0
+        assert len(diff.deletes) == 0
+        assert diff.adds[0].diff_key == ("igb0", 10)
+
+    def test_remove_only(self) -> None:
+        desired: list[spike.VlanConfig] = []
+        current = [_live("u1", "igb0", 10)]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.adds) == 0
+        assert len(diff.updates) == 0
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].uuid == "u1"
+
+    def test_update_only_when_description_differs(self) -> None:
+        desired = [_vlan("igb0", 10, desc="new-desc")]
+        current = [_live("u1", "igb0", 10, desc="old-desc")]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.adds) == 0
+        assert len(diff.updates) == 1
+        assert len(diff.deletes) == 0
+        live, want = diff.updates[0]
+        assert live.uuid == "u1"
+        assert want.description == "new-desc"
+
+    def test_update_only_when_priority_differs(self) -> None:
+        desired = [_vlan("igb0", 10, pcp=3)]
+        current = [_live("u1", "igb0", 10, pcp=0)]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.updates) == 1
+
+    def test_diff_keypair_is_device_tag_not_name_or_uuid(self) -> None:
+        # Same UUID, same description — but different (device, tag) means add+delete,
+        # not an update. Identity is parent-NIC + tag, full stop.
+        desired = [_vlan("igb1", 10, desc="same")]
+        current = [_live("u1", "igb0", 10, desc="same")]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.adds) == 1
+        assert len(diff.deletes) == 1
+        assert len(diff.updates) == 0
+        assert diff.adds[0].device == "igb1"
+        assert diff.deletes[0].device == "igb0"
+
+    def test_mixed_add_update_delete(self) -> None:
+        desired = [
+            _vlan("igb0", 10, desc="keep"),  # unchanged
+            _vlan("igb0", 20, desc="updated"),  # update
+            _vlan("igb0", 30, desc="brand-new"),  # add
+        ]
+        current = [
+            _live("u1", "igb0", 10, desc="keep"),
+            _live("u2", "igb0", 20, desc="old"),
+            _live("u3", "igb0", 99, desc="going-away"),  # delete
+        ]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.adds) == 1
+        assert len(diff.updates) == 1
+        assert len(diff.deletes) == 1
+        assert diff.adds[0].tag == 30
+        assert diff.updates[0][0].uuid == "u2"
+        assert diff.deletes[0].uuid == "u3"
+
+
+# ---------------------------------------------------------------------------
+# Typed-surface fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSearchVlansFallback:
+    """``search_vlans`` must fall back to ``client.post(...)`` when the typed surface fails."""
+
+    def test_fallback_when_typed_search_unavailable(self) -> None:
+        # Build a mock client whose typed surface raises AttributeError on .sync(),
+        # forcing the fallback path.
+        client = MagicMock()
+        function_proxy = MagicMock()
+        function_proxy.sync.side_effect = AttributeError("not generated")
+        # client.api.interfaces.<anything> -> function_proxy
+        type(client.api.interfaces).vlansettings_search_item = function_proxy
+        # Configure fallback POST to return realistic shape.
+        client.post.return_value = {
+            "rows": [
+                {"uuid": "u1", "if": "igb0", "tag": "10", "descr": "vlan10", "pcp": "0"},
+            ]
+        }
+
+        result = spike.search_vlans(client)
+
+        assert len(result) == 1
+        assert result[0].uuid == "u1"
+        assert result[0].device == "igb0"
+        assert result[0].tag == 10
+        client.post.assert_called_once_with("interfaces", "vlansettings", "searchItem")
+
+    def test_typed_search_used_when_available(self) -> None:
+        client = MagicMock()
+        # Typed surface returns rows directly — no AttributeError.
+        client.api.interfaces.vlansettings_search_item.sync.return_value = {
+            "rows": [
+                {"uuid": "u2", "if": "igb1", "tag": "20", "descr": "v20", "pcp": "3"},
+            ]
+        }
+
+        result = spike.search_vlans(client)
+
+        assert len(result) == 1
+        assert result[0].device == "igb1"
+        assert result[0].tag == 20
+        assert result[0].priority == 3
+        # Fallback must not have been used.
+        client.post.assert_not_called()
+
+    def test_empty_response_returns_empty_list(self) -> None:
+        client = MagicMock()
+        client.api.interfaces.vlansettings_search_item.sync.return_value = {"rows": []}
+        assert spike.search_vlans(client) == []
+
+    def test_malformed_rows_filtered(self) -> None:
+        client = MagicMock()
+        client.api.interfaces.vlansettings_search_item.sync.return_value = {
+            "rows": ["not-a-dict", {"uuid": "u1", "if": "igb0", "tag": "5"}],
+        }
+        result = spike.search_vlans(client)
+        assert len(result) == 1
+        assert result[0].uuid == "u1"
+
+
+# ---------------------------------------------------------------------------
+# Apply loop
+# ---------------------------------------------------------------------------
+
+
+class TestCmdApply:
+    """``cmd_apply`` dispatches mutations only when ``--confirm`` is passed."""
+
+    @staticmethod
+    def _yaml_with(tmp_path: Path, *, device: str, tag: int) -> Path:
+        path = tmp_path / "v.yaml"
+        path.write_text(
+            f"""
+- provider: opnsense
+  type: vlan
+  name: v1
+  config:
+    device: {device}
+    tag: {tag}
+    description: spike
+    priority: 0
+""",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_dry_run_dispatches_no_mutations(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = MagicMock()
+        client.api.interfaces.vlansettings_search_item.sync.return_value = {"rows": []}
+        yaml_path = self._yaml_with(tmp_path, device="igb0", tag=100)
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=False)
+
+        assert rc == 0
+        # No add/set/del/reconfigure typed calls.
+        client.api.interfaces.vlansettings_add_item.sync.assert_not_called()
+        client.api.interfaces.vlansettings_set_item.sync.assert_not_called()
+        client.api.interfaces.vlansettings_del_item.sync.assert_not_called()
+        client.api.interfaces.vlansettings_reconfigure.sync.assert_not_called()
+        # And no fallback POSTs to mutating endpoints.
+        for call in client.post.call_args_list:
+            assert call.args[2] == "searchItem"
+        out = capsys.readouterr().out
+        assert "Dry run" in out
+
+    def test_confirm_dispatches_typed_add_call(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.api.interfaces.vlansettings_search_item.sync.return_value = {"rows": []}
+        client.api.interfaces.vlansettings_add_item.sync.return_value = {
+            "result": "saved",
+            "uuid": "new-uuid",
+        }
+        client.api.interfaces.vlansettings_reconfigure.sync.return_value = {"status": "ok"}
+        yaml_path = self._yaml_with(tmp_path, device="igb0", tag=100)
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True)
+
+        assert rc == 0
+        client.api.interfaces.vlansettings_add_item.sync.assert_called_once()
+        client.api.interfaces.vlansettings_reconfigure.sync.assert_called_once()
+        # Inspect the payload that was passed to add_item — must wrap under "vlan".
+        call_kwargs = client.api.interfaces.vlansettings_add_item.sync.call_args.kwargs
+        assert "json_body" in call_kwargs
+        assert call_kwargs["json_body"]["vlan"]["if"] == "igb0"
+        assert call_kwargs["json_body"]["vlan"]["tag"] == "100"
+
+    def test_confirm_with_no_diff_skips_mutations(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        # Existing row matches the YAML exactly.
+        client.api.interfaces.vlansettings_search_item.sync.return_value = {
+            "rows": [
+                {"uuid": "u1", "if": "igb0", "tag": "100", "descr": "spike", "pcp": "0"},
+            ]
+        }
+        yaml_path = self._yaml_with(tmp_path, device="igb0", tag=100)
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True)
+
+        assert rc == 0
+        client.api.interfaces.vlansettings_add_item.sync.assert_not_called()
+        client.api.interfaces.vlansettings_set_item.sync.assert_not_called()
+        client.api.interfaces.vlansettings_del_item.sync.assert_not_called()
+        client.api.interfaces.vlansettings_reconfigure.sync.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# cmd_inspect
+# ---------------------------------------------------------------------------
+
+
+class TestCmdInspect:
+    """``cmd_inspect`` prints version + endpoint count + typed-surface readiness."""
+
+    def test_reports_version_and_endpoints(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = MagicMock()
+        client.detect_version.return_value = "25.7.6"
+        client.list_endpoints.return_value = [
+            ("/api/interfaces/vlansettings/addItem", "POST", "Add a VLAN"),
+            ("/api/interfaces/vlansettings/searchItem", "POST", "Search VLANs"),
+            ("/api/core/firmware/info", "GET", "Firmware info"),
+        ]
+        client.api.interfaces.vlansettings_search_item.sync.return_value = {"rows": []}
+
+        rc = spike.cmd_inspect(client)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "25.7.6" in out
+        assert "Total endpoints in matched spec: 3" in out
+        assert "VLAN endpoints" in out
+        assert "Typed-surface search available: True" in out
+
+    def test_typed_surface_unavailable_reported(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = MagicMock()
+        client.detect_version.return_value = "26.1.6"
+        client.list_endpoints.return_value = []
+        client.api.interfaces.vlansettings_search_item.sync.side_effect = AttributeError("nope")
+        # Fallback POST must also be wired so the inspection probe doesn't blow up.
+        client.post.return_value = {"rows": []}
+
+        rc = spike.cmd_inspect(client)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        # The typed probe returns None when AttributeError fires — reported as False.
+        assert "Typed-surface search available: False" in out
+
+
+# ---------------------------------------------------------------------------
+# build_client patches OPNsenseClient at the spike's import path
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClient:
+    """``build_client`` instantiates the OpenAPI client with auto_detect_version=True."""
+
+    def test_client_constructed_with_auto_detect(self) -> None:
+        creds = spike.Credentials(
+            api_url="https://fw",
+            api_key="k",
+            api_secret="s",
+            verify_ssl=False,
+        )
+        with patch(SPIKE_CLIENT_PATH) as client_cls:
+            spike.build_client(creds)
+        client_cls.assert_called_once_with(
+            base_url="https://fw",
+            api_key="k",
+            api_secret="s",
+            verify_ssl=False,
+            auto_detect_version=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# main() smoke test — exercises argparse + finally block
+# ---------------------------------------------------------------------------
+
+
+class TestMainEntryPoint:
+    """``main`` dispatches to the right subcommand and always closes the client."""
+
+    def test_main_inspect_closes_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPNSENSE_API_URL", "https://fw")
+        monkeypatch.setenv("OPNSENSE_API_KEY", "k")
+        monkeypatch.setenv("OPNSENSE_API_SECRET", "s")
+        monkeypatch.setenv("OPNSENSE_VERIFY_SSL", "false")
+
+        fake_client = MagicMock()
+        fake_client.detect_version.return_value = "25.7.6"
+        fake_client.list_endpoints.return_value = []
+        fake_client.api.interfaces.vlansettings_search_item.sync.return_value = {"rows": []}
+
+        with patch(SPIKE_CLIENT_PATH, return_value=fake_client):
+            rc = spike.main(["inspect"])
+
+        assert rc == 0
+        fake_client.close.assert_called_once()
+
+    def test_main_propagates_missing_env_var_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Strip env so credential loading fails fast.
+        for key in ("OPNSENSE_API_URL", "OPNSENSE_API_KEY", "OPNSENSE_API_SECRET"):
+            monkeypatch.delenv(key, raising=False)
+        with pytest.raises(RuntimeError, match="Missing"):
+            spike.main(["inspect"])
+
+
+# ---------------------------------------------------------------------------
+# VlanConfig.to_payload — payload shape pinned for OPNsense API compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestVlanPayloadShape:
+    """The API expects ``{"vlan": {"if", "tag", "descr", "pcp"}}`` with stringified ints."""
+
+    def test_payload_keys_and_types(self) -> None:
+        v = spike.VlanConfig(name="v1", device="igb0", tag=100, description="hello", priority=3)
+        payload = v.to_payload()
+        assert set(payload.keys()) == {"vlan"}
+        inner = payload["vlan"]
+        assert inner["if"] == "igb0"
+        # OPNsense expects strings even for integer-looking fields.
+        assert inner["tag"] == "100"
+        assert inner["descr"] == "hello"
+        assert inner["pcp"] == "3"
+
+
+# ---------------------------------------------------------------------------
+# Module reload sanity — confirms the spike imports cleanly with no side effects
+# ---------------------------------------------------------------------------
+
+
+def test_spike_module_imports_without_side_effects() -> None:
+    """Importing the spike must not contact the network or read env vars eagerly."""
+    # Drop and re-import — must not raise even with no OPNSENSE_* env vars set.
+    sys.modules.pop("tools.spikes.vlan_direct_api", None)
+    reloaded: Any = importlib.import_module("tools.spikes.vlan_direct_api")
+    assert hasattr(reloaded, "main")
+    assert hasattr(reloaded, "compute_diff")

--- a/tools/spikes/README.md
+++ b/tools/spikes/README.md
@@ -9,7 +9,7 @@ Demonstrates end-to-end VLAN management against OPNsense via `opnsense_openapi`'
 ### Prerequisites
 
 1. An OPNsense box you don't mind reconfiguring. **Use `opnsense-a` (staging), NOT prod.**
-2. An API key/secret with permission for `interfaces/vlansettings/*`.
+2. An API key/secret with permission for `interfaces/vlan_settings/*` (the live URL — the bundled OpenAPI spec at `opnsense-openapi` 0.3.0 calls it `vlansettings`, but live OPNsense routes to `vlan_settings`; see findings doc for details).
 3. The `opnsense_openapi` package (already in `pyproject.toml`).
 
 ### Environment variables
@@ -50,6 +50,13 @@ uv run python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.ya
 # 4. Apply the diff. Without --confirm, this is a dry run identical to `plan`.
 uv run python tools/spikes/vlan_direct_api.py apply tools/spikes/example-vlans.yaml --confirm
 ```
+
+#### Safety flags
+
+- **`--add-only`** (on `plan` and `apply`) — suppresses deletes for live VLANs that aren't in the YAML. Use this on partial migrations where the YAML doesn't yet describe everything on the box. Adds and updates still happen.
+- **`lock: true`** at the resource level in YAML — observed but untouchable. The spike records the lock in the plan output and never adds/updates/deletes the matching live resource. Useful for things like the WAN trunk that you want IaC to be aware of but never touch. See `example-vlans.yaml` for the syntax.
+
+The two are orthogonal: locks travel with specific resources in YAML; `--add-only` is a session-level "trust me, don't sweep deletes."
 
 ### Round-trip test (the load-bearing acceptance criterion)
 

--- a/tools/spikes/README.md
+++ b/tools/spikes/README.md
@@ -1,0 +1,83 @@
+# Engineering spikes
+
+Throw-away code that produces evidence for an ADR. Each spike pairs with a findings doc under `docs/development/`. Spikes ship or get deleted on their own merits — they do not modify production code.
+
+## `vlan_direct_api.py` — direct-API VLAN management (informs ADR-0014)
+
+Demonstrates end-to-end VLAN management against OPNsense via `opnsense_openapi`'s typed `.api.<module>.<function>` surface, with a `client.get/post(...)` fallback. Pairs with [`docs/development/opnsense-spike-vlan-findings.md`](../../docs/development/opnsense-spike-vlan-findings.md).
+
+### Prerequisites
+
+1. An OPNsense box you don't mind reconfiguring. **Use `opnsense-a` (staging), NOT prod.**
+2. An API key/secret with permission for `interfaces/vlansettings/*`.
+3. The `opnsense_openapi` package (already in `pyproject.toml`).
+
+### Environment variables
+
+Source these from your secrets repo before running. **Never commit them to this repo.**
+
+| Variable                | Required | Purpose                                              |
+| ----------------------- | -------- | ---------------------------------------------------- |
+| `OPNSENSE_API_URL`      | yes      | e.g. `https://opnsense-a.example.lan`                |
+| `OPNSENSE_API_KEY`      | yes      | API key from System → Access → Users → API keys      |
+| `OPNSENSE_API_SECRET`   | yes      | Paired secret                                        |
+| `OPNSENSE_VERIFY_SSL`   | no       | `true` (default), `false`, `0`, `no` — case-insensitive |
+
+These match the names the existing OPNsense validator already uses (`src/infrafoundry/providers/opnsense/validator.py:208-210`), so you can reuse the same `.envrc` snippet.
+
+Example shell setup (sourced from your private secrets repo, never committed here):
+
+```bash
+# In ~/.envrc.local or your secrets repo's bootstrap script:
+export OPNSENSE_API_URL="https://opnsense-a.example.lan"
+export OPNSENSE_API_KEY="$(sops -d secrets/opnsense-a.yaml | yq '.api_key')"
+export OPNSENSE_API_SECRET="$(sops -d secrets/opnsense-a.yaml | yq '.api_secret')"
+```
+
+### Subcommands
+
+```bash
+# 1. Sanity check — connect, detect version, count VLAN endpoints in the matched spec,
+#    and report whether the typed search method is generated.
+uv run python tools/spikes/vlan_direct_api.py inspect
+
+# 2. Print the current VLANs on the box as YAML (visually compare against the OPNsense UI).
+uv run python tools/spikes/vlan_direct_api.py list
+
+# 3. Diff a YAML file against live state (no mutations).
+uv run python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.yaml
+
+# 4. Apply the diff. Without --confirm, this is a dry run identical to `plan`.
+uv run python tools/spikes/vlan_direct_api.py apply tools/spikes/example-vlans.yaml --confirm
+```
+
+### Round-trip test (the load-bearing acceptance criterion)
+
+```bash
+# 1. Apply.
+uv run python tools/spikes/vlan_direct_api.py apply tools/spikes/example-vlans.yaml --confirm
+
+# 2. Re-plan. Must print "No changes."
+uv run python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.yaml
+
+# 3. Remove one VLAN from example-vlans.yaml; re-plan should show `1 to delete`.
+# 4. Apply with --confirm; box reconciles. Re-plan: "No changes."
+```
+
+If step 2 ever shows a non-empty diff right after a successful apply, the round-trip property is broken — capture the diff verbatim in the findings doc.
+
+### After running
+
+Fill in `docs/development/opnsense-spike-vlan-findings.md` with:
+
+- Detected version vs. matched spec version.
+- Whether each typed function (`vlansettings_search_item`, `_add_item`, `_set_item`, `_del_item`, `_reconfigure`) was generated and worked, or required the fallback.
+- Lines of code per concern (config model, diff engine, apply loop, error handling, CLI).
+- Round-trip outcome.
+- Subjective friction list — anything in `opnsense_openapi` that felt missing.
+
+ADR-0014 is written after the findings doc lands.
+
+### Cleanup
+
+The spike adds VLANs with tags 4001-4003 on the example. Delete them via the OPNsense UI or by removing them from `example-vlans.yaml` and re-running `apply --confirm` when you're done.

--- a/tools/spikes/__init__.py
+++ b/tools/spikes/__init__.py
@@ -1,0 +1,6 @@
+"""Engineering spikes — short-lived, throw-away code that produces evidence for ADRs.
+
+Spikes live here so they ship or get deleted on their own merits without entangling
+production code in ``src/infrafoundry/``. Each spike pairs with a findings document
+under ``docs/development/`` that an ADR cites.
+"""

--- a/tools/spikes/example-vlans.yaml
+++ b/tools/spikes/example-vlans.yaml
@@ -1,0 +1,37 @@
+# Example VLAN configurations for the OPNsense direct-API spike.
+#
+# Resource shape mirrors InfraFoundry's resource-centric YAML so the spike
+# operates on the same data model as the production provider, even though
+# this script does NOT go through ConfigManager / OPNsenseProvider.
+#
+# Diff identity is (device, tag) — that's what makes a VLAN unique on a box.
+# The 'name' field is operator-facing only; OPNsense never sees it.
+#
+# Target box: opnsense-a (staging), NOT prod. See tools/spikes/README.md.
+
+- provider: opnsense
+  type: vlan
+  name: spike-vlan-storage
+  config:
+    device: igb1
+    tag: 4001
+    description: "spike-test storage vlan"
+    priority: 0
+
+- provider: opnsense
+  type: vlan
+  name: spike-vlan-iot
+  config:
+    device: igb1
+    tag: 4002
+    description: "spike-test iot vlan"
+    priority: 3
+
+- provider: opnsense
+  type: vlan
+  name: spike-vlan-mgmt
+  config:
+    device: igb1
+    tag: 4003
+    description: "spike-test mgmt vlan"
+    priority: 7

--- a/tools/spikes/example-vlans.yaml
+++ b/tools/spikes/example-vlans.yaml
@@ -8,12 +8,28 @@
 # The 'name' field is operator-facing only; OPNsense never sees it.
 #
 # Target box: opnsense-a (staging), NOT prod. See tools/spikes/README.md.
+# Parent NIC `ixl1` matches opnsense-a's hardware (Intel X550, the LAN side).
+# Edit `device:` if your box uses different NIC names — run the `inspect`
+# subcommand or check the OPNsense UI for available interfaces.
+#
+# Optional top-level meta-property:
+#   lock: true   — IaC observes this resource but never adds/updates/deletes
+#                  it. Useful for partial migrations where the YAML doesn't
+#                  yet describe everything on the box (e.g. the WAN trunk).
+#                  Uncomment the block below and adjust device/tag to mirror
+#                  your live state if you want a worked example.
+#
+# - provider: opnsense
+#   type: vlan
+#   name: wan-trunk-observed
+#   lock: true
+#   config: {device: ixl0, tag: 4000, description: "", priority: 0}
 
 - provider: opnsense
   type: vlan
   name: spike-vlan-storage
   config:
-    device: igb1
+    device: ixl1
     tag: 4001
     description: "spike-test storage vlan"
     priority: 0
@@ -22,7 +38,7 @@
   type: vlan
   name: spike-vlan-iot
   config:
-    device: igb1
+    device: ixl1
     tag: 4002
     description: "spike-test iot vlan"
     priority: 3
@@ -31,7 +47,7 @@
   type: vlan
   name: spike-vlan-mgmt
   config:
-    device: igb1
+    device: ixl1
     tag: 4003
     description: "spike-test mgmt vlan"
     priority: 7

--- a/tools/spikes/vlan_direct_api.py
+++ b/tools/spikes/vlan_direct_api.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -46,18 +47,52 @@ from typing import Any
 import yaml
 from opnsense_openapi import OPNsenseClient
 
+
+def _warn_if_codegen_unavailable() -> None:
+    """Warn if ``openapi-python-client`` isn't on ``PATH``.
+
+    The typed ``.api`` surface in ``opnsense_openapi`` is auto-generated on
+    first use by shelling out to the ``openapi-python-client`` CLI. Without
+    it, ``client.api.<...>`` raises ``RuntimeError`` ("No OpenAPI spec found
+    for version ...") and the spike falls back to bare ``client.get/post``
+    for every operation. Capturing this as a clear warning at startup is
+    itself a finding for ADR-0014: a typed surface gated on an external CLI
+    binary is non-trivial to provision in production.
+    """
+    if shutil.which("openapi-python-client") is None:
+        sys.stderr.write(
+            "WARNING: openapi-python-client is not on PATH.\n"
+            "  The typed .api surface cannot be generated; the spike will\n"
+            "  fall back to bare client.get/post(...) for every operation.\n"
+            "  Install with: uv tool install openapi-python-client\n"
+            "  (See docs/development/opnsense-spike-vlan-findings.md)\n\n"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Constants — VLAN endpoint coordinates in the OPNsense REST API
 # ---------------------------------------------------------------------------
 
 VLAN_MODULE = "interfaces"
-VLAN_CONTROLLER = "vlansettings"
+# Live OPNsense 26.1.6_2 routes to ``/api/interfaces/vlan_settings/*`` (with
+# underscore). The bundled OpenAPI spec at opnsense-openapi 0.3.0 advertises
+# ``vlansettings`` (no underscore). The spec is wrong: the generator does
+# naive lowercasing of CamelCase, but OPNsense's URL routing converts
+# ``VlanSettingsController`` to snake_case. This is heterogeneous across
+# controllers — Kea uses ``dhcpv4``/``dhcpv6`` (no underscore) while
+# VlanSettings uses ``vlan_settings``. Fixing this in the upstream spec
+# generator is a hard problem (no universal rule); we use the verified-
+# correct live path here and capture the finding for ADR-0014.
+VLAN_CONTROLLER = "vlan_settings"
 
 # Typed-surface function names follow the generated client's snake_case naming
-# convention: ``api.interfaces.vlansettings_search_item``, etc. The spike
-# resolves these dynamically so we can fall back to ``client.get/post(...)``
-# if the typed surface doesn't expose a particular endpoint (e.g. when an
-# operationId is missing from the spec).
+# convention: ``api.interfaces.<controller>_<action>``. With the spec bug
+# above, the typed surface (when generated) would also point at the wrong
+# URL and 404. The spike's typed-surface probe in ``_typed_call`` absorbs
+# this — but that the typed path is non-functional against current 0.3.0
+# specs is itself a finding for ADR-0014. The names below match what the
+# generator currently emits; they will need to update to ``vlan_settings_*``
+# when the upstream spec is fixed.
 TYPED_FN_SEARCH = "vlansettings_search_item"
 TYPED_FN_ADD = "vlansettings_add_item"
 TYPED_FN_GET = "vlansettings_get_item"
@@ -95,6 +130,14 @@ class VlanConfig:
     The diff key ``(device, tag)`` is what makes a VLAN unique on an OPNsense
     box; the OPNsense-assigned ``uuid`` is opaque and the resource ``name``
     in the InfraFoundry YAML is operator-facing only.
+
+    ``lock`` is a meta-property — when ``True``, the spike treats the entry as
+    "observed but untouchable": the matching live resource is reported in the
+    plan but is never added, updated, or deleted. Useful for the partial-
+    migration case where the operator wants visibility of a resource (e.g.,
+    the WAN trunk) without IaC asserting authority over it. ADR-0014 will
+    decide whether the production contract should support locks at all, and
+    if so whether they should be granular (per-action) or boolean.
     """
 
     name: str
@@ -102,6 +145,7 @@ class VlanConfig:
     tag: int
     description: str
     priority: int
+    lock: bool = False
 
     @property
     def diff_key(self) -> tuple[str, int]:
@@ -147,6 +191,11 @@ class Diff:
     adds: list[VlanConfig] = field(default_factory=list)
     updates: list[tuple[LiveVlan, VlanConfig]] = field(default_factory=list)
     deletes: list[LiveVlan] = field(default_factory=list)
+    # Locked YAML entries paired with their live counterpart (or ``None`` if
+    # declared-but-missing). Always reported in the plan output, never acted
+    # on by ``apply``. Tracking these is itself the spike's safety
+    # affordance against silent footguns.
+    locked: list[tuple[VlanConfig, LiveVlan | None]] = field(default_factory=list)
 
     @property
     def is_empty(self) -> bool:
@@ -268,6 +317,11 @@ def load_vlans_from_yaml(path: Path) -> list[VlanConfig]:
         if not isinstance(description, str):
             raise ValueError(f"VLAN '{name}' description must be a string")
 
+        # ``lock`` is a top-level meta-property, not part of ``config``.
+        lock_raw = entry.get("lock", False)
+        if not isinstance(lock_raw, bool):
+            raise ValueError(f"VLAN '{name}' lock must be a boolean (true/false)")
+
         vlans.append(
             VlanConfig(
                 name=name,
@@ -275,6 +329,7 @@ def load_vlans_from_yaml(path: Path) -> list[VlanConfig]:
                 tag=tag,
                 description=description,
                 priority=priority,
+                lock=lock_raw,
             )
         )
 
@@ -307,10 +362,18 @@ def _typed_call(client: OPNsenseClient, function_name: str, **kwargs: Any) -> An
     """Invoke a typed-surface function, returning ``None`` if it isn't generated.
 
     The typed ``GeneratedAPI`` proxies ``__getattr__`` lazily, so attribute
-    access alone won't fail — the call only blows up when ``sync()``
-    eventually tries to ``importlib.import_module(...)`` the function. This
-    helper catches that ``AttributeError`` and signals the caller to fall
-    back to the raw ``client.get/post(...)`` path.
+    access alone won't fail — the call only blows up later. There are two
+    failure modes to absorb:
+
+    - ``AttributeError`` at ``sync()`` time when ``importlib.import_module(...)``
+      can't find the generated function module (typed surface partially
+      generated; rare).
+    - ``RuntimeError`` at ``client.api`` access time when no generated client
+      module exists for the detected version at all (e.g., the upstream
+      auto-generator couldn't run because ``openapi-python-client`` isn't on
+      ``PATH``, or the version has a security-patch suffix like ``26.1.6_2``
+      that doesn't match a generated module path). The spike falls back to
+      bare ``client.get/post(...)`` in either case.
 
     Returns:
         The function's return value, or ``None`` to indicate "not available".
@@ -319,15 +382,16 @@ def _typed_call(client: OPNsenseClient, function_name: str, **kwargs: Any) -> An
         module_proxy = client.api.interfaces  # type: ignore[no-any-return]
         function_proxy = getattr(module_proxy, function_name)
         return function_proxy.sync(**kwargs)
-    except AttributeError:
-        # Typed surface didn't expose this function — caller falls back.
+    except (AttributeError, RuntimeError):
+        # Typed surface didn't expose this function or no generated client
+        # for the running version — caller falls back to raw HTTP.
         return None
 
 
 def search_vlans(client: OPNsenseClient) -> list[LiveVlan]:
     """Fetch the live VLAN list, preferring the typed surface.
 
-    Falls back to ``client.post("interfaces", "vlansettings", "searchItem")``
+    Falls back to ``client.post("interfaces", "vlan_settings", "searchItem")``
     if the typed function isn't generated for the detected version.
     """
     response: Any = _typed_call(client, TYPED_FN_SEARCH)
@@ -405,36 +469,58 @@ def reconfigure(client: OPNsenseClient) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def compute_diff(desired: list[VlanConfig], current: list[LiveVlan]) -> Diff:
+def compute_diff(
+    desired: list[VlanConfig], current: list[LiveVlan], *, add_only: bool = False
+) -> Diff:
     """Compare desired YAML state to live state, keyed by ``(device, tag)``.
 
     Args:
         desired: VLANs the operator wants to exist.
         current: VLANs the OPNsense box currently has.
+        add_only: If ``True``, never emit deletes for live resources that
+            don't appear in ``desired``. Adds and updates still happen
+            normally. Useful for partial migrations where the YAML doesn't
+            yet describe everything on the box.
 
     Returns:
-        A ``Diff`` with adds/updates/deletes. ``updates`` carries the live
-        record alongside the desired record so the caller has the UUID.
+        A ``Diff`` with adds/updates/deletes plus a ``locked`` list of
+        observed-but-untouchable pairs. ``updates`` carries the live record
+        alongside the desired record so the caller has the UUID.
+
+    Locked entries (``VlanConfig.lock=True``) are skipped entirely — the
+    matching live record (if any) is recorded in ``Diff.locked`` and never
+    appears in ``adds``/``updates``/``deletes``. A locked-but-missing entry
+    (declared in YAML, no live counterpart) is still recorded so the plan
+    output can flag it.
     """
     desired_by_key: dict[tuple[str, int], VlanConfig] = {v.diff_key: v for v in desired}
     current_by_key: dict[tuple[str, int], LiveVlan] = {v.diff_key: v for v in current}
+    locked_keys: set[tuple[str, int]] = {v.diff_key for v in desired if v.lock}
 
     adds: list[VlanConfig] = []
     updates: list[tuple[LiveVlan, VlanConfig]] = []
     deletes: list[LiveVlan] = []
+    locked: list[tuple[VlanConfig, LiveVlan | None]] = []
 
     for key, want in desired_by_key.items():
         have = current_by_key.get(key)
+        if want.lock:
+            locked.append((want, have))
+            continue
         if have is None:
             adds.append(want)
         elif (have.description, have.priority) != (want.description, want.priority):
             updates.append((have, want))
 
-    for key, have in current_by_key.items():
-        if key not in desired_by_key:
-            deletes.append(have)
+    if not add_only:
+        for key, have in current_by_key.items():
+            if key in locked_keys:
+                # Already recorded above as locked; never emit a delete.
+                continue
+            if key not in desired_by_key:
+                deletes.append(have)
 
-    return Diff(adds=adds, updates=updates, deletes=deletes)
+    return Diff(adds=adds, updates=updates, deletes=deletes, locked=locked)
 
 
 # ---------------------------------------------------------------------------
@@ -448,11 +534,17 @@ def cmd_inspect(client: OPNsenseClient) -> int:
     print(f"Detected OPNsense version: {version}")
 
     endpoints: list[tuple[str, str, str]] = client.list_endpoints()
+    # Filter accepts both spellings: the bundled spec at opnsense-openapi 0.3.0
+    # uses "vlansettings" (no underscore) due to a generator bug; the live API
+    # uses "vlan_settings". Both substrings are matched so this works whether
+    # the spec is buggy or fixed upstream.
     vlan_endpoints: list[tuple[str, str, str]] = [
-        (path, method, summary) for path, method, summary in endpoints if "vlansettings" in path
+        (path, method, summary)
+        for path, method, summary in endpoints
+        if "vlansettings" in path or "vlan_settings" in path
     ]
     print(f"Total endpoints in matched spec: {len(endpoints)}")
-    print(f"VLAN endpoints (interfaces/vlansettings/*): {len(vlan_endpoints)}")
+    print(f"VLAN endpoints (interfaces/vlan_settings/*): {len(vlan_endpoints)}")
     for path, method, _ in vlan_endpoints:
         print(f"  {method:5s} {path}")
 
@@ -487,21 +579,23 @@ def cmd_list(client: OPNsenseClient) -> int:
     return 0
 
 
-def cmd_plan(client: OPNsenseClient, yaml_path: Path) -> int:
+def cmd_plan(client: OPNsenseClient, yaml_path: Path, *, add_only: bool = False) -> int:
     """Compute and print the diff between YAML and live state."""
     desired = load_vlans_from_yaml(yaml_path)
     current = search_vlans(client)
-    diff = compute_diff(desired, current)
-    _print_diff(diff)
+    diff = compute_diff(desired, current, add_only=add_only)
+    _print_diff(diff, add_only=add_only)
     return 0
 
 
-def cmd_apply(client: OPNsenseClient, yaml_path: Path, *, confirm: bool) -> int:
+def cmd_apply(
+    client: OPNsenseClient, yaml_path: Path, *, confirm: bool, add_only: bool = False
+) -> int:
     """Apply the diff. Without ``--confirm``, prints the plan and exits without mutating."""
     desired = load_vlans_from_yaml(yaml_path)
     current = search_vlans(client)
-    diff = compute_diff(desired, current)
-    _print_diff(diff)
+    diff = compute_diff(desired, current, add_only=add_only)
+    _print_diff(diff, add_only=add_only)
 
     if diff.is_empty:
         return 0
@@ -529,14 +623,15 @@ def cmd_apply(client: OPNsenseClient, yaml_path: Path, *, confirm: bool) -> int:
     return 0
 
 
-def _print_diff(diff: Diff) -> None:
+def _print_diff(diff: Diff, *, add_only: bool = False) -> None:
     """Render a Diff for the operator."""
-    if diff.is_empty:
+    if diff.is_empty and not diff.locked:
         print("No changes.")
         return
+    mode_suffix = " (add-only mode — deletes suppressed)" if add_only else ""
     print(
         f"Plan: {len(diff.adds)} to add, {len(diff.updates)} to update, "
-        f"{len(diff.deletes)} to delete."
+        f"{len(diff.deletes)} to delete, {len(diff.locked)} locked.{mode_suffix}"
     )
     for vlan in diff.adds:
         print(f"  + {vlan.device} tag={vlan.tag} desc={vlan.description!r} pcp={vlan.priority}")
@@ -549,6 +644,14 @@ def _print_diff(diff: Diff) -> None:
         )
     for live in diff.deletes:
         print(f"  - {live.device} tag={live.tag} desc={live.description!r} (uuid={live.uuid})")
+    for want, have in diff.locked:
+        if have is None:
+            print(f"  L {want.device} tag={want.tag} (locked, declared but not present on box)")
+        else:
+            print(
+                f"  L {have.device} tag={have.tag} (locked, uuid={have.uuid}) — "
+                "no action will be taken"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -571,6 +674,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     plan_parser = subparsers.add_parser("plan", help="Diff a YAML file against live state.")
     plan_parser.add_argument("yaml_path", type=Path, help="Path to VLAN YAML file.")
+    plan_parser.add_argument(
+        "--add-only",
+        action="store_true",
+        help=(
+            "Suppress deletes for live VLANs not in the YAML. Useful for partial "
+            "migrations where the YAML doesn't yet describe everything on the box."
+        ),
+    )
 
     apply_parser = subparsers.add_parser("apply", help="Apply a YAML file's diff to the box.")
     apply_parser.add_argument("yaml_path", type=Path, help="Path to VLAN YAML file.")
@@ -578,6 +689,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--confirm",
         action="store_true",
         help="Actually dispatch mutations. Without this flag, apply is a dry run.",
+    )
+    apply_parser.add_argument(
+        "--add-only",
+        action="store_true",
+        help=(
+            "Suppress deletes for live VLANs not in the YAML. Useful for partial "
+            "migrations where the YAML doesn't yet describe everything on the box."
+        ),
     )
 
     return parser
@@ -588,6 +707,8 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
+    _warn_if_codegen_unavailable()
+
     credentials = load_env_credentials()
     client = build_client(credentials)
 
@@ -597,9 +718,14 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "list":
             return cmd_list(client)
         if args.command == "plan":
-            return cmd_plan(client, args.yaml_path)
+            return cmd_plan(client, args.yaml_path, add_only=bool(args.add_only))
         if args.command == "apply":
-            return cmd_apply(client, args.yaml_path, confirm=bool(args.confirm))
+            return cmd_apply(
+                client,
+                args.yaml_path,
+                confirm=bool(args.confirm),
+                add_only=bool(args.add_only),
+            )
     finally:
         client.close()
 

--- a/tools/spikes/vlan_direct_api.py
+++ b/tools/spikes/vlan_direct_api.py
@@ -1,0 +1,610 @@
+"""Direct-API VLAN management spike for OPNsense — informs ADR-0014.
+
+Demonstrates end-to-end VLAN management against the OPNsense REST API using
+``opnsense_openapi``'s typed ``.api.<module>.<function>`` surface, with a
+``client.get/post(...)`` fallback for endpoints the typed surface fails to
+expose. Reads desired state from a YAML file, computes a diff against live
+state keyed by ``(device, tag)`` (the natural identity of a VLAN on a box),
+and applies changes only when ``--confirm`` is passed.
+
+This script intentionally lives outside ``src/infrafoundry/providers/opnsense/``
+so it can ship or be deleted on its own merits. It does NOT modify any
+production code path. The findings document at
+``docs/development/opnsense-spike-vlan-findings.md`` is filled in after
+running this spike against a staging box; ADR-0014 cites that document.
+
+Subcommands:
+    inspect   — connect, detect version, report endpoint count + typed-surface readiness
+    list      — dump the current VLANs on the box as YAML
+    plan      — diff a YAML file against current state, print add/update/delete counts
+    apply     — like ``plan``, but dispatches the typed mutations when ``--confirm`` is set
+
+Environment variables (matched against the existing OPNsense validator at
+``src/infrafoundry/providers/opnsense/validator.py:208-210``):
+    OPNSENSE_API_URL
+    OPNSENSE_API_KEY
+    OPNSENSE_API_SECRET
+    OPNSENSE_VERIFY_SSL    (optional; defaults to "true")
+
+Usage::
+
+    python tools/spikes/vlan_direct_api.py inspect
+    python tools/spikes/vlan_direct_api.py list
+    python tools/spikes/vlan_direct_api.py plan tools/spikes/example-vlans.yaml
+    python tools/spikes/vlan_direct_api.py apply tools/spikes/example-vlans.yaml --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from opnsense_openapi import OPNsenseClient
+
+# ---------------------------------------------------------------------------
+# Constants — VLAN endpoint coordinates in the OPNsense REST API
+# ---------------------------------------------------------------------------
+
+VLAN_MODULE = "interfaces"
+VLAN_CONTROLLER = "vlansettings"
+
+# Typed-surface function names follow the generated client's snake_case naming
+# convention: ``api.interfaces.vlansettings_search_item``, etc. The spike
+# resolves these dynamically so we can fall back to ``client.get/post(...)``
+# if the typed surface doesn't expose a particular endpoint (e.g. when an
+# operationId is missing from the spec).
+TYPED_FN_SEARCH = "vlansettings_search_item"
+TYPED_FN_ADD = "vlansettings_add_item"
+TYPED_FN_GET = "vlansettings_get_item"
+TYPED_FN_SET = "vlansettings_set_item"
+TYPED_FN_DEL = "vlansettings_del_item"
+TYPED_FN_RECONFIGURE = "vlansettings_reconfigure"
+
+# Required fields on every VLAN config. Matches the OPNsense schema:
+#   device       — parent NIC name (e.g. "igb0")
+#   tag          — 802.1Q VLAN tag (1-4094)
+#   description  — free-form label
+#   priority     — 802.1p priority code point (0-7)
+VLAN_FIELDS: tuple[str, ...] = ("device", "tag", "description", "priority")
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Credentials:
+    """Resolved OPNsense API credentials sourced from environment variables."""
+
+    api_url: str
+    api_key: str
+    api_secret: str
+    verify_ssl: bool
+
+
+@dataclass(frozen=True)
+class VlanConfig:
+    """Desired-state VLAN configuration loaded from YAML.
+
+    The diff key ``(device, tag)`` is what makes a VLAN unique on an OPNsense
+    box; the OPNsense-assigned ``uuid`` is opaque and the resource ``name``
+    in the InfraFoundry YAML is operator-facing only.
+    """
+
+    name: str
+    device: str
+    tag: int
+    description: str
+    priority: int
+
+    @property
+    def diff_key(self) -> tuple[str, int]:
+        """Identity of this VLAN on the box: parent NIC + 802.1Q tag."""
+        return (self.device, self.tag)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize to the dict shape OPNsense's addItem/setItem expect.
+
+        The payload is wrapped in a top-level ``vlan`` key; OPNsense follows
+        a consistent ``{<resource_key>: {<fields>}}`` envelope across modules
+        (cf. ``kea/dhcpv6/addSubnet`` which wraps under ``subnet6``).
+        """
+        return {
+            "vlan": {
+                "if": self.device,
+                "tag": str(self.tag),
+                "descr": self.description,
+                "pcp": str(self.priority),
+            }
+        }
+
+
+@dataclass(frozen=True)
+class LiveVlan:
+    """A VLAN as currently configured on the OPNsense box."""
+
+    uuid: str
+    device: str
+    tag: int
+    description: str
+    priority: int
+
+    @property
+    def diff_key(self) -> tuple[str, int]:
+        return (self.device, self.tag)
+
+
+@dataclass
+class Diff:
+    """Result of comparing desired YAML state to live OPNsense state."""
+
+    adds: list[VlanConfig] = field(default_factory=list)
+    updates: list[tuple[LiveVlan, VlanConfig]] = field(default_factory=list)
+    deletes: list[LiveVlan] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.adds or self.updates or self.deletes)
+
+
+# ---------------------------------------------------------------------------
+# Environment / configuration loading
+# ---------------------------------------------------------------------------
+
+
+def load_env_credentials(env: dict[str, str] | None = None) -> Credentials:
+    """Read OPNsense credentials from environment variables.
+
+    Args:
+        env: Environment mapping; defaults to ``os.environ``. Injectable for tests.
+
+    Returns:
+        A ``Credentials`` instance.
+
+    Raises:
+        RuntimeError: If any of ``OPNSENSE_API_URL``, ``OPNSENSE_API_KEY``,
+            or ``OPNSENSE_API_SECRET`` is missing or empty.
+    """
+    source: dict[str, str] = dict(os.environ if env is None else env)
+    required: tuple[str, ...] = (
+        "OPNSENSE_API_URL",
+        "OPNSENSE_API_KEY",
+        "OPNSENSE_API_SECRET",
+    )
+    missing: list[str] = [key for key in required if not source.get(key)]
+    if missing:
+        raise RuntimeError(
+            "Missing required OPNsense environment variable(s): "
+            f"{', '.join(missing)}. Source them from the secrets repo before "
+            "running this spike — see tools/spikes/README.md."
+        )
+
+    verify_raw: str = source.get("OPNSENSE_VERIFY_SSL", "true").strip().lower()
+    verify_ssl: bool = verify_raw not in ("0", "false", "no", "off")
+
+    return Credentials(
+        api_url=source["OPNSENSE_API_URL"],
+        api_key=source["OPNSENSE_API_KEY"],
+        api_secret=source["OPNSENSE_API_SECRET"],
+        verify_ssl=verify_ssl,
+    )
+
+
+def load_vlans_from_yaml(path: Path) -> list[VlanConfig]:
+    """Parse a YAML file of VLAN resource definitions.
+
+    Expects the InfraFoundry resource shape::
+
+        - provider: opnsense
+          type: vlan
+          name: vlan-storage
+          config:
+            device: igb1
+            tag: 100
+            description: Storage VLAN
+            priority: 0
+
+    Args:
+        path: Path to a YAML file.
+
+    Returns:
+        Validated list of ``VlanConfig`` instances.
+
+    Raises:
+        ValueError: If the YAML is malformed or any VLAN entry is missing a
+            required field or has an out-of-range value.
+    """
+    with path.open(encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"Expected top-level list of resources in {path}, got {type(raw).__name__}"
+        )
+
+    vlans: list[VlanConfig] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Resource at index {index} is not a mapping")
+        if entry.get("type") != "vlan":
+            # Allow non-vlan resources to coexist; they're just ignored here.
+            continue
+
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Resource at index {index} missing string 'name'")
+
+        config = entry.get("config")
+        if not isinstance(config, dict):
+            raise ValueError(f"VLAN '{name}' missing or invalid 'config' mapping")
+
+        missing_fields: list[str] = [f for f in VLAN_FIELDS if f not in config]
+        if missing_fields:
+            raise ValueError(
+                f"VLAN '{name}' missing required field(s): {', '.join(missing_fields)}"
+            )
+
+        try:
+            tag = int(config["tag"])
+            priority = int(config["priority"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"VLAN '{name}' has non-integer tag or priority") from exc
+
+        if not 1 <= tag <= 4094:
+            raise ValueError(f"VLAN '{name}' tag {tag} out of range 1-4094")
+        if not 0 <= priority <= 7:
+            raise ValueError(f"VLAN '{name}' priority {priority} out of range 0-7")
+
+        device = config["device"]
+        description = config["description"]
+        if not isinstance(device, str) or not device:
+            raise ValueError(f"VLAN '{name}' missing string 'device'")
+        if not isinstance(description, str):
+            raise ValueError(f"VLAN '{name}' description must be a string")
+
+        vlans.append(
+            VlanConfig(
+                name=name,
+                device=device,
+                tag=tag,
+                description=description,
+                priority=priority,
+            )
+        )
+
+    return vlans
+
+
+# ---------------------------------------------------------------------------
+# Client factory + typed-surface dispatch with fallback
+# ---------------------------------------------------------------------------
+
+
+def build_client(credentials: Credentials) -> OPNsenseClient:
+    """Construct an ``OPNsenseClient`` with ``auto_detect_version=True``.
+
+    This is where the spike intentionally diverges from the production wrapper at
+    ``src/infrafoundry/providers/opnsense/api_client.py:36`` (which sets
+    ``auto_detect_version=False``). Flipping the flag in production is out of
+    scope for this spike; ADR-0014 owns that decision.
+    """
+    return OPNsenseClient(
+        base_url=credentials.api_url,
+        api_key=credentials.api_key,
+        api_secret=credentials.api_secret,
+        verify_ssl=credentials.verify_ssl,
+        auto_detect_version=True,
+    )
+
+
+def _typed_call(client: OPNsenseClient, function_name: str, **kwargs: Any) -> Any:
+    """Invoke a typed-surface function, returning ``None`` if it isn't generated.
+
+    The typed ``GeneratedAPI`` proxies ``__getattr__`` lazily, so attribute
+    access alone won't fail — the call only blows up when ``sync()``
+    eventually tries to ``importlib.import_module(...)`` the function. This
+    helper catches that ``AttributeError`` and signals the caller to fall
+    back to the raw ``client.get/post(...)`` path.
+
+    Returns:
+        The function's return value, or ``None`` to indicate "not available".
+    """
+    try:
+        module_proxy = client.api.interfaces  # type: ignore[no-any-return]
+        function_proxy = getattr(module_proxy, function_name)
+        return function_proxy.sync(**kwargs)
+    except AttributeError:
+        # Typed surface didn't expose this function — caller falls back.
+        return None
+
+
+def search_vlans(client: OPNsenseClient) -> list[LiveVlan]:
+    """Fetch the live VLAN list, preferring the typed surface.
+
+    Falls back to ``client.post("interfaces", "vlansettings", "searchItem")``
+    if the typed function isn't generated for the detected version.
+    """
+    response: Any = _typed_call(client, TYPED_FN_SEARCH)
+    if response is None:
+        # OPNsense's searchItem is a POST despite being a "search" verb.
+        response = client.post(VLAN_MODULE, VLAN_CONTROLLER, "searchItem")
+
+    rows: list[dict[str, Any]] = []
+    if isinstance(response, dict):
+        raw_rows = response.get("rows")
+        if isinstance(raw_rows, list):
+            rows = [r for r in raw_rows if isinstance(r, dict)]
+
+    return [_row_to_live_vlan(row) for row in rows]
+
+
+def _row_to_live_vlan(row: dict[str, Any]) -> LiveVlan:
+    """Normalize a search-row dict into a ``LiveVlan``."""
+    uuid = str(row.get("uuid", ""))
+    device = str(row.get("if", ""))
+    try:
+        tag = int(row.get("tag", 0))
+    except (TypeError, ValueError):
+        tag = 0
+    try:
+        priority = int(row.get("pcp", 0))
+    except (TypeError, ValueError):
+        priority = 0
+    description = str(row.get("descr", ""))
+    return LiveVlan(
+        uuid=uuid,
+        device=device,
+        tag=tag,
+        description=description,
+        priority=priority,
+    )
+
+
+def add_vlan(client: OPNsenseClient, vlan: VlanConfig) -> dict[str, Any]:
+    """Create a VLAN via the typed surface, falling back to raw POST."""
+    payload = vlan.to_payload()
+    response: Any = _typed_call(client, TYPED_FN_ADD, json_body=payload)
+    if response is None:
+        response = client.post(VLAN_MODULE, VLAN_CONTROLLER, "addItem", json=payload)
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+def update_vlan(client: OPNsenseClient, uuid: str, vlan: VlanConfig) -> dict[str, Any]:
+    """Update an existing VLAN by UUID."""
+    payload = vlan.to_payload()
+    response: Any = _typed_call(client, TYPED_FN_SET, uuid=uuid, json_body=payload)
+    if response is None:
+        response = client.post(VLAN_MODULE, VLAN_CONTROLLER, "setItem", uuid, json=payload)
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+def delete_vlan(client: OPNsenseClient, uuid: str) -> dict[str, Any]:
+    """Delete a VLAN by UUID."""
+    response: Any = _typed_call(client, TYPED_FN_DEL, uuid=uuid)
+    if response is None:
+        response = client.post(VLAN_MODULE, VLAN_CONTROLLER, "delItem", uuid)
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+def reconfigure(client: OPNsenseClient) -> dict[str, Any]:
+    """Apply pending VLAN changes (commits the staged config to the running system)."""
+    response: Any = _typed_call(client, TYPED_FN_RECONFIGURE)
+    if response is None:
+        response = client.post(VLAN_MODULE, VLAN_CONTROLLER, "reconfigure")
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+# ---------------------------------------------------------------------------
+# Diff engine
+# ---------------------------------------------------------------------------
+
+
+def compute_diff(desired: list[VlanConfig], current: list[LiveVlan]) -> Diff:
+    """Compare desired YAML state to live state, keyed by ``(device, tag)``.
+
+    Args:
+        desired: VLANs the operator wants to exist.
+        current: VLANs the OPNsense box currently has.
+
+    Returns:
+        A ``Diff`` with adds/updates/deletes. ``updates`` carries the live
+        record alongside the desired record so the caller has the UUID.
+    """
+    desired_by_key: dict[tuple[str, int], VlanConfig] = {v.diff_key: v for v in desired}
+    current_by_key: dict[tuple[str, int], LiveVlan] = {v.diff_key: v for v in current}
+
+    adds: list[VlanConfig] = []
+    updates: list[tuple[LiveVlan, VlanConfig]] = []
+    deletes: list[LiveVlan] = []
+
+    for key, want in desired_by_key.items():
+        have = current_by_key.get(key)
+        if have is None:
+            adds.append(want)
+        elif (have.description, have.priority) != (want.description, want.priority):
+            updates.append((have, want))
+
+    for key, have in current_by_key.items():
+        if key not in desired_by_key:
+            deletes.append(have)
+
+    return Diff(adds=adds, updates=updates, deletes=deletes)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def cmd_inspect(client: OPNsenseClient) -> int:
+    """Connect, detect version, count endpoints, report typed-surface readiness."""
+    version: str = client.detect_version()
+    print(f"Detected OPNsense version: {version}")
+
+    endpoints: list[tuple[str, str, str]] = client.list_endpoints()
+    vlan_endpoints: list[tuple[str, str, str]] = [
+        (path, method, summary) for path, method, summary in endpoints if "vlansettings" in path
+    ]
+    print(f"Total endpoints in matched spec: {len(endpoints)}")
+    print(f"VLAN endpoints (interfaces/vlansettings/*): {len(vlan_endpoints)}")
+    for path, method, _ in vlan_endpoints:
+        print(f"  {method:5s} {path}")
+
+    # Typed-surface check — does the generated client expose searchItem?
+    probe = _typed_call(client, TYPED_FN_SEARCH)
+    typed_search_available = probe is not None
+    print(f"Typed-surface search available: {typed_search_available}")
+    return 0
+
+
+def cmd_list(client: OPNsenseClient) -> int:
+    """Print the current VLANs on the box as YAML."""
+    vlans = search_vlans(client)
+    if not vlans:
+        print("# (no VLANs found on box)")
+        return 0
+    payload = [
+        {
+            "provider": "opnsense",
+            "type": "vlan",
+            "name": f"live-{v.device}-{v.tag}",
+            "config": {
+                "device": v.device,
+                "tag": v.tag,
+                "description": v.description,
+                "priority": v.priority,
+            },
+        }
+        for v in vlans
+    ]
+    print(yaml.safe_dump(payload, sort_keys=False))
+    return 0
+
+
+def cmd_plan(client: OPNsenseClient, yaml_path: Path) -> int:
+    """Compute and print the diff between YAML and live state."""
+    desired = load_vlans_from_yaml(yaml_path)
+    current = search_vlans(client)
+    diff = compute_diff(desired, current)
+    _print_diff(diff)
+    return 0
+
+
+def cmd_apply(client: OPNsenseClient, yaml_path: Path, *, confirm: bool) -> int:
+    """Apply the diff. Without ``--confirm``, prints the plan and exits without mutating."""
+    desired = load_vlans_from_yaml(yaml_path)
+    current = search_vlans(client)
+    diff = compute_diff(desired, current)
+    _print_diff(diff)
+
+    if diff.is_empty:
+        return 0
+
+    if not confirm:
+        print("\nDry run — pass --confirm to apply these changes.")
+        return 0
+
+    print("\nApplying changes...")
+    for vlan in diff.adds:
+        result = add_vlan(client, vlan)
+        print(f"  + add  {vlan.device} tag={vlan.tag}  -> {result.get('result', result)}")
+
+    for live, want in diff.updates:
+        result = update_vlan(client, live.uuid, want)
+        print(f"  ~ set  {want.device} tag={want.tag}  -> {result.get('result', result)}")
+
+    for live in diff.deletes:
+        result = delete_vlan(client, live.uuid)
+        print(f"  - del  {live.device} tag={live.tag}  -> {result.get('result', result)}")
+
+    print("Reconfiguring service...")
+    reconfigure_result = reconfigure(client)
+    print(f"  reconfigure -> {reconfigure_result.get('status', reconfigure_result)}")
+    return 0
+
+
+def _print_diff(diff: Diff) -> None:
+    """Render a Diff for the operator."""
+    if diff.is_empty:
+        print("No changes.")
+        return
+    print(
+        f"Plan: {len(diff.adds)} to add, {len(diff.updates)} to update, "
+        f"{len(diff.deletes)} to delete."
+    )
+    for vlan in diff.adds:
+        print(f"  + {vlan.device} tag={vlan.tag} desc={vlan.description!r} pcp={vlan.priority}")
+    for live, want in diff.updates:
+        print(
+            f"  ~ {want.device} tag={want.tag} "
+            f"desc={live.description!r}->{want.description!r} "
+            f"pcp={live.priority}->{want.priority} "
+            f"(uuid={live.uuid})"
+        )
+    for live in diff.deletes:
+        print(f"  - {live.device} tag={live.tag} desc={live.description!r} (uuid={live.uuid})")
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argparse CLI."""
+    parser = argparse.ArgumentParser(
+        prog="vlan_direct_api",
+        description="Direct-API VLAN management spike for OPNsense (informs ADR-0014).",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser(
+        "inspect", help="Detect version, list VLAN endpoints, probe typed surface."
+    )
+    subparsers.add_parser("list", help="Print the current VLANs on the box as YAML.")
+
+    plan_parser = subparsers.add_parser("plan", help="Diff a YAML file against live state.")
+    plan_parser.add_argument("yaml_path", type=Path, help="Path to VLAN YAML file.")
+
+    apply_parser = subparsers.add_parser("apply", help="Apply a YAML file's diff to the box.")
+    apply_parser.add_argument("yaml_path", type=Path, help="Path to VLAN YAML file.")
+    apply_parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Actually dispatch mutations. Without this flag, apply is a dry run.",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns a process exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    credentials = load_env_credentials()
+    client = build_client(credentials)
+
+    try:
+        if args.command == "inspect":
+            return cmd_inspect(client)
+        if args.command == "list":
+            return cmd_list(client)
+        if args.command == "plan":
+            return cmd_plan(client, args.yaml_path)
+        if args.command == "apply":
+            return cmd_apply(client, args.yaml_path, confirm=bool(args.confirm))
+    finally:
+        client.close()
+
+    parser.error(f"Unknown command: {args.command}")  # NoReturn — argparse exits
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds an engineering spike under `tools/spikes/` that demonstrates end-to-end VLAN management against OPNsense via a direct REST API path, using `opnsense_openapi`'s typed `.api.<module>.<function>` surface with a `client.get/post(...)` fallback. The spike's purpose is to produce evidence — code we can read, run, and measure — that a future ADR-0014 will cite when choosing the OPNsense apply mechanism.

This is exploratory tooling. It does **not** modify any production code path under `src/infrafoundry/providers/opnsense/`, does **not** introduce a new runner or provider component, and does **not** ship an ADR. ADR-0014 lands as a follow-up PR after the operator runs the spike against the staging box (`opnsense-a`) and fills in the placeholder findings document.

## Related Issue

Addresses #705

This work is a deliberate prerequisite for **ADR-0014**, which is a follow-up PR after this spike's findings land. The chain is:

- **PR #704** — ADR-0013 (OPNsense full-IaC migration). On hold; its data-model section is explicitly deferred to ADR-0014. PR #704 already references this spike at the right place; we do **not** modify ADR-0013 in this PR.
- **This PR (#705)** — Spike code + placeholder findings doc.
- **Follow-up PR (ADR-0014)** — Authored after the operator runs the spike on `opnsense-a`, fills in `docs/development/opnsense-spike-vlan-findings.md`, and gathers the friction-point evidence the ADR needs.

## Type of Change

- [x] New feature (non-breaking change which adds functionality) — exploratory tooling under `tools/spikes/`, no production behavior change
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `tools/spikes/__init__.py` — package marker; documents the convention that spikes ship or get deleted on their own merits.
- `tools/spikes/vlan_direct_api.py` — the spike. Loads desired state from YAML, resolves credentials from `OPNSENSE_API_*` env vars (matching the existing OPNsense validator at `src/infrafoundry/providers/opnsense/validator.py:208-210`), constructs an `OPNsenseClient` with `auto_detect_version=True`, and exposes four subcommands:
  - `inspect` — connect, detect version, list VLAN endpoints, probe typed-surface readiness.
  - `list` — dump current VLANs as YAML.
  - `plan` — diff a YAML file against live state, keyed by `(device, tag)` (the natural identity of a VLAN on a box).
  - `apply [--confirm]` — dispatch typed mutations only when `--confirm` is set; otherwise dry-run.
- `tools/spikes/example-vlans.yaml` — three example VLANs on tags 4001-4003 to exercise the round-trip.
- `tools/spikes/README.md` — operator-facing run instructions (env vars, subcommands, round-trip recipe, cleanup).
- `tests/spikes/__init__.py` — test package marker.
- `tests/spikes/test_vlan_direct_api.py` — 39 unit tests covering env-var loading, YAML parsing/validation, the diff engine, the typed-surface fallback, the dry-run guard, and the `main()` finally-block client-close. No live box is contacted; `OPNsenseClient` is patched at the spike's import path.
- `docs/development/opnsense-spike-vlan-findings.md` — **placeholder shell**. The operator fills in the run log, round-trip outcome, lines-of-code breakdown, typed-surface coverage table, and friction points after running the spike against `opnsense-a`. ADR-0014 cites this completed document. The doc already captures pre-run friction points discovered while wiring the spike (typed-surface lazy resolution, `searchItem`-is-a-POST, first-use generation cost, spec-resolution edge cases) so they travel with the run results.

### Intentionally not in this PR

- No nav link from `docs/development/README.md` — that update lands with ADR-0014 once the findings doc is filled in.
- No CHANGELOG entry — `tools/spikes/` is exploratory tooling, not a behavior change for end users.
- No ADR. Issue #705 has no `needs-adr` label; ADR-0014 is the follow-up PR after the spike's findings land.
- No modification of ADR-0013. PR #704 owns it and already references the spike correctly.
- No production-code changes. `src/infrafoundry/providers/opnsense/` is untouched.

## Testing

- [x] All existing tests pass (`doit check` green: ruff format + lint, mypy strict, bandit, codespell, pytest)
- [x] Added new tests for new functionality — 39 unit tests in `tests/spikes/test_vlan_direct_api.py`, all passing in <2s
- [x] Manually tested the changes — `doit check` re-run after staging the new files; all green

The spike's *live-box* validation is operator-driven and recorded in `docs/development/opnsense-spike-vlan-findings.md`. The unit tests cover everything that doesn't need a real OPNsense to verify; the round-trip property (`plan` after `apply --confirm` returns "No changes.") is the load-bearing acceptance criterion that requires the staging box.

### LSP false positive note for reviewers

Some LSP integrations may flag the import on `tests/spikes/test_vlan_direct_api.py:26` (`from tools.spikes import vlan_direct_api as spike`). The CLI pyright run reports zero errors against this file — the LSP appears to have stale package resolution that clears on restart. The pattern matches the existing import in `tests/unit/test_blueprint_portability_lint.py` (`from tools.lint_blueprint_portability import ...`).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — operator-facing README + placeholder findings doc; nav link deferred to ADR-0014 PR by design
- [ ] I have updated the CHANGELOG.md — N/A; spike is exploratory tooling, not user-facing behavior
- [x] My changes generate no new warnings

## Additional Notes

### Friction points captured pre-run (interesting for ADR-0014)

The findings doc's `## Friction points` section already records observations from wiring the spike. ADR-0014 will weigh these against staying on Terraform:

- The typed `.api` surface is **lazy-imported, not lazy-typed**. `GeneratedAPI`'s `__getattr__` resolves every attribute access; missing functions only blow up at `.sync()` time as `AttributeError`. The spike catches this and falls back; ADR-0014 must decide if that's acceptable for production.
- `find_best_matching_spec` picks the **closest available** spec, which can be a higher patch than the running box. If the box is `25.7.5` and the package only ships `25.7.6`, the typed surface is generated against `25.7.6`'s schema. Worth a "closest-floor" mode upstream in `endavis/opnsense-openapi`.
- `searchItem` is a **POST** despite the verb. Easy to miss when skimming the spec.
- First-use generation cost: ~2 minutes the first time `client.api` is touched on a new version.

The `## Items to forward upstream to endavis/opnsense-openapi` subsection in the findings doc is reserved for upstream improvements discovered during the live run.

### Why this PR exists, and what it explicitly is not

This PR exists to land code we can run. It is **not** a recommendation about the OPNsense apply mechanism — that recommendation is ADR-0014's job. The PR is the foundation for the evidence ADR-0014 cites.
