### PR TITLE
docs: add ADR-0014 for OPNsense direct-API apply mechanism

### DIFF
--- a/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
+++ b/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
@@ -1,0 +1,94 @@
+# ADR-0014: OPNsense Direct-API Apply Mechanism
+
+**Date:** 2026-04-30
+**Status:** Accepted
+
+## Status
+
+Accepted
+
+## Decision
+
+OPNsense resources will be managed by a **direct-API apply mechanism** built on the [`opnsense_openapi`](https://github.com/endavis/opnsense-openapi) Python package, replacing the current Terraform + browningluke + Ansible pipeline as the per-component implementation issues from ADR-0013 land.
+
+The decision answers the nine open questions deferred from [ADR-0013](0013-opnsense-full-iac-migration.md). It is grounded in the live VLAN spike documented in [`opnsense-spike-vlan-findings.md`](../development/opnsense-spike-vlan-findings.md) (PR [#706](https://github.com/endavis/infrafoundry/pull/706), merged commit `584ac10`), which exercised add/update/delete + idempotency + `lock` + `--add-only` + dry-run end-to-end against `opnsense-a` running `26.1.6_2`.
+
+### 1. Apply mechanism for new components
+
+**Direct-API via `opnsense_openapi`.** The 736-line spike covered every operation the production path needs in a single readable Python module with one runtime dependency and zero external binaries. The Terraform + `browningluke/opnsense` + Ansible-reload pipeline is retained only until each existing component is migrated; net-new components ship under direct-API immediately.
+
+### 2. Schema source
+
+**Pydantic models from OPNsense's OpenAPI spec, accessed via `opnsense_openapi.list_endpoints()` and the matched spec file.** Where the spec disagrees with a live box (see [`#32`](https://github.com/endavis/opnsense-openapi/issues/32) — controller-name bug for multi-word controllers), components fall back to hand-typed dicts at the impacted call sites. `auto_detect_version=True` correctly resolved `26.1.6_2` against the bundled `26.1.6` spec during the spike, so version pinning is not required.
+
+### 3. Client surface
+
+**Default to the bare `client.post(...)` / `client.get(...)` fallback.** The typed `.api.<module>.<call>` surface is revisited only after upstream [`#32`](https://github.com/endavis/opnsense-openapi/issues/32) (blocker), [`#33`](https://github.com/endavis/opnsense-openapi/issues/33), and [`#34`](https://github.com/endavis/opnsense-openapi/issues/34) land. The typed surface is a `__getattr__` proxy at runtime — mypy and pyright cannot validate call sites against it — so the value-add over the fallback is Pydantic *payload* validation only, not call-site type-checking. The fallback path covered every spike operation cleanly (search, add, delete, reconfigure) without introducing the `openapi-python-client` external CLI dependency.
+
+### 4. Runner integration
+
+**Introduce `OPNsenseDirectRunner(BaseRunner)`.** The new runner implements the relevant [ADR-0010](0010-protocol-based-runner-interfaces.md) protocols — `Plannable`, `Applyable`, `Destroyable`, `StateAware` — by delegating to direct-API provider methods. The Provider → Component Manager → Service Layer arrangement stays unchanged and matches today's Kea DHCP pattern (`src/infrafoundry/providers/opnsense/components/kea_dhcp.py` + `services/kea_dhcp.py`). Net effect: `foundry infra plan` and `foundry infra apply` see direct-API resources alongside Terraform-managed ones with no second command needed and no bypass of the runner system.
+
+### 5. Default semantics
+
+**Fully-managed by default; `--add-only` is an opt-in CLI flag.** Env-root packages are the source of truth, and additive-by-default would let drift accumulate silently. The spike's first live `plan` against staging proposed deleting the WAN VLAN (`ixl0` tag 4000) precisely because it was absent from the test YAML — that is the contract working as designed. Cutover migrations, where a single env transitions from manual configuration to IaC piecemeal, opt into `--add-only` for the migration window.
+
+### 6. Lock contract
+
+**Top-level boolean `lock: true`** on the resource entry, matching the spike's shape. Granular locks (`lock: { delete: true, update: false }`) are deferred to a follow-up ADR if pain emerges. The boolean form was sufficient for every spike scenario (preserving the WAN trunk through repeated apply cycles) and keeps the YAML schema a single field rather than a polymorphic value.
+
+### 7. Plan-time validation
+
+**Yes — `plan` validates `device:` and other interface references against the live box.** The spike caught a bad NIC name (`igb1` against a box with only `ixl0`/`ixl1`) only at apply time; that class of error must surface during `plan`. The validation pattern already exists in `src/infrafoundry/providers/opnsense/validator.py` (`validate_references()`) and adds one extra API call per plan, well within acceptable cost.
+
+### 8. `config migrate` integration
+
+**Per-component method on the OPNsense provider, hardcoded to the CLI's choice list.** This matches today's Kea DHCP pattern. A pluggable extractor registry is acknowledged as a follow-up but is out of scope for ADR-0014; nothing in the migrate flow blocks on it.
+
+### 9. Migration of existing Terraform-based paths
+
+**Phased migration to direct-API as part of ADR-0013's implementation phase.** Net-new components from ADR-0013's list (`interface_assignments`, NAT rules, gateways, static routes, virtual IPs, Unbound extensions) ship under direct-API immediately. Existing Terraform-based paths migrate in priority order:
+
+1. **VLANs** — the spike code is the seed; first to land.
+2. `aliases`, `firewall_rules`, `unbound_host_override`.
+3. `kea_subnet` / `kea_reservation` / `dhcp_static_maps` (these already use the OPNsense REST API directly via `opnsense_openapi`; the work is normalizing them onto `OPNsenseDirectRunner`).
+
+The `templates/opnsense/playbook.yml.j2` Ansible service-reload playbook retires once the last Terraform-based component is gone.
+
+## Rationale
+
+The VLAN spike supplied the load-bearing evidence:
+
+- **Round-trip property holds.** `plan` after `apply --confirm` returned 0/0/0 for both add and delete cycles. See [Round-trip property](../development/opnsense-spike-vlan-findings.md#round-trip-property).
+- **Fallback client is sufficient.** `openapi-python-client` was not installed; the typed `.api` surface was never exercised; the fallback `client.post(...)` path covered every operation cleanly. See [Run log](../development/opnsense-spike-vlan-findings.md#run-log) and [Typed-surface coverage](../development/opnsense-spike-vlan-findings.md#typed-surface-coverage).
+- **Lock + add-only are necessary, not optional.** Pure fully-managed mode is dangerous mid-cutover (the staging WAN VLAN would have been deleted on the first run had the test YAML not been amended). Both safety affordances were exercised live. See [Friction points](../development/opnsense-spike-vlan-findings.md#friction-points).
+- **Cost trade-off is favorable.** ~600 lines of direct-API plumbing replaces three external tools (terraform binary, browningluke provider, Ansible) and the spec-vs-live drift overhead they introduce. See [Lines of code per concern](../development/opnsense-spike-vlan-findings.md#lines-of-code-per-concern).
+
+The runner integration via ADR-0010 protocols keeps the CLI surface consistent: operators run `foundry infra plan` and `apply` regardless of whether a given component is Terraform-backed or direct-API-backed during the migration window.
+
+### Prerequisites for the implementation phase
+
+- Upstream [`endavis/opnsense-openapi#32`](https://github.com/endavis/opnsense-openapi/issues/32) fixed before any consumer relies on the typed `.api` surface. The fallback path does not block on `#32` for individual call sites that hardcode the corrected controller name (as the spike's `vlan_settings` constant does).
+- [`#33`](https://github.com/endavis/opnsense-openapi/issues/33) and [`#34`](https://github.com/endavis/opnsense-openapi/issues/34) are nice-to-have, not blocking.
+
+### Known follow-ups (not in scope here)
+
+- Pluggable extractor registry for `config migrate` (see decision #8).
+- Granular lock semantics if boolean `lock: true` proves insufficient (see decision #6).
+- Lossy round-trip validation (descriptions with quotes/unicode/long strings) before any production lift; see the [Round-trip property](../development/opnsense-spike-vlan-findings.md#round-trip-property) caveat.
+- Retirement of `templates/opnsense/playbook.yml.j2` after the last Terraform-based component migrates (see decision #9).
+
+## Related Issues
+
+- Issue [#707](https://github.com/endavis/infrafoundry/issues/707): chore: write ADR-0014 codifying OPNsense direct-API apply mechanism (this ADR).
+- Issue [#705](https://github.com/endavis/infrafoundry/issues/705): feat: spike direct-API VLAN component to inform ADR-0014 (closed; PR [#706](https://github.com/endavis/infrafoundry/pull/706) merged).
+- Issue [#701](https://github.com/endavis/infrafoundry/issues/701): the ADR-0013 work that deferred this decision (PR [#704](https://github.com/endavis/infrafoundry/pull/704)).
+- Upstream [`endavis/opnsense-openapi#32`](https://github.com/endavis/opnsense-openapi/issues/32): bug — spec generator emits wrong controller names for multi-word controllers (blocker for typed surface).
+- Upstream [`endavis/opnsense-openapi#33`](https://github.com/endavis/opnsense-openapi/issues/33): bug — misleading "No OpenAPI spec found" error when `openapi-python-client` is missing.
+- Upstream [`endavis/opnsense-openapi#34`](https://github.com/endavis/opnsense-openapi/issues/34): refactor — stabilize generated-client module path across patch revisions; add closest-floor spec matching.
+
+## Related Documentation
+
+- [`docs/development/opnsense-spike-vlan-findings.md`](../development/opnsense-spike-vlan-findings.md) — load-bearing evidence cited throughout this ADR.
+- [ADR-0010: Protocol-Based Runner Interfaces](0010-protocol-based-runner-interfaces.md) — the contract `OPNsenseDirectRunner` implements.
+- [ADR-0013: OPNsense Full-IaC Migration](0013-opnsense-full-iac-migration.md) — the deferral this ADR closes (lands when PR [#704](https://github.com/endavis/infrafoundry/pull/704) merges).


### PR DESCRIPTION
## Description

Adds [ADR-0014: OPNsense Direct-API Apply Mechanism](../blob/chore/707-adr-0014-direct-api-apply-mechanism/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md) (status **Accepted**, dated 2026-04-30). The ADR closes the apply-mechanism deferral from ADR-0013 and takes nine explicit positions on the questions enumerated in #707. The load-bearing evidence is the live VLAN spike (PR #706, merged commit `584ac10`) and its findings doc, [`docs/development/opnsense-spike-vlan-findings.md`](../blob/chore/707-adr-0014-direct-api-apply-mechanism/docs/development/opnsense-spike-vlan-findings.md).

This PR is documentation-only: a single new file under `docs/decisions/`. No code, tests, or navigation are touched.

### Decisions encoded in the ADR

1. **Apply mechanism for new components** — direct-API via `opnsense_openapi`; Terraform + browningluke + Ansible-reload retained only until existing components migrate.
2. **Schema source** — Pydantic models from OPNsense's OpenAPI spec via `opnsense_openapi.list_endpoints()`; hand-typed dict fallback at sites impacted by `endavis/opnsense-openapi#32`.
3. **Client surface** — default to the bare `client.post(...)` / `client.get(...)` fallback; the typed `.api.<module>` surface is revisited only after upstream `#32`/`#33`/`#34` land.
4. **Runner integration** — introduce `OPNsenseDirectRunner(BaseRunner)` implementing the ADR-0010 `Plannable`/`Applyable`/`Destroyable`/`StateAware` protocols.
5. **Default semantics** — fully-managed by default; `--add-only` is an opt-in CLI flag for cutover migrations.
6. **Lock contract** — top-level boolean `lock: true`; granular locks deferred to a follow-up ADR if needed.
7. **Plan-time validation** — `plan` validates `device:` and other interface references against the live box.
8. **`config migrate` integration** — per-component method on the OPNsense provider, hardcoded to the CLI choice list (matches today's Kea DHCP pattern).
9. **Migration of existing Terraform-based paths** — phased migration as part of ADR-0013 implementation; VLANs first, then aliases/firewall rules/Unbound, then Kea-related resources; Ansible playbook retires when the last Terraform-based component is gone.

## Related Issue

Addresses #707

This PR also references:
- PR #704 — ADR-0013 (on hold). The ADR-0013 file lives on PR #704's branch and has not been merged to `main`.
- PR #706 — VLAN direct-API spike (merged, commit `584ac10`); supplies the load-bearing evidence cited throughout ADR-0014.
- Upstream `endavis/opnsense-openapi#32`/`#33`/`#34` — referenced as prerequisites and known issues, not blockers for this ADR.

### Known transient: dangling link to ADR-0013

ADR-0014 cross-links to ADR-0013 in the opening paragraph and the "Related Documentation" section. Because ADR-0013 has not yet merged to `main`, that relative link will 404 on this branch and on `main` until PR #704 lands. **This is expected.** ADR-0014's own decision #9 and the PR #706 findings doc both flag the chain. Reviewers should not file this under "broken link" — it resolves automatically when PR #704 merges.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `docs/decisions/0014-opnsense-direct-api-apply-mechanism.md` (new file, 94 lines) — Accepted ADR codifying the nine decisions above, citing PR #706, the spike findings doc, ADR-0010, ADR-0013, and the three upstream `opnsense-openapi` issues.

That's the entire scope. The plan explicitly excludes:
- Modifications to ADR-0013 (lives on PR #704's branch).
- Modifications to the spike findings doc.
- Any navigation updates or `CHANGELOG.md` entries.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` was run from a clean state and all checks pass:

```
✓ All checks passed!
```

This includes `format_check`, `lint`, `lint_blueprints`, `type_check`, `security` (bandit), `spell_check` (codespell), and `test` (pytest).

Documentation-only change, so no new tests are required by the project's "tests with code" rule. The ADR file itself satisfies the issue's `needs-adr` label.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — docs-only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR is the documentation update)
- [ ] I have updated the CHANGELOG.md (intentionally skipped per plan; ADR additions are not changelog-eligible)
- [x] My changes generate no new warnings

## Additional Notes

- The 9 positions encoded in ADR-0014 were enumerated and approved during the planning step on issue #707; this PR codifies them verbatim into an Accepted ADR.
- The `needs-adr` label on #707 is satisfied by this PR's single new ADR file. No other ADRs are touched.
- After merge, please manually close #707 (per project policy: GitHub auto-close is disabled).
