### PR TITLE
feat: add OPNsense interface_assignments (read-only) + dispatch table

### DIFF
--- a/docs/decisions/0013-opnsense-full-iac-migration.md
+++ b/docs/decisions/0013-opnsense-full-iac-migration.md
@@ -55,11 +55,15 @@ ADR-0014 takes positions on schema source, client surface, runner integration (a
 
 The XML `config.xml` format is not part of any apply or migrate path. It is used only for one-shot scoping (as in [docs/development/opnsense-resource-coverage.md](../development/opnsense-resource-coverage.md)) and remains a per-component fallback only if no stable API endpoint exists for a resource type. That decision would be made per-component and recorded in its issue.
 
+**Per-component decisions recorded so far:**
+
+- `interface_assignments` (#711, 2026-05-02): no REST CRUD endpoint on OPNsense `26.1.6_2` (`/api/interfaces/overview/*` is read-only; the GUI uses legacy PHP form posts that ultimately edit `<interfaces>` in `config.xml`). Component ships read-only — `list` / `migrate` / validation work; `apply` / `destroy` are loud no-ops. The cutover runbook documents the manual GUI step. The XML-edit write path is a future concern.
+
 ## Implementation order
 
 Each step ships under the direct-API pattern codified in [ADR-0014](0014-opnsense-direct-api-apply-mechanism.md). The VLAN spike (PR [#706](https://github.com/endavis/infrafoundry/pull/706), merged) seeds the VLAN component migration.
 
-1. `interface_assignments` — gates everything that depends on physical NIC mapping.
+1. `interface_assignments` — gates everything that depends on physical NIC mapping. *Read-only / migrate shipped in #711; write path deferred per the per-component decision recorded above.*
 2. `nat_rules`.
 3. `gateways` and `static_routes`.
 4. `virtual_ips`.
@@ -75,6 +79,7 @@ Each step above is a separate feature issue. Issue numbers will be added to this
 - Issue [#705](https://github.com/endavis/infrafoundry/issues/705): VLAN direct-API spike that informed ADR-0014 (closed; PR [#706](https://github.com/endavis/infrafoundry/pull/706) merged).
 - Issue [#707](https://github.com/endavis/infrafoundry/issues/707): ADR-0014 (closed; PR [#708](https://github.com/endavis/infrafoundry/pull/708) merged).
 - Issue [#709](https://github.com/endavis/infrafoundry/issues/709): VLAN component direct-API migration (`OPNsenseDirectRunner` seed).
+- Issue [#711](https://github.com/endavis/infrafoundry/issues/711): `interface_assignments` component (read-only / migrate; dispatch-table refactor).
 
 ## Related Documentation
 

--- a/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
+++ b/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
@@ -71,6 +71,8 @@ Granular locks (`lock: { delete: true, update: false }`) are deferred to a follo
 
 The `templates/opnsense/playbook.yml.j2` Ansible service-reload playbook retires once the last Terraform-based component is gone.
 
+> **Note (interface_assignments, #711):** OPNsense `26.1.6_2` exposes only a read-only API for interface assignments (`/api/interfaces/overview/*`); there is no REST CRUD surface and the GUI uses legacy PHP form posts that ultimately edit `<interfaces>` in `config.xml`. The component ships read-only — `list` / `migrate` / validation work; `apply` and `destroy` are loud no-ops. Operators perform interface assignment manually via the OPNsense GUI as a one-time step during cutover. The XML-edit write path is a future concern. See ADR-0013 §"Per-component decisions recorded so far".
+
 ## Rationale
 
 The VLAN spike supplied the load-bearing evidence:
@@ -97,6 +99,7 @@ The runner integration via ADR-0010 protocols keeps the CLI surface consistent: 
 ## Related Issues
 
 - Issue [#709](https://github.com/endavis/infrafoundry/issues/709): feat: add `OPNsenseDirectRunner` and migrate VLAN component to direct-API (first implementation).
+- Issue [#711](https://github.com/endavis/infrafoundry/issues/711): feat: add OPNsense `interface_assignments` component (read-only / migrate; dispatch-table refactor).
 - Issue [#707](https://github.com/endavis/infrafoundry/issues/707): chore: write ADR-0014 codifying OPNsense direct-API apply mechanism (this ADR).
 - Issue [#705](https://github.com/endavis/infrafoundry/issues/705): feat: spike direct-API VLAN component to inform ADR-0014 (closed; PR [#706](https://github.com/endavis/infrafoundry/pull/706) merged).
 - Issue [#701](https://github.com/endavis/infrafoundry/issues/701): the ADR-0013 work that deferred this decision (PR [#704](https://github.com/endavis/infrafoundry/pull/704)).

--- a/docs/development/opnsense-resource-coverage.md
+++ b/docs/development/opnsense-resource-coverage.md
@@ -19,7 +19,7 @@ Source of truth for "supported": `OPNsenseProvider.get_resource_types()` in `src
 | `<OPNsense>/Kea` (DHCPv6 reservations) | `kea_dhcp6_reservation` | Supported |
 | `<OPNsense>/unboundplus/hosts/host` | `unbound_host_override` | Supported |
 | `<dhcpd>` (legacy ISC) | `dhcp_static_maps` | Supported (legacy; new deployments should use Kea) |
-| `<interfaces>` | — | **Gap** (needs new component) |
+| `<interfaces>` | `interface_assignments` | Read-only / migrate (direct-API; #711). No write API exists on OPNsense `26.1.6_2`; logical-to-physical interface mapping is a one-time manual GUI step during cutover. |
 | `<nat>/rule` and `<nat>/outbound/rule` | — | **Gap** |
 | `<OPNsense>/Gateways` | — | **Gap** |
 | `<staticroutes>/route` | — | **Gap** |
@@ -45,12 +45,13 @@ This template assumes you are cutting over a current box (`OLD`) to a new box (`
 
 1. **Extract**: run `foundry config migrate --env <env> --provider opnsense --component <type>` for every supported resource type on `OLD` to dump live state into YAML under `envs/<env>/opnsense/`.
 2. **Edit interface map**: in the YAML, remap physical NIC names (`igc0` → `ixl0`, etc.) and any VLAN parent interface references. This is the only manual edit if the new box has different NICs.
-3. **Out-of-IaC import**: on `NEW`, System → Configuration → Backups → Restore, choose "Restore area" and import only the sections from "out of IaC scope" above. **Do not** restore VLANs, interfaces, filter, NAT, or DHCP — those come from IaC.
-4. **Switch endpoint**: update `provider_settings.opnsense.api_url` in `envs/<env>/settings.yaml` to point at `NEW`.
-5. **Plan**: `foundry infra plan --env <env>` and review the diff. Expect a clean apply against the (mostly empty) `NEW` box.
-6. **Apply**: `foundry infra apply --env <env>`.
-7. **Verify**: confirm interfaces, VLAN trunks, and firewall connectivity. Roll DNS / Tailscale / WAN cutover as appropriate to your environment.
-8. **Decommission `OLD`**: power off after a soak period.
+3. **Out-of-IaC import**: on `NEW`, System → Configuration → Backups → Restore, choose "Restore area" and import only the sections from "out of IaC scope" above. **Do not** restore VLANs, filter, NAT, or DHCP — those come from IaC.
+4. **Manual GUI step — interface assignments** (one-time per cutover): on `NEW`, navigate to **Interfaces → Assignments** and bind each logical interface (LAN, WAN, OPT1, etc.) to the correct physical NIC or VLAN per the `interface_assignments` YAML in `envs/<env>/opnsense/`. OPNsense `26.1.6_2` has no REST write API for assignments (#711); the YAML is the source of truth and `foundry` reads-and-validates it but cannot apply it. Save and apply within the GUI before continuing.
+5. **Switch endpoint**: update `provider_settings.opnsense.api_url` in `envs/<env>/settings.yaml` to point at `NEW`.
+6. **Plan**: `foundry infra plan --env <env>` and review the diff. The `interface_assignments` line will show "read-only / 0 changes" — that's expected; the manual step above is the source of writes. Expect a clean apply against the (mostly empty) `NEW` box for everything else.
+7. **Apply**: `foundry infra apply --env <env>`.
+8. **Verify**: confirm interfaces, VLAN trunks, and firewall connectivity. Roll DNS / Tailscale / WAN cutover as appropriate to your environment.
+9. **Decommission `OLD`**: power off after a soak period.
 
 ### Same-spec follow-on migration
 
@@ -71,7 +72,7 @@ After the cleanup, terraform plan should show zero VLAN-related changes; the dir
 
 Each gap row in the matrix above corresponds to a planned feature issue. The implementation order in [ADR-0013](../decisions/0013-opnsense-full-iac-migration.md) is:
 
-1. `interface_assignments` (the NIC remap point — blocks every VLAN/firewall placement)
+1. `interface_assignments` (read-only / migrate shipped in #711; write path deferred pending an XML-edit or upstream-API mechanism)
 2. `nat_rules`
 3. `gateways`, `static_routes`
 4. `virtual_ips`

--- a/src/infrafoundry/core/runners/opnsense_direct_runner.py
+++ b/src/infrafoundry/core/runners/opnsense_direct_runner.py
@@ -6,6 +6,12 @@ ADR-0010 runner protocols (``Plannable``, ``Applyable``, ``Destroyable``,
 ``StateAware``) by delegating to component managers under
 ``infrafoundry.providers.opnsense.components``.
 
+Components participate by declaring themselves in
+``OPNsenseProvider.get_direct_api_resource_types()`` — the runner iterates
+that dispatch table at plan/apply/destroy/get_resource_ids time. Adding a
+new direct-API component is a one-entry change in the provider; no runner
+edits are required.
+
 The runner deliberately runs at ``priority = -10`` so that direct-API resources
 (e.g., VLANs) are applied before any terraform-managed dependents
 (``firewall_rules``, ``dhcp_static_maps``) within the same provider. See
@@ -35,9 +41,12 @@ logger = logging.getLogger(__name__)
 class OPNsenseDirectRunner(BaseRunner):
     """Runner that drives OPNsense components via the direct-API path.
 
-    The runner is hardcoded for the components currently migrated to
-    direct-API (VLANs as of #709). When additional components migrate, extend
-    ``_dispatch_*`` methods to instantiate the relevant component manager.
+    The runner is dispatch-table driven: ``provider.get_direct_api_resource_types()``
+    returns ``{type_name: ComponentManager}`` and each public method
+    (``plan``/``apply``/``destroy``/``get_resource_ids``) iterates that
+    table, filters resources by type, and delegates to the manager. New
+    components opt in by adding a single entry to the provider's dispatch
+    table; no runner code changes required.
 
     The provider must expose ``generate_opnsense_direct(resources)`` (a no-op
     is fine — see ``OPNsenseProvider.generate_opnsense_direct``) so the
@@ -147,11 +156,37 @@ class OPNsenseDirectRunner(BaseRunner):
         return str(env_name)
 
     @staticmethod
+    def _filter_by_type(
+        resources: list[ResourceConfig],
+        type_name: str,
+        target_resources: list[str] | None,
+    ) -> list[ResourceConfig]:
+        """Pick out resources of a given type, optionally filtering by name.
+
+        Args:
+            resources: All provider resources for the current environment.
+            type_name: ``ResourceConfig.type`` to keep (e.g., ``"vlans"``).
+            target_resources: Optional name filter (CLI ``--resource``).
+
+        Returns:
+            Matching ResourceConfig entries the runner should act on.
+        """
+        filtered = [r for r in resources if r.type == type_name]
+        if target_resources:
+            target_set = set(target_resources)
+            filtered = [r for r in filtered if r.name in target_set]
+        return filtered
+
+    @staticmethod
     def _filter_vlans(
         resources: list[ResourceConfig],
         target_resources: list[str] | None,
     ) -> list[ResourceConfig]:
         """Pick out the VLAN resources, optionally filtering by name.
+
+        Thin compatibility wrapper around ``_filter_by_type`` retained
+        because existing callers and tests reach for the VLAN-specific
+        helper directly.
 
         Args:
             resources: All provider resources for the current environment.
@@ -160,11 +195,24 @@ class OPNsenseDirectRunner(BaseRunner):
         Returns:
             VLAN ResourceConfig entries the runner should act on.
         """
-        vlans = [r for r in resources if r.type == "vlans"]
-        if target_resources:
-            target_set = set(target_resources)
-            vlans = [v for v in vlans if v.name in target_set]
-        return vlans
+        return OPNsenseDirectRunner._filter_by_type(resources, "vlans", target_resources)
+
+    @staticmethod
+    def _resolve_dispatch_table(provider: ProviderBase) -> dict[str, type[Any]]:
+        """Return the provider's direct-API dispatch table or an empty dict.
+
+        Centralizes the ``getattr`` + callable check so each method body
+        stays readable. If the provider doesn't expose
+        ``get_direct_api_resource_types``, the runner treats it as having
+        no direct-API components — a safe default.
+        """
+        getter = getattr(provider, "get_direct_api_resource_types", None)
+        if not callable(getter):
+            return {}
+        table = getter()
+        if not isinstance(table, dict):
+            return {}
+        return table
 
     @staticmethod
     def _load_provider_resources(provider: ProviderBase) -> list[ResourceConfig]:
@@ -205,6 +253,12 @@ class OPNsenseDirectRunner(BaseRunner):
     def plan(self, provider: ProviderBase, **kwargs: Any) -> PlanResult:
         """Compute a diff between desired YAML state and live OPNsense state.
 
+        Iterates ``provider.get_direct_api_resource_types()`` and dispatches
+        each registered component manager's ``plan``. Aggregates per-type
+        results into a single ``PlanResult``: ``has_changes`` is True if any
+        component reports changes; ``changes_summary`` concatenates each
+        component's summary line.
+
         Args:
             provider: OPNsense provider instance (env must be set).
             **kwargs: Runner options:
@@ -216,44 +270,84 @@ class OPNsenseDirectRunner(BaseRunner):
         """
         if not self._supports_direct_api(provider):
             return PlanResult(success=True, has_changes=False, changes_summary="No changes")
+
+        dispatch_table = self._resolve_dispatch_table(provider)
+        if not dispatch_table:
+            return PlanResult(success=True, has_changes=False, changes_summary="No changes")
+
         env_name = self._resolve_env_name(provider)
         target_resources = kwargs.get("target_resources")
         add_only = bool(kwargs.get("add_only", False))
 
         resources = self._load_provider_resources(provider)
-        vlans = self._filter_vlans(resources, target_resources)
 
-        if not vlans:
+        any_changes = False
+        summary_parts: list[str] = []
+
+        for type_name, manager_cls in dispatch_table.items():
+            typed_resources = self._filter_by_type(resources, type_name, target_resources)
+            if not typed_resources:
+                continue
+
+            manager = manager_cls(provider.config_dir)
+            try:
+                diff = manager.plan(env_name, typed_resources, add_only=add_only)
+            except Exception as exc:
+                logger.exception("opnsense_direct %s plan failed", type_name)
+                return PlanResult(success=False, error=str(exc))
+
+            type_summary = self._format_plan_summary(type_name, diff, add_only=add_only)
+            summary_parts.append(type_summary)
+            self.console.print(f"  [dim]opnsense_direct: {type_summary}[/dim]")
+
+            if not diff.is_empty:
+                any_changes = True
+
+        if not summary_parts:
             self.console.print("  [dim]opnsense_direct: no direct-API resources to plan[/dim]")
             return PlanResult(success=True, has_changes=False, changes_summary="No changes")
 
-        from infrafoundry.providers.opnsense.components.vlan import VlanManager
+        return PlanResult(
+            success=True,
+            has_changes=any_changes,
+            changes_summary=" | ".join(summary_parts),
+        )
 
-        manager = VlanManager(provider.config_dir)
-        try:
-            diff = manager.plan(env_name, vlans, add_only=add_only)
-        except Exception as exc:
-            logger.exception("opnsense_direct VLAN plan failed")
-            return PlanResult(success=False, error=str(exc))
+    @staticmethod
+    def _format_plan_summary(type_name: str, diff: Any, *, add_only: bool) -> str:
+        """Render a one-line plan summary for a single component's diff.
 
+        Args:
+            type_name: Resource type name (e.g., ``"vlans"``).
+            diff: A ``Diff``-like object exposing ``adds``/``updates``/
+                ``deletes``/``locked`` lists. Read-only components may
+                supply additional attributes (e.g., ``read_only``,
+                ``message``) which are surfaced verbatim when present.
+            add_only: Whether the runner is in add-only mode.
+
+        Returns:
+            Human-readable summary line; downstream code joins these with
+            " | " for the aggregate ``PlanResult``.
+        """
+        if getattr(diff, "read_only", False):
+            note = getattr(diff, "message", "read-only")
+            return f"{type_name}: {note}"
         summary = (
-            f"Plan: {len(diff.adds)} to add, {len(diff.updates)} to update, "
+            f"{type_name}: {len(diff.adds)} to add, {len(diff.updates)} to update, "
             f"{len(diff.deletes)} to delete, {len(diff.locked)} locked."
         )
         if add_only:
             summary += " (add-only mode)"
-        self.console.print(f"  [dim]opnsense_direct: {summary}[/dim]")
-
-        return PlanResult(
-            success=True,
-            has_changes=not diff.is_empty,
-            changes_summary=summary,
-        )
+        return summary
 
     def apply(
         self, provider: ProviderBase, auto_approve: bool = True, **kwargs: Any
     ) -> ApplyResult:
         """Apply direct-API changes for managed components.
+
+        Iterates ``provider.get_direct_api_resource_types()`` and dispatches
+        each registered component manager's ``apply``. Aggregates counts
+        and ``resource_outcomes`` across types into a single ``ApplyResult``.
 
         Args:
             provider: OPNsense provider instance (env must be set).
@@ -267,65 +361,107 @@ class OPNsenseDirectRunner(BaseRunner):
             for downstream lifecycle event firing.
         """
         if not self._supports_direct_api(provider):
-            empty_other: ApplyResult = {
-                "success": True,
-                "resources_created": 0,
-                "resources_updated": 0,
-                "resources_deleted": 0,
-            }
-            empty_other["resource_outcomes"] = []  # type: ignore[typeddict-unknown-key]
-            return empty_other
+            return self._empty_apply_result()
+
+        dispatch_table = self._resolve_dispatch_table(provider)
+        if not dispatch_table:
+            return self._empty_apply_result()
+
         env_name = self._resolve_env_name(provider)
         target_resources = kwargs.get("target_resources")
         add_only = bool(kwargs.get("add_only", False))
 
         resources = self._load_provider_resources(provider)
-        vlans = self._filter_vlans(resources, target_resources)
 
-        if not vlans:
+        total_created = 0
+        total_updated = 0
+        total_deleted = 0
+        all_outcomes: list[ResourceOutcome] = []
+        any_dispatched = False
+
+        for type_name, manager_cls in dispatch_table.items():
+            typed_resources = self._filter_by_type(resources, type_name, target_resources)
+            if not typed_resources:
+                continue
+            any_dispatched = True
+
+            manager = manager_cls(provider.config_dir)
+            try:
+                result = manager.apply(
+                    env_name, typed_resources, auto_approve=auto_approve, add_only=add_only
+                )
+            except Exception as exc:
+                logger.exception("opnsense_direct %s apply failed", type_name)
+                return ApplyResult(success=False, error=str(exc))
+
+            created = int(result.get("resources_created", 0))
+            updated = int(result.get("resources_updated", 0))
+            deleted = int(result.get("resources_deleted", 0))
+            total_created += created
+            total_updated += updated
+            total_deleted += deleted
+            all_outcomes.extend(result.get("resource_outcomes", []))
+
+            self._log_apply_progress(type_name, result, created, updated, deleted)
+
+        if not any_dispatched:
             self.console.print("  [dim]opnsense_direct: no direct-API resources to apply[/dim]")
-            empty: ApplyResult = {
-                "success": True,
-                "resources_created": 0,
-                "resources_updated": 0,
-                "resources_deleted": 0,
-            }
-            empty["resource_outcomes"] = []  # type: ignore[typeddict-unknown-key]
-            return empty
-
-        from infrafoundry.providers.opnsense.components.vlan import VlanManager
-
-        manager = VlanManager(provider.config_dir)
-        try:
-            result = manager.apply(env_name, vlans, auto_approve=auto_approve, add_only=add_only)
-        except Exception as exc:
-            logger.exception("opnsense_direct VLAN apply failed")
-            return ApplyResult(success=False, error=str(exc))
-
-        outcomes: list[ResourceOutcome] = result.get("resource_outcomes", [])
-        self.console.print(
-            f"  [dim]opnsense_direct: applied "
-            f"{result.get('resources_created', 0)} adds, "
-            f"{result.get('resources_updated', 0)} updates, "
-            f"{result.get('resources_deleted', 0)} deletes[/dim]"
-        )
+            return self._empty_apply_result()
 
         applied: ApplyResult = {
             "success": True,
-            "resources_created": result.get("resources_created", 0),
-            "resources_updated": result.get("resources_updated", 0),
-            "resources_deleted": result.get("resources_deleted", 0),
+            "resources_created": total_created,
+            "resources_updated": total_updated,
+            "resources_deleted": total_deleted,
         }
-        applied["resource_outcomes"] = outcomes  # type: ignore[typeddict-unknown-key]
+        applied["resource_outcomes"] = all_outcomes  # type: ignore[typeddict-unknown-key]
         applied["resource_outcomes_summary"] = [  # type: ignore[typeddict-unknown-key]
-            o.to_dict() for o in outcomes
+            o.to_dict() for o in all_outcomes
         ]
         return applied
+
+    @staticmethod
+    def _empty_apply_result() -> ApplyResult:
+        """Build an ``ApplyResult`` with zero counts and an empty outcomes list."""
+        empty: ApplyResult = {
+            "success": True,
+            "resources_created": 0,
+            "resources_updated": 0,
+            "resources_deleted": 0,
+        }
+        empty["resource_outcomes"] = []  # type: ignore[typeddict-unknown-key]
+        return empty
+
+    def _log_apply_progress(
+        self,
+        type_name: str,
+        result: dict[str, Any],
+        created: int,
+        updated: int,
+        deleted: int,
+    ) -> None:
+        """Log per-type apply progress, surfacing read-only informational messages.
+
+        Read-only components (e.g., ``interface_assignments``) include a
+        ``message`` key in their result so the no-op is loud, not silent.
+        """
+        message = result.get("message")
+        if message:
+            self.console.print(f"  [dim]opnsense_direct: {type_name}: {message}[/dim]")
+            return
+        self.console.print(
+            f"  [dim]opnsense_direct: {type_name}: applied "
+            f"{created} adds, {updated} updates, {deleted} deletes[/dim]"
+        )
 
     def destroy(
         self, provider: ProviderBase, auto_approve: bool = True, **kwargs: Any
     ) -> DestroyResult:
         """Delete direct-API resources for managed components.
+
+        Iterates ``provider.get_direct_api_resource_types()`` and dispatches
+        each registered component manager's ``destroy``. Aggregates counts
+        across types.
 
         Args:
             provider: OPNsense provider instance (env must be set).
@@ -338,39 +474,56 @@ class OPNsenseDirectRunner(BaseRunner):
         """
         if not self._supports_direct_api(provider):
             return DestroyResult(success=True, resources_destroyed=0)
+
+        dispatch_table = self._resolve_dispatch_table(provider)
+        if not dispatch_table:
+            return DestroyResult(success=True, resources_destroyed=0)
+
         env_name = self._resolve_env_name(provider)
         target_resources = kwargs.get("target_resources")
 
         resources = self._load_provider_resources(provider)
-        vlans = self._filter_vlans(resources, target_resources)
 
-        if not vlans:
+        total_destroyed = 0
+        any_dispatched = False
+
+        for type_name, manager_cls in dispatch_table.items():
+            typed_resources = self._filter_by_type(resources, type_name, target_resources)
+            if not typed_resources:
+                continue
+            any_dispatched = True
+
+            manager = manager_cls(provider.config_dir)
+            try:
+                result = manager.destroy(env_name, typed_resources, auto_approve=auto_approve)
+            except Exception as exc:
+                logger.exception("opnsense_direct %s destroy failed", type_name)
+                return DestroyResult(success=False, error=str(exc))
+
+            destroyed = int(result.get("resources_destroyed", 0))
+            total_destroyed += destroyed
+
+            message = result.get("message")
+            if message:
+                self.console.print(f"  [dim]opnsense_direct: {type_name}: {message}[/dim]")
+            else:
+                self.console.print(
+                    f"  [dim]opnsense_direct: {type_name}: destroyed {destroyed} resources[/dim]"
+                )
+
+        if not any_dispatched:
             self.console.print("  [dim]opnsense_direct: no direct-API resources to destroy[/dim]")
             return DestroyResult(success=True, resources_destroyed=0)
 
-        from infrafoundry.providers.opnsense.components.vlan import VlanManager
-
-        manager = VlanManager(provider.config_dir)
-        try:
-            result = manager.destroy(env_name, vlans, auto_approve=auto_approve)
-        except Exception as exc:
-            logger.exception("opnsense_direct VLAN destroy failed")
-            return DestroyResult(success=False, error=str(exc))
-
-        self.console.print(
-            f"  [dim]opnsense_direct: destroyed "
-            f"{result.get('resources_destroyed', 0)} resources[/dim]"
-        )
-        return DestroyResult(
-            success=True,
-            resources_destroyed=int(result.get("resources_destroyed", 0)),
-        )
+        return DestroyResult(success=True, resources_destroyed=total_destroyed)
 
     def get_resource_ids(self, provider: ProviderBase) -> dict[str, str]:
         """Return ``{resource_name: opnsense_uuid}`` for live direct-API resources.
 
-        Used by ``DeploymentExecutor`` (``deployment_executor.py:531-540``)
-        to persist UUIDs after a successful apply via ``StateManager``.
+        Iterates ``provider.get_direct_api_resource_types()`` and merges
+        each component's ``get_resource_ids`` mapping. Used by
+        ``DeploymentExecutor`` (``deployment_executor.py:531-540``) to
+        persist UUIDs after a successful apply via ``StateManager``.
 
         Args:
             provider: OPNsense provider instance (env must be set).
@@ -382,17 +535,27 @@ class OPNsenseDirectRunner(BaseRunner):
         """
         if not self._supports_direct_api(provider):
             return {}
+
+        dispatch_table = self._resolve_dispatch_table(provider)
+        if not dispatch_table:
+            return {}
+
         env_name = self._resolve_env_name(provider)
         resources = self._load_provider_resources(provider)
-        vlans = self._filter_vlans(resources, target_resources=None)
-        if not vlans:
-            return {}
 
-        from infrafoundry.providers.opnsense.components.vlan import VlanManager
+        merged: dict[str, str] = {}
+        for type_name, manager_cls in dispatch_table.items():
+            typed_resources = self._filter_by_type(resources, type_name, target_resources=None)
+            if not typed_resources:
+                continue
 
-        manager = VlanManager(provider.config_dir)
-        try:
-            return manager.get_resource_ids(env_name, vlans)
-        except Exception as exc:
-            logger.warning("opnsense_direct get_resource_ids failed: %s", exc)
-            return {}
+            manager = manager_cls(provider.config_dir)
+            try:
+                ids = manager.get_resource_ids(env_name, typed_resources)
+            except Exception as exc:
+                logger.warning("opnsense_direct %s get_resource_ids failed: %s", type_name, exc)
+                continue
+            if isinstance(ids, dict):
+                merged.update(ids)
+
+        return merged

--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -145,6 +145,30 @@ class OPNsenseProvider(
         del resources  # consumed by the runner directly via ConfigManager
         logger.debug("generate_opnsense_direct invoked; runner will read resources at apply time")
 
+    def get_direct_api_resource_types(self) -> dict[str, type[Any]]:
+        """Map InfraFoundry resource type names to their direct-API component manager.
+
+        The ``OPNsenseDirectRunner`` iterates this dict to dispatch
+        plan/apply/destroy/get_resource_ids across every component that
+        opted into the direct-API path (ADR-0014). Adding a new entry
+        here is the only provider-side change required to wire a new
+        component into the runner.
+
+        Returns:
+            ``{resource_type_name: component_manager_class}`` mapping. The
+            value type is annotated as ``type[Any]`` to avoid a hard import
+            of ``BaseComponentManager`` at module-load time; the runner
+            knows the duck-typed surface (``plan``, ``apply``, ``destroy``,
+            ``get_resource_ids``) each manager must expose.
+        """
+        from .components.interface_assignment import InterfaceAssignmentManager
+        from .components.vlan import VlanManager
+
+        return {
+            "vlans": VlanManager,
+            "interface_assignments": InterfaceAssignmentManager,
+        }
+
     def _generate_aliases_terraform(self, aliases: list[ResourceConfig]) -> None:
         """Generate Terraform for OPNsense aliases."""
         self.render_and_write_terraform(
@@ -593,6 +617,7 @@ class OPNsenseProvider(
         return [
             "firewall_rules",
             "vlans",
+            "interface_assignments",
             "aliases",
             "dhcp_static_maps",
             "kea_subnet",
@@ -624,6 +649,7 @@ class OPNsenseProvider(
         return {
             "firewall_rules": ["aliases", "vlans"],
             "vlans": [],
+            "interface_assignments": ["vlans"],
             "aliases": [],
             "dhcp_static_maps": ["vlans"],
             "kea_subnet": ["vlans"],
@@ -714,6 +740,28 @@ class OPNsenseProvider(
         from .components.vlan import VlanManager
 
         manager = VlanManager(self.config_dir)
+        return manager.migrate(env_name)
+
+    def migrate_interface_assignment(self, env_name: str) -> str:
+        """Migrate current interface assignments to InfraFoundry YAML.
+
+        Reads the live interface assignment table from OPNsense via the
+        direct-API path and generates InfraFoundry-compatible YAML.
+        Mirrors ``migrate_vlan``. Apply/destroy for ``interface_assignments``
+        is a no-op on OPNsense `26.1.6_2` (no REST write endpoint), so
+        the YAML this method emits is intended for cutover dumps and
+        documentation. Not yet exposed via ``config migrate`` CLI — that
+        wiring is a follow-up.
+
+        Args:
+            env_name: Environment name
+
+        Returns:
+            YAML configuration as a string
+        """
+        from .components.interface_assignment import InterfaceAssignmentManager
+
+        manager = InterfaceAssignmentManager(self.config_dir)
         return manager.migrate(env_name)
 
     def migrate_isc_to_kea(self, env_name: str, interfaces: list[str] | None = None) -> str:

--- a/src/infrafoundry/providers/opnsense/components/__init__.py
+++ b/src/infrafoundry/providers/opnsense/components/__init__.py
@@ -1,6 +1,7 @@
 """OPNsense component manager implementations."""
 
 from .base import BaseComponentManager
+from .interface_assignment import InterfaceAssignmentManager
 from .isc_to_kea_migration import ISCToKeaMigrationManager
 from .kea_dhcp import KeaDHCPManager
 from .vlan import VlanManager
@@ -8,6 +9,7 @@ from .vlan import VlanManager
 __all__ = [
     "BaseComponentManager",
     "ISCToKeaMigrationManager",
+    "InterfaceAssignmentManager",
     "KeaDHCPManager",
     "VlanManager",
 ]

--- a/src/infrafoundry/providers/opnsense/components/interface_assignment.py
+++ b/src/infrafoundry/providers/opnsense/components/interface_assignment.py
@@ -1,0 +1,273 @@
+"""Interface-assignment component manager for OPNsense (ADR-0014, #711).
+
+OPNsense `26.1.6_2` exposes interface assignments as **read-only** via
+``GET /api/interfaces/overview/interfacesInfo``; no REST write endpoint
+exists today (the GUI's "Interfaces → Assignments" page edits
+``config.xml`` via legacy PHP form posts). This manager mirrors the
+``VlanManager`` shape so the dispatch-table-driven runner can iterate
+both uniformly, but ``apply``/``destroy`` are loud no-op stubs that
+return zero counts and an explicit informational message.
+
+Operators wire interface assignments via the OPNsense GUI as a one-time
+manual cutover step; ``infra plan`` surfaces the read-only state, and
+``foundry config migrate --component interface_assignment`` (provider
+method only — CLI wiring is a follow-up) extracts the live state into
+YAML.
+
+The runner forwards ``message`` from the apply result through to its
+human-readable output; the runner's plan-summary helper recognizes
+``Diff`` objects with ``read_only=True`` and surfaces ``message`` there
+too.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from infrafoundry.core.provider import ResourceConfig
+
+from ..services.interface_assignment import (
+    InterfaceAssignmentService,
+    LiveInterfaceAssignment,
+    interface_assignment_configs_from_resources,
+)
+from .base import BaseComponentManager
+
+logger = logging.getLogger(__name__)
+
+_READ_ONLY_MESSAGE = (
+    "interface_assignments are read-only on this OPNsense version; "
+    "manual GUI configuration required (Interfaces → Assignments)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Read-only Diff shim
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReadOnlyDiff:
+    """Diff-shaped payload for a read-only component.
+
+    Mirrors the structural surface of ``services.vlan.Diff`` (so the
+    runner's plan-summary helper can iterate ``adds``/``updates``/
+    ``deletes``/``locked`` without special-casing). The ``read_only``
+    flag is the marker the runner checks; ``message`` is surfaced
+    verbatim in the plan output.
+
+    Attributes:
+        adds: Always empty for read-only components.
+        updates: Always empty.
+        deletes: Always empty.
+        locked: Always empty.
+        read_only: Marker set to True so the runner formats this diff
+            with the informational message rather than the count line.
+        message: Human-readable note shown alongside the type name.
+    """
+
+    adds: list[Any] = field(default_factory=list)
+    updates: list[Any] = field(default_factory=list)
+    deletes: list[Any] = field(default_factory=list)
+    locked: list[Any] = field(default_factory=list)
+    read_only: bool = True
+    message: str = _READ_ONLY_MESSAGE
+
+    @property
+    def is_empty(self) -> bool:
+        """Read-only diffs never represent pending work."""
+        return True
+
+
+class InterfaceAssignmentManager(BaseComponentManager):
+    """Manager for OPNsense interface-assignment operations (read-only).
+
+    Public interface mirrors ``VlanManager`` so the runner's dispatch
+    table can call any registered manager uniformly. Write methods
+    (``apply``/``destroy``) return zero counts and an informational
+    ``message`` field; read methods (``plan``/``get_resource_ids``/
+    ``list``) hit the live API.
+    """
+
+    # ------------------------------------------------------------------
+    # Plan / apply / destroy
+    # ------------------------------------------------------------------
+
+    def plan(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        add_only: bool = False,
+        provider_name: str = "opnsense",
+    ) -> ReadOnlyDiff:
+        """Return a read-only diff with an informational message.
+
+        We don't validate ``resources`` against live state because writes
+        are no-op anyway — surfacing the read-only constraint is more
+        useful to the operator than reporting a delta they cannot apply.
+        The validator is the source of truth for cross-resource reference
+        checks; this method is purely informational at plan time.
+
+        Args:
+            env_name: Active environment name (unused — read-only).
+            resources: Interface-assignment ``ResourceConfig`` entries
+                (unused for now; reserved for future write path).
+            add_only: Reserved; ignored for read-only.
+            provider_name: Provider identifier.
+
+        Returns:
+            ``ReadOnlyDiff`` with empty add/update/delete lists and the
+            read-only informational message.
+        """
+        del env_name, resources, add_only, provider_name  # read-only no-op
+        return ReadOnlyDiff()
+
+    def apply(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        auto_approve: bool = True,
+        add_only: bool = False,
+        provider_name: str = "opnsense",
+    ) -> dict[str, Any]:
+        """Loud no-op apply.
+
+        Logs an informational line and returns success with zero counts
+        plus a ``message`` field the runner surfaces verbatim. Accepts
+        every kwarg ``VlanManager.apply`` does so dispatch is uniform.
+
+        Args:
+            env_name: Active environment name (unused).
+            resources: Interface-assignment ``ResourceConfig`` entries.
+                Counted into the message; not otherwise touched.
+            auto_approve: Unused.
+            add_only: Unused.
+            provider_name: Provider identifier (unused).
+
+        Returns:
+            Dict with ``success=True``, zero counts, an empty
+            ``resource_outcomes`` list, and a ``message`` field the
+            runner surfaces.
+        """
+        del env_name, auto_approve, add_only, provider_name  # read-only no-op
+        count = len(resources)
+        message = (
+            f"{_READ_ONLY_MESSAGE}; {count} assignment{'s' if count != 1 else ''} described in YAML"
+        )
+        logger.info(message)
+        return {
+            "success": True,
+            "resources_created": 0,
+            "resources_updated": 0,
+            "resources_deleted": 0,
+            "resource_outcomes": [],
+            "message": message,
+        }
+
+    def destroy(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        auto_approve: bool = True,
+        provider_name: str = "opnsense",
+    ) -> dict[str, Any]:
+        """Loud no-op destroy.
+
+        Args:
+            env_name: Active environment name (unused).
+            resources: Interface-assignment ``ResourceConfig`` entries
+                (counted into the message only).
+            auto_approve: Unused.
+            provider_name: Provider identifier (unused).
+
+        Returns:
+            Dict with ``success=True``, ``resources_destroyed=0``, and
+            a ``message`` field the runner surfaces.
+        """
+        del env_name, auto_approve, provider_name  # read-only no-op
+        count = len(resources)
+        message = (
+            f"{_READ_ONLY_MESSAGE}; {count} assignment"
+            f"{'s' if count != 1 else ''} listed in YAML; nothing destroyed"
+        )
+        logger.info(message)
+        return {
+            "success": True,
+            "resources_destroyed": 0,
+            "message": message,
+        }
+
+    # ------------------------------------------------------------------
+    # State / migration helpers
+    # ------------------------------------------------------------------
+
+    def get_resource_ids(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        provider_name: str = "opnsense",
+    ) -> dict[str, str]:
+        """Return ``{resource_name: identifier}`` for live entries matching ``resources``.
+
+        For read-only resources the live ``identifier`` doubles as the
+        resource ID (it's both the operator-facing name and the
+        OPNsense-side primary key — there's no UUID layer for interface
+        assignments). State DB updates via this map.
+
+        Resources without a matching live record are simply omitted —
+        the state DB will skip updating those rows and they'll surface
+        as plan-time validation errors via the validator.
+
+        Args:
+            env_name: Active environment name.
+            resources: Interface-assignment ``ResourceConfig`` entries.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            Mapping of resource name to live identifier.
+        """
+        configs = interface_assignment_configs_from_resources(resources)
+        if not configs:
+            return {}
+        service = InterfaceAssignmentService.from_environment(
+            env_name, provider_name, self.config_dir
+        )
+        live_by_id = {entry.identifier: entry for entry in service.list()}
+        return {
+            cfg.name: live_by_id[cfg.name].identifier for cfg in configs if cfg.name in live_by_id
+        }
+
+    def list(
+        self, env_name: str, *, provider_name: str = "opnsense"
+    ) -> list[LiveInterfaceAssignment]:
+        """Return the live interface assignments on the OPNsense box.
+
+        Args:
+            env_name: Active environment name.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+        """
+        service = InterfaceAssignmentService.from_environment(
+            env_name, provider_name, self.config_dir
+        )
+        return service.list()
+
+    def migrate(self, env_name: str, *, provider_name: str = "opnsense") -> str:
+        """Export the current interface assignments to InfraFoundry YAML.
+
+        Args:
+            env_name: Active environment name.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            YAML string containing the live assignments in resource-centric form.
+        """
+        service = InterfaceAssignmentService.from_environment(
+            env_name, provider_name, self.config_dir
+        )
+        return service.export_to_yaml()

--- a/src/infrafoundry/providers/opnsense/services/__init__.py
+++ b/src/infrafoundry/providers/opnsense/services/__init__.py
@@ -1,6 +1,12 @@
 """Service layer package for OPNsense operations."""
 
 from .base import BaseService
+from .interface_assignment import (
+    InterfaceAssignmentConfig,
+    InterfaceAssignmentService,
+    LiveInterfaceAssignment,
+    interface_assignment_configs_from_resources,
+)
 from .isc_dhcp import ISCDHCPService
 from .kea_dhcp import KeaDHCPService
 from .vlan import Diff, LiveVlan, VlanConfig, VlanService, compute_diff
@@ -9,9 +15,13 @@ __all__ = [
     "BaseService",
     "Diff",
     "ISCDHCPService",
+    "InterfaceAssignmentConfig",
+    "InterfaceAssignmentService",
     "KeaDHCPService",
+    "LiveInterfaceAssignment",
     "LiveVlan",
     "VlanConfig",
     "VlanService",
     "compute_diff",
+    "interface_assignment_configs_from_resources",
 ]

--- a/src/infrafoundry/providers/opnsense/services/interface_assignment.py
+++ b/src/infrafoundry/providers/opnsense/services/interface_assignment.py
@@ -1,0 +1,281 @@
+"""Interface-assignment service for OPNsense direct-API operations (ADR-0014).
+
+This service provides **read-only** access to OPNsense interface assignments
+on the OPNsense `26.1.6_2` REST surface. The OPNsense GUI's
+"Interfaces → Assignments" page edits ``config.xml`` via legacy PHP form posts
+(``interfaces_assign.php``); no REST write endpoint exists today. The
+``InterfaceAssignmentManager`` consumes this service for ``list``/``migrate``
+flows and exposes loud no-op stubs for ``apply``/``destroy``.
+
+Live data source: ``client.request("GET", "interfaces/overview/interfacesInfo")``
+returns ``{"rows": [...]}`` where each row carries ``identifier`` (logical
+interface name like ``lan``/``wan``/``opt1``), ``device`` (physical NIC or
+VLAN child), ``description``, ``ipv4``/``ipv6`` (raw dicts), ``is_physical``,
+and others. Rows with empty ``identifier`` are physical NICs that are
+not assigned to any logical interface — the service skips them.
+
+The data model intentionally keeps ``ipv4``/``ipv6`` as raw ``dict[str, Any]``
+pass-throughs. The OPNsense API exposes a heterogeneous mix of static, DHCP,
+PPPoE, and tracking modes; deep parsing is deferred until the write path
+arrives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+from infrafoundry.core.provider import ResourceConfig
+
+from .base import BaseService
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LiveInterfaceAssignment:
+    """An interface assignment as currently configured on the OPNsense box.
+
+    Attributes:
+        identifier: Logical interface name (e.g., ``"lan"``, ``"wan"``,
+            ``"opt1"``). Used as the resource ``name`` in YAML.
+        device: Physical NIC or VLAN child device (e.g., ``"ixl0"``,
+            ``"ixl0_vlan4000"``).
+        description: Free-form description from the GUI.
+        is_physical: ``True`` if ``device`` is a real NIC (not a VLAN child).
+        ipv4: Raw ipv4 config from the API (mode, address, gateway, etc.).
+        ipv6: Raw ipv6 config from the API.
+        macaddr: Effective MAC address.
+        mtu: Configured MTU (0 if unset).
+    """
+
+    identifier: str
+    device: str
+    description: str
+    is_physical: bool
+    ipv4: dict[str, Any]
+    ipv6: dict[str, Any]
+    macaddr: str
+    mtu: int
+
+
+@dataclass(frozen=True)
+class InterfaceAssignmentConfig:
+    """Desired-state interface-assignment configuration.
+
+    Forward-compat schema (ADR-0013, #711): ``ipv4``/``ipv6``/``enabled``/
+    ``lock`` are accepted at parse time even though writes are no-op
+    today. When the write path lands, the runtime begins honoring them
+    without breaking existing YAML.
+
+    Attributes:
+        name: Operator-facing identifier; equals ``identifier`` on the box.
+        device: Physical NIC or VLAN child device.
+        description: Free-form description.
+        enabled: Forward-compat; defaults True. Ignored at runtime.
+        lock: Forward-compat; defaults False. Ignored at runtime.
+        ipv4: Forward-compat raw dict; ignored at runtime.
+        ipv6: Forward-compat raw dict; ignored at runtime.
+    """
+
+    name: str
+    device: str
+    description: str
+    enabled: bool = True
+    lock: bool = False
+    ipv4: dict[str, Any] = field(default_factory=dict)
+    ipv6: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Resource-to-domain conversion
+# ---------------------------------------------------------------------------
+
+
+def interface_assignment_configs_from_resources(
+    resources: list[ResourceConfig],
+) -> list[InterfaceAssignmentConfig]:
+    """Convert ``ResourceConfig`` entries to ``InterfaceAssignmentConfig`` instances.
+
+    Non-matching resource types are silently skipped. Validation here is
+    intentionally light — the validator handles cross-resource references;
+    the service only enforces type sanity so manager code can rely on
+    ``device`` being a ``str``, etc.
+
+    Args:
+        resources: All provider resources from ConfigManager.
+
+    Returns:
+        Validated ``InterfaceAssignmentConfig`` list.
+
+    Raises:
+        ValueError: If an entry has a non-dict config, missing ``device``,
+            or non-bool ``enabled``/``lock``.
+    """
+    configs: list[InterfaceAssignmentConfig] = []
+    for resource in resources:
+        if resource.type != "interface_assignments":
+            continue
+
+        config = resource.config
+        if not isinstance(config, dict):
+            raise ValueError(f"interface_assignment '{resource.name}' has non-dict config")
+
+        device = config.get("device")
+        if not isinstance(device, str) or not device:
+            raise ValueError(f"interface_assignment '{resource.name}' missing string 'device'")
+
+        description = config.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"interface_assignment '{resource.name}' description must be a string")
+
+        enabled_raw = config.get("enabled", True)
+        if not isinstance(enabled_raw, bool):
+            raise ValueError(f"interface_assignment '{resource.name}' enabled must be a boolean")
+
+        lock_raw = config.get("lock", False)
+        if not isinstance(lock_raw, bool):
+            raise ValueError(f"interface_assignment '{resource.name}' lock must be a boolean")
+
+        ipv4_raw = config.get("ipv4", {}) or {}
+        if not isinstance(ipv4_raw, dict):
+            raise ValueError(f"interface_assignment '{resource.name}' ipv4 must be a mapping")
+
+        ipv6_raw = config.get("ipv6", {}) or {}
+        if not isinstance(ipv6_raw, dict):
+            raise ValueError(f"interface_assignment '{resource.name}' ipv6 must be a mapping")
+
+        configs.append(
+            InterfaceAssignmentConfig(
+                name=resource.name,
+                device=device,
+                description=description,
+                enabled=enabled_raw,
+                lock=lock_raw,
+                ipv4=dict(ipv4_raw),
+                ipv6=dict(ipv6_raw),
+            )
+        )
+
+    return configs
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class InterfaceAssignmentService(BaseService):
+    """Read-only service for OPNsense interface assignments via direct API.
+
+    OPNsense `26.1.6_2` exposes interface assignment state at
+    ``GET /api/interfaces/overview/interfacesInfo`` but offers no REST
+    write endpoint; writes are deferred until either an upstream API
+    addition or an XML-edit shim lands. The service therefore provides:
+
+    - ``list()`` — fetch live assignments (skip unassigned NICs).
+    - ``export_to_yaml()`` — render the live state as InfraFoundry YAML.
+
+    Method names follow the VLAN service for consistency.
+    """
+
+    def list(self) -> list[LiveInterfaceAssignment]:
+        """Return all interface assignments currently configured on the box.
+
+        Skips rows with an empty ``identifier`` — those are physical NICs
+        that are not assigned to any logical interface, which is not what
+        operators want to manage with this resource type.
+
+        Returns:
+            ``LiveInterfaceAssignment`` entries normalized from the API.
+        """
+        response = self.client.request("GET", "interfaces/overview/interfacesInfo")
+
+        rows: list[dict[str, Any]] = []
+        if isinstance(response, dict):
+            raw_rows = response.get("rows")
+            if isinstance(raw_rows, list):
+                rows = [r for r in raw_rows if isinstance(r, dict)]
+
+        return [_row_to_live_assignment(row) for row in rows if row.get("identifier")]
+
+    # ------------------------------------------------------------------
+    # Migration / export
+    # ------------------------------------------------------------------
+
+    def export_to_yaml(self) -> str:
+        """Export the current interface assignments to InfraFoundry YAML.
+
+        Produces a resource-centric YAML document where each row's
+        ``identifier`` becomes both ``name`` (operator-facing) and the
+        future-state binding key. ``ipv4``/``ipv6`` are emitted verbatim
+        for forward-compat — the schema accepts them today even though
+        the write path doesn't yet honor them.
+
+        Returns:
+            YAML string suitable for placement under
+            ``envs/<env>/resources/`` or
+            ``envs/<env>/opnsense/interface_assignments.yaml``.
+        """
+        live = self.list()
+        resources = [
+            {
+                "provider": "opnsense",
+                "type": "interface_assignments",
+                "name": entry.identifier,
+                "config": {
+                    "device": entry.device,
+                    "description": entry.description,
+                    "enabled": True,
+                    "ipv4": entry.ipv4,
+                    "ipv6": entry.ipv6,
+                },
+            }
+            for entry in live
+        ]
+        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_live_assignment(row: dict[str, Any]) -> LiveInterfaceAssignment:
+    """Normalize an ``interfacesInfo`` row into a ``LiveInterfaceAssignment``.
+
+    The API returns ``mtu`` as a string in some versions and as a missing
+    key in others; we coerce defensively. ``ipv4``/``ipv6`` are passed
+    through as raw dicts.
+    """
+    identifier = str(row.get("identifier", ""))
+    device = str(row.get("device", ""))
+    description = str(row.get("description", "") or "")
+    is_physical = bool(row.get("is_physical", False))
+    macaddr = str(row.get("macaddr", "") or "")
+
+    ipv4_raw = row.get("ipv4", {})
+    ipv4: dict[str, Any] = ipv4_raw if isinstance(ipv4_raw, dict) else {}
+
+    ipv6_raw = row.get("ipv6", {})
+    ipv6: dict[str, Any] = ipv6_raw if isinstance(ipv6_raw, dict) else {}
+
+    try:
+        mtu = int(row.get("mtu", 0) or 0)
+    except (TypeError, ValueError):
+        mtu = 0
+
+    return LiveInterfaceAssignment(
+        identifier=identifier,
+        device=device,
+        description=description,
+        is_physical=is_physical,
+        ipv4=ipv4,
+        ipv6=ipv6,
+        macaddr=macaddr,
+        mtu=mtu,
+    )

--- a/src/infrafoundry/providers/opnsense/validator.py
+++ b/src/infrafoundry/providers/opnsense/validator.py
@@ -18,6 +18,7 @@ from infrafoundry.core.validation_helpers import BaseAPIValidator
 from infrafoundry.providers.opnsense.validators import (
     DHCPValidator,
     FirewallValidator,
+    InterfaceAssignmentValidator,
     ResourceNameValidator,
     UnboundValidator,
     VLANValidator,
@@ -77,6 +78,7 @@ class OPNsenseValidator:
         self.vlan_validator = VLANValidator(report)
         self.unbound_validator = UnboundValidator(report)
         self.resource_name_validator = ResourceNameValidator(report)
+        self.interface_assignment_validator = InterfaceAssignmentValidator(report)
 
     def validate_connectivity(self) -> None:
         """Validate connectivity to OPNsense API.
@@ -194,6 +196,11 @@ class OPNsenseValidator:
                 resource_refs["vlans"],
                 existing_interfaces,
             )
+            self.interface_assignment_validator.validate(
+                resource_refs["interface_assignments"],
+                resource_refs["vlan_names"],
+                existing_interfaces,
+            )
             self.unbound_validator.validate(resource_refs["unbound_host_overrides"])
             self.resource_name_validator.validate(resources)
 
@@ -221,9 +228,11 @@ class OPNsenseValidator:
         firewall_rules = [r for r in resources if r.type == "firewall_rules"]
         dhcp_maps = [r for r in resources if r.type == "dhcp_static_maps"]
         unbound_host_overrides = [r for r in resources if r.type == "unbound_host_override"]
+        interface_assignments = [r for r in resources if r.type == "interface_assignments"]
 
         alias_names = {a.name for a in aliases}
         vlan_names = {v.name for v in vlans}
+        interface_assignment_names = {a.name for a in interface_assignments}
 
         return {
             "aliases": aliases,
@@ -233,6 +242,8 @@ class OPNsenseValidator:
             "firewall_rules": firewall_rules,
             "dhcp_maps": dhcp_maps,
             "unbound_host_overrides": unbound_host_overrides,
+            "interface_assignments": interface_assignments,
+            "interface_assignment_names": interface_assignment_names,
         }
 
     def _get_existing_aliases(

--- a/src/infrafoundry/providers/opnsense/validators/__init__.py
+++ b/src/infrafoundry/providers/opnsense/validators/__init__.py
@@ -2,6 +2,9 @@
 
 from infrafoundry.providers.opnsense.validators.dhcp_validator import DHCPValidator
 from infrafoundry.providers.opnsense.validators.firewall_validator import FirewallValidator
+from infrafoundry.providers.opnsense.validators.interface_assignment_validator import (
+    InterfaceAssignmentValidator,
+)
 from infrafoundry.providers.opnsense.validators.resource_name_validator import (
     ResourceNameValidator,
 )
@@ -11,6 +14,7 @@ from infrafoundry.providers.opnsense.validators.vlan_validator import VLANValida
 __all__ = [
     "DHCPValidator",
     "FirewallValidator",
+    "InterfaceAssignmentValidator",
     "ResourceNameValidator",
     "UnboundValidator",
     "VLANValidator",

--- a/src/infrafoundry/providers/opnsense/validators/interface_assignment_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/interface_assignment_validator.py
@@ -1,0 +1,230 @@
+"""Interface-assignment validation for OPNsense (ADR-0014 §7, #711).
+
+Mirrors ``DHCPValidator``'s pattern of cross-referencing a logical name
+against the live interface list AND the managed VLAN list. The validator
+runs at ``infra plan`` time so a bad ``device:`` surfaces before the
+operator hits the (no-op) apply path.
+
+Schema fields validated:
+
+- ``device``: must resolve to a physical NIC, a managed VLAN by name, or
+  a VLAN child notation ``<nic>_vlan<tag>`` (split on ``_vlan``; both
+  parts validated separately).
+- ``description``: string if present.
+- ``enabled``: bool if present.
+- ``lock``: bool if present.
+- ``ipv4`` / ``ipv6``: dicts if present (deep validation deferred until
+  the write path lands; ADR-0013/0014 forward-compat).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+
+# ``<nic>_vlan<tag>`` — capture the parent NIC and tag separately. The
+# OPNsense convention is e.g. ``ixl0_vlan4000``; the underscore between
+# nic and "vlan" prefix is mandatory.
+_VLAN_CHILD_PATTERN = re.compile(r"^(?P<nic>[A-Za-z0-9_]+?)_vlan(?P<tag>\d+)$")
+
+
+class InterfaceAssignmentValidator:
+    """Validates OPNsense interface assignments against live + managed state."""
+
+    def __init__(self, report: ValidationReport) -> None:
+        """Initialize validator.
+
+        Args:
+            report: ValidationReport to add results to.
+        """
+        self.report = report
+
+    def validate(
+        self,
+        assignments: list[ResourceConfig],
+        vlan_names: set[str],
+        existing_interfaces: dict[str, Any],
+    ) -> None:
+        """Validate interface-assignment resources.
+
+        Args:
+            assignments: ``interface_assignments`` ``ResourceConfig`` entries.
+            vlan_names: Set of VLAN resource names declared in the config —
+                a ``device:`` may reference a managed VLAN by name.
+            existing_interfaces: Map of NIC name -> interface metadata
+                returned by ``OPNsenseValidator._get_existing_interfaces``.
+        """
+        for assignment in assignments:
+            self._validate_one(assignment, vlan_names, existing_interfaces)
+
+    def _validate_one(
+        self,
+        assignment: ResourceConfig,
+        vlan_names: set[str],
+        existing_interfaces: dict[str, Any],
+    ) -> None:
+        """Run all checks for one assignment."""
+        self._validate_device(assignment, vlan_names, existing_interfaces)
+        self._validate_description(assignment)
+        self._validate_enabled(assignment)
+        self._validate_lock(assignment)
+        self._validate_ipv4_ipv6(assignment)
+
+    # ------------------------------------------------------------------
+    # device
+    # ------------------------------------------------------------------
+
+    def _validate_device(
+        self,
+        assignment: ResourceConfig,
+        vlan_names: set[str],
+        existing_interfaces: dict[str, Any],
+    ) -> None:
+        """Check ``config.device`` resolves to a known NIC, managed VLAN, or VLAN child."""
+        device = assignment.config.get("device")
+        if device is None:
+            return  # absence handled by the load-time required-field check
+
+        if not isinstance(device, str) or not device:
+            self.report.add_check(
+                check_name=f"interface_assignment_{assignment.name}_device",
+                passed=False,
+                message=(
+                    f"interface_assignment '{assignment.name}' device must be a non-empty string"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+            return
+
+        if self._device_resolves(device, vlan_names, existing_interfaces):
+            self.report.add_check(
+                check_name=f"interface_assignment_{assignment.name}_device",
+                passed=True,
+                message=(
+                    f"Device '{device}' resolved for interface_assignment '{assignment.name}'"
+                ),
+                level=ValidationLevel.INFO,
+            )
+            return
+
+        self.report.add_check(
+            check_name=f"interface_assignment_{assignment.name}_device",
+            passed=False,
+            message=(
+                f"interface_assignment '{assignment.name}' references unknown device '{device}'; "
+                f"expected a physical NIC, a managed VLAN name, or '<nic>_vlan<tag>' notation"
+            ),
+            level=ValidationLevel.ERROR,
+        )
+
+    def _device_resolves(
+        self,
+        device: str,
+        vlan_names: set[str],
+        existing_interfaces: dict[str, Any],
+    ) -> bool:
+        """Return True if ``device`` matches a NIC, VLAN name, or VLAN child."""
+        # 1. Direct match against a physical NIC reported by the live API.
+        if device in existing_interfaces:
+            return True
+
+        # 2. Match against a managed VLAN by its operator-facing name.
+        if device in vlan_names:
+            return True
+
+        # 3. VLAN-child notation: split on '_vlan' and validate parts.
+        match = _VLAN_CHILD_PATTERN.match(device)
+        if match is None:
+            return False
+        nic = match.group("nic")
+        tag_str = match.group("tag")
+        # Parent NIC must exist; tag must be a valid 802.1Q tag.
+        if nic not in existing_interfaces:
+            return False
+        try:
+            tag = int(tag_str)
+        except ValueError:  # pragma: no cover  # regex guarantees integer
+            return False
+        return 1 <= tag <= 4094
+
+    # ------------------------------------------------------------------
+    # description / enabled / lock
+    # ------------------------------------------------------------------
+
+    def _validate_description(self, assignment: ResourceConfig) -> None:
+        if "description" not in assignment.config:
+            return
+        description = assignment.config["description"]
+        if not isinstance(description, str):
+            self.report.add_check(
+                check_name=f"interface_assignment_{assignment.name}_description",
+                passed=False,
+                message=(
+                    f"interface_assignment '{assignment.name}' description must be a string, "
+                    f"got {type(description).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_enabled(self, assignment: ResourceConfig) -> None:
+        if "enabled" not in assignment.config:
+            return
+        enabled = assignment.config["enabled"]
+        if not isinstance(enabled, bool):
+            self.report.add_check(
+                check_name=f"interface_assignment_{assignment.name}_enabled",
+                passed=False,
+                message=(
+                    f"interface_assignment '{assignment.name}' enabled must be a boolean "
+                    f"(true/false), got {type(enabled).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_lock(self, assignment: ResourceConfig) -> None:
+        if "lock" not in assignment.config:
+            return
+        lock = assignment.config["lock"]
+        if not isinstance(lock, bool):
+            self.report.add_check(
+                check_name=f"interface_assignment_{assignment.name}_lock",
+                passed=False,
+                message=(
+                    f"interface_assignment '{assignment.name}' lock must be a boolean "
+                    f"(true/false), got {type(lock).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    # ------------------------------------------------------------------
+    # ipv4 / ipv6 (forward-compat shape check only)
+    # ------------------------------------------------------------------
+
+    def _validate_ipv4_ipv6(self, assignment: ResourceConfig) -> None:
+        """Confirm ``ipv4``/``ipv6`` are dicts; deep validation is deferred.
+
+        Per ADR-0013/0014 forward-compat schema (#711), these fields are
+        accepted in YAML even though writes are no-op; we still want to
+        catch a fundamentally wrong shape (string instead of mapping)
+        early.
+        """
+        for field_name in ("ipv4", "ipv6"):
+            if field_name not in assignment.config:
+                continue
+            value = assignment.config[field_name]
+            # YAML "ipv4:" with no value parses to None — treat as empty.
+            if value is None:
+                continue
+            if not isinstance(value, dict):
+                self.report.add_check(
+                    check_name=f"interface_assignment_{assignment.name}_{field_name}",
+                    passed=False,
+                    message=(
+                        f"interface_assignment '{assignment.name}' {field_name} must be a "
+                        f"mapping, got {type(value).__name__}"
+                    ),
+                    level=ValidationLevel.ERROR,
+                )

--- a/tests/integration/opnsense/test_interface_assignment_live.py
+++ b/tests/integration/opnsense/test_interface_assignment_live.py
@@ -1,0 +1,102 @@
+"""Live integration tests for the OPNsense interface-assignment direct-API path (#711).
+
+These tests are gated by ``@pytest.mark.integration`` AND an explicit opt-in
+env var so they don't run as part of the default test suite. They contact a
+real OPNsense box.
+
+Required:
+    OPNSENSE_INTEGRATION_TESTS=1   (explicit opt-in)
+    OPNSENSE_API_URL
+    OPNSENSE_API_KEY
+    OPNSENSE_API_SECRET
+    OPNSENSE_VERIFY_SSL  (optional; defaults to "true")
+
+Run with::
+
+    OPNSENSE_INTEGRATION_TESTS=1 OPNSENSE_API_URL=... OPNSENSE_API_KEY=... \\
+    OPNSENSE_API_SECRET=... uv run pytest -m integration tests/integration/opnsense/
+
+Coverage: ``service.list()`` against the live box returns at least one
+assignment with a non-empty ``identifier``. Writes are not exercised
+because OPNsense `26.1.6_2` exposes no REST write endpoint for this
+resource (#711 reduced scope).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from infrafoundry.providers.opnsense.api_client import OPNsenseClient
+from infrafoundry.providers.opnsense.services.interface_assignment import (
+    InterfaceAssignmentService,
+)
+
+REQUIRED_VARS = ("OPNSENSE_API_URL", "OPNSENSE_API_KEY", "OPNSENSE_API_SECRET")
+
+
+def _opted_in() -> bool:
+    return bool(os.getenv("OPNSENSE_INTEGRATION_TESTS")) and all(
+        os.getenv(v) for v in REQUIRED_VARS
+    )
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _opted_in(),
+        reason=(
+            "OPNsense live integration tests require OPNSENSE_INTEGRATION_TESTS=1 "
+            "plus OPNSENSE_API_URL/KEY/SECRET — they hit a real box."
+        ),
+    ),
+]
+
+
+@pytest.fixture
+def service() -> Iterator[InterfaceAssignmentService]:
+    """Build an ``InterfaceAssignmentService`` against the live OPNsense box."""
+    verify_raw = os.getenv("OPNSENSE_VERIFY_SSL", "true").strip().lower()
+    verify_ssl = verify_raw not in ("0", "false", "no", "off")
+
+    client = OPNsenseClient(
+        api_key=os.environ["OPNSENSE_API_KEY"],
+        api_secret=os.environ["OPNSENSE_API_SECRET"],
+        base_url=os.environ["OPNSENSE_API_URL"],
+        verify_ssl=verify_ssl,
+    )
+    yield InterfaceAssignmentService(client)
+
+
+def test_list_returns_assignments(service: InterfaceAssignmentService) -> None:
+    """`list()` against the live box returns at least one assignment.
+
+    Every functioning OPNsense box has at least a LAN interface; if this
+    returns zero rows the parser is broken or the box is misconfigured.
+    Each row must carry a non-empty ``identifier`` (the service skips
+    unassigned NICs) and a ``device`` string.
+    """
+    assignments = service.list()
+    assert len(assignments) >= 1
+    for entry in assignments:
+        assert entry.identifier  # non-empty per service contract
+        assert isinstance(entry.device, str)
+        assert isinstance(entry.ipv4, dict)
+        assert isinstance(entry.ipv6, dict)
+
+
+def test_export_to_yaml_round_trip_parses(
+    service: InterfaceAssignmentService,
+) -> None:
+    """`export_to_yaml()` produces a parseable resource-centric document."""
+    import yaml
+
+    rendered = service.export_to_yaml()
+    parsed = yaml.safe_load(rendered)
+    assert "resources" in parsed
+    for entry in parsed["resources"]:
+        assert entry["provider"] == "opnsense"
+        assert entry["type"] == "interface_assignments"
+        assert "device" in entry["config"]

--- a/tests/unit/providers/opnsense/test_interface_assignment_manager.py
+++ b/tests/unit/providers/opnsense/test_interface_assignment_manager.py
@@ -1,0 +1,251 @@
+"""Unit tests for ``InterfaceAssignmentManager``.
+
+Coverage:
+    - plan/apply/destroy are loud no-ops returning success and informational messages.
+    - get_resource_ids maps operator names to live identifiers via the service.
+    - list/migrate delegate to ``InterfaceAssignmentService``.
+    - Result shape matches what the runner expects (counts + ``message``).
+    - The ``ReadOnlyDiff`` helper has the surface the runner's plan summary expects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.components.interface_assignment import (
+    InterfaceAssignmentManager,
+    ReadOnlyDiff,
+)
+from infrafoundry.providers.opnsense.services.interface_assignment import (
+    LiveInterfaceAssignment,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resource(
+    name: str,
+    *,
+    device: str = "ixl1",
+    description: str = "",
+    extra: dict[str, Any] | None = None,
+) -> ResourceConfig:
+    config: dict[str, Any] = {"device": device, "description": description}
+    if extra:
+        config.update(extra)
+    return ResourceConfig(
+        name=name, type="interface_assignments", provider="opnsense", config=config
+    )
+
+
+def _live(identifier: str, device: str = "ixl1") -> LiveInterfaceAssignment:
+    return LiveInterfaceAssignment(
+        identifier=identifier,
+        device=device,
+        description=identifier.upper(),
+        is_physical=True,
+        ipv4={},
+        ipv6={},
+        macaddr="00:11:22:33:44:55",
+        mtu=1500,
+    )
+
+
+SERVICE_PATH = (
+    "infrafoundry.providers.opnsense.components.interface_assignment.InterfaceAssignmentService"
+)
+
+
+# ---------------------------------------------------------------------------
+# ReadOnlyDiff
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyDiff:
+    def test_has_runner_recognized_shape(self) -> None:
+        diff = ReadOnlyDiff()
+        # Runner's plan-summary helper checks read_only first.
+        assert diff.read_only is True
+        assert "read-only" in diff.message
+        # All operation lists are empty so summary aggregation works.
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+        assert diff.locked == []
+        # is_empty drives runner's has_changes aggregation.
+        assert diff.is_empty is True
+
+
+# ---------------------------------------------------------------------------
+# plan
+# ---------------------------------------------------------------------------
+
+
+class TestPlan:
+    def test_returns_read_only_diff(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        diff = manager.plan("test-env", [_resource("lan")])
+        assert isinstance(diff, ReadOnlyDiff)
+        assert diff.is_empty is True
+        assert diff.read_only is True
+
+    def test_does_not_call_service(self, tmp_path: Path) -> None:
+        # plan is purely informational — no API call should fire.
+        manager = InterfaceAssignmentManager(tmp_path)
+        with patch(SERVICE_PATH) as svc_cls:
+            manager.plan("test-env", [_resource("lan")])
+        svc_cls.from_environment.assert_not_called()
+
+    def test_plan_accepts_add_only_kwarg(self, tmp_path: Path) -> None:
+        # The runner threads add_only into manager.plan — even though
+        # this manager ignores it, the kwarg must not raise.
+        manager = InterfaceAssignmentManager(tmp_path)
+        diff = manager.plan("test-env", [_resource("lan")], add_only=True)
+        assert isinstance(diff, ReadOnlyDiff)
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    def test_returns_zero_counts_and_message(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        result = manager.apply("test-env", [_resource("lan")])
+        assert result["success"] is True
+        assert result["resources_created"] == 0
+        assert result["resources_updated"] == 0
+        assert result["resources_deleted"] == 0
+        assert result["resource_outcomes"] == []
+        assert "read-only" in result["message"]
+        assert "1 assignment" in result["message"]
+
+    def test_pluralization_on_zero_assignments(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        result = manager.apply("test-env", [])
+        # "0 assignments" is grammatical English; we use 's' suffix when count != 1.
+        assert "0 assignments" in result["message"]
+
+    def test_pluralization_on_multiple_assignments(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        result = manager.apply("test-env", [_resource("lan"), _resource("wan", device="ixl0")])
+        assert "2 assignments" in result["message"]
+
+    def test_apply_does_not_call_service(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        with patch(SERVICE_PATH) as svc_cls:
+            manager.apply("test-env", [_resource("lan")])
+        svc_cls.from_environment.assert_not_called()
+
+    def test_apply_accepts_kwargs(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        # Both kwargs the runner threads in must be accepted.
+        result = manager.apply("test-env", [_resource("lan")], auto_approve=True, add_only=True)
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# destroy
+# ---------------------------------------------------------------------------
+
+
+class TestDestroy:
+    def test_returns_zero_destroyed(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        result = manager.destroy("test-env", [_resource("lan")])
+        assert result["success"] is True
+        assert result["resources_destroyed"] == 0
+        assert "read-only" in result["message"]
+        assert "nothing destroyed" in result["message"]
+
+    def test_destroy_does_not_call_service(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        with patch(SERVICE_PATH) as svc_cls:
+            manager.destroy("test-env", [_resource("lan")])
+        svc_cls.from_environment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_resource_ids
+# ---------------------------------------------------------------------------
+
+
+class TestGetResourceIds:
+    def test_maps_resource_name_to_live_identifier(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        service_mock = MagicMock()
+        service_mock.list.return_value = [_live("lan"), _live("wan", device="ixl0")]
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            ids = manager.get_resource_ids(
+                "test-env", [_resource("lan"), _resource("wan", device="ixl0")]
+            )
+        assert ids == {"lan": "lan", "wan": "wan"}
+
+    def test_omits_resources_without_live_match(self, tmp_path: Path) -> None:
+        # If YAML names don't appear on the box, omit them — the state DB
+        # will skip those updates and they'll surface in validation.
+        manager = InterfaceAssignmentManager(tmp_path)
+        service_mock = MagicMock()
+        service_mock.list.return_value = [_live("lan")]
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            ids = manager.get_resource_ids("test-env", [_resource("lan"), _resource("opt99")])
+        assert ids == {"lan": "lan"}
+
+    def test_returns_empty_when_no_resources(self, tmp_path: Path) -> None:
+        # Should not even hit the service when there's nothing to match.
+        manager = InterfaceAssignmentManager(tmp_path)
+        with patch(SERVICE_PATH) as svc_cls:
+            ids = manager.get_resource_ids("test-env", [])
+        assert ids == {}
+        svc_cls.from_environment.assert_not_called()
+
+    def test_calls_service_with_env_name(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        service_mock = MagicMock()
+        service_mock.list.return_value = []
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            manager.get_resource_ids("test-env", [_resource("lan")])
+        svc_cls.from_environment.assert_called_once_with("test-env", "opnsense", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_returns_service_results(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        live = [_live("lan"), _live("wan", device="ixl0")]
+        service_mock = MagicMock()
+        service_mock.list.return_value = live
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.list("test-env")
+        assert result == live
+
+
+# ---------------------------------------------------------------------------
+# migrate
+# ---------------------------------------------------------------------------
+
+
+class TestMigrate:
+    def test_delegates_to_service(self, tmp_path: Path) -> None:
+        manager = InterfaceAssignmentManager(tmp_path)
+        service_mock = MagicMock()
+        service_mock.export_to_yaml.return_value = "resources: []\n"
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            yaml_str = manager.migrate("test-env")
+        assert yaml_str == "resources: []\n"
+        service_mock.export_to_yaml.assert_called_once()

--- a/tests/unit/providers/opnsense/test_interface_assignment_service.py
+++ b/tests/unit/providers/opnsense/test_interface_assignment_service.py
@@ -1,0 +1,465 @@
+"""Unit tests for ``infrafoundry.providers.opnsense.services.interface_assignment``.
+
+Coverage:
+    - ``LiveInterfaceAssignment`` dataclass invariants.
+    - ``InterfaceAssignmentConfig`` parsing from ``ResourceConfig`` (forward-compat
+      schema; ``ipv4``/``ipv6``/``enabled``/``lock`` accepted).
+    - ``InterfaceAssignmentService.list()`` against a mocked API client:
+      skips rows with empty ``identifier``, parses ``is_physical``/``mtu``,
+      passes ``ipv4``/``ipv6`` through.
+    - ``export_to_yaml()`` round-trip.
+    - ``_row_to_live_assignment`` defensive coercion.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.services.interface_assignment import (
+    InterfaceAssignmentConfig,
+    InterfaceAssignmentService,
+    LiveInterfaceAssignment,
+    _row_to_live_assignment,
+    interface_assignment_configs_from_resources,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(
+    identifier: str = "lan",
+    device: str = "ixl1",
+    *,
+    description: str = "",
+    is_physical: bool = True,
+    ipv4: dict[str, Any] | None = None,
+    ipv6: dict[str, Any] | None = None,
+    macaddr: str = "00:11:22:33:44:55",
+    mtu: int | str = 1500,
+) -> dict[str, Any]:
+    return {
+        "identifier": identifier,
+        "device": device,
+        "description": description,
+        "is_physical": is_physical,
+        "ipv4": ipv4 if ipv4 is not None else {},
+        "ipv6": ipv6 if ipv6 is not None else {},
+        "macaddr": macaddr,
+        "mtu": mtu,
+    }
+
+
+def _resource(
+    name: str,
+    *,
+    device: str = "ixl1",
+    description: str = "",
+    enabled: bool | None = None,
+    lock: bool | None = None,
+    ipv4: dict[str, Any] | None = None,
+    ipv6: dict[str, Any] | None = None,
+) -> ResourceConfig:
+    config: dict[str, Any] = {"device": device, "description": description}
+    if enabled is not None:
+        config["enabled"] = enabled
+    if lock is not None:
+        config["lock"] = lock
+    if ipv4 is not None:
+        config["ipv4"] = ipv4
+    if ipv6 is not None:
+        config["ipv6"] = ipv6
+    return ResourceConfig(
+        name=name, type="interface_assignments", provider="opnsense", config=config
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dataclass invariants
+# ---------------------------------------------------------------------------
+
+
+class TestLiveInterfaceAssignment:
+    def test_frozen_dataclass(self) -> None:
+        live = LiveInterfaceAssignment(
+            identifier="lan",
+            device="ixl1",
+            description="LAN",
+            is_physical=True,
+            ipv4={},
+            ipv6={},
+            macaddr="aa:bb:cc:dd:ee:ff",
+            mtu=1500,
+        )
+        with pytest.raises(Exception):  # frozen — any attribute write fails  # noqa: B017
+            live.identifier = "wan"  # type: ignore[misc]
+
+
+class TestInterfaceAssignmentConfigDefaults:
+    def test_defaults(self) -> None:
+        cfg = InterfaceAssignmentConfig(name="lan", device="ixl1", description="")
+        assert cfg.enabled is True
+        assert cfg.lock is False
+        assert cfg.ipv4 == {}
+        assert cfg.ipv6 == {}
+
+
+# ---------------------------------------------------------------------------
+# interface_assignment_configs_from_resources
+# ---------------------------------------------------------------------------
+
+
+class TestConfigsFromResources:
+    def test_minimal_resource_parses(self) -> None:
+        result = interface_assignment_configs_from_resources([_resource("lan")])
+        assert len(result) == 1
+        assert result[0].name == "lan"
+        assert result[0].device == "ixl1"
+        assert result[0].description == ""
+        assert result[0].enabled is True
+        assert result[0].lock is False
+
+    def test_non_matching_resources_ignored(self) -> None:
+        ifa = _resource("lan")
+        alias = ResourceConfig(name="a", type="aliases", provider="opnsense", config={})
+        result = interface_assignment_configs_from_resources([ifa, alias])
+        assert len(result) == 1
+        assert result[0].name == "lan"
+
+    def test_forward_compat_fields_accepted(self) -> None:
+        result = interface_assignment_configs_from_resources(
+            [
+                _resource(
+                    "lan",
+                    enabled=False,
+                    lock=True,
+                    ipv4={"mode": "static", "address": "10.0.0.1/24"},
+                    ipv6={"mode": "track6"},
+                )
+            ]
+        )
+        cfg = result[0]
+        assert cfg.enabled is False
+        assert cfg.lock is True
+        assert cfg.ipv4["mode"] == "static"
+        assert cfg.ipv6["mode"] == "track6"
+
+    def test_missing_device_rejected(self) -> None:
+        bad = ResourceConfig(
+            name="lan",
+            type="interface_assignments",
+            provider="opnsense",
+            config={"description": "lan"},
+        )
+        with pytest.raises(ValueError, match="device"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_empty_device_rejected(self) -> None:
+        bad = _resource("lan", device="")
+        with pytest.raises(ValueError, match="device"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_non_string_description_rejected(self) -> None:
+        bad = ResourceConfig(
+            name="lan",
+            type="interface_assignments",
+            provider="opnsense",
+            config={"device": "ixl1", "description": 123},
+        )
+        with pytest.raises(ValueError, match="description"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_non_bool_enabled_rejected(self) -> None:
+        bad = ResourceConfig(
+            name="lan",
+            type="interface_assignments",
+            provider="opnsense",
+            config={"device": "ixl1", "enabled": "yes"},
+        )
+        with pytest.raises(ValueError, match="enabled"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_non_bool_lock_rejected(self) -> None:
+        bad = ResourceConfig(
+            name="lan",
+            type="interface_assignments",
+            provider="opnsense",
+            config={"device": "ixl1", "lock": "yes"},
+        )
+        with pytest.raises(ValueError, match="lock"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_non_dict_ipv4_rejected(self) -> None:
+        bad = ResourceConfig(
+            name="lan",
+            type="interface_assignments",
+            provider="opnsense",
+            config={"device": "ixl1", "ipv4": "static"},
+        )
+        with pytest.raises(ValueError, match="ipv4"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_non_dict_ipv6_rejected(self) -> None:
+        bad = ResourceConfig(
+            name="lan",
+            type="interface_assignments",
+            provider="opnsense",
+            config={"device": "ixl1", "ipv6": "track6"},
+        )
+        with pytest.raises(ValueError, match="ipv6"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_non_dict_config_rejected(self) -> None:
+        # Pydantic forbids non-dict config at construction time, so the
+        # path runs only when external code shoves a string in. Build the
+        # ResourceConfig and then mutate.
+        bad = _resource("lan")
+        object.__setattr__(bad, "config", "not-a-dict")
+        with pytest.raises(ValueError, match="non-dict config"):
+            interface_assignment_configs_from_resources([bad])
+
+    def test_ipv4_none_treated_as_empty(self) -> None:
+        # YAML `ipv4:` with no value parses as None — accept and normalize.
+        bad = ResourceConfig(
+            name="lan",
+            type="interface_assignments",
+            provider="opnsense",
+            config={"device": "ixl1", "ipv4": None},
+        )
+        result = interface_assignment_configs_from_resources([bad])
+        assert result[0].ipv4 == {}
+
+
+# ---------------------------------------------------------------------------
+# _row_to_live_assignment
+# ---------------------------------------------------------------------------
+
+
+class TestRowToLiveAssignment:
+    def test_normal_row(self) -> None:
+        row = _row(
+            identifier="lan",
+            device="ixl1",
+            description="LAN",
+            is_physical=True,
+            ipv4={"mode": "static", "address": "10.0.0.1/24"},
+            mtu=1500,
+        )
+        live = _row_to_live_assignment(row)
+        assert live.identifier == "lan"
+        assert live.device == "ixl1"
+        assert live.description == "LAN"
+        assert live.is_physical is True
+        assert live.ipv4["address"] == "10.0.0.1/24"
+        assert live.mtu == 1500
+
+    def test_string_mtu_coerced(self) -> None:
+        live = _row_to_live_assignment(_row(mtu="9000"))
+        assert live.mtu == 9000
+
+    def test_invalid_mtu_falls_back_to_zero(self) -> None:
+        live = _row_to_live_assignment(_row(mtu="not-a-number"))
+        assert live.mtu == 0
+
+    def test_missing_keys_default(self) -> None:
+        live = _row_to_live_assignment({"identifier": "lan"})
+        assert live.identifier == "lan"
+        assert live.device == ""
+        assert live.description == ""
+        assert live.is_physical is False
+        assert live.ipv4 == {}
+        assert live.ipv6 == {}
+        assert live.macaddr == ""
+        assert live.mtu == 0
+
+    def test_non_dict_ipv4_normalized_to_empty_dict(self) -> None:
+        # Defensive: if upstream API ever returns a string for ipv4,
+        # we don't crash and treat it as no config.
+        row = _row()
+        row["ipv4"] = "static-mode-as-string"
+        live = _row_to_live_assignment(row)
+        assert live.ipv4 == {}
+
+
+# ---------------------------------------------------------------------------
+# InterfaceAssignmentService.list
+# ---------------------------------------------------------------------------
+
+
+class TestInterfaceAssignmentServiceList:
+    def test_calls_get_interfacesinfo(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        service = InterfaceAssignmentService(client)
+        result = service.list()
+        client.request.assert_called_once_with("GET", "interfaces/overview/interfacesInfo")
+        assert result == []
+
+    def test_skips_rows_with_empty_identifier(self) -> None:
+        # Rows without an identifier are physical NICs not assigned to
+        # any logical interface — they don't belong in the dump.
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                _row(identifier="lan", device="ixl1"),
+                _row(identifier="", device="ixl2"),  # unassigned
+                _row(identifier="wan", device="ixl0"),
+            ]
+        }
+        service = InterfaceAssignmentService(client)
+        result = service.list()
+        assert {r.identifier for r in result} == {"lan", "wan"}
+        assert len(result) == 2
+
+    def test_skips_rows_with_missing_identifier(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {"device": "ixl0"},  # no identifier key at all
+                _row(identifier="lan"),
+            ]
+        }
+        service = InterfaceAssignmentService(client)
+        result = service.list()
+        assert len(result) == 1
+        assert result[0].identifier == "lan"
+
+    def test_filters_non_dict_rows(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                _row(identifier="lan"),
+                "not-a-dict",
+                _row(identifier="wan", device="ixl0"),
+            ]
+        }
+        service = InterfaceAssignmentService(client)
+        result = service.list()
+        assert len(result) == 2
+
+    def test_handles_empty_response(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {}
+        service = InterfaceAssignmentService(client)
+        assert service.list() == []
+
+    def test_handles_non_dict_response(self) -> None:
+        client = MagicMock()
+        client.request.return_value = "garbage"
+        service = InterfaceAssignmentService(client)
+        assert service.list() == []
+
+    def test_handles_non_list_rows(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": "garbage"}
+        service = InterfaceAssignmentService(client)
+        assert service.list() == []
+
+    def test_parses_is_physical_and_mtu(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                _row(
+                    identifier="vlan4000",
+                    device="ixl0_vlan4000",
+                    is_physical=False,
+                    mtu=9000,
+                ),
+            ]
+        }
+        service = InterfaceAssignmentService(client)
+        result = service.list()
+        assert result[0].is_physical is False
+        assert result[0].mtu == 9000
+
+    def test_passes_ipv4_ipv6_through_as_dicts(self) -> None:
+        ipv4_payload = {"mode": "static", "address": "10.0.0.1", "subnet": 24}
+        ipv6_payload = {"mode": "track6", "track6_interface": "wan"}
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                _row(identifier="lan", ipv4=ipv4_payload, ipv6=ipv6_payload),
+            ]
+        }
+        service = InterfaceAssignmentService(client)
+        result = service.list()
+        assert result[0].ipv4 == ipv4_payload
+        assert result[0].ipv6 == ipv6_payload
+
+
+# ---------------------------------------------------------------------------
+# export_to_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestExportToYaml:
+    def test_round_trip_structure(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                _row(
+                    identifier="lan",
+                    device="ixl1",
+                    description="LAN",
+                    ipv4={"mode": "static", "address": "10.0.0.1/24"},
+                ),
+                _row(
+                    identifier="wan",
+                    device="ixl0",
+                    description="WAN trunk",
+                    ipv4={"mode": "dhcp"},
+                ),
+            ]
+        }
+        service = InterfaceAssignmentService(client)
+        rendered = service.export_to_yaml()
+        parsed = yaml.safe_load(rendered)
+        assert "resources" in parsed
+        names = {r["name"] for r in parsed["resources"]}
+        assert names == {"lan", "wan"}
+        for entry in parsed["resources"]:
+            assert entry["provider"] == "opnsense"
+            assert entry["type"] == "interface_assignments"
+            assert "device" in entry["config"]
+            assert "description" in entry["config"]
+            assert "ipv4" in entry["config"]
+            assert "ipv6" in entry["config"]
+            assert entry["config"]["enabled"] is True
+
+    def test_export_with_no_assignments(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        service = InterfaceAssignmentService(client)
+        parsed = yaml.safe_load(service.export_to_yaml())
+        assert parsed == {"resources": []}
+
+    def test_export_skips_unassigned_interfaces(self) -> None:
+        # Rows with empty identifier shouldn't end up in the export — the
+        # operator is migrating logical interfaces, not raw NICs.
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                _row(identifier="lan"),
+                _row(identifier="", device="ixl5"),  # unassigned NIC
+            ]
+        }
+        service = InterfaceAssignmentService(client)
+        parsed = yaml.safe_load(service.export_to_yaml())
+        assert len(parsed["resources"]) == 1
+        assert parsed["resources"][0]["name"] == "lan"
+
+    def test_yaml_is_valid_yaml(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [_row(identifier="lan", description="The LAN interface")]
+        }
+        service = InterfaceAssignmentService(client)
+        rendered = service.export_to_yaml()
+        # If yaml.safe_load raises, we have a YAML emission bug.
+        assert yaml.safe_load(rendered) is not None

--- a/tests/unit/providers/opnsense/test_interface_assignment_validator.py
+++ b/tests/unit/providers/opnsense/test_interface_assignment_validator.py
@@ -1,0 +1,401 @@
+"""Unit tests for ``InterfaceAssignmentValidator``.
+
+Coverage:
+    - ``device:`` references a physical NIC → pass.
+    - ``device:`` references a managed VLAN by name → pass.
+    - ``device:`` is ``<nic>_vlan<tag>`` and both parts valid → pass.
+    - ``device:`` references unknown things → ERROR.
+    - Forward-compat field type checks (``description``, ``enabled``,
+      ``lock``, ``ipv4``, ``ipv6``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.opnsense.validators.interface_assignment_validator import (
+    InterfaceAssignmentValidator,
+)
+
+
+def _resource(
+    name: str,
+    *,
+    device: Any = "ixl1",
+    description: Any = None,
+    enabled: Any = None,
+    lock: Any = None,
+    ipv4: Any = None,
+    ipv6: Any = None,
+) -> ResourceConfig:
+    config: dict[str, Any] = {}
+    if device is not None:
+        config["device"] = device
+    if description is not None:
+        config["description"] = description
+    if enabled is not None:
+        config["enabled"] = enabled
+    if lock is not None:
+        config["lock"] = lock
+    if ipv4 is not None:
+        config["ipv4"] = ipv4
+    if ipv6 is not None:
+        config["ipv6"] = ipv6
+    return ResourceConfig(
+        name=name, type="interface_assignments", provider="opnsense", config=config
+    )
+
+
+@pytest.fixture
+def report() -> ValidationReport:
+    return ValidationReport()
+
+
+@pytest.fixture
+def validator(report: ValidationReport) -> InterfaceAssignmentValidator:
+    return InterfaceAssignmentValidator(report)
+
+
+# ---------------------------------------------------------------------------
+# device — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceResolution:
+    def test_physical_nic_passes(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", device="ixl1")],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}, "ixl1": {}},
+        )
+        assert all(c.passed for c in report.results)
+
+    def test_managed_vlan_name_passes(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("storage", device="vlan-storage")],
+            vlan_names={"vlan-storage"},
+            existing_interfaces={"ixl0": {}, "ixl1": {}},
+        )
+        assert all(c.passed for c in report.results)
+
+    def test_vlan_child_notation_passes(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        # The OPNsense convention: <nic>_vlan<tag>
+        validator.validate(
+            [_resource("wan-vlan", device="ixl0_vlan4000")],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}},
+        )
+        assert all(c.passed for c in report.results)
+
+    def test_vlan_child_with_underscored_nic_passes(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        # NIC names sometimes contain underscores (less common but possible).
+        validator.validate(
+            [_resource("foo", device="igb_0_vlan100")],
+            vlan_names=set(),
+            existing_interfaces={"igb_0": {}},
+        )
+        assert all(c.passed for c in report.results)
+
+
+# ---------------------------------------------------------------------------
+# device — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceErrors:
+    def test_unknown_nic_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", device="igc0")],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}, "ixl1": {}},
+        )
+        device_checks = [
+            c for c in report.results if c.check_name == "interface_assignment_lan_device"
+        ]
+        assert any(not c.passed for c in device_checks)
+        assert any(c.level == ValidationLevel.ERROR for c in device_checks)
+
+    def test_vlan_child_with_unknown_nic_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("wan-vlan", device="igc0_vlan100")],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}},
+        )
+        device_checks = [
+            c for c in report.results if c.check_name == "interface_assignment_wan-vlan_device"
+        ]
+        assert any(not c.passed for c in device_checks)
+
+    def test_vlan_child_with_out_of_range_tag_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("bad", device="ixl0_vlan5000")],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}},
+        )
+        device_checks = [
+            c for c in report.results if c.check_name == "interface_assignment_bad_device"
+        ]
+        assert any(not c.passed for c in device_checks)
+
+    def test_empty_string_device_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", device="")],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}},
+        )
+        assert any(
+            not c.passed and c.check_name == "interface_assignment_lan_device"
+            for c in report.results
+        )
+
+    def test_non_string_device_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", device=123)],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}},
+        )
+        assert any(
+            not c.passed and c.check_name == "interface_assignment_lan_device"
+            for c in report.results
+        )
+
+    def test_missing_device_skipped(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        # Missing device is the load-time required-field check's job —
+        # this validator should not error here.
+        validator.validate(
+            [_resource("lan", device=None)],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}},
+        )
+        device_checks = [
+            c for c in report.results if c.check_name == "interface_assignment_lan_device"
+        ]
+        assert device_checks == []
+
+
+# ---------------------------------------------------------------------------
+# Forward-compat field types
+# ---------------------------------------------------------------------------
+
+
+class TestFieldTypes:
+    def test_non_string_description_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", description=123)],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        assert any(
+            not c.passed and c.check_name == "interface_assignment_lan_description"
+            for c in report.results
+        )
+
+    def test_non_bool_enabled_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", enabled="yes")],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        assert any(
+            not c.passed and c.check_name == "interface_assignment_lan_enabled"
+            for c in report.results
+        )
+
+    def test_non_bool_lock_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", lock="yes")],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        assert any(
+            not c.passed and c.check_name == "interface_assignment_lan_lock" for c in report.results
+        )
+
+    def test_non_dict_ipv4_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", ipv4="static")],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        assert any(
+            not c.passed and c.check_name == "interface_assignment_lan_ipv4" for c in report.results
+        )
+
+    def test_non_dict_ipv6_fails(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", ipv6=["track6"])],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        assert any(
+            not c.passed and c.check_name == "interface_assignment_lan_ipv6" for c in report.results
+        )
+
+    def test_dict_ipv4_passes(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", ipv4={"mode": "static", "address": "10.0.0.1/24"})],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        # No ipv4 check failure — the only check should be the device pass.
+        ipv4_failures = [
+            c
+            for c in report.results
+            if c.check_name == "interface_assignment_lan_ipv4" and not c.passed
+        ]
+        assert ipv4_failures == []
+
+    def test_none_ipv4_skipped(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        # YAML "ipv4:" with no value parses to None — validator must not error.
+        validator.validate(
+            [_resource("lan", ipv4=None)],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        ipv4_failures = [
+            c
+            for c in report.results
+            if c.check_name == "interface_assignment_lan_ipv4" and not c.passed
+        ]
+        assert ipv4_failures == []
+
+    def test_string_description_passes_silently(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", description="The LAN interface")],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        # Only the device-pass check should be present; no description failure.
+        description_failures = [
+            c
+            for c in report.results
+            if c.check_name == "interface_assignment_lan_description" and not c.passed
+        ]
+        assert description_failures == []
+
+    def test_bool_enabled_passes_silently(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [_resource("lan", enabled=False)],
+            vlan_names=set(),
+            existing_interfaces={"ixl1": {}},
+        )
+        enabled_failures = [
+            c
+            for c in report.results
+            if c.check_name == "interface_assignment_lan_enabled" and not c.passed
+        ]
+        assert enabled_failures == []
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_assignments_list(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate([], vlan_names=set(), existing_interfaces={})
+        assert report.results == []
+
+    def test_multiple_assignments_all_validated(
+        self,
+        validator: InterfaceAssignmentValidator,
+        report: ValidationReport,
+    ) -> None:
+        validator.validate(
+            [
+                _resource("lan", device="ixl1"),
+                _resource("wan", device="ixl0"),
+                _resource("opt1", device="ixl0_vlan4000"),
+            ],
+            vlan_names=set(),
+            existing_interfaces={"ixl0": {}, "ixl1": {}},
+        )
+        # Each assignment yields a device check; all should pass.
+        device_checks = [c for c in report.results if c.check_name.endswith("_device")]
+        assert len(device_checks) == 3
+        assert all(c.passed for c in device_checks)

--- a/tests/unit/providers/opnsense/test_opnsense_direct_runner.py
+++ b/tests/unit/providers/opnsense/test_opnsense_direct_runner.py
@@ -4,9 +4,10 @@ Coverage:
     - Protocol conformance against ADR-0010 protocols.
     - Tool metadata (name, priority, IaC flag, availability).
     - Initialize is a no-op.
-    - Resource filtering.
-    - Plan/apply/destroy delegate to the VLAN manager.
+    - Resource filtering (per-type and legacy VLAN-specific helper).
+    - Plan/apply/destroy iterate the dispatch table and delegate.
     - get_resource_ids surface for StateAware integration.
+    - Aggregation across multiple registered components.
 """
 
 from __future__ import annotations
@@ -153,6 +154,65 @@ class TestFilterVlans:
         assert len(result) == 2
 
 
+class TestFilterByType:
+    """``_filter_by_type`` is the generic dispatch-table primitive."""
+
+    def test_picks_resources_by_type_name(self) -> None:
+        resources = [
+            _vlan_resource("v1", "igb0", 10),
+            _alias_resource("a1"),
+            _vlan_resource("v2", "igb0", 20),
+        ]
+        vlans = OPNsenseDirectRunner._filter_by_type(resources, "vlans", target_resources=None)
+        assert {r.name for r in vlans} == {"v1", "v2"}
+        aliases = OPNsenseDirectRunner._filter_by_type(resources, "aliases", target_resources=None)
+        assert {r.name for r in aliases} == {"a1"}
+
+    def test_unknown_type_returns_empty(self) -> None:
+        resources = [_vlan_resource("v1", "igb0", 10)]
+        result = OPNsenseDirectRunner._filter_by_type(resources, "nonexistent", None)
+        assert result == []
+
+    def test_target_resources_scopes_within_type(self) -> None:
+        resources = [
+            _vlan_resource("v1", "igb0", 10),
+            _vlan_resource("v2", "igb0", 20),
+            _alias_resource("v1"),  # same name, different type
+        ]
+        result = OPNsenseDirectRunner._filter_by_type(resources, "vlans", ["v1"])
+        assert [r.type for r in result] == ["vlans"]
+        assert [r.name for r in result] == ["v1"]
+
+
+class TestResolveDispatchTable:
+    """``_resolve_dispatch_table`` survives providers that don't expose the hook."""
+
+    def test_returns_provider_table_when_callable(self) -> None:
+        provider = MagicMock()
+        provider.get_direct_api_resource_types.return_value = {"vlans": object}
+        table = OPNsenseDirectRunner._resolve_dispatch_table(provider)
+        assert table == {"vlans": object}
+
+    def test_returns_empty_when_attribute_missing(self) -> None:
+        class _Bare:
+            pass
+
+        table = OPNsenseDirectRunner._resolve_dispatch_table(_Bare())  # type: ignore[arg-type]
+        assert table == {}
+
+    def test_returns_empty_when_attribute_not_callable(self) -> None:
+        provider = MagicMock()
+        provider.get_direct_api_resource_types = "not callable"
+        table = OPNsenseDirectRunner._resolve_dispatch_table(provider)
+        assert table == {}
+
+    def test_returns_empty_when_table_not_a_dict(self) -> None:
+        provider = MagicMock()
+        provider.get_direct_api_resource_types.return_value = ["not", "a", "dict"]
+        table = OPNsenseDirectRunner._resolve_dispatch_table(provider)
+        assert table == {}
+
+
 class TestResolveEnvName:
     """``_resolve_env_name`` reads ``provider._current_environment``."""
 
@@ -175,19 +235,42 @@ class TestResolveEnvName:
 
 @pytest.fixture
 def provider_with_env(tmp_path: Path) -> MagicMock:
+    """Provider whose dispatch table only registers ``vlans``.
+
+    Most legacy tests assume a single-component dispatch; new tests
+    cover multi-component aggregation explicitly via dedicated fixtures.
+    """
     provider = MagicMock()
     provider._current_environment = "test-env"
     provider.config_dir = tmp_path
     provider.name = "opnsense"
+    # Default to an empty dispatch; tests configure as needed.
+    provider.get_direct_api_resource_types.return_value = {}
     return provider
 
 
 class TestPlanDelegation:
-    """``runner.plan`` delegates to ``VlanManager.plan``."""
+    """``runner.plan`` iterates the dispatch table and delegates to each manager."""
 
     def test_returns_no_changes_when_no_vlans(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
+        # Even with VLAN registered, an empty resource list means no dispatch.
+        manager_cls = MagicMock()
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
+            result = runner.plan(provider_with_env)
+        assert result["success"] is True
+        assert result["has_changes"] is False  # type: ignore[typeddict-item]
+        manager_cls.assert_not_called()
+
+    def test_returns_no_changes_when_dispatch_empty(self, provider_with_env: MagicMock) -> None:
+        runner = OPNsenseDirectRunner()
+        # Dispatch table empty: nothing to plan even if resources exist.
+        with patch.object(
+            OPNsenseDirectRunner,
+            "_load_provider_resources",
+            return_value=[_vlan_resource("v1", "igb0", 10)],
+        ):
             result = runner.plan(provider_with_env)
         assert result["success"] is True
         assert result["has_changes"] is False  # type: ignore[typeddict-item]
@@ -199,16 +282,14 @@ class TestPlanDelegation:
 
         manager_mock = MagicMock()
         manager_mock.plan.return_value = diff
+        manager_cls = MagicMock(return_value=manager_mock)
 
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.plan(provider_with_env, add_only=True)
 
+        manager_cls.assert_called_once_with(provider_with_env.config_dir)
         manager_mock.plan.assert_called_once_with("test-env", resources, add_only=True)
         assert result["success"] is True
         assert result["has_changes"] is True  # type: ignore[typeddict-item]
@@ -221,14 +302,11 @@ class TestPlanDelegation:
 
         manager_mock = MagicMock()
         manager_mock.plan.side_effect = RuntimeError("boom")
+        manager_cls = MagicMock(return_value=manager_mock)
 
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.plan(provider_with_env)
 
         assert result["success"] is False
@@ -236,10 +314,12 @@ class TestPlanDelegation:
 
 
 class TestApplyDelegation:
-    """``runner.apply`` delegates to ``VlanManager.apply`` and threads ``add_only``."""
+    """``runner.apply`` iterates the dispatch table and threads ``add_only``."""
 
     def test_no_vlans_returns_zero_counts(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
+        manager_cls = MagicMock()
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
             result = runner.apply(provider_with_env)
         assert result["success"] is True
@@ -247,6 +327,7 @@ class TestApplyDelegation:
         assert result["resources_updated"] == 0  # type: ignore[typeddict-item]
         assert result["resources_deleted"] == 0  # type: ignore[typeddict-item]
         assert result["resource_outcomes"] == []  # type: ignore[typeddict-item]
+        manager_cls.assert_not_called()
 
     def test_outcomes_returned(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
@@ -260,14 +341,10 @@ class TestApplyDelegation:
             "resources_deleted": 0,
             "resource_outcomes": [outcome],
         }
+        manager_cls = MagicMock(return_value=manager_mock)
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
 
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.apply(provider_with_env, auto_approve=True, add_only=False)
 
         manager_mock.apply.assert_called_once_with(
@@ -287,13 +364,9 @@ class TestApplyDelegation:
             "resources_deleted": 0,
             "resource_outcomes": [],
         }
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        manager_cls = MagicMock(return_value=manager_mock)
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             runner.apply(provider_with_env, add_only=True)
         # add_only kwarg propagated.
         assert manager_mock.apply.call_args.kwargs["add_only"] is True
@@ -303,23 +376,21 @@ class TestApplyDelegation:
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_mock = MagicMock()
         manager_mock.apply.side_effect = RuntimeError("api down")
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        manager_cls = MagicMock(return_value=manager_mock)
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.apply(provider_with_env)
         assert result["success"] is False
         assert "api down" in result["error"]  # type: ignore[typeddict-item]
 
 
 class TestDestroyDelegation:
-    """``runner.destroy`` delegates to ``VlanManager.destroy``."""
+    """``runner.destroy`` iterates the dispatch table and aggregates counts."""
 
     def test_no_vlans_returns_zero(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
+        manager_cls = MagicMock()
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
             result = runner.destroy(provider_with_env)
         assert result["success"] is True
@@ -334,55 +405,201 @@ class TestDestroyDelegation:
             "resources_destroyed": 1,
             "locked_skipped": 0,
         }
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        manager_cls = MagicMock(return_value=manager_mock)
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.destroy(provider_with_env, auto_approve=True)
         assert result["resources_destroyed"] == 1  # type: ignore[typeddict-item]
         manager_mock.destroy.assert_called_once_with("test-env", resources, auto_approve=True)
 
 
 class TestGetResourceIds:
-    """``get_resource_ids`` returns the live UUID map."""
+    """``get_resource_ids`` merges UUID maps across all registered components."""
 
     def test_returns_uuid_map(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_mock = MagicMock()
         manager_mock.get_resource_ids.return_value = {"v1": "uuid-1"}
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        manager_cls = MagicMock(return_value=manager_mock)
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             ids = runner.get_resource_ids(provider_with_env)
         assert ids == {"v1": "uuid-1"}
 
     def test_empty_when_no_vlans(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
+        manager_cls = MagicMock()
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
             ids = runner.get_resource_ids(provider_with_env)
         assert ids == {}
 
     def test_swallows_errors(self, provider_with_env: MagicMock) -> None:
         # Failures here are non-fatal — we don't want a state-lookup blip
-        # to abort an apply that already succeeded.
+        # to abort an apply that already succeeded. Per-component failures
+        # are skipped so other components can still report their IDs.
         runner = OPNsenseDirectRunner()
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_mock = MagicMock()
         manager_mock.get_resource_ids.side_effect = RuntimeError("transient")
-        with (
-            patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources),
-            patch(
-                "infrafoundry.providers.opnsense.components.vlan.VlanManager",
-                return_value=manager_mock,
-            ),
-        ):
+        manager_cls = MagicMock(return_value=manager_mock)
+        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             ids = runner.get_resource_ids(provider_with_env)
         assert ids == {}
+
+
+# ---------------------------------------------------------------------------
+# Multi-component dispatch
+# ---------------------------------------------------------------------------
+
+
+def _ifa_resource(name: str) -> ResourceConfig:
+    return ResourceConfig(
+        name=name,
+        type="interface_assignments",
+        provider="opnsense",
+        config={"device": "igb0", "description": name},
+    )
+
+
+class TestMultiComponentDispatch:
+    """Runner aggregates plan/apply/destroy/IDs across every registered type."""
+
+    def test_plan_aggregates_summaries_across_types(self, provider_with_env: MagicMock) -> None:
+        runner = OPNsenseDirectRunner()
+        resources = [_vlan_resource("v1", "igb0", 10), _ifa_resource("lan")]
+
+        vlan_manager = MagicMock()
+        vlan_manager.plan.return_value = Diff(adds=[VlanConfig("v1", "igb0", 10, "x", 0)])
+
+        # Simulate a read-only manager: a Diff-shaped value with read_only=True
+        # and a message attribute. The runner must surface the message and
+        # NOT count the result toward has_changes.
+        readonly_diff = Diff()
+        readonly_diff.read_only = True  # type: ignore[attr-defined]
+        readonly_diff.message = "interface_assignments are read-only on this OPNsense version"  # type: ignore[attr-defined]
+        ifa_manager = MagicMock()
+        ifa_manager.plan.return_value = readonly_diff
+
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "vlans": MagicMock(return_value=vlan_manager),
+            "interface_assignments": MagicMock(return_value=ifa_manager),
+        }
+
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
+            result = runner.plan(provider_with_env)
+
+        assert result["success"] is True
+        # vlans diff has an add → has_changes is True overall.
+        assert result["has_changes"] is True  # type: ignore[typeddict-item]
+        summary = result["changes_summary"]  # type: ignore[typeddict-item]
+        assert "vlans:" in summary
+        assert "interface_assignments:" in summary
+        assert "read-only" in summary
+
+    def test_apply_aggregates_counts_and_outcomes(self, provider_with_env: MagicMock) -> None:
+        runner = OPNsenseDirectRunner()
+        resources = [_vlan_resource("v1", "igb0", 10), _ifa_resource("lan")]
+
+        outcome = ResourceOutcome(address="opnsense_vlan.v1", action="add", resource_name="v1")
+        vlan_manager = MagicMock()
+        vlan_manager.apply.return_value = {
+            "success": True,
+            "resources_created": 1,
+            "resources_updated": 0,
+            "resources_deleted": 0,
+            "resource_outcomes": [outcome],
+        }
+
+        ifa_manager = MagicMock()
+        ifa_manager.apply.return_value = {
+            "success": True,
+            "resources_created": 0,
+            "resources_updated": 0,
+            "resources_deleted": 0,
+            "resource_outcomes": [],
+            "message": "1 assignment described, manual GUI configuration required",
+        }
+
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "vlans": MagicMock(return_value=vlan_manager),
+            "interface_assignments": MagicMock(return_value=ifa_manager),
+        }
+
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
+            result = runner.apply(provider_with_env)
+
+        assert result["resources_created"] == 1  # type: ignore[typeddict-item]
+        assert result["resource_outcomes"] == [outcome]  # type: ignore[typeddict-item]
+        # Each manager dispatched exactly once.
+        vlan_manager.apply.assert_called_once()
+        ifa_manager.apply.assert_called_once()
+
+    def test_destroy_sums_destroyed_counts(self, provider_with_env: MagicMock) -> None:
+        runner = OPNsenseDirectRunner()
+        resources = [_vlan_resource("v1", "igb0", 10), _ifa_resource("lan")]
+
+        vlan_manager = MagicMock()
+        vlan_manager.destroy.return_value = {
+            "success": True,
+            "resources_destroyed": 1,
+            "locked_skipped": 0,
+        }
+        ifa_manager = MagicMock()
+        ifa_manager.destroy.return_value = {
+            "success": True,
+            "resources_destroyed": 0,
+            "message": "interface_assignments are read-only; nothing destroyed",
+        }
+
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "vlans": MagicMock(return_value=vlan_manager),
+            "interface_assignments": MagicMock(return_value=ifa_manager),
+        }
+
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
+            result = runner.destroy(provider_with_env)
+
+        assert result["resources_destroyed"] == 1  # type: ignore[typeddict-item]
+
+    def test_get_resource_ids_merges_across_components(self, provider_with_env: MagicMock) -> None:
+        runner = OPNsenseDirectRunner()
+        resources = [_vlan_resource("v1", "igb0", 10), _ifa_resource("lan")]
+
+        vlan_manager = MagicMock()
+        vlan_manager.get_resource_ids.return_value = {"v1": "uuid-vlan"}
+        ifa_manager = MagicMock()
+        ifa_manager.get_resource_ids.return_value = {"lan": "lan"}
+
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "vlans": MagicMock(return_value=vlan_manager),
+            "interface_assignments": MagicMock(return_value=ifa_manager),
+        }
+
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
+            ids = runner.get_resource_ids(provider_with_env)
+        assert ids == {"v1": "uuid-vlan", "lan": "lan"}
+
+    def test_unregistered_resource_types_ignored(self, provider_with_env: MagicMock) -> None:
+        # A resource type missing from the dispatch table is silently
+        # ignored — terraform/other paths still see it; the direct-API
+        # runner just doesn't dispatch it.
+        runner = OPNsenseDirectRunner()
+        resources = [
+            _alias_resource("a1"),  # type "aliases" is NOT in the dispatch table
+            _vlan_resource("v1", "igb0", 10),
+        ]
+        vlan_manager = MagicMock()
+        vlan_manager.plan.return_value = Diff()
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "vlans": MagicMock(return_value=vlan_manager),
+        }
+        with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
+            result = runner.plan(provider_with_env)
+        assert result["success"] is True
+        # vlan_manager.plan called with only the VLAN resource, never the alias.
+        vlan_manager.plan.assert_called_once()
+        passed_resources = vlan_manager.plan.call_args.args[1]
+        assert all(r.type == "vlans" for r in passed_resources)

--- a/tests/unit/providers/opnsense/test_opnsense_validator.py
+++ b/tests/unit/providers/opnsense/test_opnsense_validator.py
@@ -11,6 +11,7 @@ from infrafoundry.providers.opnsense.validator import OPNsenseValidator
 from infrafoundry.providers.opnsense.validators import (
     DHCPValidator,
     FirewallValidator,
+    InterfaceAssignmentValidator,
     ResourceNameValidator,
     UnboundValidator,
     VLANValidator,
@@ -58,6 +59,7 @@ class TestComposition:
         assert isinstance(validator.vlan_validator, VLANValidator)
         assert isinstance(validator.unbound_validator, UnboundValidator)
         assert isinstance(validator.resource_name_validator, ResourceNameValidator)
+        assert isinstance(validator.interface_assignment_validator, InterfaceAssignmentValidator)
 
 
 class TestValidateConnectivity:
@@ -190,6 +192,7 @@ class TestValidateReferences:
         validator.vlan_validator = MagicMock()
         validator.unbound_validator = MagicMock()
         validator.resource_name_validator = MagicMock()
+        validator.interface_assignment_validator = MagicMock()
 
         resources = [
             ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
@@ -202,6 +205,7 @@ class TestValidateReferences:
         validator.vlan_validator.validate.assert_called_once()
         validator.unbound_validator.validate.assert_called_once()
         validator.resource_name_validator.validate.assert_called_once()
+        validator.interface_assignment_validator.validate.assert_called_once()
 
     def test_exception_caught_gracefully(self, validator):
         """Exceptions during validation are caught and reported."""
@@ -281,6 +285,22 @@ class TestCollectResourceReferences:
 
         assert len(refs["unbound_host_overrides"]) == 1
 
+    def test_collects_interface_assignments(self, validator):
+        """Collects interface_assignment resources."""
+        resources = [
+            ResourceConfig(
+                name="lan",
+                type="interface_assignments",
+                provider="opnsense",
+                config={"device": "ixl1"},
+            ),
+        ]
+
+        refs = validator._collect_resource_references(resources)
+
+        assert len(refs["interface_assignments"]) == 1
+        assert "lan" in refs["interface_assignment_names"]
+
     def test_empty_resources(self, validator):
         """Returns empty collections for empty resources."""
         refs = validator._collect_resource_references([])
@@ -288,6 +308,8 @@ class TestCollectResourceReferences:
         assert len(refs["aliases"]) == 0
         assert len(refs["alias_names"]) == 0
         assert len(refs["vlans"]) == 0
+        assert len(refs["interface_assignments"]) == 0
+        assert len(refs["interface_assignment_names"]) == 0
 
 
 class TestGetExistingAliases:


### PR DESCRIPTION
## Description

Adds the OPNsense `interface_assignments` component as a **read-only / migrate**
component, plus the dispatch-table refactor of `OPNsenseDirectRunner` that the
deferred `provider.get_direct_api_resource_types()` extensibility hook from
#709 was waiting for. This is the **reduced-scope** ship of the original issue
framing — `apply` and `destroy` are loud no-op stubs because OPNsense
`26.1.6_2` exposes no REST write API for interface assignments.

## Related Issue

Addresses #711

## Why reduced scope

A live API probe at the start of planning confirmed that OPNsense `26.1.6_2`
exposes only read-only endpoints for interface assignments
(`/api/interfaces/overview/*`). There is no REST CRUD surface; the OPNsense
GUI uses legacy PHP form posts that ultimately edit `<interfaces>` in
`config.xml`. Per ADR-0013 §"Data model and apply mechanism" — which
explicitly allows per-component fallback when no stable API endpoint exists
— this is the right per-component decision today. The XML-edit write path
is a future concern.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring (dispatch-table extensibility hook in
      `OPNsenseDirectRunner`)
- [x] Test improvement (4 new unit test files + 1 live integration test)

## Changes Made

**New `interface_assignments` component (read-only):**
- `services/interface_assignment.py` — `InterfaceAssignmentService(BaseService)`
  + dataclasses; uses `client.request("GET", "interfaces/overview/interfacesInfo")`.
- `components/interface_assignment.py` — `InterfaceAssignmentManager(BaseComponentManager)`;
  `apply` / `destroy` are loud no-ops that surface a `message` field in
  the result so the runner can log "read-only" rather than silently
  reporting zero changes.
- `validators/interface_assignment_validator.py` — validates `device:`
  against physical NICs OR managed VLANs OR `<nic>_vlan<tag>`.

**Provider wiring (`src/infrafoundry/providers/opnsense/__init__.py`):**
- New `get_direct_api_resource_types()` returning
  `{"vlans": VlanManager, "interface_assignments": InterfaceAssignmentManager}`.
- `interface_assignments` added to `get_resource_types()` and to the
  `get_dependencies()` map (depends on `vlans`).
- New `migrate_interface_assignment()` mirrors `migrate_vlan` for cutover
  dumps. Not yet exposed via `config migrate` CLI — that wiring is a
  follow-up.

**Runner refactor (`src/infrafoundry/core/runners/opnsense_direct_runner.py`):**
- `plan` / `apply` / `destroy` / `get_resource_ids` now iterate
  `provider.get_direct_api_resource_types()` and dispatch each component's
  manager. Aggregates per-type results into a single
  `PlanResult` / `ApplyResult` / `DestroyResult`.
- Adding a new direct-API component is now a one-entry change in the
  provider; no runner edits required.
- VLAN behavior is unchanged. Existing VLAN tests pass without
  modification beyond mocking the dispatch table.

**Validator dispatch:**
- `validator.py::_collect_resource_references` now also collects assignment
  names; `validate_references` dispatches the new
  `InterfaceAssignmentValidator`.

**ADR amendments (no new ADR; #711 has no `needs-adr` label):**
- ADR-0013: per-component decision recorded for `interface_assignments`
  under "Per-component decisions recorded so far"; implementation-order
  step 1 annotated; #711 added to Related Issues.
- ADR-0014: §9 footnote documenting the read-only constraint; #711 added
  to Related Issues.

**Documentation:**
- `docs/development/opnsense-resource-coverage.md`: matrix updated for
  `interface_assignments` (status: "Read-only / migrate"); cutover runbook
  step 4 added documenting the **manual GUI step** (Interfaces →
  Assignments) operators must perform once during cutover.
- `cli-reference.md` / `pluggable-runners.md` /
  `runner-protocol-quick-reference.md` need no #711-specific changes —
  the runner identity didn't change and `migrate_interface_assignment` is
  not yet on the CLI surface.

## Forward-compatible YAML schema

Even though writes are no-op today, the YAML schema accepts the full
forward-compat shape so when the write path eventually arrives the
schema carries forward unchanged:

```yaml
- provider: opnsense
  type: interface_assignments
  name: lan
  config:
    device: ixl1                 # physical NIC, managed VLAN, or <nic>_vlan<tag>
    description: LAN
    enabled: true
    ipv4: { type: dhcp }
    ipv6: { type: track-interface, track: wan }
    lock: true                   # ADR-0014 §6 lock contract; honored when writes land
```

## Cutover runbook step 4 (LOUD)

Operators **must manually perform interface assignment via the OPNsense
GUI** (Interfaces → Assignments) one time during cutover, before
`infra apply`. The YAML is the source of truth that informs the manual
step. `foundry infra plan` will surface
`opnsense_direct: interface_assignments: read-only / 0 changes` so the
no-op is loud, not silent.

The runbook update is in
`docs/development/opnsense-resource-coverage.md` step 4.

## Testing

- [x] All existing tests pass — 3594 passed, 6 skipped
- [x] Added new tests for new functionality
  - `tests/unit/providers/opnsense/test_interface_assignment_service.py`
  - `tests/unit/providers/opnsense/test_interface_assignment_manager.py`
  - `tests/unit/providers/opnsense/test_interface_assignment_validator.py`
  - `tests/integration/opnsense/test_interface_assignment_live.py`
    (gated by `OPNSENSE_INTEGRATION_TESTS=1`)
- [x] Existing `test_opnsense_direct_runner.py` and
      `test_opnsense_validator.py` adapted for the dispatch-table refactor.
- [x] `doit check` passes locally; total coverage **82.29%** (gate ≥70%).

## Out of scope

- **Write side of `interface_assignments`** — deferred pending an
  XML-edit mechanism or upstream OPNsense API. Component manager raises
  loud no-op messages so the gap is visible at plan/apply time.
- **`config migrate` CLI plumbing for `interface_assignments`** —
  `migrate_interface_assignment` exists on the provider for cutover
  dumps; CLI wiring is a follow-up.
- **Other ADR-0013 components** (`nat_rules` is next per the
  implementation order in ADR-0013).

## Note on deviation from #709's pattern

#709 introduced `OPNsenseDirectRunner` with the full plan→apply→destroy
contract for VLANs (read+write). #711 reuses the same dispatch pattern
but adds the **first read-only component**. The runner accommodates this
via two affordances:

1. The `Diff`-like object can set `read_only=True` and a `message` field;
   `_format_plan_summary` surfaces the message verbatim instead of the
   add/update/delete counts.
2. The `apply` / `destroy` results may include a `message` field;
   `_log_apply_progress` and the destroy log path surface it instead of
   the count line.

This keeps the dispatch contract uniform across read-only and read-write
components without special-casing component types in the runner.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (matrix + runbook +
      ADR-0013 + ADR-0014)
- [ ] I have updated the CHANGELOG.md (auto-generated at release time
      from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

The issue body has been updated with a "Resolved scope" callout reflecting
the reduced-scope ship (read-only only, write deferred). Future work on
the write path will open as a separate issue when an XML-edit mechanism
or upstream API endpoint becomes available.
