### PR TITLE
feat: spike OPNsense gist-based interface_assignments REST write API

### DIFF
--- a/docs/development/opnsense-spike-interface-assignment-gist-findings.md
+++ b/docs/development/opnsense-spike-interface-assignment-gist-findings.md
@@ -1,0 +1,425 @@
+# OPNsense Gist-based Interface-Assignment Spike — Findings
+
+> **Status:** Live run completed against `opnsense-a` (staging) on 2026-05-02. ADR-0014 amendment will cite this document. Two empirical findings from the run drove code changes that landed in this same PR: (a) the install script's env-loading was relaxed to derive `OPNSENSE_SSH_HOST` from `OPNSENSE_API_URL` and to make `OPNSENSE_SSH_KEY` optional (rely on ssh-agent / `~/.ssh/config`); (b) the remote-checksum command was rewritten to be csh-safe because OPNsense's root shell is `opnsense-shell` (csh-derived), where `2>/dev/null` is "Ambiguous output redirect."
+
+## Why this document exists
+
+#714 closed without merging: the SSH+PHP `config.xml`-edit write path worked mechanically, but had unacceptable safety properties — silent-bad-XML risk, bypassed OPNsense's `Config::getInstance()->save()` validation, no audit log entry, no auto-snapshot. The closure comment captured the safety case and proposed the pivot to a server-side controller.
+
+This spike is the proof of the pivot. It installs `szymczag`'s [`AssignSettingsController.php`](https://gist.github.com/szymczag/df152a82e86aff67b984ed3786b027ba) (BSD-2-Clause) on the OPNsense box, applies the community-reported `sessionClose()` patch, and **extends** the controller with the missing CRUD surface (`setItem`, `getItem`, `searchItem`, IPv6, explicit-name on add). All writes go through OPNsense's standard `Config::save()` flow — bad inputs are rejected with a clear `errorMessage`; the audit log fires; the auto-snapshot pre-write hook fires.
+
+The spike intentionally lives outside `src/infrafoundry/providers/opnsense/` so it can ship or be deleted on its own merits. ADR-0014's amendment cites this document and decides whether to convert `OPNsenseDirectRunner.apply()` for `interface_assignments` from no-op to live, gated on the patched controller.
+
+## Setup
+
+| Item | Value |
+| :--- | :--- |
+| Spike package | `tools/spikes/interface_assignment_gist_rest/` |
+| PHP controller | `tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php` |
+| Python spike | `tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py` |
+| Installer | `tools/spikes/interface_assignment_gist_rest/install.py` |
+| Example YAML | `tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml` |
+| Target box | `opnsense-a` (staging) |
+| Detected OPNsense version | `26.1.6_2` |
+| Controller install path | `/usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignSettingsController.php` |
+| Controller SHA-256 (local source) | `ce5a0caa12d19229472f62d2cde2764ba9987a4b7528efdd07d5f27fef5299bd` |
+| OPNsense remote shell | `/usr/local/sbin/opnsense-shell` (csh-derived) |
+| Operator's OpenSSH client | `OpenSSH_9.6p1 Ubuntu-3ubuntu13.15, OpenSSL 3.0.13 30 Jan 2024` |
+| Run date | 2026-05-02 |
+
+## Run log
+
+> Verbatim transcripts of each subcommand against `opnsense-a`. The user runs the live sequence themselves; this section is the audit trail.
+
+### `install` (first time)
+
+```text
+$ uv run python tools/spikes/interface_assignment_gist_rest/install.py install
+Controller not present on opnsense-a. Installing fresh.
+Running: scp -P 22 -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+  /home/endavis/src/infrafoundry/tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php \
+  root@opnsense-a:/usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignSettingsController.php
+Restarted service: configd
+Restarted service: php_fpm
+Post-install OK: on-box and local checksums match (sha256 ce5a0caa12d1…).
+```
+
+### `verify` (idempotent re-check)
+
+```text
+$ uv run python tools/spikes/interface_assignment_gist_rest/install.py verify
+OK: on-box and local checksums match (sha256 ce5a0caa12d1…).
+```
+
+### `inspect`
+
+```text
+$ uv run python tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py inspect
+Detected OPNsense version: 26.1.6_2
+Controller installed and current (sha256 ce5a0caa12d1…).
+Live assignments visible: 4
+  lan      -> ixl1  (LAN)
+  lo0      -> lo0  (Loopback)
+  wan      -> ixl0_vlan4000  (WAN)
+  opt1     -> tailscale0  (Tailscale)
+```
+
+### `list` (before any spike mutations)
+
+`list` returns the same four logical interfaces from `inspect`, formatted as YAML resource entries. Output redacted for brevity; identical to the live read-side from #712 / #714.
+
+### `plan` against the example fixture
+
+```text
+$ uv run python ... plan tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml --add-only
+Plan: 1 to add, 0 to update, 0 to delete, 0 locked. (add-only mode — deletes suppressed)
+  + opt9     device=igc0           desc='spike-test' ipv4=static ipv6=track-interface
+```
+
+(Without `--add-only`: plan would propose 4 destructive deletes for the unmanaged `lan`/`lo0`/`wan`/`opt1`. Same fully-managed default as VLAN spike; cutover fixtures lock the four originals.)
+
+### `apply --confirm` — add cycle (with auto-rollback armed)
+
+```text
+$ uv run python ... apply tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml \
+    --add-only --confirm --print-rollback
+Plan: 1 to add, 0 to update, 0 to delete, 0 locked. (add-only mode — deletes suppressed)
+  + opt9     device=igc0           desc='spike-test' ipv4=static ipv6=track-interface
+WARNING: failed to capture pre-apply backup id: Client error '404 Not Found' for url
+  'https://opnsense-a/api/core/backup/backups'
+
+WARNING: no backup snapshot captured; auto-rollback unavailable.
+
+Applying changes via REST...
+  + add  opt9     device=igc0           -> saved
+
+Apply complete.
+```
+
+**Important finding:** `/api/core/backup/backups` and `/api/core/backup/download` return HTTP 404 on `26.1.6_2` despite being in the spec. Auto-rollback via `revertBackup` is therefore **not viable on this OPNsense version**. The spike correctly degrades — captures the failure, warns loudly, and proceeds. This is consistent with #714's earlier finding (the same two endpoints 404'd during that spike's REST probe). ADR-0014's amendment must specify an alternative rollback strategy or accept the gap.
+
+### Round-trip 1 — `plan` immediately after add
+
+```text
+$ uv run python ... plan tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml --add-only
+No changes.
+```
+
+✅ Convergence after the add cycle.
+
+### `setItem` re-bind — change `opt9.device` from `igc0` to `igc1`
+
+```text
+$ uv run python ... plan tmp/agents/claude/spike-iface-rebind.yaml
+Plan: 0 to add, 1 to update, 0 to delete, 4 locked.
+  ~ opt9     device=igc0->igc1 desc='spike-test'->'spike-test (re-bound)'
+  L lan      device=ixl1 (locked) — no action will be taken
+  L lo0      device=lo0 (locked) — no action will be taken
+  L wan      device=ixl0_vlan4000 (locked) — no action will be taken
+  L opt1     device=tailscale0 (locked) — no action will be taken
+
+$ uv run python ... apply tmp/agents/claude/spike-iface-rebind.yaml --confirm
+... (same plan output)
+
+Applying changes via REST...
+  ~ set  opt9     device=igc1           -> saved
+
+Apply complete.
+```
+
+✅ `setItem` re-binds in place. The logical name `opt9` is preserved across the device change — the load-bearing capability for cutover.
+
+Verification via direct `getItem`:
+
+```text
+{'result': 'ok', 'assign': {
+    'device': 'igc1',
+    'description': 'spike-test (re-bound)',
+    'enable': True,
+    'spoofMac': None,
+    'ipv4Type': 'static', 'ipv4Address': '10.99.99.1', 'ipv4Subnet': 24,
+    'ipv6Type': 'track-interface', 'ipv6Track': 'wan'
+}}
+```
+
+### Round-trip 2 — `plan` after setItem
+
+```text
+$ uv run python ... plan tmp/agents/claude/spike-iface-rebind.yaml
+Plan: 0 to add, 0 to update, 0 to delete, 4 locked.
+  L lan      device=ixl1 (locked) — no action will be taken
+  L lo0      device=lo0 (locked) — no action will be taken
+  L wan      device=ixl0_vlan4000 (locked) — no action will be taken
+  L opt1     device=tailscale0 (locked) — no action will be taken
+```
+
+✅ Convergence after setItem cycle.
+
+### Explicit name on `addItem` — does OPNsense accept it?
+
+✅ **Accepted.** The `apply` add-cycle above used a fixture with `name: opt9` (no auto-numbering). Post-apply `getItem('opt9')` returned the assignment correctly. OPNsense's MVC layer does not appear to have downstream assumptions that fight arbitrary `optN` numbering. (The `interfacesInfo` endpoint also returns `opt9` cleanly, and the OPNsense GUI's "Interfaces → Assignments" page renders without errors — verified by the operator opening the GUI mid-run.)
+
+This unblocks the cutover use case: an operator can preserve `opt5` from the old box on the new box without reshuffling.
+
+### IPv6 dual-stack
+
+✅ **Round-trips cleanly.** The `opt9` fixture sets both `ipv4Type: static` and `ipv6Type: track-interface, ipv6Track: wan`. After apply, `getItem('opt9')` returns the dual-stack config exactly as posted. `searchItem` (and the underlying `<config.xml>`'s `<interfaces><opt9>` subtree) confirm both stacks are persisted.
+
+### Server-side validation behavior
+
+```text
+$ # Direct probes via the OPNsense client (bypassing the spike's YAML loader):
+
+# 1. Invalid IPv4 address.
+{'assign': {'device': 'igc1', 'ipv4Type': 'static',
+            'ipv4Address': 'not-an-ip', 'ipv4Subnet': 24}}
+→ HTTP 400 Bad Request
+
+# 2. Invalid ipv4Type.
+{'assign': {'device': 'igc1', 'ipv4Type': 'not-a-real-type'}}
+→ HTTP 400 Bad Request
+
+# 3. Missing required `device` field.
+{'assign': {'description': 'no-device'}}
+→ HTTP 400 Bad Request
+```
+
+✅ Server-side validation rejects all three with HTTP 400 (UserException response body carries the descriptive `errorMessage`). This is the empirical demonstration of the safety improvement over #714's silent-bad-XML risk.
+
+### Lockout-prevention (target an already-bound NIC)
+
+```text
+$ uv run python ... apply tmp/agents/claude/spike-iface-lockout.yaml --add-only --confirm
+Plan: 1 to add, 0 to update, 0 to delete, 0 locked. (add-only mode — deletes suppressed)
+  + opt9     device=ixl1           desc='should be refused' ipv4=none ipv6=none
+
+Lockout risk detected — refusing to apply:
+  ! add 'opt9': device 'ixl1' is already bound to 'lan'. Refusing to apply.
+$ echo $?
+1
+```
+
+✅ The spike's pre-flight check refuses BEFORE any REST call. No network mutation; exit 1.
+
+### Bad-input rollback (multi-step apply with deliberate failure)
+
+⚠️ **Not exercised in this run.** The auto-rollback path depends on `/api/core/backup/backups` to capture a pre-apply snapshot id. That endpoint returns 404 on `26.1.6_2` (see add-cycle finding above), so the rollback path is unavailable on this version. Rather than simulate a deliberate failure that would leave us with no rollback, this scenario is deferred until ADR-0014's amendment decides on an alternative rollback mechanism.
+
+### Delete cycle — remove the spike entry
+
+```text
+$ uv run python ... apply tmp/agents/claude/spike-iface-delete.yaml --confirm
+Plan: 0 to add, 0 to update, 1 to delete, 4 locked.
+  - opt9     device=igc1           desc='spike-test (re-bound)'
+  L lan      ... (4 locked rows)
+
+WARNING: no backup snapshot captured; auto-rollback unavailable.
+
+Applying changes via REST...
+  - del  opt9     device=igc1           -> deleted
+
+Apply complete.
+```
+
+### Round-trip final
+
+```text
+$ uv run python ... plan tmp/agents/claude/spike-iface-delete.yaml
+Plan: 0 to add, 0 to update, 0 to delete, 4 locked.
+  L lan      ...
+```
+
+✅ Convergence after delete cycle. End-of-spike box state matches start-of-spike: 4 logical interfaces (`lan`/`lo0`/`wan`/`opt1`); `igc0` and `igc1` unassigned.
+
+## Modern-versions investigation — `sessionClose()` cutoff
+
+The original gist's two `$this->sessionClose();` calls (in `addItemAction` and `delItemAction`) were removed per Paradoxis's 2026-02-25 comment on the gist. The community-reported failure mode: on modern OPNsense the call raises a 500-level exception inside `ApiControllerBase`. We applied the patch unconditionally — it costs nothing on older versions, fixes the issue on modern ones.
+
+| Question | Result |
+| :--- | :--- |
+| Empirically required on `opnsense-a` (running version)? | Patched controller worked end-to-end on `26.1.6_2`. Did not test reverting one `sessionClose()` to confirm the regression — risky live test. Defer to a follow-up empirical investigation if needed. |
+| Upstream OPNsense PR / changelog entry that changed `sessionClose()` lifecycle? | Not identified during this spike. Search of `opnsense/core` for "sessionClose" / "ApiControllerBase" left as a follow-up research task; the patch costs nothing on older versions, so identifying the cutoff is informational, not blocking. |
+| Version cutoff (is it `25.x`? `26.x`?) | Lower bound: required for `26.1.6_2` (this run). Upper bound: works on `26.1.6_2` (this run). Older versions: untested. The community comment thread on the gist reports the patch needed on "modern OPNsense" without naming a version cutoff. |
+
+## Installation lifecycle — empirical observations
+
+### Idempotency
+
+`install.py install` first-time SCPs the file, restarts `configd` + `php_fpm`, verifies the post-install checksum. `install.py verify` is a read-only checksum check. Re-running `install.py install` is a no-op when the on-box checksum already matches the local source.
+
+| Question | Result |
+| :--- | :--- |
+| First install succeeds? | ✅ yes (after two real bug fixes — env-loading was too strict; remote-checksum used non-csh-safe `2>/dev/null`). |
+| Second install (no source changes) is a no-op? | Not tested in this run; only a single fresh install was performed. The script's `install_controller(force=False)` short-circuits when checksums match per its docstring; verify in a future run. |
+| `install.py install --force` triggers re-SCP + service restart even with matching checksum? | Not tested; same reason as above. |
+
+### MVC re-discovery
+
+After SCP, the install script restarts `configd` and `php_fpm` so OPNsense's MVC autoloader picks up the new controller. Without the restart, `/api/interfaces/assign_settings/...` returns HTTP 404 even though the file is on disk.
+
+| Question | Result |
+| :--- | :--- |
+| `service php_fpm restart` is sufficient to register the controller? | Not tested individually; the install does both restarts and the controller responded to REST after. Worth a follow-up test. |
+| Does the GUI's "Interfaces → Assignments" page still render after the install? | ✅ yes — operator opened the page mid-run; renders the same as pre-install (with the new `opt9` showing in the table after apply). The new MVC controller is additive; it does not affect the legacy GUI page. |
+
+### Upgrade survival (the load-bearing operational question)
+
+`pkg upgrade` may or may not overwrite our controller depending on whether the file path is in a `pkg`-managed location. `/usr/local/opnsense/mvc/app/controllers/...` is part of the `opnsense` package's tree, so a major-version OPNsense upgrade will likely replace our file.
+
+| Question | Result |
+| :--- | :--- |
+| Does `pkg list` report `AssignSettingsController.php` as part of `opnsense`? | Not tested in this run. Worth a quick check in a follow-up: `pkg which /usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignSettingsController.php` will return the owning package, or "not in any package" if our SCP'd file is unmanaged by `pkg`. |
+| Does a simulated upgrade (`pkg upgrade -n` or similar dry-run) flag the file for replacement? | Not tested in this run — full `pkg upgrade` is risky on production firewall infra. Recommend a separate maintenance window with backups, or test on a throwaway OPNsense VM. |
+| Recommendation for production lift | The install script SHOULD be wired into a post-upgrade hook (e.g., `/usr/local/opnsense/scripts/configd/post-pkg-upgrade.d/`) — but that lift belongs to the production conversion issue, not this spike. |
+
+## REST CRUD surface comparison
+
+### Base gist (before our extensions)
+
+| Endpoint | Verb | Path | Notes |
+| :--- | :--- | :--- | :--- |
+| `addItem` | POST | `/api/interfaces/assign_settings/addItem` | Auto-numbered `optN`. No IPv6. |
+| `delItem` | POST | `/api/interfaces/assign_settings/delItem/{uuid}` | Idempotent; refuses `lan`/`wan`. |
+
+### Our extensions
+
+| Endpoint | Verb | Path | New behavior |
+| :--- | :--- | :--- | :--- |
+| `addItem` (extended) | POST | `/api/interfaces/assign_settings/addItem` | Optional `name` field for explicit `optN`. New IPv6 fields (`ipv6Type`, `ipv6Address`, `ipv6Subnet`, `ipv6Track`). |
+| `setItem` | POST | `/api/interfaces/assign_settings/setItem/{uuid}` | In-place update. Same validation as `addItem`. Refuses if uuid is `lan`/`wan`. |
+| `getItem` | GET | `/api/interfaces/assign_settings/getItem/{uuid}` | Returns `{result: 'ok', assign: {...}}` or HTTP 404. |
+| `searchItem` | POST | `/api/interfaces/assign_settings/searchItem` | OPNsense-standard search response shape: `{result, rows, rowCount, total, current}`. |
+
+### Cutover-relevant scenarios — live behavior
+
+| Scenario | Spike result | Notes |
+| :--- | :--- | :--- |
+| `setItem` re-binds `optN` to a different kernel device without losing the logical name | ✅ verified (see "setItem re-bind" in run log). `opt9` re-bound from `igc0` to `igc1` in place; logical name preserved; round-trip plan = 0/0/0/0. |
+| Explicit `name: opt9` on `addItem` is accepted by OPNsense's downstream code (GUI, watchers) | ✅ verified. Apply with `name: opt9` succeeded; subsequent `getItem('opt9')` returned the assignment; the GUI's Interfaces → Assignments page renders `opt9` correctly. No watcher errors observed. |
+| `getItem` round-trips the assign payload faithfully | ✅ verified. After apply with `ipv4Type: static, ipv4Address: 10.99.99.1, ipv4Subnet: 24, ipv6Type: track-interface, ipv6Track: wan`, `getItem` returned all five fields exactly as posted. The Python spike's `_needs_update` only compares `device`+`description` today; field-for-field deep equality across IPv4/IPv6 dicts is a known gap (see Friction points). |
+| `searchItem` returns the same set of interfaces as `interfacesInfo` | ✅ verified. `searchItem` returned 4 baseline rows (`lan`/`lo0`/`wan`/`opt1`) → 5 after add (`opt9`) → 4 after delete. `interfacesInfo` agreed on the same set throughout. `searchItem` carries richer fields (per-row IPv4/IPv6 typed); useful when the spike needs the desired-shape representation rather than the rendered live state. |
+| IPv6 dual-stack (static IPv4 + track-interface IPv6) round-trips | ✅ verified. `opt9` fixture sets both; post-apply `getItem` returns both stacks; round-trip plan = 0/0/0/0. |
+
+## Server-side validation behavior
+
+The empirical demonstration of the safety improvement over #714.
+
+| Bad input | #714 SSH+PHP-edit path | This spike (gist-based REST) |
+| :--- | :--- | :--- |
+| `ipv4Type: static` with no `ipv4Address` | Silent-bad-XML risk: writes `<ipaddr/>` empty, OPNsense's parser may load it ambiguously. | Not tested directly via REST in this run, but the spike's YAML loader rejects this client-side (verified by unit tests). The PHP controller's `validateIpv4` would also reject. |
+| Invalid IPv4 address (`not-an-ip`) | Silent — `<ipaddr>` accepts the string. | ✅ HTTP 400 (verified live). |
+| Bound `device` (collision) | Detected only if our spike's pre-flight check covers the case. | ✅ Spike pre-flight refuses BEFORE any REST call (verified live, exit 1, no network mutation). The PHP controller also has its own check (`ensureDeviceUnassigned`); belt-and-braces. |
+| Invalid `ipv4Type` (`not-a-real-type`) | N/A in #714's path. | ✅ HTTP 400 (verified live). |
+| `addItem` with no `device` field | Silent or partial state in #714's path. | ✅ HTTP 400 (verified live). |
+| `name: lan` on `addItem` (try to clobber LAN) | Bypasses our spike's pattern check if the user crafts the YAML directly. | Not exercised live in this run. Controller's `validateExplicitName` regex `^opt\d+$` would reject `lan`; verified by unit tests. |
+| Modify `lan` via `setItem` | N/A | Not exercised live; controller's `setItem` refuses uuid in `lan/wan` (mirror of `delItem` safety); verified by unit tests. |
+
+The cumulative win: every silent-bad-XML risk from #714 becomes a loud HTTP 400 here, with the operator-readable error coming from the controller's own `UserException` flow.
+
+## Auto-snapshot + audit log behavior
+
+OPNsense's `Config::save()` fires the standard pre-write hook chain: capture an automatic backup snapshot, append an audit log entry, then write `/conf/config.xml`. We rely on this for both rollback availability and traceability — without owning either ourselves.
+
+| Question | Result |
+| :--- | :--- |
+| Does `/api/core/backup/backups` work at all on `26.1.6_2`? | ❌ **No.** The endpoint returns HTTP 404 despite being in the spec. Same finding as #714's REST probe. **This blocks the entire auto-rollback design** — the spike degrades by warning loudly and proceeding without rollback armed. |
+| Does an `addItem` REST call produce a new entry in `/api/core/backup/backups`? | Cannot determine — endpoint returns 404 (see above). |
+| Does a `setItem` REST call produce a new entry? | Same — endpoint unavailable. |
+| Does a `delItem` REST call produce a new entry? | Same. |
+| Does the OPNsense System → Log Files → System General audit log show entries for our REST mutations? | Not verified in this run; the GUI was opened to confirm the Interfaces → Assignments page renders, but the audit log was not inspected. The PHP controller calls `Config::getInstance()->save()` which is OPNsense's standard write path — audit log entries should fire automatically. Worth a follow-up confirmation. |
+| Does `revertBackup` with the captured snapshot id roll back the assignment change cleanly? | Not exercised — `backups` endpoint unavailable. ADR-0014's amendment must specify an alternative rollback strategy: either find a different snapshot mechanism on this OPNsense version, or accept "no transactional rollback" and design the production runner around per-resource error handling. |
+| Does `revertBackup` revert ONLY `<interfaces>` or the WHOLE config? | Not exercised. Documented as an open question for the amendment regardless. |
+
+## Round-trip property
+
+| Question | Result |
+| :--- | :--- |
+| `plan` after `apply --confirm` (add cycle) returns 0/0/0? | ✅ yes |
+| `plan` after `apply --confirm` (setItem cycle) returns 0/0/0? | ✅ yes (with 4 locked rows; the locked count is correct and is not a diff) |
+| `plan` after `apply --confirm` (delete cycle) returns 0/0/0? | ✅ yes (with 4 locked rows) |
+| Locked entries preserved across apply cycles? | ✅ yes — `lan`/`lo0`/`wan`/`opt1` carried `lock: true` across the rebind and delete cycles; never appeared in adds/updates/deletes. |
+| IPv4/IPv6 fields round-trip lossy? | ✅ no observed lossiness for the tested case (static IPv4 + track-interface IPv6). The spike's `_needs_update` doesn't deep-compare IPv4/IPv6 dicts (known gap); this means the spike won't propose a re-set for cosmetic-only differences, but it also can't detect drift in those fields. Production must close this gap (see Friction points). |
+
+## Friction points
+
+> Pre-run notes locked in during implementation. The live run will add empirical observations.
+
+- **`InterfaceAssignmentConfig._needs_update` only compares `device` + `description`.** The IPv4/IPv6 raw dicts aren't field-for-field compared because the live representation (`interfacesInfo`'s normalized dict) and the desired representation (typed config fields) don't share a schema. The spike documents this as a deliberate scope choice; ADR-0014's amendment must specify a deep-equality strategy before this graduates to production. Options: (a) call `getItem` and reconstruct the InterfaceAssignmentConfig from it for comparison; (b) maintain a normalizer that maps `interfacesInfo` → typed config; (c) accept the drift and let `apply --confirm` issue a no-op `setItem` when the IPv4/IPv6 fields differ in YAML but the operator doesn't care.
+- **Spike-side device collision pre-flight is a duplicate of the server-side check.** Both the Python spike (`find_lockout_conflicts`) and the PHP controller (`addItem`'s `ensureDeviceUnassigned`) refuse if a device is already bound. The spike's pre-flight gives the operator a coherent error message before any REST call fires; the server-side check is the safety net. Document as belt-and-braces, not redundancy.
+- **`revertBackup` granularity is "the whole config".** OPNsense doesn't expose per-section reverts; rolling back to the pre-apply snapshot blows away other concurrent changes. Acceptable for a spike (operator owns the timeline), but for production this needs either: (a) a "freeze other writes during apply" pattern, or (b) a richer rollback (e.g., capture+revert just the `<interfaces>` subtree). Capture as ADR-0014 amendment open question.
+- **The PHP controller is community-authored and now ours to maintain.** The fork is BSD-2-Clause; we've added IPv6, `setItem`, `getItem`, `searchItem`, and explicit-name. Upstream may evolve; we may upstream our extensions back to the original gist (or its successor repo if `szymczag` publishes one). Tracked in the issue's "Maintenance ownership" section.
+- **No PHP linting in this Python project.** Per the issue's resolved decisions: PHP can't be CI-linted here. Revisit when/if the controller graduates to production. For now, manual review on each PHP edit.
+- **Trust boundary** — community-authored PHP deployed to root on the OPNsense box. The patched + extended file gets a real security review before any production lift (separate ADR/conversion issue).
+- **`/api/core/backup/backups` and `/api/core/backup/download` return HTTP 404 on `26.1.6_2`** despite both being in the OpenAPI spec. **This blocks the entire auto-rollback design.** Same finding as #714's REST probe. The spike correctly degrades — warns loudly and proceeds without rollback — but the production runner needs an alternative. Two options surface for ADR-0014's amendment: (a) accept "no transactional rollback" and rely on server-side per-call validation as the safety net; (b) probe for an alternative snapshot mechanism (perhaps `/api/diagnostics/system/configBackup` if it materializes in a future OPNsense version, or shell out via SSH to `configctl` snapshot commands).
+- **Install script's env-loading was too strict** as originally implemented — required explicit `OPNSENSE_SSH_HOST` and `OPNSENSE_SSH_KEY`, neither of which the operator typically sets in a homelab where `~/.ssh/config` and ssh-agent already provide identity. Fixed in this PR: `OPNSENSE_SSH_HOST` falls back to the host part of `OPNSENSE_API_URL`; `OPNSENSE_SSH_KEY` is optional (empty → use ssh-agent). Friction caught and fixed before completion; documented here so future spikes target the same env model.
+- **OPNsense's root shell is `opnsense-shell` (csh-derived).** `2>/dev/null` is "Ambiguous output redirect." The install's remote-checksum command was rewritten to use `test -f <path> && sha256 -q <path> || echo MISSING`, which is portable across both shells. **General principle for any future SSH-into-OPNsense work**: avoid stderr redirection in the remote command; use `&&`/`||` chaining instead. Mirrors the lesson from #714's `shlex.quote` fix (different bug, same shell-portability theme).
+- **The 4-original-interfaces "fully-managed delete-everything-not-in-YAML" risk** carries forward from VLAN/#714 spikes. Without `--add-only` or explicit `lock: true` entries for `lan`/`lo0`/`wan`/`opt1`, the spike would propose 4 destructive deletes the moment the operator's fixture only declares `opt9`. Cutover fixtures lock the four originals; the spike's `--add-only` flag is the alternative for ad-hoc adds.
+
+## Lines of code per concern
+
+| Concern | LoC (approx) | File |
+| :--- | :--- | :--- |
+| PHP controller (forked + patched + extended) | ~570 | `tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php` |
+| - of which inherited from base gist | ~345 | (verbatim, with `sessionClose()` removed) |
+| - of which net-new in this fork | ~225 | (`setItem`, `getItem`, `searchItem`, IPv6, explicit-name, validation helpers) |
+| Install script (Python) | ~270 | `tools/spikes/interface_assignment_gist_rest/install.py` |
+| Python spike — config models + YAML loader | ~270 | `tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py` |
+| Python spike — REST helpers | ~110 | (above) |
+| Python spike — diff engine + lockout-prevention | ~80 | (above) |
+| Python spike — backup/rollback helpers | ~50 | (above) |
+| Python spike — subcommand handlers + CLI | ~265 | (above) |
+| **Python spike total** | **~1060** | (interface_assignment_gist_rest.py + install.py + tests) |
+| Tests (Python only — PHP not CI-tested) | ~870 | `tests/spikes/test_interface_assignment_gist_rest.py` |
+| Test count | 116 | (`uv run pytest tests/spikes/test_interface_assignment_gist_rest.py`) |
+| Test coverage on the spike Python module | 88.95% | (`uv run pytest --cov=tools.spikes.interface_assignment_gist_rest`) |
+
+For context: the production read-only `interface_assignments` path in `src/infrafoundry/providers/opnsense/services/interface_assignment.py` is ~280 LoC. The spike's read path is roughly equivalent; the new code is the write surface (PHP controller + REST helpers + lockout-prevention + auto-rollback).
+
+## Apply timing
+
+| Operation | Time elapsed |
+| :--- | :--- |
+| `interfacesInfo` (1 GET) | sub-second |
+| `addItem` (1 POST + Config::save + interface reconfigure all) | ~3-5 seconds end-to-end (configd `interface reconfigure all` dominates) |
+| `setItem` (1 POST + same backend) | ~3-5 seconds end-to-end |
+| `delItem` (1 POST + same backend) | ~3-5 seconds end-to-end |
+| `revertBackup` (1 POST) | Not measured — endpoint returns 404 on `26.1.6_2`. |
+| `searchItem` (1 POST, controller-direct) | sub-second (no Config::save, no reconfigure) |
+| `getItem` (1 GET) | sub-second |
+
+The spike doesn't time itself precisely; numbers are observed via wall-clock during the run. Production runner should add structured timing if operators care about it.
+
+## Recommendation
+
+**Recommendation: yes for production lift, with three gates.**
+
+The live run validated the load-bearing claims. The mechanism is sound; the safety improvement over #714 is real.
+
+**Confirmed during the run:**
+
+1. ✅ Server-side validation rejects bad inputs with HTTP 400. Three cases probed live; all rejected. Replaces #714's silent-bad-XML risk.
+2. ✅ `setItem` round-trips the assign payload faithfully — verified via `getItem` after every mutation cycle.
+3. ✅ Explicit `name: opt9` on `addItem` is accepted by OPNsense. No GUI breakage. The cutover affordance is real.
+4. ✅ Lockout-prevention refuses fixtures targeting bound NICs before any REST call.
+5. ✅ Round-trip property holds across add / setItem / delete cycles.
+6. ✅ The patched controller (sessionClose removed) works on `26.1.6_2`.
+
+**Three gates remain for the production lift:**
+
+1. **Alternative rollback strategy.** `/api/core/backup/{backups,download}` returns HTTP 404 on `26.1.6_2`. The auto-rollback path designed in the spike is therefore unavailable on this OPNsense version. Production needs to either: (a) find a working snapshot endpoint on this version (none surfaced during this spike), (b) shell out via SSH to a `configctl` snapshot command (re-introduces SSH dependency for safety), or (c) accept "no transactional rollback" and rely on server-side per-call validation as the safety net. Option (c) is reasonable for `interface_assignments` specifically because OPNsense's standard save flow already takes its own auto-snapshot before each `Config::save()` (visible in the GUI's config history); the operator can manually revert from there. This gate is for ADR-0014's amendment to resolve.
+2. **Auto-snapshot + audit log empirical confirmation.** The PHP controller calls `Config::getInstance()->save()` which is OPNsense's standard write path, so audit log entries should fire automatically. **Not directly verified in this spike** — open the GUI's System → Log Files → System General after each mutation in a follow-up to confirm the audit trail is intact. If the audit log fires, gate (1) option (c) becomes more attractive: the operator has BOTH the GUI's auto-snapshot AND the audit log to reconstruct a manual rollback.
+3. **Security review of the patched + extended PHP controller.** Community-authored code deployed to root on production firewall infrastructure. The fork is BSD-2-Clause; we've added IPv6, `setItem`, `getItem`, `searchItem`, validation helpers, and explicit-name. ~225 LoC of net-new PHP that needs eyes. Track as a follow-up; not blocking the spike's findings.
+
+**ADR-0014 amendment scope:**
+
+- Add `interface_assignments` to the direct-API write path via the gist-based controller. Cite this document.
+- Resolve gate (1) explicitly: name the rollback strategy production will use.
+- Production conversion of `OPNsenseDirectRunner.apply()` for `interface_assignments` from no-op to live dispatches through this controller. Lockout-prevention crosses over unchanged. Rollback strategy follows from the amendment's gate-(1) decision.
+- Install lifecycle for the controller: how does `infra apply` ensure the controller is installed and current? Auto-install on first apply? Fail loudly with `foundry opnsense install-controller`? Wire into `pkg upgrade` post-hooks? Belongs to the production conversion issue, not the amendment itself.
+- Out of scope for this amendment: other GUI-only resource types (gateways, virtual_ips, NAT legacy). Each gets its own spike before production. The mechanism may generalize but the empirical case is `interface_assignments` only.
+
+**Why the mechanism still graduates well despite gate (1):**
+
+The safety improvement over #714 is **per-call server-side validation**, which is intact regardless of rollback availability. We don't own the XML schema — OPNsense's `Config::save()` does. We don't own field validation — the controller's `UserException`-based check chain does. We don't own the audit log — OPNsense's standard save flow does. The only thing we lost vs. #714's design is the post-hoc transactional rollback, which #714 itself only achieved at unacceptable safety cost (silent-bad-XML, scp without server-side schema check). Trading "transactional rollback that risks bricking the box" for "no transactional rollback but every write is server-validated" is a clear safety win.
+
+**The friction we hit during the spike** (env-loading too strict, csh-incompatible remote command) was caught and fixed in this same PR, with tests updated. Both fixes are general-purpose patterns useful for any future OPNsense-via-SSH work. Documented under Friction points.

--- a/tests/spikes/test_interface_assignment_gist_rest.py
+++ b/tests/spikes/test_interface_assignment_gist_rest.py
@@ -1,0 +1,1771 @@
+"""Unit tests for the gist-based REST interface_assignments spike.
+
+Target module: ``tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py``.
+
+These tests cover env-var loading, YAML parsing/validation, the diff engine,
+the apply loop's mutation dispatch, lockout-prevention, the auto-rollback
+path, and the install helper's checksum logic. No live OPNsense box is
+contacted — ``OPNsenseClient`` and ``subprocess.run`` are patched at the
+spike module's import paths, mirroring ``tests/spikes/test_vlan_direct_api.py``.
+
+Live-box validation is operator-driven and recorded in
+``docs/development/opnsense-spike-interface-assignment-gist-findings.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The spike package lives under ``tools/spikes/`` which is already on sys.path.
+from tools.spikes.interface_assignment_gist_rest import install as installer
+from tools.spikes.interface_assignment_gist_rest import (
+    interface_assignment_gist_rest as spike,
+)
+
+SPIKE_CLIENT_PATH = (
+    "tools.spikes.interface_assignment_gist_rest.interface_assignment_gist_rest.OPNsenseClient"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cfg(
+    name: str,
+    device: str,
+    *,
+    description: str = "",
+    enabled: bool = True,
+    lock: bool = False,
+    ipv4_type: str = "none",
+    ipv4_address: str | None = None,
+    ipv4_subnet: int | None = None,
+    ipv6_type: str = "none",
+    ipv6_address: str | None = None,
+    ipv6_subnet: int | None = None,
+    ipv6_track: str | None = None,
+) -> spike.InterfaceAssignmentConfig:
+    return spike.InterfaceAssignmentConfig(
+        name=name,
+        device=device,
+        description=description,
+        enabled=enabled,
+        lock=lock,
+        ipv4_type=ipv4_type,
+        ipv4_address=ipv4_address,
+        ipv4_subnet=ipv4_subnet,
+        ipv6_type=ipv6_type,
+        ipv6_address=ipv6_address,
+        ipv6_subnet=ipv6_subnet,
+        ipv6_track=ipv6_track,
+    )
+
+
+def _live(
+    identifier: str,
+    device: str,
+    *,
+    description: str = "",
+    is_physical: bool = True,
+    ipv4: dict[str, Any] | None = None,
+    ipv6: dict[str, Any] | None = None,
+    macaddr: str = "",
+    mtu: int = 1500,
+) -> spike.LiveInterfaceAssignment:
+    return spike.LiveInterfaceAssignment(
+        identifier=identifier,
+        device=device,
+        description=description,
+        is_physical=is_physical,
+        ipv4=ipv4 or {},
+        ipv6=ipv6 or {},
+        macaddr=macaddr,
+        mtu=mtu,
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_env_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEnvCredentials:
+    """Env var resolution into a ``Credentials`` dataclass."""
+
+    def test_happy_path(self) -> None:
+        env = {
+            "OPNSENSE_API_URL": "https://fw.example.lan",
+            "OPNSENSE_API_KEY": "key-123",
+            "OPNSENSE_API_SECRET": "secret-456",
+            "OPNSENSE_VERIFY_SSL": "true",
+        }
+        creds = spike.load_env_credentials(env)
+        assert creds.api_url == "https://fw.example.lan"
+        assert creds.api_key == "key-123"
+        assert creds.api_secret == "secret-456"
+        assert creds.verify_ssl is True
+
+    def test_missing_api_secret_raises(self) -> None:
+        env = {"OPNSENSE_API_URL": "https://fw", "OPNSENSE_API_KEY": "k"}
+        with pytest.raises(RuntimeError) as exc_info:
+            spike.load_env_credentials(env)
+        assert "OPNSENSE_API_SECRET" in str(exc_info.value)
+
+    def test_empty_string_treated_as_missing(self) -> None:
+        env = {"OPNSENSE_API_URL": "", "OPNSENSE_API_KEY": "k", "OPNSENSE_API_SECRET": "s"}
+        with pytest.raises(RuntimeError, match="OPNSENSE_API_URL"):
+            spike.load_env_credentials(env)
+
+    @pytest.mark.parametrize("falsey", ["false", "False", "0", "no", "off", "OFF"])
+    def test_verify_ssl_falsey(self, falsey: str) -> None:
+        env = {
+            "OPNSENSE_API_URL": "https://fw",
+            "OPNSENSE_API_KEY": "k",
+            "OPNSENSE_API_SECRET": "s",
+            "OPNSENSE_VERIFY_SSL": falsey,
+        }
+        creds = spike.load_env_credentials(env)
+        assert creds.verify_ssl is False
+
+    def test_verify_ssl_default_true(self) -> None:
+        env = {
+            "OPNSENSE_API_URL": "https://fw",
+            "OPNSENSE_API_KEY": "k",
+            "OPNSENSE_API_SECRET": "s",
+        }
+        creds = spike.load_env_credentials(env)
+        assert creds.verify_ssl is True
+
+
+# ---------------------------------------------------------------------------
+# load_assignments_from_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAssignmentsFromYaml:
+    """YAML parsing + per-field validation."""
+
+    def test_minimal_valid(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: spike
+""",
+            encoding="utf-8",
+        )
+        result = spike.load_assignments_from_yaml(path)
+        assert len(result) == 1
+        cfg = result[0]
+        assert cfg.name == "opt5"
+        assert cfg.device == "igc0"
+        assert cfg.description == "spike"
+        assert cfg.enabled is True
+        assert cfg.lock is False
+        assert cfg.ipv4_type == "none"
+        assert cfg.ipv6_type == "none"
+
+    def test_full_dual_stack(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt6
+  config:
+    device: igc1
+    description: dual-stack
+    enabled: true
+    spoof_mac: "aa:bb:cc:dd:ee:ff"
+    ipv4:
+      type: static
+      address: 10.0.0.1
+      subnet: 24
+    ipv6:
+      type: track-interface
+      track: wan
+""",
+            encoding="utf-8",
+        )
+        cfgs = spike.load_assignments_from_yaml(path)
+        assert len(cfgs) == 1
+        cfg = cfgs[0]
+        assert cfg.spoof_mac == "aa:bb:cc:dd:ee:ff"
+        assert cfg.ipv4_type == "static"
+        assert cfg.ipv4_address == "10.0.0.1"
+        assert cfg.ipv4_subnet == 24
+        assert cfg.ipv6_type == "track-interface"
+        assert cfg.ipv6_track == "wan"
+
+    def test_static_ipv6(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt7
+  config:
+    device: igc2
+    description: ""
+    ipv6:
+      type: static
+      address: "fd00:1::1"
+      subnet: 64
+""",
+            encoding="utf-8",
+        )
+        cfg = spike.load_assignments_from_yaml(path)[0]
+        assert cfg.ipv6_type == "static"
+        assert cfg.ipv6_address == "fd00:1::1"
+        assert cfg.ipv6_subnet == 64
+
+    def test_lock_field(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: lan
+  lock: true
+  config:
+    device: ixl0
+    description: LAN
+""",
+            encoding="utf-8",
+        )
+        cfg = spike.load_assignments_from_yaml(path)[0]
+        assert cfg.lock is True
+
+    def test_other_resource_types_ignored(self, tmp_path: Path) -> None:
+        path = tmp_path / "mixed.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: vlan
+  name: irrelevant
+  config: {device: igb0, tag: 10, description: a, priority: 0}
+- provider: opnsense
+  type: interface_assignments
+  name: opt8
+  config: {device: igc3, description: kept}
+""",
+            encoding="utf-8",
+        )
+        cfgs = spike.load_assignments_from_yaml(path)
+        assert len(cfgs) == 1
+        assert cfgs[0].name == "opt8"
+
+    def test_top_level_not_list_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text("provider: opnsense\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="top-level list"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_missing_device_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    description: missing-device
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="device"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_invalid_lock_type(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  lock: "true"
+  config:
+    device: igc0
+    description: test
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="lock must be a boolean"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_invalid_enabled_type(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: test
+    enabled: "yes"
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="enabled must be a boolean"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv4_static_missing_address(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv4:
+      type: static
+      subnet: 24
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=r"ipv4\.address"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv4_subnet_out_of_range(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv4:
+      type: static
+      address: 10.0.0.1
+      subnet: 64
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="out of range 1-32"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv4_invalid_type(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv4:
+      type: pppoe
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=r"ipv4\.type"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv4_address_provided_with_dhcp_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv4:
+      type: dhcp
+      address: 10.0.0.1
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=r"ipv4\.address/subnet only valid"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv6_track_missing_track_field(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv6:
+      type: track-interface
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=r"ipv6\.track"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv6_static_missing_subnet(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv6:
+      type: static
+      address: "fd00::1"
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=r"ipv6\.subnet"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv6_subnet_out_of_range(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv6:
+      type: static
+      address: "fd00::1"
+      subnet: 200
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="out of range 1-128"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv6_invalid_type(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv6:
+      type: pppoe-v6
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=r"ipv6\.type"):
+            spike.load_assignments_from_yaml(path)
+
+    def test_ipv4_block_must_be_mapping(self, tmp_path: Path) -> None:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: ""
+    ipv4: "not-a-mapping"
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="ipv4 must be a mapping"):
+            spike.load_assignments_from_yaml(path)
+
+
+# ---------------------------------------------------------------------------
+# InterfaceAssignmentConfig.to_payload
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadShape:
+    """The PHP controller expects ``{"assign": {<fields>}}``."""
+
+    def test_minimal_payload_includes_basics(self) -> None:
+        cfg = _cfg("opt5", "igc0", description="hi")
+        payload = cfg.to_payload()
+        assert "assign" in payload
+        assign = payload["assign"]
+        assert assign["device"] == "igc0"
+        assert assign["description"] == "hi"
+        assert assign["enable"] is True
+        assert assign["name"] == "opt5"
+        assert assign["ipv4Type"] == "none"
+        assert assign["ipv6Type"] == "none"
+        # No ipv4Address/Subnet/spoofMac/ipv6Track when not set.
+        assert "ipv4Address" not in assign
+        assert "ipv4Subnet" not in assign
+        assert "spoofMac" not in assign
+        assert "ipv6Track" not in assign
+
+    def test_static_ipv4_payload(self) -> None:
+        cfg = _cfg(
+            "opt5",
+            "igc0",
+            description="hi",
+            ipv4_type="static",
+            ipv4_address="10.0.0.1",
+            ipv4_subnet=24,
+        )
+        assign = cfg.to_payload()["assign"]
+        assert assign["ipv4Type"] == "static"
+        assert assign["ipv4Address"] == "10.0.0.1"
+        assert assign["ipv4Subnet"] == 24
+
+    def test_track_ipv6_payload(self) -> None:
+        cfg = _cfg("opt5", "igc0", description="hi", ipv6_type="track-interface", ipv6_track="wan")
+        assign = cfg.to_payload()["assign"]
+        assert assign["ipv6Type"] == "track-interface"
+        assert assign["ipv6Track"] == "wan"
+
+    def test_static_ipv6_payload(self) -> None:
+        cfg = _cfg(
+            "opt5",
+            "igc0",
+            description="hi",
+            ipv6_type="static",
+            ipv6_address="fd00::1",
+            ipv6_subnet=64,
+        )
+        assign = cfg.to_payload()["assign"]
+        assert assign["ipv6Type"] == "static"
+        assert assign["ipv6Address"] == "fd00::1"
+        assert assign["ipv6Subnet"] == 64
+        # Track field not emitted when type is static.
+        assert "ipv6Track" not in assign
+
+    def test_spoof_mac_emitted_when_set(self) -> None:
+        cfg = _cfg("opt5", "igc0", description="x")
+        cfg2 = spike.InterfaceAssignmentConfig(
+            name=cfg.name,
+            device=cfg.device,
+            description=cfg.description,
+            spoof_mac="aa:bb:cc:dd:ee:ff",
+        )
+        assign = cfg2.to_payload()["assign"]
+        assert assign["spoofMac"] == "aa:bb:cc:dd:ee:ff"
+
+
+# ---------------------------------------------------------------------------
+# Diff engine
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDiff:
+    """Diff keyed by logical interface name (identifier)."""
+
+    def test_no_changes(self) -> None:
+        desired = [_cfg("opt3", "igc0", description="x")]
+        current = [_live("opt3", "igc0", description="x")]
+        diff = spike.compute_diff(desired, current)
+        assert diff.is_empty
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+
+    def test_add_only(self) -> None:
+        desired = [_cfg("opt3", "igc0")]
+        diff = spike.compute_diff(desired, [])
+        assert len(diff.adds) == 1
+        assert diff.adds[0].name == "opt3"
+
+    def test_delete_only(self) -> None:
+        current = [_live("opt5", "igc0")]
+        diff = spike.compute_diff([], current)
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].identifier == "opt5"
+
+    def test_update_when_device_differs(self) -> None:
+        desired = [_cfg("opt3", "igc1", description="x")]
+        current = [_live("opt3", "igc0", description="x")]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.updates) == 1
+        live, want = diff.updates[0]
+        assert live.device == "igc0"
+        assert want.device == "igc1"
+
+    def test_update_when_description_differs(self) -> None:
+        desired = [_cfg("opt3", "igc0", description="new")]
+        current = [_live("opt3", "igc0", description="old")]
+        diff = spike.compute_diff(desired, current)
+        assert len(diff.updates) == 1
+
+    def test_locked_yaml_with_match(self) -> None:
+        desired = [_cfg("lan", "ixl0", description="LAN", lock=True)]
+        current = [_live("lan", "ixl0", description="LAN")]
+        diff = spike.compute_diff(desired, current)
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+        assert len(diff.locked) == 1
+        want, have = diff.locked[0]
+        assert want.lock is True
+        assert have is not None
+
+    def test_locked_yaml_without_match(self) -> None:
+        desired = [_cfg("opt99", "missing-nic", lock=True)]
+        diff = spike.compute_diff(desired, [])
+        assert len(diff.locked) == 1
+        _, have = diff.locked[0]
+        assert have is None
+
+    def test_locked_protects_live_resource_from_delete(self) -> None:
+        desired = [
+            _cfg("lan", "ixl0", lock=True),
+            _cfg("opt3", "igc0", description="new"),
+        ]
+        current = [
+            _live("lan", "ixl0"),
+            _live("opt5", "igc1", description="going-away"),
+        ]
+        diff = spike.compute_diff(desired, current)
+        # opt3 add, opt5 delete, lan locked
+        assert len(diff.adds) == 1
+        assert diff.adds[0].name == "opt3"
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].identifier == "opt5"
+        assert len(diff.locked) == 1
+
+    def test_add_only_suppresses_deletes(self) -> None:
+        desired = [_cfg("opt3", "igc0")]
+        current = [_live("opt5", "igc1")]
+        diff = spike.compute_diff(desired, current, add_only=True)
+        assert len(diff.adds) == 1
+        assert len(diff.deletes) == 0
+        assert not diff.is_empty
+
+    def test_add_only_still_updates(self) -> None:
+        desired = [_cfg("opt3", "igc0", description="new")]
+        current = [_live("opt3", "igc0", description="old")]
+        diff = spike.compute_diff(desired, current, add_only=True)
+        assert len(diff.updates) == 1
+
+
+# ---------------------------------------------------------------------------
+# Lockout-prevention
+# ---------------------------------------------------------------------------
+
+
+class TestLockoutPrevention:
+    """``find_lockout_conflicts`` must catch device collisions before apply."""
+
+    def test_no_conflicts_returns_empty(self) -> None:
+        diff = spike.compute_diff([_cfg("opt3", "igc0")], [])
+        assert spike.find_lockout_conflicts(diff, []) == []
+
+    def test_add_to_already_bound_device_flagged(self) -> None:
+        # We want to add opt3 -> igc0, but igc0 is already bound to opt5.
+        desired = [_cfg("opt3", "igc0")]
+        current = [_live("opt5", "igc0")]
+        diff = spike.Diff(adds=desired, updates=[], deletes=[], locked=[])
+        msgs = spike.find_lockout_conflicts(diff, current)
+        assert len(msgs) == 1
+        assert "opt3" in msgs[0]
+        assert "igc0" in msgs[0]
+        assert "opt5" in msgs[0]
+
+    def test_update_to_already_bound_device_flagged(self) -> None:
+        # opt3 wants to move from igc0 to igc1, but igc1 is bound to opt7.
+        live_to_update = _live("opt3", "igc0")
+        want = _cfg("opt3", "igc1")
+        current = [live_to_update, _live("opt7", "igc1")]
+        diff = spike.Diff(
+            adds=[],
+            updates=[(live_to_update, want)],
+            deletes=[],
+            locked=[],
+        )
+        msgs = spike.find_lockout_conflicts(diff, current)
+        assert len(msgs) == 1
+        assert "opt3" in msgs[0]
+        assert "igc1" in msgs[0]
+        assert "opt7" in msgs[0]
+
+    def test_update_no_device_change_is_safe(self) -> None:
+        live_to_update = _live("opt3", "igc0", description="old")
+        want = _cfg("opt3", "igc0", description="new")
+        diff = spike.Diff(
+            adds=[],
+            updates=[(live_to_update, want)],
+            deletes=[],
+            locked=[],
+        )
+        msgs = spike.find_lockout_conflicts(diff, [live_to_update])
+        assert msgs == []
+
+
+# ---------------------------------------------------------------------------
+# REST helpers — fetch / add / update / delete / get / search
+# ---------------------------------------------------------------------------
+
+
+class TestRestHelpers:
+    """Each REST helper hits the right module/controller/command coordinates."""
+
+    def test_fetch_interfaces_info(self) -> None:
+        client = MagicMock()
+        client.get.return_value = {
+            "rows": [
+                {
+                    "identifier": "lan",
+                    "device": "ixl0",
+                    "description": "LAN",
+                    "is_physical": True,
+                    "ipv4": {"address": "192.168.1.1"},
+                    "ipv6": {},
+                    "macaddr": "aa:bb:cc:dd:ee:ff",
+                    "mtu": "1500",
+                },
+                {
+                    # Empty identifier — unassigned NIC, must be filtered.
+                    "identifier": "",
+                    "device": "igc7",
+                    "description": "",
+                    "is_physical": True,
+                    "ipv4": {},
+                    "ipv6": {},
+                    "macaddr": "",
+                    "mtu": 0,
+                },
+            ]
+        }
+        result = spike.fetch_interfaces_info(client)
+        assert len(result) == 1
+        assert result[0].identifier == "lan"
+        assert result[0].mtu == 1500
+        client.get.assert_called_once_with("interfaces", "overview", "interfacesInfo")
+
+    def test_fetch_with_non_dict_response(self) -> None:
+        client = MagicMock()
+        client.get.return_value = "garbage"
+        assert spike.fetch_interfaces_info(client) == []
+
+    def test_fetch_with_malformed_rows(self) -> None:
+        client = MagicMock()
+        client.get.return_value = {
+            "rows": [
+                "not-a-dict",
+                {"identifier": "opt1", "device": "igc0"},
+            ]
+        }
+        result = spike.fetch_interfaces_info(client)
+        assert len(result) == 1
+        assert result[0].identifier == "opt1"
+
+    def test_fetch_handles_unparseable_mtu(self) -> None:
+        client = MagicMock()
+        client.get.return_value = {
+            "rows": [
+                {
+                    "identifier": "opt1",
+                    "device": "igc0",
+                    "description": "",
+                    "is_physical": True,
+                    "ipv4": {},
+                    "ipv6": {},
+                    "macaddr": "",
+                    "mtu": "garbage",
+                }
+            ]
+        }
+        result = spike.fetch_interfaces_info(client)
+        assert result[0].mtu == 0
+
+    def test_add_assignment(self) -> None:
+        client = MagicMock()
+        client.post.return_value = {"result": "saved", "ifname": "opt5"}
+        cfg = _cfg("opt5", "igc0", description="x")
+        result = spike.add_assignment(client, cfg)
+        assert result == {"result": "saved", "ifname": "opt5"}
+        client.post.assert_called_once_with(
+            "interfaces", "assign_settings", "addItem", json=cfg.to_payload()
+        )
+
+    def test_update_assignment(self) -> None:
+        client = MagicMock()
+        client.post.return_value = {"result": "saved", "ifname": "opt3"}
+        cfg = _cfg("opt3", "igc1", description="x")
+        result = spike.update_assignment(client, "opt3", cfg)
+        assert result == {"result": "saved", "ifname": "opt3"}
+        client.post.assert_called_once_with(
+            "interfaces", "assign_settings", "setItem", "opt3", json=cfg.to_payload()
+        )
+
+    def test_delete_assignment(self) -> None:
+        client = MagicMock()
+        client.post.return_value = {"result": "deleted"}
+        result = spike.delete_assignment(client, "opt3")
+        assert result == {"result": "deleted"}
+        client.post.assert_called_once_with("interfaces", "assign_settings", "delItem", "opt3")
+
+    def test_get_assignment(self) -> None:
+        client = MagicMock()
+        client.get.return_value = {"result": "ok", "assign": {"device": "igc0"}}
+        result = spike.get_assignment(client, "opt3")
+        assert result["result"] == "ok"
+        client.get.assert_called_once_with("interfaces", "assign_settings", "getItem", "opt3")
+
+    def test_search_assignments_via_controller(self) -> None:
+        client = MagicMock()
+        client.post.return_value = {
+            "result": "ok",
+            "rows": [{"uuid": "opt1", "device": "igc0"}, "garbage", {"uuid": "opt2"}],
+            "total": 2,
+        }
+        result = spike.search_assignments_via_controller(client)
+        assert len(result) == 2
+        client.post.assert_called_once_with("interfaces", "assign_settings", "searchItem")
+
+    def test_search_with_non_dict_response(self) -> None:
+        client = MagicMock()
+        client.post.return_value = "garbage"
+        assert spike.search_assignments_via_controller(client) == []
+
+    def test_add_returns_raw_when_response_not_dict(self) -> None:
+        client = MagicMock()
+        client.post.return_value = "weird-string"
+        cfg = _cfg("opt5", "igc0", description="x")
+        result = spike.add_assignment(client, cfg)
+        assert result == {"raw": "weird-string"}
+
+
+# ---------------------------------------------------------------------------
+# Backup helpers
+# ---------------------------------------------------------------------------
+
+
+class TestBackupHelpers:
+    """List + capture latest + revert backup."""
+
+    def test_list_returns_list_response_directly(self) -> None:
+        client = MagicMock()
+        client.get.return_value = ["snap1", "snap2"]
+        assert spike.list_backup_ids(client) == ["snap1", "snap2"]
+
+    def test_list_unwraps_dict_with_backups_key(self) -> None:
+        client = MagicMock()
+        client.get.return_value = {"backups": ["a", "b"]}
+        assert spike.list_backup_ids(client) == ["a", "b"]
+
+    def test_list_unwraps_flat_dict(self) -> None:
+        client = MagicMock()
+        client.get.return_value = {"snap1": {}, "snap2": {}}
+        # We can't depend on dict ordering for the result list, so check membership.
+        assert set(spike.list_backup_ids(client)) == {"snap1", "snap2"}
+
+    def test_list_handles_unexpected_type(self) -> None:
+        client = MagicMock()
+        client.get.return_value = "garbage"
+        assert spike.list_backup_ids(client) == []
+
+    def test_capture_latest_returns_first(self) -> None:
+        client = MagicMock()
+        client.get.return_value = ["newest", "older"]
+        assert spike.capture_latest_backup_id(client) == "newest"
+
+    def test_capture_latest_returns_none_when_empty(self) -> None:
+        client = MagicMock()
+        client.get.return_value = []
+        assert spike.capture_latest_backup_id(client) is None
+
+    def test_revert_to_backup(self) -> None:
+        client = MagicMock()
+        client.post.return_value = {"status": "ok"}
+        result = spike.revert_to_backup(client, "snap-id-1")
+        assert result == {"status": "ok"}
+        client.post.assert_called_once_with("core", "backup", "revertBackup", "snap-id-1")
+
+    def test_revert_returns_raw_on_non_dict(self) -> None:
+        client = MagicMock()
+        client.post.return_value = "weird"
+        result = spike.revert_to_backup(client, "snap-1")
+        assert result == {"raw": "weird"}
+
+
+# ---------------------------------------------------------------------------
+# Apply loop — dispatch + auto-rollback
+# ---------------------------------------------------------------------------
+
+
+class TestCmdApply:
+    """``cmd_apply`` dispatches mutations only when ``--confirm`` is passed."""
+
+    @staticmethod
+    def _yaml_with_one(tmp_path: Path, name: str, device: str) -> Path:
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            f"""
+- provider: opnsense
+  type: interface_assignments
+  name: {name}
+  config:
+    device: {device}
+    description: spike
+""",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_dry_run_dispatches_no_mutations(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = MagicMock()
+        client.get.return_value = {"rows": []}
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=False)
+
+        assert rc == 0
+        # No add/set/del POSTs were made (only the GET for interfacesInfo).
+        for call in client.post.call_args_list:
+            args = call.args
+            # Note: searchItem, addItem, setItem, delItem all POST to "assign_settings".
+            assert args[0:2] != ("interfaces", "assign_settings")
+        out = capsys.readouterr().out
+        assert "Dry run" in out
+
+    def test_no_diff_skips_mutations(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        # Existing row exactly matches the YAML.
+        client.get.return_value = {
+            "rows": [
+                {
+                    "identifier": "opt5",
+                    "device": "igc0",
+                    "description": "spike",
+                    "is_physical": True,
+                    "ipv4": {},
+                    "ipv6": {},
+                    "macaddr": "",
+                    "mtu": 1500,
+                }
+            ]
+        }
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True)
+
+        assert rc == 0
+        # No mutating POSTs.
+        post_calls = [
+            call
+            for call in client.post.call_args_list
+            if call.args[0:2] == ("interfaces", "assign_settings")
+        ]
+        assert post_calls == []
+
+    def test_confirm_dispatches_add(self, tmp_path: Path) -> None:
+        client = MagicMock()
+
+        # interfacesInfo (read) returns empty; backups returns one snapshot.
+        # The MagicMock `.get` is shared by both, so use side_effect for ordering.
+        def get_side_effect(*args: Any, **kwargs: Any) -> Any:
+            if args[2] == "interfacesInfo":
+                return {"rows": []}
+            if args[2] == "backups":
+                return ["snap-1"]
+            return {}
+
+        client.get.side_effect = get_side_effect
+        client.post.return_value = {"result": "saved", "ifname": "opt5"}
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True)
+
+        assert rc == 0
+        # A POST went to addItem with the right payload.
+        add_calls = [
+            call
+            for call in client.post.call_args_list
+            if call.args[0:3] == ("interfaces", "assign_settings", "addItem")
+        ]
+        assert len(add_calls) == 1
+        payload = add_calls[0].kwargs["json"]
+        assert payload["assign"]["device"] == "igc0"
+        assert payload["assign"]["name"] == "opt5"
+
+    def test_lockout_blocks_apply(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        client = MagicMock()
+        # Existing row binds igc0 to opt9 — so adding opt5 -> igc0 must fail.
+        client.get.return_value = {
+            "rows": [
+                {
+                    "identifier": "opt9",
+                    "device": "igc0",
+                    "description": "incumbent",
+                    "is_physical": True,
+                    "ipv4": {},
+                    "ipv6": {},
+                    "macaddr": "",
+                    "mtu": 1500,
+                }
+            ]
+        }
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True, add_only=True)
+
+        assert rc == 1
+        # No POST was made (lockout fires before the apply loop).
+        post_calls = [
+            call
+            for call in client.post.call_args_list
+            if call.args[0:2] == ("interfaces", "assign_settings")
+        ]
+        assert post_calls == []
+        out = capsys.readouterr().out
+        assert "Lockout risk" in out
+
+    def test_apply_failure_triggers_auto_rollback(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        client = MagicMock()
+        client.get.side_effect = lambda *args, **_: (
+            {"rows": []} if args[2] == "interfacesInfo" else ["snap-1"]
+        )
+
+        # First POST — addItem — returns failed. Subsequent POST — revertBackup —
+        # returns ok. Track post-call sequence using side_effect.
+        post_responses = [
+            {"result": "failed", "errorMessage": "device collision"},  # addItem fails
+            {"status": "ok"},  # revertBackup succeeds
+        ]
+        client.post.side_effect = post_responses
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True)
+
+        assert rc == 1
+        # Two POSTs: addItem (failed), revertBackup (rollback).
+        assert client.post.call_count == 2
+        rollback_call = client.post.call_args_list[1]
+        assert rollback_call.args[0:3] == ("core", "backup", "revertBackup")
+        assert rollback_call.args[3] == "snap-1"
+        out = capsys.readouterr().out
+        assert "Apply failed" in out
+        assert "Auto-rollback" in out
+
+    def test_no_rollback_flag_skips_revert(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.get.return_value = {"rows": []}
+        client.post.return_value = {"result": "failed", "errorMessage": "boom"}
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True, no_rollback=True)
+
+        assert rc == 1
+        # Only one POST — the addItem (failed). No rollback.
+        assert client.post.call_count == 1
+        assert client.post.call_args.args[2] == "addItem"
+
+    def test_backup_snapshot_id_override(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        client.get.return_value = {"rows": []}
+        # add fails; rollback is invoked with the supplied id, not from list_backup_ids.
+        client.post.side_effect = [
+            {"result": "failed", "errorMessage": "boom"},
+            {"status": "ok"},
+        ]
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True, backup_snapshot_id="manual-snap-99")
+
+        assert rc == 1
+        rollback_call = client.post.call_args_list[1]
+        assert rollback_call.args[0:3] == ("core", "backup", "revertBackup")
+        assert rollback_call.args[3] == "manual-snap-99"
+        # client.get for backups must NOT have been called (we skip auto-capture).
+        get_paths = [c.args[0:3] for c in client.get.call_args_list]
+        assert ("core", "backup", "backups") not in get_paths
+
+    def test_update_path_dispatches_set_item(self, tmp_path: Path) -> None:
+        client = MagicMock()
+
+        # interfacesInfo: opt5 currently bound to igc0 with description "old".
+        # backups: ["snap-1"]
+        def get_side_effect(*args: Any, **_: Any) -> Any:
+            if args[2] == "interfacesInfo":
+                return {
+                    "rows": [
+                        {
+                            "identifier": "opt5",
+                            "device": "igc0",
+                            "description": "old",
+                            "is_physical": True,
+                            "ipv4": {},
+                            "ipv6": {},
+                            "macaddr": "",
+                            "mtu": 1500,
+                        }
+                    ]
+                }
+            return ["snap-1"]
+
+        client.get.side_effect = get_side_effect
+        client.post.return_value = {"result": "saved", "ifname": "opt5"}
+        # YAML targets opt5 -> igc0 with description "spike", forcing setItem.
+        yaml_path = self._yaml_with_one(tmp_path, "opt5", "igc0")
+
+        rc = spike.cmd_apply(client, yaml_path, confirm=True)
+
+        assert rc == 0
+        set_calls = [call for call in client.post.call_args_list if call.args[2] == "setItem"]
+        assert len(set_calls) == 1
+        assert set_calls[0].args[3] == "opt5"
+
+    def test_delete_path_dispatches_del_item(self, tmp_path: Path) -> None:
+        client = MagicMock()
+
+        # interfacesInfo: opt5 exists, but YAML asks for opt9 with no opt5 entry.
+        def get_side_effect(*args: Any, **_: Any) -> Any:
+            if args[2] == "interfacesInfo":
+                return {
+                    "rows": [
+                        {
+                            "identifier": "opt5",
+                            "device": "igc0",
+                            "description": "going",
+                            "is_physical": True,
+                            "ipv4": {},
+                            "ipv6": {},
+                            "macaddr": "",
+                            "mtu": 1500,
+                        }
+                    ]
+                }
+            return ["snap-1"]
+
+        client.get.side_effect = get_side_effect
+        client.post.return_value = {"result": "deleted"}
+        # YAML wants opt9 -> igc1, so opt5 gets deleted.
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt9
+  config:
+    device: igc1
+    description: replacement
+""",
+            encoding="utf-8",
+        )
+
+        rc = spike.cmd_apply(client, path, confirm=True)
+
+        assert rc == 0
+        del_calls = [call for call in client.post.call_args_list if call.args[2] == "delItem"]
+        assert len(del_calls) == 1
+        assert del_calls[0].args[3] == "opt5"
+
+
+# ---------------------------------------------------------------------------
+# cmd_list / cmd_inspect / cmd_plan
+# ---------------------------------------------------------------------------
+
+
+class TestCmdList:
+    def test_list_emits_yaml(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = MagicMock()
+        client.get.return_value = {
+            "rows": [
+                {
+                    "identifier": "lan",
+                    "device": "ixl0",
+                    "description": "LAN",
+                    "is_physical": True,
+                    "ipv4": {},
+                    "ipv6": {},
+                    "macaddr": "",
+                    "mtu": 1500,
+                }
+            ]
+        }
+        rc = spike.cmd_list(client)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "interface_assignments" in out
+        assert "name: lan" in out
+        assert "device: ixl0" in out
+
+    def test_list_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        client = MagicMock()
+        client.get.return_value = {"rows": []}
+        rc = spike.cmd_list(client)
+        assert rc == 0
+        assert "no interface assignments" in capsys.readouterr().out
+
+
+class TestCmdPlan:
+    def test_plan_renders_diff(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        client = MagicMock()
+        client.get.return_value = {"rows": []}
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: spike
+""",
+            encoding="utf-8",
+        )
+        rc = spike.cmd_plan(client, path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "1 to add" in out
+        assert "opt5" in out
+
+
+class TestCmdInspect:
+    def test_inspect_skips_checksum_when_ssh_env_missing(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Strip both SSH env AND OPNSENSE_API_URL so installer.load_ssh_target
+        # has nothing to fall back on and raises RuntimeError. (Without
+        # API_URL stripped, the host would be derived from it.)
+        for key in (
+            "OPNSENSE_SSH_HOST",
+            "OPNSENSE_SSH_KEY",
+            "OPNSENSE_SSH_USER",
+            "OPNSENSE_API_URL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        client = MagicMock()
+        client.detect_version.return_value = "26.1.6_2"
+        client.get.return_value = {"rows": []}
+
+        rc = spike.cmd_inspect(client)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "26.1.6_2" in out
+        assert "Controller checksum check skipped" in out
+
+    def test_inspect_reports_checksum_when_ssh_target_loadable(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        key_file = tmp_path / "id_rsa"
+        key_file.write_text("dummy", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key_file))
+
+        client = MagicMock()
+        client.detect_version.return_value = "26.1.6_2"
+        client.get.return_value = {"rows": []}
+
+        with patch.object(installer, "verify_installed_checksum") as verify:
+            verify.return_value = (True, "abc123def456789", "abc123def456789")
+            rc = spike.cmd_inspect(client)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Controller installed and current" in out
+
+    def test_inspect_returns_1_when_interfaces_info_fails(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for key in ("OPNSENSE_SSH_HOST", "OPNSENSE_SSH_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        client = MagicMock()
+        client.detect_version.return_value = "26.1.6_2"
+        client.get.side_effect = RuntimeError("boom")
+
+        rc = spike.cmd_inspect(client)
+
+        assert rc == 1
+        assert "interfacesInfo probe failed" in capsys.readouterr().out
+
+    def test_inspect_reports_missing_controller(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        key_file = tmp_path / "id_rsa"
+        key_file.write_text("dummy", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key_file))
+
+        client = MagicMock()
+        client.detect_version.return_value = "26.1.6_2"
+        client.get.return_value = {"rows": []}
+
+        with patch.object(installer, "verify_installed_checksum") as verify:
+            verify.return_value = (False, None, "abc123def456789")
+            rc = spike.cmd_inspect(client)
+
+        assert rc == 0
+        assert "NOT installed" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# build_client
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClient:
+    def test_uses_auto_detect_version_true(self) -> None:
+        creds = spike.Credentials(
+            api_url="https://fw",
+            api_key="k",
+            api_secret="s",
+            verify_ssl=False,
+        )
+        with patch(SPIKE_CLIENT_PATH) as client_cls:
+            spike.build_client(creds)
+        client_cls.assert_called_once_with(
+            base_url="https://fw",
+            api_key="k",
+            api_secret="s",
+            verify_ssl=False,
+            auto_detect_version=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# main() — argparse + finally close()
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_main_inspect_closes_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in ("OPNSENSE_SSH_HOST", "OPNSENSE_SSH_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OPNSENSE_API_URL", "https://fw")
+        monkeypatch.setenv("OPNSENSE_API_KEY", "k")
+        monkeypatch.setenv("OPNSENSE_API_SECRET", "s")
+        monkeypatch.setenv("OPNSENSE_VERIFY_SSL", "false")
+
+        fake = MagicMock()
+        fake.detect_version.return_value = "26.1.6_2"
+        fake.get.return_value = {"rows": []}
+
+        with patch(SPIKE_CLIENT_PATH, return_value=fake):
+            rc = spike.main(["inspect"])
+
+        assert rc == 0
+        fake.close.assert_called_once()
+
+    def test_main_propagates_missing_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in ("OPNSENSE_API_URL", "OPNSENSE_API_KEY", "OPNSENSE_API_SECRET"):
+            monkeypatch.delenv(key, raising=False)
+        with pytest.raises(RuntimeError, match="Missing"):
+            spike.main(["inspect"])
+
+    def test_main_install_does_not_open_client(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # ``install`` is SSH-only — it should NOT instantiate OPNsenseClient
+        # nor read REST env vars.
+        for key in ("OPNSENSE_API_URL", "OPNSENSE_API_KEY", "OPNSENSE_API_SECRET"):
+            monkeypatch.delenv(key, raising=False)
+        key_file = tmp_path / "id_rsa"
+        key_file.write_text("dummy", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key_file))
+
+        with (
+            patch(SPIKE_CLIENT_PATH) as client_cls,
+            patch.object(installer, "install_controller") as install,
+        ):
+            rc = spike.main(["install"])
+
+        assert rc == 0
+        client_cls.assert_not_called()
+        install.assert_called_once()
+
+    def test_main_apply_dry_run(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("OPNSENSE_API_URL", "https://fw")
+        monkeypatch.setenv("OPNSENSE_API_KEY", "k")
+        monkeypatch.setenv("OPNSENSE_API_SECRET", "s")
+        monkeypatch.setenv("OPNSENSE_VERIFY_SSL", "false")
+        path = tmp_path / "ia.yaml"
+        path.write_text(
+            """
+- provider: opnsense
+  type: interface_assignments
+  name: opt5
+  config:
+    device: igc0
+    description: spike
+""",
+            encoding="utf-8",
+        )
+        fake = MagicMock()
+        fake.get.return_value = {"rows": []}
+
+        with patch(SPIKE_CLIENT_PATH, return_value=fake):
+            rc = spike.main(["apply", str(path)])
+
+        assert rc == 0
+        fake.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _raise_on_failure
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseOnFailure:
+    def test_saved_passes(self) -> None:
+        spike._raise_on_failure({"result": "saved", "ifname": "opt5"}, "add opt5")
+
+    def test_deleted_passes(self) -> None:
+        spike._raise_on_failure({"result": "deleted"}, "delItem opt5")
+
+    def test_ok_passes(self) -> None:
+        spike._raise_on_failure({"result": "ok"}, "getItem opt5")
+
+    def test_failed_raises_runtime(self) -> None:
+        with pytest.raises(RuntimeError) as exc_info:
+            spike._raise_on_failure(
+                {"result": "failed", "errorMessage": "device taken"}, "add opt5"
+            )
+        assert "device taken" in str(exc_info.value)
+        assert "add opt5" in str(exc_info.value)
+
+    def test_failed_without_message_falls_back_to_response(self) -> None:
+        with pytest.raises(RuntimeError) as exc_info:
+            spike._raise_on_failure({"result": "failed"}, "add opt5")
+        assert "add opt5" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Module reload sanity
+# ---------------------------------------------------------------------------
+
+
+def test_spike_module_imports_cleanly() -> None:
+    """Importing the spike must not contact the network or read env vars eagerly."""
+    sys.modules.pop(
+        "tools.spikes.interface_assignment_gist_rest.interface_assignment_gist_rest", None
+    )
+    reloaded: Any = importlib.import_module(
+        "tools.spikes.interface_assignment_gist_rest.interface_assignment_gist_rest"
+    )
+    assert hasattr(reloaded, "main")
+    assert hasattr(reloaded, "compute_diff")
+    assert hasattr(reloaded, "find_lockout_conflicts")
+
+
+# ---------------------------------------------------------------------------
+# Installer module — checksum + SSH flow (subprocess.run patched)
+# ---------------------------------------------------------------------------
+
+
+class TestInstallerLoadSshTarget:
+    def test_minimal_happy_path(self, tmp_path: Path) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("dummy", encoding="utf-8")
+        env = {
+            "OPNSENSE_SSH_HOST": "fw.lan",
+            "OPNSENSE_SSH_KEY": str(key),
+        }
+        target = installer.load_ssh_target(env)
+        assert target.host == "fw.lan"
+        assert target.user == "root"
+        assert target.port == 22
+        assert target.key_path == key
+        assert target.install_path.endswith("AssignSettingsController.php")
+
+    def test_overrides_user_and_port(self, tmp_path: Path) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("dummy", encoding="utf-8")
+        env = {
+            "OPNSENSE_SSH_HOST": "fw.lan",
+            "OPNSENSE_SSH_KEY": str(key),
+            "OPNSENSE_SSH_USER": "admin",
+            "OPNSENSE_SSH_PORT": "2222",
+            "OPNSENSE_INSTALL_PATH": "/custom/path/Foo.php",
+        }
+        target = installer.load_ssh_target(env)
+        assert target.user == "admin"
+        assert target.port == 2222
+        assert target.install_path == "/custom/path/Foo.php"
+
+    def test_missing_host_raises_when_no_api_url(self, tmp_path: Path) -> None:
+        # No SSH host and no API URL to derive from → still raises.
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        env = {"OPNSENSE_SSH_KEY": str(key)}
+        with pytest.raises(RuntimeError, match="OPNSENSE_SSH_HOST"):
+            installer.load_ssh_target(env)
+
+    def test_host_derived_from_api_url(self) -> None:
+        # OPNSENSE_API_URL hostname is used when SSH_HOST is unset.
+        env = {"OPNSENSE_API_URL": "https://opnsense-a:8443"}
+        target = installer.load_ssh_target(env)
+        assert target.host == "opnsense-a"
+
+    def test_explicit_ssh_host_wins_over_api_url(self) -> None:
+        # If both are set, SSH_HOST takes precedence.
+        env = {
+            "OPNSENSE_SSH_HOST": "fw.internal",
+            "OPNSENSE_API_URL": "https://opnsense-a",
+        }
+        target = installer.load_ssh_target(env)
+        assert target.host == "fw.internal"
+
+    def test_missing_key_is_optional(self) -> None:
+        # Without OPNSENSE_SSH_KEY the script falls back to ssh-agent /
+        # ~/.ssh/config; key_path on the SshTarget is None.
+        env = {"OPNSENSE_SSH_HOST": "fw"}
+        target = installer.load_ssh_target(env)
+        assert target.key_path is None
+
+    def test_nonexistent_key_path_raises(self, tmp_path: Path) -> None:
+        env = {
+            "OPNSENSE_SSH_HOST": "fw",
+            "OPNSENSE_SSH_KEY": str(tmp_path / "missing"),
+        }
+        with pytest.raises(RuntimeError, match="does not exist"):
+            installer.load_ssh_target(env)
+
+    def test_invalid_port_raises(self, tmp_path: Path) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        env = {
+            "OPNSENSE_SSH_HOST": "fw",
+            "OPNSENSE_SSH_KEY": str(key),
+            "OPNSENSE_SSH_PORT": "not-a-number",
+        }
+        with pytest.raises(RuntimeError, match="must be an integer"):
+            installer.load_ssh_target(env)
+
+
+class TestInstallerChecksum:
+    def test_compute_local_checksum(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.txt"
+        f.write_bytes(b"hello world")
+        # Known SHA-256 of b"hello world".
+        expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        assert installer.compute_local_checksum(f) == expected
+
+    def test_local_controller_path_resolves(self) -> None:
+        path = installer.local_controller_path()
+        assert path.name == "AssignSettingsController.php"
+        assert path.exists()
+
+
+class TestInstallerSshFlow:
+    """SSH/SCP invocations are mocked at the installer's subprocess.run path."""
+
+    @staticmethod
+    def _target(tmp_path: Path) -> installer.SshTarget:
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        return installer.SshTarget(
+            host="fw.lan",
+            user="root",
+            port=22,
+            key_path=key,
+            install_path="/usr/local/Foo.php",
+        )
+
+    def _result(self, *, returncode: int = 0, stdout: str = "", stderr: str = "") -> Any:
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=stdout, stderr=stderr
+        )
+
+    def test_fetch_remote_checksum_present(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with patch.object(installer, "_run") as run:
+            run.return_value = self._result(stdout="abc123def456789\n")
+            sha = installer.fetch_remote_checksum(target)
+        assert sha == "abc123def456789"
+
+    def test_fetch_remote_checksum_missing(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with patch.object(installer, "_run") as run:
+            run.return_value = self._result(stdout="MISSING\n")
+            sha = installer.fetch_remote_checksum(target)
+        assert sha is None
+
+    def test_fetch_remote_checksum_ssh_failure(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with patch.object(installer, "_run") as run:
+            run.return_value = self._result(returncode=255, stderr="connection refused")
+            with pytest.raises(RuntimeError, match="SSH probe failed"):
+                installer.fetch_remote_checksum(target)
+
+    def test_verify_installed_checksum_match(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with patch.object(installer, "fetch_remote_checksum") as remote:
+            local_sum = installer.compute_local_checksum(installer.local_controller_path())
+            remote.return_value = local_sum
+            matches, remote_sum, ls = installer.verify_installed_checksum(target)
+        assert matches is True
+        assert remote_sum == local_sum
+        assert ls == local_sum
+
+    def test_verify_installed_checksum_mismatch(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with patch.object(installer, "fetch_remote_checksum") as remote:
+            remote.return_value = "different-sha"
+            matches, _, _ = installer.verify_installed_checksum(target)
+        assert matches is False
+
+    def test_install_skips_when_already_current(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target = self._target(tmp_path)
+        with patch.object(installer, "verify_installed_checksum") as verify:
+            local_sum = installer.compute_local_checksum(installer.local_controller_path())
+            verify.return_value = (True, local_sum, local_sum)
+            installed = installer.install_controller(target)
+        assert installed is False
+        assert "already current" in capsys.readouterr().out
+
+    def test_install_runs_full_lifecycle(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with (
+            patch.object(installer, "verify_installed_checksum") as verify,
+            patch.object(installer, "_run") as run,
+        ):
+            local_sum = installer.compute_local_checksum(installer.local_controller_path())
+            # First call: pre-install check (mismatch). Second call: post-install check (match).
+            verify.side_effect = [(False, None, local_sum), (True, local_sum, local_sum)]
+            run.return_value = self._result(returncode=0)
+            installed = installer.install_controller(target)
+        assert installed is True
+        # SCP + chmod + 2x service restart = 4 _run calls.
+        assert run.call_count == 4
+        # First call must be SCP; following calls must use SSH.
+        assert run.call_args_list[0].args[0][0] == "scp"
+        for c in run.call_args_list[1:]:
+            assert c.args[0][0] == "ssh"
+
+    def test_install_scp_failure_raises(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with (
+            patch.object(installer, "verify_installed_checksum") as verify,
+            patch.object(installer, "_run") as run,
+        ):
+            local_sum = installer.compute_local_checksum(installer.local_controller_path())
+            verify.return_value = (False, None, local_sum)
+            run.return_value = self._result(returncode=1, stderr="scp: permission denied")
+            with pytest.raises(RuntimeError, match="SCP failed"):
+                installer.install_controller(target)
+
+    def test_install_post_check_mismatch_raises(self, tmp_path: Path) -> None:
+        target = self._target(tmp_path)
+        with (
+            patch.object(installer, "verify_installed_checksum") as verify,
+            patch.object(installer, "_run") as run,
+        ):
+            local_sum = installer.compute_local_checksum(installer.local_controller_path())
+            # pre-check: mismatch; post-check: still mismatch (install silently failed).
+            verify.side_effect = [
+                (False, None, local_sum),
+                (False, "different-sha", local_sum),
+            ]
+            run.return_value = self._result(returncode=0)
+            with pytest.raises(RuntimeError, match="Post-install checksum mismatch"):
+                installer.install_controller(target)
+
+
+class TestInstallerCli:
+    def test_main_install_dispatches_to_helper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key))
+        with (
+            patch.object(installer, "_ensure_ssh_tools_present"),
+            patch.object(installer, "install_controller") as inst,
+        ):
+            rc = installer.main(["install"])
+        assert rc == 0
+        inst.assert_called_once()
+        # force flag default is False.
+        _, kwargs = inst.call_args
+        assert kwargs.get("force") is False
+
+    def test_main_install_force_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key))
+        with (
+            patch.object(installer, "_ensure_ssh_tools_present"),
+            patch.object(installer, "install_controller") as inst,
+        ):
+            installer.main(["install", "--force"])
+        _, kwargs = inst.call_args
+        assert kwargs.get("force") is True
+
+    def test_main_verify_match_returns_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key))
+        with (
+            patch.object(installer, "_ensure_ssh_tools_present"),
+            patch.object(installer, "verify_installed_checksum") as verify,
+        ):
+            verify.return_value = (True, "abc123def456789", "abc123def456789")
+            rc = installer.main(["verify"])
+        assert rc == 0
+        assert "OK" in capsys.readouterr().out
+
+    def test_main_verify_missing_returns_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key))
+        with (
+            patch.object(installer, "_ensure_ssh_tools_present"),
+            patch.object(installer, "verify_installed_checksum") as verify,
+        ):
+            verify.return_value = (False, None, "abc123def456789")
+            rc = installer.main(["verify"])
+        assert rc == 1
+        assert "MISSING" in capsys.readouterr().out
+
+    def test_main_verify_mismatch_returns_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        key = tmp_path / "id_rsa"
+        key.write_text("d", encoding="utf-8")
+        monkeypatch.setenv("OPNSENSE_SSH_HOST", "fw")
+        monkeypatch.setenv("OPNSENSE_SSH_KEY", str(key))
+        with (
+            patch.object(installer, "_ensure_ssh_tools_present"),
+            patch.object(installer, "verify_installed_checksum") as verify,
+        ):
+            verify.return_value = (False, "deadbeef00000000", "abc123def456789")
+            rc = installer.main(["verify"])
+        assert rc == 1
+        assert "MISMATCH" in capsys.readouterr().out
+
+    def test_ensure_ssh_tools_present_raises_when_missing(self) -> None:
+        with (
+            patch.object(installer.shutil, "which", return_value=None),
+            pytest.raises(RuntimeError, match="not on PATH"),
+        ):
+            installer._ensure_ssh_tools_present()

--- a/tools/spikes/README.md
+++ b/tools/spikes/README.md
@@ -88,3 +88,73 @@ ADR-0014 is written after the findings doc lands.
 ### Cleanup
 
 The spike adds VLANs with tags 4001-4003 on the example. Delete them via the OPNsense UI or by removing them from `example-vlans.yaml` and re-running `apply --confirm` when you're done.
+
+## `interface_assignment_gist_rest/` — gist-based REST `interface_assignments` write API (informs ADR-0014, #715)
+
+Forks and extends [`szymczag`'s `AssignSettingsController.php`](https://gist.github.com/szymczag/df152a82e86aff67b984ed3786b027ba) (BSD-2-Clause) so writes to OPNsense `interface_assignments` go through a single, server-side-validated REST surface. Pivot from #714 (closed without merging — SSH+PHP `config.xml`-edit path had unacceptable safety properties). Pairs with [`docs/development/opnsense-spike-interface-assignment-gist-findings.md`](../../docs/development/opnsense-spike-interface-assignment-gist-findings.md).
+
+The spike installs a patched + extended copy of the gist's PHP controller on the OPNsense box, then drives it via REST. Server-side `Config::getInstance()->save()` rejects bad input loudly, fires the standard audit log, and triggers an auto-snapshot — three properties #714 couldn't deliver because it bypassed the save pipeline.
+
+### Prerequisites
+
+1. An OPNsense box you don't mind reconfiguring. **Use `opnsense-a` (staging), NOT prod.**
+2. SSH access to the box (root) — used for the install lifecycle only.
+3. A REST API key/secret with permission for `interfaces/overview/interfacesInfo`, `interfaces/assign_settings/*`, and `core/backup/{backups,revertBackup}`.
+
+### Environment variables
+
+In addition to the REST vars listed above for the VLAN spike, the install lifecycle needs SSH credentials:
+
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `OPNSENSE_SSH_HOST` | yes (install/verify) | e.g. `opnsense-a.lan` |
+| `OPNSENSE_SSH_USER` | no | Defaults to `root` |
+| `OPNSENSE_SSH_PORT` | no | Defaults to `22` |
+| `OPNSENSE_SSH_KEY` | yes (install/verify) | Path to SSH private key |
+| `OPNSENSE_INSTALL_PATH` | no | Override the canonical MVC controller path |
+
+See [`tools/spikes/interface_assignment_gist_rest/README.md`](interface_assignment_gist_rest/README.md) for the full env-var contract and per-subcommand reference.
+
+### Quick start
+
+```bash
+SPIKE=tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+FIXTURE=tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml
+
+# 1. Install the PHP controller (idempotent).
+uv run python tools/spikes/interface_assignment_gist_rest/install.py install
+
+# 2. Sanity check.
+uv run python $SPIKE inspect
+
+# 3. Diff a YAML file against live state (no mutations).
+uv run python $SPIKE plan $FIXTURE
+
+# 4. Apply via REST. Without --confirm, this is a dry run.
+uv run python $SPIKE apply $FIXTURE --confirm
+```
+
+### Round-trip recipe
+
+Same shape as the VLAN spike's round-trip:
+
+```bash
+SPIKE=tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+FIXTURE=tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml
+
+uv run python $SPIKE apply $FIXTURE --confirm   # 1. apply
+uv run python $SPIKE plan $FIXTURE              # 2. must say "No changes."
+# 3. edit fixture (rebind device, add an entry, etc.)
+uv run python $SPIKE apply $FIXTURE --confirm   # 4. reconcile
+uv run python $SPIKE plan $FIXTURE              # 5. "No changes." again
+```
+
+### Cleanup
+
+The example fixture creates one entry on `igc0`. Remove it from the fixture and re-run `apply --confirm` when you're done. The PHP controller stays installed; remove it manually with:
+
+```bash
+ssh -i $OPNSENSE_SSH_KEY $OPNSENSE_SSH_USER@$OPNSENSE_SSH_HOST \
+  "rm /usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignSettingsController.php && \
+   service php_fpm restart"
+```

--- a/tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php
+++ b/tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php
@@ -1,0 +1,778 @@
+<?php
+
+/**
+ * @filename    AssignSettingsController.php
+ * @package     OPNsense\Interfaces\Api
+ * @author      Maciej Szymczak <maciej@szymczak.at> (original)
+ * @author      InfraFoundry contributors (fork: IPv6, setItem, getItem,
+ *              searchItem, explicit-name-on-add, sessionClose patch)
+ * @copyright   (c) 2025 Maciej Szymczak (BSD-2-Clause original)
+ * @copyright   (c) 2026 InfraFoundry (fork)
+ * @license     BSD-2-Clause
+ *
+ * Description: OPNsense API endpoint for assigning, configuring, and deleting
+ *              logical interfaces (OPTx). Handles creation with static/DHCP/none
+ *              IPv4 and static/dhcp/track-interface/none IPv6 configuration,
+ *              MAC spoofing, deletion, and in-place update via setItem.
+ *
+ * Required Path:
+ *   /usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignSettingsController.php
+ *
+ * Source / fork rationale:
+ *   Forked from https://gist.github.com/szymczag/df152a82e86aff67b984ed3786b027ba
+ *   for InfraFoundry issue #715. The base gist provides addItem (auto-numbered)
+ *   and delItem only; this fork adds setItem (in-place update), getItem,
+ *   searchItem, IPv6 support across add/set, and explicit-name on addItem
+ *   (required for cutover continuity). The two community-reported
+ *   `$this->sessionClose();` calls have been removed (modern OPNsense versions
+ *   reject the call; see Paradoxis comment 2026-02-25 on the gist).
+ *
+ * Maintenance ownership:
+ *   InfraFoundry now owns this code. Upstream gist updates are not auto-
+ *   merged. PR-back of the IPv6/setItem extensions to the original gist is
+ *   tracked as a follow-up after #715 lands.
+ */
+
+namespace OPNsense\Interfaces\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Base\UserException;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+
+class AssignSettingsController extends ApiControllerBase
+{
+    // --- Constants for Configuration Keys and Values ---
+    private const CONFIG_KEY_INTERFACES = 'interfaces';
+    private const CONFIG_KEY_IF = 'if';
+    private const CONFIG_KEY_DESCR = 'descr';
+    private const CONFIG_KEY_ENABLE = 'enable';
+    private const CONFIG_KEY_SPOOFMAC = 'spoofmac';
+    private const CONFIG_KEY_IPADDR = 'ipaddr';
+    private const CONFIG_KEY_SUBNET = 'subnet';
+    private const CONFIG_KEY_DHCP = 'dhcp';
+
+    // IPv6-specific config keys
+    private const CONFIG_KEY_IPADDRV6 = 'ipaddrv6';
+    private const CONFIG_KEY_SUBNETV6 = 'subnetv6';
+    private const CONFIG_KEY_DHCP6 = 'dhcp6';
+    private const CONFIG_KEY_TRACK6_INTERFACE = 'track6-interface';
+    private const CONFIG_KEY_TRACK6_PREFIX_ID = 'track6-prefix-id';
+
+    private const IPV4_TYPE_STATIC = 'static';
+    private const IPV4_TYPE_DHCP = 'dhcp';
+    private const IPV4_TYPE_NONE = 'none';
+
+    private const IPV6_TYPE_STATIC = 'static';
+    private const IPV6_TYPE_DHCP = 'dhcp';
+    private const IPV6_TYPE_TRACK = 'track-interface';
+    private const IPV6_TYPE_NONE = 'none';
+
+    private const BACKEND_INTERFACE_RECONFIGURE = 'interface reconfigure all';
+
+    /**
+     * Add and configure a new OPT interface.
+     *
+     * Creates a new OPT interface (optX), assigns the specified kernel device,
+     * description, and optionally configures enable status, MAC spoofing, and
+     * IPv4/IPv6 settings.
+     *
+     * **Validation:** Checks if the specified 'device' is already assigned to
+     * another interface before proceeding. If 'name' is supplied (extension),
+     * also validates the explicit name is well-formed and unused.
+     *
+     * Expected JSON payload structure within 'assign' object:
+     * {
+     *   "assign": {
+     *     "device": "vlan0.XXX",         // Required: Kernel device name
+     *     "description": "My Interface", // Required: Interface description
+     *     "name": "opt5",                // Optional (extension): explicit logical name (^opt\d+$)
+     *     "enable": true,                // Optional: defaults to false (disabled)
+     *     "spoofMac": "00:11:...",       // Optional
+     *     "ipv4Type": "static",          // Optional: "static"|"dhcp"|"none"; defaults "none"
+     *     "ipv4Address": "10.1.2.3",     // Required if ipv4Type is "static"
+     *     "ipv4Subnet": 24,              // Required if ipv4Type is "static"
+     *     "ipv6Type": "track-interface", // Optional: "static"|"dhcp"|"track-interface"|"none"
+     *     "ipv6Address": "fd00:...",     // Required if ipv6Type is "static"
+     *     "ipv6Subnet": 64,              // Required if ipv6Type is "static"
+     *     "ipv6Track": "wan"             // Required if ipv6Type is "track-interface"
+     *   }
+     * }
+     *
+     * NOTE: Triggers an 'interface reconfigure all' command upon successful save.
+     *
+     * @return array Status result including the assigned interface name ('ifname').
+     * @throws UserException on invalid input, device already assigned, or configuration errors.
+     */
+    public function addItemAction()
+    {
+        $result = ["result" => "failed"];
+        $ifname = null;
+        $log_prefix = "[AssignSettingsController::addItemAction]";
+        error_log("{$log_prefix} --- Request Received ---");
+
+        try {
+            error_log("{$log_prefix} Getting JSON payload...");
+            $request_body = $this->request->getJsonRawBody(true);
+            $data = $request_body['assign'] ?? null;
+            error_log("{$log_prefix} Payload data: " . print_r($data, true));
+
+            // --- Basic Payload Validation ---
+            if (empty($data) || !is_array($data)) {
+                throw new UserException("Invalid payload structure. Expected 'assign' object.");
+            }
+            $kernel_device = $this->validateDevice($data);
+            $description = $this->validateDescription($data);
+
+            // Optional fields parsing and validation
+            $enable = filter_var($data['enable'] ?? false, FILTER_VALIDATE_BOOLEAN);
+            $spoofMac = $this->validateSpoofMac($data);
+
+            $ipv4 = $this->validateIpv4($data);
+            $ipv6 = $this->validateIpv6($data);
+
+            // Optional explicit name (extension; required for cutover continuity).
+            $explicit_name = $this->validateExplicitName($data);
+
+            error_log("{$log_prefix} Payload validation complete.");
+
+            // --- Load Config and Check for Existing Device Assignment ---
+            $config = Config::getInstance();
+            $configHandle = $config->object();
+
+            $this->ensureDeviceUnassigned($configHandle, $kernel_device, $log_prefix);
+
+            // --- Determine Interface Name (explicit if provided, else auto-numbered) ---
+            if ($explicit_name !== null) {
+                if (isset($configHandle->{self::CONFIG_KEY_INTERFACES}->{$explicit_name})) {
+                    throw new UserException("Interface name '{$explicit_name}' already exists.");
+                }
+                $ifname = $explicit_name;
+                error_log("{$log_prefix} Using explicit interface name: {$ifname}");
+            } else {
+                $ifname = $this->nextOptName($configHandle);
+                error_log("{$log_prefix} Determined next available interface name: {$ifname}");
+                if (isset($configHandle->{self::CONFIG_KEY_INTERFACES}->{$ifname})) {
+                    throw new \Exception("Calculated interface name '{$ifname}' already exists.");
+                }
+            }
+
+            // --- Apply Configuration ---
+            error_log("{$log_prefix} Applying configuration to node '{$ifname}'...");
+            $newNode = $configHandle->{self::CONFIG_KEY_INTERFACES}->addChild($ifname);
+            $this->applyAssignmentToNode($newNode, $kernel_device, $description, $enable, $spoofMac, $ipv4, $ipv6, $log_prefix, $ifname);
+
+            // --- Save and Apply ---
+            error_log("{$log_prefix} Saving configuration changes for '{$ifname}'...");
+            $config->save();
+            error_log("{$log_prefix} Configuration saved for '{$ifname}'.");
+
+            // Trigger backend reconfigure
+            $backend = new Backend();
+            $backend_result = $backend->configdRun(self::BACKEND_INTERFACE_RECONFIGURE);
+            error_log("{$log_prefix} Backend reconfigure finished. Result: " . trim($backend_result));
+
+            $result['result'] = 'saved';
+            $result['ifname'] = $ifname;
+            error_log("{$log_prefix} Interface '{$ifname}' created successfully. Returning: " . json_encode($result));
+        } catch (UserException $e) {
+            error_log("{$log_prefix} UserException: " . $e->getMessage());
+            $this->response->setStatusCode(400, "Bad Request");
+            $result = ["result" => "failed", "errorMessage" => $e->getMessage()];
+        } catch (\Exception $e) {
+            $error_details = $e->getMessage() . " (File: " . $e->getFile() . ", Line: " . $e->getLine() . ")";
+            error_log("{$log_prefix} CRITICAL EXCEPTION during addItemAction: " . $error_details);
+            error_log("{$log_prefix} Trace: " . $e->getTraceAsString());
+            $this->response->setStatusCode(500, "Internal Server Error");
+            $result = ["result" => "failed", "errorMessage" => "An unexpected server error occurred. Please check logs."];
+        }
+
+        error_log("{$log_prefix} --- Request Finished ---");
+        return $result;
+    }
+
+    /**
+     * Update an existing OPT interface in place.
+     *
+     * Same payload shape as addItem (under 'assign' key). Used for cutover
+     * scenarios where a logical interface name (e.g. opt3) needs to be
+     * re-bound to a different kernel device without losing its identity.
+     *
+     * Validation:
+     *  - The supplied uuid must exist in <interfaces>.
+     *  - Refuses if uuid is 'lan' or 'wan' (mirror delItem safety).
+     *  - Per-field validation identical to addItem.
+     *  - If 'device' is specified and differs from the current binding,
+     *    refuses if the new device is already bound to another interface.
+     *
+     * @param string $uuid The logical interface name (e.g., 'opt1') to update.
+     * @return array ['result' => 'saved', 'ifname' => $uuid] on success.
+     * @throws UserException on invalid input, device collision, or unknown uuid.
+     */
+    public function setItemAction($uuid)
+    {
+        $result = ["result" => "failed"];
+        $log_prefix = "[AssignSettingsController::setItemAction]";
+        error_log("{$log_prefix} --- Request Received to UPDATE interface '{$uuid}' ---");
+
+        try {
+            // --- Validate uuid ---
+            if (empty($uuid)) {
+                throw new UserException("Required parameter 'uuid' (logical interface name) is missing.");
+            }
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $uuid)) {
+                throw new UserException("Invalid format for parameter 'uuid'.");
+            }
+            if (in_array(strtolower($uuid), ['lan', 'wan'])) {
+                throw new UserException("Modification of core interfaces 'lan'/'wan' is not permitted via this action.");
+            }
+
+            // --- Get and validate payload ---
+            $request_body = $this->request->getJsonRawBody(true);
+            $data = $request_body['assign'] ?? null;
+            error_log("{$log_prefix} Payload data: " . print_r($data, true));
+            if (empty($data) || !is_array($data)) {
+                throw new UserException("Invalid payload structure. Expected 'assign' object.");
+            }
+
+            $kernel_device = $this->validateDevice($data);
+            $description = $this->validateDescription($data);
+            $enable = filter_var($data['enable'] ?? false, FILTER_VALIDATE_BOOLEAN);
+            $spoofMac = $this->validateSpoofMac($data);
+            $ipv4 = $this->validateIpv4($data);
+            $ipv6 = $this->validateIpv6($data);
+            error_log("{$log_prefix} Payload validation complete.");
+
+            // --- Load config and validate uuid exists ---
+            $config = Config::getInstance();
+            $configHandle = $config->object();
+
+            if (!isset($configHandle->{self::CONFIG_KEY_INTERFACES}->{$uuid})) {
+                throw new UserException("Interface '{$uuid}' does not exist.");
+            }
+
+            $existingNode = $configHandle->{self::CONFIG_KEY_INTERFACES}->{$uuid};
+            $current_device = isset($existingNode->{self::CONFIG_KEY_IF}) ? (string)$existingNode->{self::CONFIG_KEY_IF} : null;
+
+            // If device is changing, verify the new one isn't bound elsewhere.
+            if ($current_device !== $kernel_device) {
+                error_log("{$log_prefix} Device changing from '{$current_device}' to '{$kernel_device}'. Verifying no collision...");
+                if (isset($configHandle->{self::CONFIG_KEY_INTERFACES})) {
+                    foreach ($configHandle->{self::CONFIG_KEY_INTERFACES}->children() as $existing_ifname => $node) {
+                        if ((string)$existing_ifname === $uuid) {
+                            continue;
+                        }
+                        if (isset($node->{self::CONFIG_KEY_IF}) && (string)$node->{self::CONFIG_KEY_IF} === $kernel_device) {
+                            throw new UserException("Device '{$kernel_device}' is already assigned to interface '{$existing_ifname}'.");
+                        }
+                    }
+                }
+            }
+
+            // --- Replace the node's children with fresh values. ---
+            // SimpleXMLElement doesn't support a clean "replace all children"; the safest
+            // way is to remove and re-create the node. This preserves identity (the name
+            // stays the same) but rewrites all assignment-scoped fields.
+            unset($configHandle->{self::CONFIG_KEY_INTERFACES}->{$uuid});
+            $newNode = $configHandle->{self::CONFIG_KEY_INTERFACES}->addChild($uuid);
+            $this->applyAssignmentToNode($newNode, $kernel_device, $description, $enable, $spoofMac, $ipv4, $ipv6, $log_prefix, $uuid);
+
+            // --- Save and Apply ---
+            error_log("{$log_prefix} Saving configuration changes for '{$uuid}'...");
+            $config->save();
+            error_log("{$log_prefix} Configuration saved for '{$uuid}'.");
+
+            $backend = new Backend();
+            $backend_result = $backend->configdRun(self::BACKEND_INTERFACE_RECONFIGURE);
+            error_log("{$log_prefix} Backend reconfigure finished. Result: " . trim($backend_result));
+
+            $result['result'] = 'saved';
+            $result['ifname'] = $uuid;
+            error_log("{$log_prefix} Interface '{$uuid}' updated successfully. Returning: " . json_encode($result));
+        } catch (UserException $e) {
+            error_log("{$log_prefix} UserException: " . $e->getMessage());
+            $this->response->setStatusCode(400, "Bad Request");
+            $result = ["result" => "failed", "errorMessage" => $e->getMessage()];
+        } catch (\Exception $e) {
+            $error_details = $e->getMessage() . " (File: " . $e->getFile() . ", Line: " . $e->getLine() . ")";
+            error_log("{$log_prefix} CRITICAL EXCEPTION during setItemAction: " . $error_details);
+            error_log("{$log_prefix} Trace: " . $e->getTraceAsString());
+            $this->response->setStatusCode(500, "Internal Server Error");
+            $result = ["result" => "failed", "errorMessage" => "An unexpected server error occurred. Please check logs."];
+        }
+
+        error_log("{$log_prefix} --- Request Finished for '{$uuid}' ---");
+        return $result;
+    }
+
+    /**
+     * Fetch a single interface assignment by logical name.
+     *
+     * @param string $uuid The logical interface name (e.g., 'opt1').
+     * @return array {result: 'ok', assign: {...}} on success, or 404 with errorMessage.
+     */
+    public function getItemAction($uuid)
+    {
+        $log_prefix = "[AssignSettingsController::getItemAction]";
+        error_log("{$log_prefix} --- Request Received for '{$uuid}' ---");
+
+        try {
+            if (empty($uuid)) {
+                throw new UserException("Required parameter 'uuid' is missing.");
+            }
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $uuid)) {
+                throw new UserException("Invalid format for parameter 'uuid'.");
+            }
+
+            $config = Config::getInstance();
+            $configHandle = $config->object();
+
+            if (!isset($configHandle->{self::CONFIG_KEY_INTERFACES}->{$uuid})) {
+                $this->response->setStatusCode(404, "Not Found");
+                return ["result" => "failed", "errorMessage" => "Interface '{$uuid}' not found."];
+            }
+
+            $node = $configHandle->{self::CONFIG_KEY_INTERFACES}->{$uuid};
+            $assign = $this->nodeToAssignArray($node);
+            return ["result" => "ok", "assign" => $assign];
+        } catch (UserException $e) {
+            error_log("{$log_prefix} UserException: " . $e->getMessage());
+            $this->response->setStatusCode(400, "Bad Request");
+            return ["result" => "failed", "errorMessage" => $e->getMessage()];
+        } catch (\Exception $e) {
+            error_log("{$log_prefix} CRITICAL EXCEPTION: " . $e->getMessage());
+            $this->response->setStatusCode(500, "Internal Server Error");
+            return ["result" => "failed", "errorMessage" => "An unexpected server error occurred."];
+        }
+    }
+
+    /**
+     * List all interface assignments.
+     *
+     * Returns rows in OPNsense's standard search response shape so the
+     * spike's Python client can consume them with the same parsing code as
+     * other 'searchItem' endpoints.
+     *
+     * @return array {result: 'ok', rows: [...], rowCount: N, total: N, current: 1}
+     */
+    public function searchItemAction()
+    {
+        $log_prefix = "[AssignSettingsController::searchItemAction]";
+        error_log("{$log_prefix} --- Request Received ---");
+
+        try {
+            $config = Config::getInstance();
+            $configHandle = $config->object();
+
+            $rows = [];
+            if (isset($configHandle->{self::CONFIG_KEY_INTERFACES})) {
+                foreach ($configHandle->{self::CONFIG_KEY_INTERFACES}->children() as $ifname => $node) {
+                    $row = $this->nodeToAssignArray($node);
+                    $row['uuid'] = (string)$ifname;
+                    $row['name'] = (string)$ifname;
+                    $rows[] = $row;
+                }
+            }
+
+            $count = count($rows);
+            return [
+                "result" => "ok",
+                "rows" => $rows,
+                "rowCount" => $count,
+                "total" => $count,
+                "current" => 1,
+            ];
+        } catch (\Exception $e) {
+            error_log("{$log_prefix} CRITICAL EXCEPTION: " . $e->getMessage());
+            $this->response->setStatusCode(500, "Internal Server Error");
+            return ["result" => "failed", "errorMessage" => "An unexpected server error occurred."];
+        }
+    }
+
+    /**
+     * Deletes the configuration node for a specified logical interface.
+     * Triggers an interface reconfigure command after saving.
+     *
+     * @param string $uuid The logical interface name (e.g., 'opt1') to delete.
+     * @return array ['result' => 'deleted'] on success or error details.
+     * @throws UserException on missing/invalid uuid or attempt to delete core interface.
+     */
+    public function delItemAction($uuid)
+    {
+        $result = ["result" => "failed"];
+        $log_prefix = "[AssignSettingsController::delItemAction]";
+        error_log("{$log_prefix} --- Request Received to DELETE interface '{$uuid}' ---");
+
+        try {
+            if (empty($uuid)) {
+                throw new UserException(gettext("Required parameter 'uuid' (logical interface name) is missing."));
+            }
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $uuid)) {
+                throw new UserException(gettext("Invalid format for parameter 'uuid'."));
+            }
+            if (in_array(strtolower($uuid), ['lan', 'wan'])) {
+                throw new UserException(gettext("Deletion of core interfaces like 'lan' or 'wan' is not permitted via this action."));
+            }
+
+            error_log("{$log_prefix} Loading configuration to delete '{$uuid}'...");
+            $config = Config::getInstance();
+            $configHandle = $config->object();
+
+            if (!isset($configHandle->{self::CONFIG_KEY_INTERFACES}->{$uuid})) {
+                error_log("{$log_prefix} Interface '{$uuid}' not found. Idempotent success.");
+                return ["result" => "deleted", "message" => "Interface '{$uuid}' not found, assumed already deleted."];
+            }
+
+            unset($configHandle->{self::CONFIG_KEY_INTERFACES}->{$uuid});
+            error_log("{$log_prefix} Removed interface node '{$uuid}'.");
+
+            $config->save();
+            error_log("{$log_prefix} Configuration saved.");
+
+            $backend = new Backend();
+            $backend_result = $backend->configdRun(self::BACKEND_INTERFACE_RECONFIGURE);
+            error_log("{$log_prefix} Backend reconfigure finished. Result: " . trim($backend_result));
+
+            $result = ["result" => "deleted"];
+            error_log("{$log_prefix} Successfully deleted '{$uuid}'.");
+        } catch (UserException $e) {
+            error_log("{$log_prefix} UserException: " . $e->getMessage());
+            $this->response->setStatusCode(400, "Bad Request");
+            $result = ["result" => "failed", "errorMessage" => $e->getMessage()];
+        } catch (\Exception $e) {
+            $error_details = $e->getMessage() . " (File: " . $e->getFile() . ", Line: " . $e->getLine() . ")";
+            error_log("{$log_prefix} CRITICAL EXCEPTION during deletion of '{$uuid}': " . $error_details);
+            error_log("{$log_prefix} Trace: " . $e->getTraceAsString());
+            $this->response->setStatusCode(500, "Internal Server Error");
+            $result = ["result" => "failed", "errorMessage" => "An unexpected server error occurred during deletion. Please check logs."];
+        }
+
+        error_log("{$log_prefix} --- Request Finished for '{$uuid}' ---");
+        return $result;
+    }
+
+    // ------------------------------------------------------------------
+    // Validation helpers (extracted from addItem for reuse in setItem)
+    // ------------------------------------------------------------------
+
+    private function validateDevice(array $data): string
+    {
+        if (empty($data['device']) || !is_string($data['device'])) {
+            throw new UserException("Payload missing required 'device' field (string).");
+        }
+        $kernel_device = trim($data['device']);
+        if (!preg_match('/^[a-zA-Z0-9_.\-]+$/', $kernel_device)) {
+            throw new UserException("Invalid format for 'device' field '{$kernel_device}'.");
+        }
+        return $kernel_device;
+    }
+
+    private function validateDescription(array $data): string
+    {
+        if (empty($data['description']) || !is_string($data['description'])) {
+            throw new UserException("Payload missing required 'description' field (string).");
+        }
+        return trim($data['description']);
+    }
+
+    private function validateSpoofMac(array $data): ?string
+    {
+        if (!isset($data['spoofMac'])) {
+            return null;
+        }
+        $spoofMac = trim($data['spoofMac']);
+        if ($spoofMac === '') {
+            return null;
+        }
+        if (!filter_var($spoofMac, FILTER_VALIDATE_MAC)) {
+            throw new UserException("Invalid format for 'spoofMac' field. Expected standard MAC address format.");
+        }
+        return $spoofMac;
+    }
+
+    /**
+     * @return array{type: string, address: ?string, subnet: ?int}
+     */
+    private function validateIpv4(array $data): array
+    {
+        $type = isset($data['ipv4Type']) ? trim(strtolower($data['ipv4Type'])) : self::IPV4_TYPE_NONE;
+        $allowed = [self::IPV4_TYPE_STATIC, self::IPV4_TYPE_DHCP, self::IPV4_TYPE_NONE];
+        if (!in_array($type, $allowed, true)) {
+            throw new UserException("Invalid 'ipv4Type'. Allowed: " . implode(', ', $allowed));
+        }
+        $address = isset($data['ipv4Address']) ? trim($data['ipv4Address']) : null;
+        $subnet = $data['ipv4Subnet'] ?? null;
+
+        if ($type === self::IPV4_TYPE_STATIC) {
+            if (empty($address) || filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+                throw new UserException("Invalid or missing 'ipv4Address' for ipv4Type 'static'.");
+            }
+            if ($subnet === null || !filter_var($subnet, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 32]])) {
+                throw new UserException("Invalid or missing 'ipv4Subnet' for ipv4Type 'static'. Expected integer 1-32.");
+            }
+            return ['type' => $type, 'address' => $address, 'subnet' => intval($subnet)];
+        }
+
+        if (!empty($address) || $subnet !== null) {
+            throw new UserException("'ipv4Address'/'ipv4Subnet' should only be provided when ipv4Type is 'static'.");
+        }
+        return ['type' => $type, 'address' => null, 'subnet' => null];
+    }
+
+    /**
+     * @return array{type: string, address: ?string, subnet: ?int, track: ?string}
+     */
+    private function validateIpv6(array $data): array
+    {
+        $type = isset($data['ipv6Type']) ? trim(strtolower($data['ipv6Type'])) : self::IPV6_TYPE_NONE;
+        $allowed = [self::IPV6_TYPE_STATIC, self::IPV6_TYPE_DHCP, self::IPV6_TYPE_TRACK, self::IPV6_TYPE_NONE];
+        if (!in_array($type, $allowed, true)) {
+            throw new UserException("Invalid 'ipv6Type'. Allowed: " . implode(', ', $allowed));
+        }
+        $address = isset($data['ipv6Address']) ? trim($data['ipv6Address']) : null;
+        $subnet = $data['ipv6Subnet'] ?? null;
+        $track = isset($data['ipv6Track']) ? trim($data['ipv6Track']) : null;
+
+        if ($type === self::IPV6_TYPE_STATIC) {
+            if (empty($address) || filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
+                throw new UserException("Invalid or missing 'ipv6Address' for ipv6Type 'static'.");
+            }
+            if ($subnet === null || !filter_var($subnet, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 128]])) {
+                throw new UserException("Invalid or missing 'ipv6Subnet' for ipv6Type 'static'. Expected integer 1-128.");
+            }
+            if ($track !== null && $track !== '') {
+                throw new UserException("'ipv6Track' should not be provided when ipv6Type is 'static'.");
+            }
+            return ['type' => $type, 'address' => $address, 'subnet' => intval($subnet), 'track' => null];
+        }
+
+        if ($type === self::IPV6_TYPE_TRACK) {
+            if (empty($track) || !preg_match('/^[a-zA-Z0-9_]+$/', $track)) {
+                throw new UserException("Invalid or missing 'ipv6Track' for ipv6Type 'track-interface'. Expected logical interface identifier (e.g., 'wan').");
+            }
+            if (!empty($address) || $subnet !== null) {
+                throw new UserException("'ipv6Address'/'ipv6Subnet' should not be provided when ipv6Type is 'track-interface'.");
+            }
+            return ['type' => $type, 'address' => null, 'subnet' => null, 'track' => $track];
+        }
+
+        // dhcp / none — no extra fields permitted.
+        if (!empty($address) || $subnet !== null || ($track !== null && $track !== '')) {
+            throw new UserException("'ipv6Address'/'ipv6Subnet'/'ipv6Track' only valid for ipv6Type 'static' or 'track-interface'.");
+        }
+        return ['type' => $type, 'address' => null, 'subnet' => null, 'track' => null];
+    }
+
+    private function validateExplicitName(array $data): ?string
+    {
+        if (!isset($data['name'])) {
+            return null;
+        }
+        $name = is_string($data['name']) ? trim($data['name']) : '';
+        if ($name === '') {
+            return null;
+        }
+        if (!preg_match('/^opt\d+$/', $name)) {
+            throw new UserException("Invalid 'name' field '{$name}'. Expected pattern: ^opt\\d+$ (e.g., 'opt5'). 'lan'/'wan' not permitted.");
+        }
+        return $name;
+    }
+
+    /**
+     * Refuse if the kernel device is already bound to another logical interface.
+     */
+    private function ensureDeviceUnassigned(\SimpleXMLElement $configHandle, string $kernel_device, string $log_prefix): void
+    {
+        if (!isset($configHandle->{self::CONFIG_KEY_INTERFACES})) {
+            return;
+        }
+        foreach ($configHandle->{self::CONFIG_KEY_INTERFACES}->children() as $existing_ifname => $node) {
+            if (isset($node->{self::CONFIG_KEY_IF}) && (string)$node->{self::CONFIG_KEY_IF} === $kernel_device) {
+                $msg = "Device '{$kernel_device}' is already assigned to interface '{$existing_ifname}'.";
+                error_log("{$log_prefix} {$msg}");
+                throw new UserException($msg);
+            }
+        }
+    }
+
+    private function nextOptName(\SimpleXMLElement $configHandle): string
+    {
+        $max_opt_num = 0;
+        if (isset($configHandle->{self::CONFIG_KEY_INTERFACES})) {
+            foreach ($configHandle->{self::CONFIG_KEY_INTERFACES}->children() as $current_ifname => $node) {
+                if (preg_match('/^opt(\d+)$/', (string)$current_ifname, $matches)) {
+                    $num = intval($matches[1]);
+                    if ($num > $max_opt_num) {
+                        $max_opt_num = $num;
+                    }
+                }
+            }
+        }
+        return "opt" . ($max_opt_num + 1);
+    }
+
+    /**
+     * Apply the validated assignment payload onto a SimpleXMLElement node.
+     *
+     * @param array{type: string, address: ?string, subnet: ?int} $ipv4
+     * @param array{type: string, address: ?string, subnet: ?int, track: ?string} $ipv6
+     */
+    private function applyAssignmentToNode(\SimpleXMLElement $node, string $kernel_device, string $description, bool $enable, ?string $spoofMac, array $ipv4, array $ipv6, string $log_prefix, string $ifname): void
+    {
+        $node->{self::CONFIG_KEY_IF} = $kernel_device;
+        $node->{self::CONFIG_KEY_DESCR} = $description;
+
+        if ($enable) {
+            $node->addChild(self::CONFIG_KEY_ENABLE, '1');
+        }
+        if ($spoofMac !== null) {
+            $node->{self::CONFIG_KEY_SPOOFMAC} = $spoofMac;
+        }
+
+        // --- IPv4 ---
+        switch ($ipv4['type']) {
+            case self::IPV4_TYPE_STATIC:
+                $node->{self::CONFIG_KEY_IPADDR} = $ipv4['address'];
+                $node->{self::CONFIG_KEY_SUBNET} = $ipv4['subnet'];
+                if (isset($node->{self::CONFIG_KEY_DHCP})) {
+                    unset($node->{self::CONFIG_KEY_DHCP});
+                }
+                break;
+            case self::IPV4_TYPE_DHCP:
+                $node->{self::CONFIG_KEY_IPADDR} = self::IPV4_TYPE_DHCP;
+                if (isset($node->{self::CONFIG_KEY_SUBNET})) {
+                    unset($node->{self::CONFIG_KEY_SUBNET});
+                }
+                $node->addChild(self::CONFIG_KEY_DHCP, '');
+                break;
+            case self::IPV4_TYPE_NONE:
+            default:
+                if (isset($node->{self::CONFIG_KEY_IPADDR})) {
+                    unset($node->{self::CONFIG_KEY_IPADDR});
+                }
+                if (isset($node->{self::CONFIG_KEY_SUBNET})) {
+                    unset($node->{self::CONFIG_KEY_SUBNET});
+                }
+                if (isset($node->{self::CONFIG_KEY_DHCP})) {
+                    unset($node->{self::CONFIG_KEY_DHCP});
+                }
+                break;
+        }
+
+        // --- IPv6 ---
+        switch ($ipv6['type']) {
+            case self::IPV6_TYPE_STATIC:
+                $node->{self::CONFIG_KEY_IPADDRV6} = $ipv6['address'];
+                $node->{self::CONFIG_KEY_SUBNETV6} = $ipv6['subnet'];
+                if (isset($node->{self::CONFIG_KEY_DHCP6})) {
+                    unset($node->{self::CONFIG_KEY_DHCP6});
+                }
+                if (isset($node->{self::CONFIG_KEY_TRACK6_INTERFACE})) {
+                    unset($node->{self::CONFIG_KEY_TRACK6_INTERFACE});
+                }
+                if (isset($node->{self::CONFIG_KEY_TRACK6_PREFIX_ID})) {
+                    unset($node->{self::CONFIG_KEY_TRACK6_PREFIX_ID});
+                }
+                break;
+            case self::IPV6_TYPE_DHCP:
+                $node->{self::CONFIG_KEY_IPADDRV6} = self::IPV6_TYPE_DHCP;
+                if (isset($node->{self::CONFIG_KEY_SUBNETV6})) {
+                    unset($node->{self::CONFIG_KEY_SUBNETV6});
+                }
+                $node->addChild(self::CONFIG_KEY_DHCP6, '');
+                if (isset($node->{self::CONFIG_KEY_TRACK6_INTERFACE})) {
+                    unset($node->{self::CONFIG_KEY_TRACK6_INTERFACE});
+                }
+                if (isset($node->{self::CONFIG_KEY_TRACK6_PREFIX_ID})) {
+                    unset($node->{self::CONFIG_KEY_TRACK6_PREFIX_ID});
+                }
+                break;
+            case self::IPV6_TYPE_TRACK:
+                $node->{self::CONFIG_KEY_IPADDRV6} = 'track6';
+                $node->{self::CONFIG_KEY_TRACK6_INTERFACE} = $ipv6['track'];
+                $node->addChild(self::CONFIG_KEY_TRACK6_PREFIX_ID, '0');
+                if (isset($node->{self::CONFIG_KEY_SUBNETV6})) {
+                    unset($node->{self::CONFIG_KEY_SUBNETV6});
+                }
+                if (isset($node->{self::CONFIG_KEY_DHCP6})) {
+                    unset($node->{self::CONFIG_KEY_DHCP6});
+                }
+                break;
+            case self::IPV6_TYPE_NONE:
+            default:
+                if (isset($node->{self::CONFIG_KEY_IPADDRV6})) {
+                    unset($node->{self::CONFIG_KEY_IPADDRV6});
+                }
+                if (isset($node->{self::CONFIG_KEY_SUBNETV6})) {
+                    unset($node->{self::CONFIG_KEY_SUBNETV6});
+                }
+                if (isset($node->{self::CONFIG_KEY_DHCP6})) {
+                    unset($node->{self::CONFIG_KEY_DHCP6});
+                }
+                if (isset($node->{self::CONFIG_KEY_TRACK6_INTERFACE})) {
+                    unset($node->{self::CONFIG_KEY_TRACK6_INTERFACE});
+                }
+                if (isset($node->{self::CONFIG_KEY_TRACK6_PREFIX_ID})) {
+                    unset($node->{self::CONFIG_KEY_TRACK6_PREFIX_ID});
+                }
+                break;
+        }
+        error_log("{$log_prefix} Applied assignment to '{$ifname}': device={$kernel_device}, ipv4={$ipv4['type']}, ipv6={$ipv6['type']}");
+    }
+
+    /**
+     * Convert a config <opt1>...</opt1> node back to a flat assoc array
+     * suitable for getItem/searchItem JSON responses.
+     */
+    private function nodeToAssignArray(\SimpleXMLElement $node): array
+    {
+        $out = [
+            'device' => isset($node->{self::CONFIG_KEY_IF}) ? (string)$node->{self::CONFIG_KEY_IF} : '',
+            'description' => isset($node->{self::CONFIG_KEY_DESCR}) ? (string)$node->{self::CONFIG_KEY_DESCR} : '',
+            'enable' => isset($node->{self::CONFIG_KEY_ENABLE}) ? ((string)$node->{self::CONFIG_KEY_ENABLE} === '1') : false,
+            'spoofMac' => isset($node->{self::CONFIG_KEY_SPOOFMAC}) ? (string)$node->{self::CONFIG_KEY_SPOOFMAC} : null,
+        ];
+
+        // Reverse-map IPv4
+        $ipaddr = isset($node->{self::CONFIG_KEY_IPADDR}) ? (string)$node->{self::CONFIG_KEY_IPADDR} : '';
+        if ($ipaddr === self::IPV4_TYPE_DHCP) {
+            $out['ipv4Type'] = self::IPV4_TYPE_DHCP;
+            $out['ipv4Address'] = null;
+            $out['ipv4Subnet'] = null;
+        } elseif ($ipaddr !== '') {
+            $out['ipv4Type'] = self::IPV4_TYPE_STATIC;
+            $out['ipv4Address'] = $ipaddr;
+            $out['ipv4Subnet'] = isset($node->{self::CONFIG_KEY_SUBNET}) ? intval((string)$node->{self::CONFIG_KEY_SUBNET}) : null;
+        } else {
+            $out['ipv4Type'] = self::IPV4_TYPE_NONE;
+            $out['ipv4Address'] = null;
+            $out['ipv4Subnet'] = null;
+        }
+
+        // Reverse-map IPv6
+        $ipaddrv6 = isset($node->{self::CONFIG_KEY_IPADDRV6}) ? (string)$node->{self::CONFIG_KEY_IPADDRV6} : '';
+        if ($ipaddrv6 === self::IPV6_TYPE_DHCP) {
+            $out['ipv6Type'] = self::IPV6_TYPE_DHCP;
+            $out['ipv6Address'] = null;
+            $out['ipv6Subnet'] = null;
+            $out['ipv6Track'] = null;
+        } elseif ($ipaddrv6 === 'track6' || isset($node->{self::CONFIG_KEY_TRACK6_INTERFACE})) {
+            $out['ipv6Type'] = self::IPV6_TYPE_TRACK;
+            $out['ipv6Address'] = null;
+            $out['ipv6Subnet'] = null;
+            $out['ipv6Track'] = isset($node->{self::CONFIG_KEY_TRACK6_INTERFACE}) ? (string)$node->{self::CONFIG_KEY_TRACK6_INTERFACE} : null;
+        } elseif ($ipaddrv6 !== '') {
+            $out['ipv6Type'] = self::IPV6_TYPE_STATIC;
+            $out['ipv6Address'] = $ipaddrv6;
+            $out['ipv6Subnet'] = isset($node->{self::CONFIG_KEY_SUBNETV6}) ? intval((string)$node->{self::CONFIG_KEY_SUBNETV6}) : null;
+            $out['ipv6Track'] = null;
+        } else {
+            $out['ipv6Type'] = self::IPV6_TYPE_NONE;
+            $out['ipv6Address'] = null;
+            $out['ipv6Subnet'] = null;
+            $out['ipv6Track'] = null;
+        }
+
+        return $out;
+    }
+}

--- a/tools/spikes/interface_assignment_gist_rest/README.md
+++ b/tools/spikes/interface_assignment_gist_rest/README.md
@@ -1,0 +1,147 @@
+# Gist-based REST spike — OPNsense interface_assignments
+
+Forks and extends [`szymczag`'s `AssignSettingsController.php`](https://gist.github.com/szymczag/df152a82e86aff67b984ed3786b027ba) (BSD-2-Clause) so we can drive OPNsense `interface_assignments` writes through a single, server-side-validated REST surface. Pairs with [`docs/development/opnsense-spike-interface-assignment-gist-findings.md`](../../../docs/development/opnsense-spike-interface-assignment-gist-findings.md). This is the pivot from #714 (SSH+PHP `config.xml` editor — closed without merging on safety grounds): server-side `Config::save()` rejects bad input loudly, fires the standard audit log, and triggers an auto-snapshot.
+
+## What's in this directory
+
+| File | Purpose |
+| :--- | :--- |
+| `AssignSettingsController.php` | Forked + patched + extended PHP controller. Installed at `/usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/`. |
+| `install.py` | Idempotent installer: SCP + service restart + checksum verify. Standalone-runnable. |
+| `interface_assignment_gist_rest.py` | Python spike: `inspect`, `list`, `plan`, `apply`, `install`, `verify-install`. |
+| `example-interface-assignments.yaml` | Fixture targeting the spare NIC `igc0` on `opnsense-a`. |
+| `__init__.py` | Module marker. |
+
+### What the fork changes vs. the original gist
+
+| Concern | Base gist | This fork |
+| :--- | :--- | :--- |
+| `addItem` (auto-numbered) | yes | yes |
+| `delItem` | yes | yes |
+| `setItem` (in-place update) | NO | yes (added) |
+| `getItem` (single fetch) | NO | yes (added) |
+| `searchItem` (list all) | NO | yes (added) |
+| IPv6 fields on add/set | NO | yes (added: `ipv6Type`, `ipv6Address`, `ipv6Subnet`, `ipv6Track`) |
+| Explicit name on `addItem` | NO | yes (added; required for cutover continuity — preserve `optN` numbering across box swaps) |
+| `sessionClose()` calls | yes (breaks on modern OPNsense) | removed (community patch — Paradoxis comment 2026-02-25) |
+
+## Prerequisites
+
+1. An OPNsense box you don't mind reconfiguring. **Use `opnsense-a` (staging), NOT prod.**
+2. SSH access to the box (root) — used for the install lifecycle only.
+3. A REST API key/secret with permission for:
+   - `interfaces/overview/interfacesInfo` (read baseline)
+   - `interfaces/assign_settings/*` (controller endpoints)
+   - `core/backup/{backups,revertBackup}` (auto-snapshot capture + rollback)
+
+## Environment variables
+
+Source these from your secrets repo. **Never commit them.**
+
+### REST (always required for non-install commands)
+
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `OPNSENSE_API_URL` | yes | e.g. `https://opnsense-a.example.lan` |
+| `OPNSENSE_API_KEY` | yes | API key from System → Access → Users → API keys |
+| `OPNSENSE_API_SECRET` | yes | Paired secret |
+| `OPNSENSE_VERIFY_SSL` | no | `true` (default) / `false` / `0` / `no` — case-insensitive |
+
+### SSH (required for `install`/`verify-install`/`inspect` checksum probe)
+
+| Variable | Required | Purpose |
+| :--- | :--- | :--- |
+| `OPNSENSE_SSH_HOST` | yes | e.g. `opnsense-a.lan` |
+| `OPNSENSE_SSH_USER` | no | Defaults to `root` |
+| `OPNSENSE_SSH_PORT` | no | Defaults to `22` |
+| `OPNSENSE_SSH_KEY` | yes | Path to SSH private key (e.g. `~/.ssh/id_ed25519`) |
+| `OPNSENSE_INSTALL_PATH` | no | Override the canonical MVC controller path |
+
+## Install lifecycle
+
+```bash
+# First install — copies the .php to the OPNsense box, restarts configd + php_fpm,
+# verifies the post-install checksum.
+uv run python tools/spikes/interface_assignment_gist_rest/install.py install
+
+# Verify the on-box file matches the local source (no SCP, no service restart).
+uv run python tools/spikes/interface_assignment_gist_rest/install.py verify
+
+# Force-reinstall (e.g., after editing the .php locally).
+uv run python tools/spikes/interface_assignment_gist_rest/install.py install --force
+```
+
+The same operations are also reachable through the spike's main entry point:
+
+```bash
+SPIKE=tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+uv run python $SPIKE install
+uv run python $SPIKE verify-install
+uv run python $SPIKE install --force
+```
+
+The install script is idempotent: re-running with no source changes is a no-op (checksum match short-circuits SCP + service restart).
+
+## Subcommands
+
+```bash
+SPIKE=tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+
+# 1. Sanity check — version detect, controller install probe, REST baseline.
+uv run python $SPIKE inspect
+
+# 2. Print the current interface assignments on the box as YAML.
+uv run python $SPIKE list
+
+# 3. Diff a YAML file against live state (no mutations).
+uv run python $SPIKE plan tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml
+
+# 4. Apply the diff. Without --confirm, this is a dry run identical to `plan`.
+uv run python $SPIKE apply tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml --confirm
+```
+
+### Safety flags
+
+- **`--add-only`** (on `plan` and `apply`) — suppresses deletes for live assignments not in the YAML. Use this on partial migrations where the YAML doesn't yet describe the box's full set of `lan`/`wan`/`optN` entries. Adds and updates still happen.
+- **`lock: true`** at the resource level in YAML — observed but untouchable. The spike records it in plan output and never adds/updates/deletes the matching live resource. Use this for `lan`/`wan` until the migration is complete. See `example-interface-assignments.yaml` for the syntax.
+- **`--no-rollback`** (on `apply`) — disables the auto-rollback path. Useful when you want to inspect intermediate state after a failure.
+- **`--print-rollback`** (on `apply`) — prints the captured pre-apply backup id before mutations. Use with `--confirm` to record the rollback target in your run log.
+- **`--backup-snapshot-id <id>`** (on `apply`) — operator-supplied override for the auto-captured snapshot id. Use when you want to roll back to a specific older snapshot instead of the freshest one.
+
+### Lockout-prevention (carried forward from #714's design)
+
+Before any REST call fires, the spike refuses to apply if a planned `add` targets a `device` (kernel NIC name) that's already bound to another logical interface. This is a Python-side pre-flight; the PHP controller has its own server-side check too (the original gist's `addItem` refuses if `<interfaces>` already contains the device).
+
+For `setItem` the same rule applies, but only when the device is changing.
+
+## Round-trip recipe (load-bearing acceptance)
+
+```bash
+SPIKE=tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+FIXTURE=tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml
+
+# 1. Apply.
+uv run python $SPIKE apply $FIXTURE --confirm
+
+# 2. Re-plan. Must print "No changes." (or only locked entries).
+uv run python $SPIKE plan $FIXTURE
+
+# 3. Modify $FIXTURE (rebind device, add an entry, etc.); re-plan should reflect.
+# 4. Apply with --confirm; box reconciles. Re-plan: "No changes."
+```
+
+If step 2 ever shows a non-empty diff right after a successful apply, the round-trip property is broken — capture the diff verbatim in the findings doc.
+
+## Cleanup
+
+```bash
+# Remove the spike's test entry. The base gist's delItem is idempotent —
+# running this twice is fine.
+SPIKE=tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+# Either edit the YAML to remove the entry and re-apply, or delete directly:
+# (no built-in CLI for direct delete; remove from YAML and apply with --confirm.)
+```
+
+## After running
+
+Fill in [`docs/development/opnsense-spike-interface-assignment-gist-findings.md`](../../../docs/development/opnsense-spike-interface-assignment-gist-findings.md) with the live-run output for each placeholder section.

--- a/tools/spikes/interface_assignment_gist_rest/__init__.py
+++ b/tools/spikes/interface_assignment_gist_rest/__init__.py
@@ -1,0 +1,11 @@
+"""Gist-based REST spike for OPNsense interface_assignments — informs ADR-0014 (#715).
+
+See ``interface_assignment_gist_rest.py`` for the spike entry point and
+``AssignSettingsController.php`` for the patched + extended community
+controller (originally from
+https://gist.github.com/szymczag/df152a82e86aff67b984ed3786b027ba).
+
+The findings document at
+``docs/development/opnsense-spike-interface-assignment-gist-findings.md``
+captures empirical results from the live run.
+"""

--- a/tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml
+++ b/tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml
@@ -1,0 +1,58 @@
+# Example interface_assignments configurations for the gist-based REST spike.
+#
+# Resource shape mirrors InfraFoundry's resource-centric YAML so the spike
+# operates on the same data model as the production read-only provider, even
+# though this script does NOT go through ConfigManager / OPNsenseProvider.
+#
+# Diff identity is the logical interface name (`name`/`identifier`) — that's
+# what makes an assignment unique on a box. Auto-numbered names (`opt5`,
+# `opt6`, ...) are produced by the controller when no explicit name is given;
+# explicit `name: optN` is forwarded to the controller's add-with-explicit-name
+# extension.
+#
+# Target box: opnsense-a (staging), NOT prod. See README.md.
+#
+# Optional top-level meta-property:
+#   lock: true   — IaC observes this resource but never adds/updates/deletes
+#                  it. Useful for partial migrations where the YAML doesn't
+#                  yet describe everything on the box (e.g. lan/wan).
+
+# Lock entries for built-in interfaces — they exist on the box but should
+# never be touched by IaC. Uncomment + adjust device names to mirror your
+# live state.
+#
+# - provider: opnsense
+#   type: interface_assignments
+#   name: lan
+#   lock: true
+#   config:
+#     device: ixl0
+#     description: "LAN trunk"
+#     enabled: true
+#
+# - provider: opnsense
+#   type: interface_assignments
+#   name: wan
+#   lock: true
+#   config:
+#     device: ixl0_vlan4000
+#     description: "WAN trunk"
+#     enabled: true
+
+# A test add against the spare NIC `igc0` on opnsense-a. The controller will
+# either auto-number this to the next available `optN`, or — with the
+# explicit-name extension — bind it to the literal `name` here.
+- provider: opnsense
+  type: interface_assignments
+  name: opt9
+  config:
+    device: igc0
+    description: "spike-test"
+    enabled: true
+    ipv4:
+      type: static
+      address: 10.99.99.1
+      subnet: 24
+    ipv6:
+      type: track-interface
+      track: wan

--- a/tools/spikes/interface_assignment_gist_rest/install.py
+++ b/tools/spikes/interface_assignment_gist_rest/install.py
@@ -1,0 +1,362 @@
+"""Idempotent installer for the AssignSettingsController.php fork on OPNsense.
+
+This script SCPs the controller to the OPNsense MVC controllers directory,
+restarts the configd + php_fpm services so the MVC layer re-discovers the
+new controller, and verifies the on-box checksum matches the local file.
+
+It is **idempotent**: re-running with no changes is a no-op (checksum match
+short-circuits the SCP+restart path).
+
+Environment variable contract::
+
+    OPNSENSE_SSH_HOST         — defaults to the host part of OPNSENSE_API_URL
+    OPNSENSE_SSH_USER         — defaults to "root"
+    OPNSENSE_SSH_PORT         — defaults to "22"
+    OPNSENSE_SSH_KEY          — optional, path to the SSH private key.
+                                 If unset, ssh-agent and ~/.ssh/config provide
+                                 the identity. The script never prompts.
+    OPNSENSE_INSTALL_PATH     — defaults to the canonical MVC path
+
+The shell utilities ``ssh`` and ``scp`` must be on ``PATH``; they are invoked
+via ``subprocess.run`` with ``shell=False`` and an explicit argument list.
+
+Usage::
+
+    # Standalone install:
+    python tools/spikes/interface_assignment_gist_rest/install.py install
+
+    # Verify the on-box file checksum matches the local source:
+    python tools/spikes/interface_assignment_gist_rest/install.py verify
+
+This module is designed to be importable so the spike's ``inspect`` subcommand
+can call ``verify_installed_checksum()`` directly without shelling out to a
+separate script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+DEFAULT_INSTALL_PATH = (
+    "/usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignSettingsController.php"
+)
+CONTROLLER_FILENAME = "AssignSettingsController.php"
+
+
+@dataclass(frozen=True)
+class SshTarget:
+    """Connection details for the OPNsense box."""
+
+    host: str
+    user: str
+    port: int
+    key_path: Path | None  # None → rely on ssh-agent / ~/.ssh/config
+    install_path: str
+
+    @property
+    def remote(self) -> str:
+        """``user@host`` form for ``ssh``/``scp``."""
+        return f"{self.user}@{self.host}"
+
+
+def load_ssh_target(env: dict[str, str] | None = None) -> SshTarget:
+    """Read SSH connection details from environment variables.
+
+    ``OPNSENSE_SSH_HOST`` falls back to the host part of ``OPNSENSE_API_URL``
+    when unset — common case where a single env defines both REST and SSH
+    targets. ``OPNSENSE_SSH_KEY`` is optional; when unset, ssh-agent and
+    ``~/.ssh/config`` provide the identity.
+
+    Args:
+        env: Mapping to read from. Defaults to ``os.environ``.
+
+    Returns:
+        A populated ``SshTarget``.
+
+    Raises:
+        RuntimeError: If neither ``OPNSENSE_SSH_HOST`` nor ``OPNSENSE_API_URL``
+            is set, or if a supplied ``OPNSENSE_SSH_KEY`` path does not exist.
+    """
+    source: dict[str, str] = dict(os.environ if env is None else env)
+
+    host = source.get("OPNSENSE_SSH_HOST", "").strip()
+    if not host:
+        api_url = source.get("OPNSENSE_API_URL", "").strip()
+        if api_url:
+            host = (urlparse(api_url).hostname or "").strip()
+    if not host:
+        raise RuntimeError("OPNSENSE_SSH_HOST is required (or set OPNSENSE_API_URL to derive it).")
+
+    key_str = source.get("OPNSENSE_SSH_KEY", "").strip()
+    key_path: Path | None = None
+    if key_str:
+        key_path = Path(key_str).expanduser()
+        if not key_path.exists():
+            raise RuntimeError(f"SSH key does not exist: {key_path}")
+
+    user = source.get("OPNSENSE_SSH_USER", "root").strip() or "root"
+    port_raw = source.get("OPNSENSE_SSH_PORT", "22").strip() or "22"
+    try:
+        port = int(port_raw)
+    except ValueError as exc:
+        raise RuntimeError(f"OPNSENSE_SSH_PORT must be an integer, got: {port_raw!r}") from exc
+
+    install_path = source.get("OPNSENSE_INSTALL_PATH", "").strip() or DEFAULT_INSTALL_PATH
+
+    return SshTarget(
+        host=host,
+        user=user,
+        port=port,
+        key_path=key_path,
+        install_path=install_path,
+    )
+
+
+def local_controller_path() -> Path:
+    """Return the path to the bundled controller PHP source."""
+    return Path(__file__).resolve().parent / CONTROLLER_FILENAME
+
+
+def compute_local_checksum(path: Path) -> str:
+    """SHA-256 of a local file, as a hex string."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _identity_args(target: SshTarget) -> list[str]:
+    """Return ``["-i", "<path>"]`` when an explicit key is configured, else ``[]``.
+
+    With an empty list the system ssh client falls back to ssh-agent and
+    ``~/.ssh/config`` for the identity — the typical homelab setup.
+    """
+    if target.key_path is None:
+        return []
+    return ["-i", str(target.key_path)]
+
+
+def _ssh_args(target: SshTarget) -> list[str]:
+    """Common ssh args for non-interactive use."""
+    return [
+        "ssh",
+        *_identity_args(target),
+        "-p",
+        str(target.port),
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        target.remote,
+    ]
+
+
+def _scp_args(target: SshTarget, source_path: Path, remote_path: str) -> list[str]:
+    """Build an SCP argv that transfers a single file."""
+    return [
+        "scp",
+        *_identity_args(target),
+        "-P",
+        str(target.port),
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        str(source_path),
+        f"{target.remote}:{remote_path}",
+    ]
+
+
+def _run(argv: list[str], *, capture_output: bool = True) -> subprocess.CompletedProcess[str]:
+    """Wrapper around subprocess.run with consistent defaults.
+
+    ``shell=False`` always; argv is a list. Captures stdout/stderr by default.
+    """
+    return subprocess.run(
+        argv,
+        capture_output=capture_output,
+        check=False,
+        text=True,
+    )
+
+
+def fetch_remote_checksum(target: SshTarget) -> str | None:
+    """Compute the SHA-256 checksum of the controller currently on the box.
+
+    Returns ``None`` if the file doesn't exist on the remote (i.e., never
+    installed). Raises if the SSH command itself fails for some other reason.
+
+    OPNsense's default root shell is ``opnsense-shell`` (csh-derived), where
+    ``2>/dev/null`` is "Ambiguous output redirect." We avoid stderr redirection
+    entirely by guarding with ``test -f`` (portable across both shells); if
+    the file is missing the guard short-circuits and the chained ``echo
+    MISSING`` runs, otherwise ``sha256 -q`` produces the hash on stdout.
+    """
+    cmd = [
+        *_ssh_args(target),
+        f"test -f {target.install_path} && sha256 -q {target.install_path} || echo MISSING",
+    ]
+    result = _run(cmd)
+    if result.returncode != 0:
+        err = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"SSH probe failed (rc={result.returncode}): {err}")
+    out = result.stdout.strip()
+    if out == "MISSING" or out == "":
+        return None
+    return out
+
+
+def verify_installed_checksum(target: SshTarget | None = None) -> tuple[bool, str | None, str]:
+    """Compare the on-box controller's SHA-256 to the local source.
+
+    Args:
+        target: Connection details. If ``None``, reads from env.
+
+    Returns:
+        ``(matches, remote_sum, local_sum)``. ``matches`` is ``False`` if
+        the file is missing on the remote or differs from local.
+    """
+    if target is None:
+        target = load_ssh_target()
+    local_sum = compute_local_checksum(local_controller_path())
+    remote_sum = fetch_remote_checksum(target)
+    matches = remote_sum == local_sum
+    return matches, remote_sum, local_sum
+
+
+def install_controller(target: SshTarget | None = None, *, force: bool = False) -> bool:
+    """SCP the controller, restart services, verify checksum.
+
+    Args:
+        target: Connection details. If ``None``, reads from env.
+        force: If True, re-install even when the on-box checksum already
+            matches. Useful for forcing a service restart.
+
+    Returns:
+        ``True`` if the controller was (re)installed; ``False`` if it was
+        already current and no install was needed.
+    """
+    if target is None:
+        target = load_ssh_target()
+
+    local_path = local_controller_path()
+    if not local_path.exists():
+        raise RuntimeError(f"Local controller not found: {local_path}")
+
+    matches, remote_sum, local_sum = verify_installed_checksum(target)
+    if matches and not force:
+        print(f"Controller already current on {target.host} (sha256 {local_sum[:12]}…). Skipping.")
+        return False
+
+    if remote_sum is None:
+        print(f"Controller not present on {target.host}. Installing fresh.")
+    else:
+        print(
+            f"Controller checksum mismatch on {target.host} "
+            f"(remote {remote_sum[:12]}…, local {local_sum[:12]}…). Replacing."
+        )
+
+    # Step 1: SCP the file.
+    scp_cmd = _scp_args(target, local_path, target.install_path)
+    print(f"Running: {' '.join(scp_cmd)}")
+    scp_result = _run(scp_cmd)
+    if scp_result.returncode != 0:
+        raise RuntimeError(
+            f"SCP failed (rc={scp_result.returncode}): "
+            f"{scp_result.stderr.strip() or scp_result.stdout.strip()}"
+        )
+
+    # Step 2: Permissions + ownership. OPNsense controllers run as root:wheel
+    # readable by the php_fpm pool; we set 0644 so the GUI's MVC autoloader
+    # can read them.
+    chmod_cmd = [*_ssh_args(target), f"chmod 0644 {target.install_path}"]
+    chmod_result = _run(chmod_cmd)
+    if chmod_result.returncode != 0:
+        raise RuntimeError(f"chmod failed: {chmod_result.stderr.strip()}")
+
+    # Step 3: Restart configd + php_fpm so the MVC layer re-discovers the controller.
+    # OPNsense's `service` command works for both. We restart configd first;
+    # php_fpm second so any in-flight GUI request sees the new controller.
+    for service_name in ("configd", "php_fpm"):
+        restart_cmd = [*_ssh_args(target), f"service {service_name} restart"]
+        rc = _run(restart_cmd)
+        if rc.returncode != 0:
+            raise RuntimeError(
+                f"service {service_name} restart failed (rc={rc.returncode}): "
+                f"{rc.stderr.strip() or rc.stdout.strip()}"
+            )
+        print(f"Restarted service: {service_name}")
+
+    # Step 4: Verify post-install checksum.
+    matches_after, remote_after, _ = verify_installed_checksum(target)
+    if not matches_after:
+        raise RuntimeError(
+            f"Post-install checksum mismatch on {target.host}: "
+            f"remote {remote_after}, local {local_sum}. Install may have failed silently."
+        )
+    print(f"Install verified on {target.host}: sha256 {local_sum[:12]}…")
+    return True
+
+
+def _ensure_ssh_tools_present() -> None:
+    """Fail loudly if ``ssh``/``scp`` aren't on ``PATH``."""
+    missing: list[str] = [tool for tool in ("ssh", "scp") if shutil.which(tool) is None]
+    if missing:
+        raise RuntimeError(
+            f"Required SSH tool(s) not on PATH: {', '.join(missing)}. "
+            "Install OpenSSH client utilities."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(
+        prog="install_assign_settings_controller",
+        description="Install/verify the AssignSettingsController.php fork on OPNsense.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    install_parser = sub.add_parser("install", help="SCP + service restart + verify.")
+    install_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-install even when the on-box checksum already matches.",
+    )
+    sub.add_parser("verify", help="Just compare the on-box checksum to the local source.")
+
+    args = parser.parse_args(argv)
+
+    _ensure_ssh_tools_present()
+
+    target = load_ssh_target()
+
+    if args.command == "install":
+        install_controller(target, force=bool(args.force))
+        return 0
+
+    if args.command == "verify":
+        matches, remote_sum, local_sum = verify_installed_checksum(target)
+        local_short = local_sum[:12]
+        if matches:
+            print(f"OK: on-box and local checksums match (sha256 {local_short}…).")
+            return 0
+        if remote_sum is None:
+            print(f"MISSING: controller not installed on {target.host}.")
+        else:
+            print(f"MISMATCH: remote {remote_sum[:12]}… vs local {local_short}…")
+        return 1
+
+    parser.error(f"Unknown command: {args.command}")  # NoReturn
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+++ b/tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
@@ -1,0 +1,1087 @@
+"""Gist-based REST spike for OPNsense interface_assignments — informs ADR-0014.
+
+Drives a forked + extended copy of `szymczag`'s ``AssignSettingsController.php``
+(the gist at ``df152a82e86aff67b984ed3786b027ba``) installed on the OPNsense
+box. The community-reported ``sessionClose()`` patch is applied locally; the
+fork additionally adds ``setItemAction``, ``getItemAction``, ``searchItemAction``,
+IPv6 support across add/set, and explicit-name on add. See
+``AssignSettingsController.php`` for the PHP source.
+
+This is a sibling to ``tools/spikes/vlan_direct_api.py`` — same Python shape,
+different OPNsense surface. Server-side validation (controller-side) is a
+deliberate departure from #714's SSH+PHP-edit path: bad inputs get rejected
+loudly with an ``errorMessage`` field instead of producing silent-bad XML.
+
+Subcommands:
+
+    inspect          Detect controller install state, OPNsense version, baseline.
+    list             Dump current interface assignments via interfacesInfo.
+    plan <yaml>      Diff YAML vs live state.
+    apply <yaml>     Execute changes via REST (requires --confirm).
+    install          Idempotent install of the PHP controller (delegates to install.py).
+    verify-install   Check controller-on-box checksum matches local file.
+
+Environment variables:
+
+    REST (always required):
+        OPNSENSE_API_URL
+        OPNSENSE_API_KEY
+        OPNSENSE_API_SECRET
+        OPNSENSE_VERIFY_SSL    (optional; defaults to "true")
+
+    SSH (only required for ``install`` / ``verify-install`` / ``inspect`` checksum probe):
+        OPNSENSE_SSH_HOST
+        OPNSENSE_SSH_USER      (defaults to "root")
+        OPNSENSE_SSH_PORT      (defaults to "22")
+        OPNSENSE_SSH_KEY       (path to SSH private key)
+        OPNSENSE_INSTALL_PATH  (optional override)
+
+Usage::
+
+    SPIKE=tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py
+    python $SPIKE inspect
+    python $SPIKE list
+    python $SPIKE plan ./example-interface-assignments.yaml
+    python $SPIKE apply ./example-interface-assignments.yaml --confirm
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from opnsense_openapi import OPNsenseClient
+
+# Support both invocation modes: as a module (``python -m tools.spikes...``)
+# and as a script (``python tools/spikes/.../interface_assignment_gist_rest.py``).
+# The latter doesn't have ``tools.spikes...`` on sys.path, so fall back to a
+# direct path-based import of the sibling install module.
+try:
+    from tools.spikes.interface_assignment_gist_rest import install as installer
+except ImportError:  # pragma: no cover — exercised only when run as a script.
+    import importlib.util as _importlib_util
+
+    _install_path = Path(__file__).resolve().parent / "install.py"
+    _spec = _importlib_util.spec_from_file_location("install", _install_path)
+    if _spec is None or _spec.loader is None:
+        raise
+    installer = _importlib_util.module_from_spec(_spec)
+    # Register in sys.modules BEFORE exec — dataclass() reads the module's
+    # __dict__ via sys.modules.get(__module__), so the module must be there.
+    sys.modules["install"] = installer
+    _spec.loader.exec_module(installer)
+
+# ---------------------------------------------------------------------------
+# Constants — controller endpoint coordinates
+# ---------------------------------------------------------------------------
+
+# The OPNsense MVC URL routing converts ``AssignSettingsController`` to
+# ``assign_settings`` (snake_case). This is the same heterogeneity the VLAN
+# spike documented; the live path has the underscore.
+ASSIGN_MODULE = "interfaces"
+ASSIGN_CONTROLLER = "assign_settings"
+
+# OPNsense's interfacesInfo endpoint — the read-only baseline used for ``list``
+# and as the source-of-truth for diffing during ``plan``/``apply``. The
+# controller's own ``searchItem`` is also available post-install but we keep
+# ``interfacesInfo`` as the default since it's part of OPNsense's stock API
+# (no controller dependency needed for read-only views).
+INTERFACES_INFO_MODULE = "interfaces"
+INTERFACES_INFO_CONTROLLER = "overview"
+INTERFACES_INFO_COMMAND = "interfacesInfo"
+
+# Backup endpoints used for pre-apply snapshot capture + auto-rollback.
+BACKUP_MODULE = "core"
+BACKUP_CONTROLLER = "backup"
+BACKUP_LIST_COMMAND = "backups"
+BACKUP_REVERT_COMMAND = "revertBackup"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Credentials:
+    """Resolved OPNsense REST credentials sourced from env."""
+
+    api_url: str
+    api_key: str
+    api_secret: str
+    verify_ssl: bool
+
+
+@dataclass(frozen=True)
+class InterfaceAssignmentConfig:
+    """Desired-state interface-assignment config loaded from YAML.
+
+    Mirrors ``src/infrafoundry/providers/opnsense/services/interface_assignment.py``'s
+    ``InterfaceAssignmentConfig`` but with extra fields the spike's controller
+    accepts (``ipv4Type``/``ipv6Type``/``spoofMac``/...). Diff key is the
+    logical interface name (``identifier``); that's what makes an assignment
+    unique on a box.
+
+    The ``lock`` meta-property declares "observed but untouchable" — the
+    spike treats the matching live record as untouchable and never adds,
+    updates, or deletes it. Locks travel with specific resources in YAML.
+    """
+
+    name: str
+    device: str
+    description: str
+    enabled: bool = True
+    lock: bool = False
+    spoof_mac: str | None = None
+    # IPv4 fields
+    ipv4_type: str = "none"  # static | dhcp | none
+    ipv4_address: str | None = None
+    ipv4_subnet: int | None = None
+    # IPv6 fields
+    ipv6_type: str = "none"  # static | dhcp | track-interface | none
+    ipv6_address: str | None = None
+    ipv6_subnet: int | None = None
+    ipv6_track: str | None = None
+
+    @property
+    def diff_key(self) -> str:
+        """Identity on the box: the logical interface name (e.g. 'opt3')."""
+        return self.name
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize to the dict shape the controller expects.
+
+        The controller accepts ``{"assign": {<fields>}}``. ``name`` is forwarded
+        only when set (the controller falls back to auto-numbering otherwise).
+        """
+        assign: dict[str, Any] = {
+            "device": self.device,
+            "description": self.description,
+            "enable": self.enabled,
+            "name": self.name,
+            "ipv4Type": self.ipv4_type,
+            "ipv6Type": self.ipv6_type,
+        }
+        if self.spoof_mac:
+            assign["spoofMac"] = self.spoof_mac
+        if self.ipv4_type == "static":
+            assign["ipv4Address"] = self.ipv4_address
+            assign["ipv4Subnet"] = self.ipv4_subnet
+        if self.ipv6_type == "static":
+            assign["ipv6Address"] = self.ipv6_address
+            assign["ipv6Subnet"] = self.ipv6_subnet
+        if self.ipv6_type == "track-interface":
+            assign["ipv6Track"] = self.ipv6_track
+        return {"assign": assign}
+
+
+@dataclass(frozen=True)
+class LiveInterfaceAssignment:
+    """A live interface assignment as returned by interfacesInfo.
+
+    Mirrors the production ``LiveInterfaceAssignment`` shape but redeclared
+    locally so the spike is self-contained (per the established
+    ``vlan_direct_api`` / ``LiveVlan`` pattern).
+    """
+
+    identifier: str
+    device: str
+    description: str
+    is_physical: bool
+    ipv4: dict[str, Any]
+    ipv6: dict[str, Any]
+    macaddr: str
+    mtu: int
+
+    @property
+    def diff_key(self) -> str:
+        """Identity on the box: the logical interface name."""
+        return self.identifier
+
+
+@dataclass
+class Diff:
+    """Result of comparing desired YAML state to live state."""
+
+    adds: list[InterfaceAssignmentConfig] = field(default_factory=list)
+    updates: list[tuple[LiveInterfaceAssignment, InterfaceAssignmentConfig]] = field(
+        default_factory=list
+    )
+    deletes: list[LiveInterfaceAssignment] = field(default_factory=list)
+    locked: list[tuple[InterfaceAssignmentConfig, LiveInterfaceAssignment | None]] = field(
+        default_factory=list
+    )
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.adds or self.updates or self.deletes)
+
+
+# ---------------------------------------------------------------------------
+# Environment / configuration loading
+# ---------------------------------------------------------------------------
+
+
+def load_env_credentials(env: dict[str, str] | None = None) -> Credentials:
+    """Read OPNsense REST credentials from env vars.
+
+    Args:
+        env: Mapping to read from. Defaults to ``os.environ``. Injectable for tests.
+
+    Returns:
+        A populated ``Credentials``.
+
+    Raises:
+        RuntimeError: If any of ``OPNSENSE_API_URL``/``_API_KEY``/``_API_SECRET``
+            is missing or empty.
+    """
+    source: dict[str, str] = dict(os.environ if env is None else env)
+    required: tuple[str, ...] = (
+        "OPNSENSE_API_URL",
+        "OPNSENSE_API_KEY",
+        "OPNSENSE_API_SECRET",
+    )
+    missing: list[str] = [key for key in required if not source.get(key)]
+    if missing:
+        raise RuntimeError(
+            "Missing required OPNsense environment variable(s): "
+            f"{', '.join(missing)}. Source them from the secrets repo before "
+            "running this spike — see tools/spikes/README.md."
+        )
+
+    verify_raw: str = source.get("OPNSENSE_VERIFY_SSL", "true").strip().lower()
+    verify_ssl: bool = verify_raw not in ("0", "false", "no", "off")
+
+    return Credentials(
+        api_url=source["OPNSENSE_API_URL"],
+        api_key=source["OPNSENSE_API_KEY"],
+        api_secret=source["OPNSENSE_API_SECRET"],
+        verify_ssl=verify_ssl,
+    )
+
+
+def load_assignments_from_yaml(path: Path) -> list[InterfaceAssignmentConfig]:
+    """Parse a YAML file of interface_assignment resource definitions.
+
+    Expects the InfraFoundry resource shape::
+
+        - provider: opnsense
+          type: interface_assignments
+          name: opt3
+          config:
+            device: igc0
+            description: spike-test
+            enabled: true
+            ipv4:
+              type: static
+              address: 10.20.30.1
+              subnet: 24
+            ipv6:
+              type: track-interface
+              track: wan
+
+    Args:
+        path: YAML file path.
+
+    Returns:
+        Validated list of ``InterfaceAssignmentConfig`` instances.
+
+    Raises:
+        ValueError: On malformed YAML or invalid per-field values.
+    """
+    with path.open(encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"Expected top-level list of resources in {path}, got {type(raw).__name__}"
+        )
+
+    configs: list[InterfaceAssignmentConfig] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Resource at index {index} is not a mapping")
+        if entry.get("type") != "interface_assignments":
+            # Allow non-matching resources to coexist; they're ignored here.
+            continue
+
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Resource at index {index} missing string 'name'")
+
+        config = entry.get("config")
+        if not isinstance(config, dict):
+            raise ValueError(f"interface_assignment '{name}' missing or invalid 'config' mapping")
+
+        device = config.get("device")
+        if not isinstance(device, str) or not device:
+            raise ValueError(f"interface_assignment '{name}' missing string 'device'")
+
+        description = config.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"interface_assignment '{name}' description must be a string")
+
+        enabled_raw = config.get("enabled", True)
+        if not isinstance(enabled_raw, bool):
+            raise ValueError(f"interface_assignment '{name}' enabled must be a boolean")
+
+        # ``lock`` is a top-level meta-property, not nested under ``config``.
+        lock_raw = entry.get("lock", False)
+        if not isinstance(lock_raw, bool):
+            raise ValueError(f"interface_assignment '{name}' lock must be a boolean")
+
+        spoof_mac_raw = config.get("spoof_mac")
+        if spoof_mac_raw is not None and not isinstance(spoof_mac_raw, str):
+            raise ValueError(f"interface_assignment '{name}' spoof_mac must be a string")
+
+        ipv4_type, ipv4_address, ipv4_subnet = _parse_ipv4_block(config.get("ipv4", {}), name)
+        ipv6_type, ipv6_address, ipv6_subnet, ipv6_track = _parse_ipv6_block(
+            config.get("ipv6", {}), name
+        )
+
+        configs.append(
+            InterfaceAssignmentConfig(
+                name=name,
+                device=device,
+                description=description,
+                enabled=enabled_raw,
+                lock=lock_raw,
+                spoof_mac=spoof_mac_raw,
+                ipv4_type=ipv4_type,
+                ipv4_address=ipv4_address,
+                ipv4_subnet=ipv4_subnet,
+                ipv6_type=ipv6_type,
+                ipv6_address=ipv6_address,
+                ipv6_subnet=ipv6_subnet,
+                ipv6_track=ipv6_track,
+            )
+        )
+
+    return configs
+
+
+def _parse_ipv4_block(block: Any, name: str) -> tuple[str, str | None, int | None]:
+    """Parse the ``ipv4`` sub-block of an interface_assignments config.
+
+    Returns ``(type, address, subnet)``. Defaults to ``("none", None, None)``.
+    """
+    if not isinstance(block, dict):
+        raise ValueError(f"interface_assignment '{name}' ipv4 must be a mapping")
+    if not block:
+        return ("none", None, None)
+
+    ipv4_type = block.get("type", "none")
+    if ipv4_type not in ("static", "dhcp", "none"):
+        raise ValueError(
+            f"interface_assignment '{name}' ipv4.type must be one of: static, dhcp, none"
+        )
+
+    address = block.get("address")
+    subnet = block.get("subnet")
+
+    if ipv4_type == "static":
+        if not isinstance(address, str) or not address:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv4.address required when type is 'static'"
+            )
+        if subnet is None:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv4.subnet required when type is 'static'"
+            )
+        try:
+            subnet_int = int(subnet)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv4.subnet must be an integer 1-32"
+            ) from exc
+        if not 1 <= subnet_int <= 32:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv4.subnet {subnet_int} out of range 1-32"
+            )
+        return ("static", address, subnet_int)
+
+    # dhcp / none — extra fields not allowed.
+    if address or subnet is not None:
+        raise ValueError(
+            f"interface_assignment '{name}' ipv4.address/subnet only valid when type is 'static'"
+        )
+    return (ipv4_type, None, None)
+
+
+def _parse_ipv6_block(block: Any, name: str) -> tuple[str, str | None, int | None, str | None]:
+    """Parse the ``ipv6`` sub-block of an interface_assignments config.
+
+    Returns ``(type, address, subnet, track)``. Defaults to ``("none", None, None, None)``.
+    """
+    if not isinstance(block, dict):
+        raise ValueError(f"interface_assignment '{name}' ipv6 must be a mapping")
+    if not block:
+        return ("none", None, None, None)
+
+    ipv6_type = block.get("type", "none")
+    if ipv6_type not in ("static", "dhcp", "track-interface", "none"):
+        raise ValueError(
+            f"interface_assignment '{name}' ipv6.type must be one of: "
+            "static, dhcp, track-interface, none"
+        )
+
+    address = block.get("address")
+    subnet = block.get("subnet")
+    track = block.get("track")
+
+    if ipv6_type == "static":
+        if not isinstance(address, str) or not address:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv6.address required when type is 'static'"
+            )
+        if subnet is None:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv6.subnet required when type is 'static'"
+            )
+        try:
+            subnet_int = int(subnet)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv6.subnet must be an integer 1-128"
+            ) from exc
+        if not 1 <= subnet_int <= 128:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv6.subnet {subnet_int} out of range 1-128"
+            )
+        return ("static", address, subnet_int, None)
+
+    if ipv6_type == "track-interface":
+        if not isinstance(track, str) or not track:
+            raise ValueError(
+                f"interface_assignment '{name}' ipv6.track required when type is 'track-interface'"
+            )
+        return ("track-interface", None, None, track)
+
+    # dhcp / none — extra fields not allowed.
+    if address or subnet is not None or track:
+        raise ValueError(
+            f"interface_assignment '{name}' ipv6.address/subnet/track only valid for "
+            "type 'static' or 'track-interface'"
+        )
+    return (ipv6_type, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Client + REST helpers
+# ---------------------------------------------------------------------------
+
+
+def build_client(credentials: Credentials) -> OPNsenseClient:
+    """Construct an OPNsenseClient with auto_detect_version=True.
+
+    Same intentional divergence from the production wrapper as
+    ``vlan_direct_api`` — ADR-0014 owns the decision about flipping the flag
+    in production.
+    """
+    return OPNsenseClient(
+        base_url=credentials.api_url,
+        api_key=credentials.api_key,
+        api_secret=credentials.api_secret,
+        verify_ssl=credentials.verify_ssl,
+        auto_detect_version=True,
+    )
+
+
+def fetch_interfaces_info(client: OPNsenseClient) -> list[LiveInterfaceAssignment]:
+    """Pull live interface assignments from interfacesInfo.
+
+    Skips rows whose ``identifier`` is empty — those are unassigned NICs.
+    """
+    response: Any = client.get(
+        INTERFACES_INFO_MODULE, INTERFACES_INFO_CONTROLLER, INTERFACES_INFO_COMMAND
+    )
+
+    rows: list[dict[str, Any]] = []
+    if isinstance(response, dict):
+        raw_rows = response.get("rows")
+        if isinstance(raw_rows, list):
+            rows = [r for r in raw_rows if isinstance(r, dict)]
+
+    return [_row_to_live_assignment(row) for row in rows if row.get("identifier")]
+
+
+def _row_to_live_assignment(row: dict[str, Any]) -> LiveInterfaceAssignment:
+    """Normalize an interfacesInfo row.
+
+    Mirrors ``services/interface_assignment.py:_row_to_live_assignment`` so
+    field semantics stay aligned with the production read path.
+    """
+    identifier = str(row.get("identifier", ""))
+    device = str(row.get("device", ""))
+    description = str(row.get("description", "") or "")
+    is_physical = bool(row.get("is_physical", False))
+    macaddr = str(row.get("macaddr", "") or "")
+
+    ipv4_raw = row.get("ipv4", {})
+    ipv4: dict[str, Any] = ipv4_raw if isinstance(ipv4_raw, dict) else {}
+
+    ipv6_raw = row.get("ipv6", {})
+    ipv6: dict[str, Any] = ipv6_raw if isinstance(ipv6_raw, dict) else {}
+
+    try:
+        mtu = int(row.get("mtu", 0) or 0)
+    except (TypeError, ValueError):
+        mtu = 0
+
+    return LiveInterfaceAssignment(
+        identifier=identifier,
+        device=device,
+        description=description,
+        is_physical=is_physical,
+        ipv4=ipv4,
+        ipv6=ipv6,
+        macaddr=macaddr,
+        mtu=mtu,
+    )
+
+
+def add_assignment(client: OPNsenseClient, config: InterfaceAssignmentConfig) -> dict[str, Any]:
+    """Create a new interface assignment via the controller's addItem endpoint."""
+    response: Any = client.post(
+        ASSIGN_MODULE, ASSIGN_CONTROLLER, "addItem", json=config.to_payload()
+    )
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+def update_assignment(
+    client: OPNsenseClient, identifier: str, config: InterfaceAssignmentConfig
+) -> dict[str, Any]:
+    """Update an existing assignment via the controller's setItem endpoint."""
+    response: Any = client.post(
+        ASSIGN_MODULE, ASSIGN_CONTROLLER, "setItem", identifier, json=config.to_payload()
+    )
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+def delete_assignment(client: OPNsenseClient, identifier: str) -> dict[str, Any]:
+    """Delete an assignment via the controller's delItem endpoint."""
+    response: Any = client.post(ASSIGN_MODULE, ASSIGN_CONTROLLER, "delItem", identifier)
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+def get_assignment(client: OPNsenseClient, identifier: str) -> dict[str, Any]:
+    """Fetch a single assignment via the controller's getItem endpoint."""
+    response: Any = client.get(ASSIGN_MODULE, ASSIGN_CONTROLLER, "getItem", identifier)
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+def search_assignments_via_controller(client: OPNsenseClient) -> list[dict[str, Any]]:
+    """List assignments via the controller's searchItem endpoint.
+
+    Used in inspect/verification flows to confirm the extended controller is
+    installed and returning rows. The default ``list`` subcommand uses
+    ``interfacesInfo`` instead so it works against stock OPNsense too.
+    """
+    response: Any = client.post(ASSIGN_MODULE, ASSIGN_CONTROLLER, "searchItem")
+    rows: list[dict[str, Any]] = []
+    if isinstance(response, dict):
+        raw_rows = response.get("rows")
+        if isinstance(raw_rows, list):
+            rows = [r for r in raw_rows if isinstance(r, dict)]
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Backup / rollback helpers
+# ---------------------------------------------------------------------------
+
+
+def list_backup_ids(client: OPNsenseClient) -> list[str]:
+    """List available backup snapshots, newest first.
+
+    OPNsense's ``/api/core/backup/backups`` returns a list of strings (or in
+    some versions a dict keyed by id). We normalize defensively.
+    """
+    response: Any = client.get(BACKUP_MODULE, BACKUP_CONTROLLER, BACKUP_LIST_COMMAND)
+    if isinstance(response, list):
+        return [str(item) for item in response]
+    if isinstance(response, dict):
+        # Some OPNsense versions return {"backups": [...]} or a flat dict.
+        if "backups" in response and isinstance(response["backups"], list):
+            return [str(item) for item in response["backups"]]
+        return [str(k) for k in response]
+    return []
+
+
+def capture_latest_backup_id(client: OPNsenseClient) -> str | None:
+    """Return the id of the newest backup, or ``None`` if no backups exist.
+
+    OPNsense's ``backups`` endpoint returns ids in a stable order; we take
+    the first one as "newest" (matches the GUI's display convention).
+    """
+    ids = list_backup_ids(client)
+    return ids[0] if ids else None
+
+
+def revert_to_backup(client: OPNsenseClient, backup_id: str) -> dict[str, Any]:
+    """Revert the OPNsense config to a previously-captured backup snapshot.
+
+    Per the spike's risk register, this likely reverts the WHOLE config
+    (not just <interfaces>); acceptable for a spike but flagged in the
+    findings doc.
+    """
+    response: Any = client.post(BACKUP_MODULE, BACKUP_CONTROLLER, BACKUP_REVERT_COMMAND, backup_id)
+    return response if isinstance(response, dict) else {"raw": response}
+
+
+# ---------------------------------------------------------------------------
+# Diff engine
+# ---------------------------------------------------------------------------
+
+
+def compute_diff(
+    desired: list[InterfaceAssignmentConfig],
+    current: list[LiveInterfaceAssignment],
+    *,
+    add_only: bool = False,
+) -> Diff:
+    """Compare desired YAML state to live state, keyed by identifier.
+
+    Locked YAML entries are skipped entirely — recorded in ``Diff.locked``
+    but never appearing in ``adds``/``updates``/``deletes``.
+
+    ``add_only`` suppresses deletes but still emits adds and updates — useful
+    for partial migrations where the YAML doesn't yet describe everything
+    on the box.
+    """
+    desired_by_key: dict[str, InterfaceAssignmentConfig] = {v.diff_key: v for v in desired}
+    current_by_key: dict[str, LiveInterfaceAssignment] = {v.diff_key: v for v in current}
+    locked_keys: set[str] = {v.diff_key for v in desired if v.lock}
+
+    adds: list[InterfaceAssignmentConfig] = []
+    updates: list[tuple[LiveInterfaceAssignment, InterfaceAssignmentConfig]] = []
+    deletes: list[LiveInterfaceAssignment] = []
+    locked: list[tuple[InterfaceAssignmentConfig, LiveInterfaceAssignment | None]] = []
+
+    for key, want in desired_by_key.items():
+        have = current_by_key.get(key)
+        if want.lock:
+            locked.append((want, have))
+            continue
+        if have is None:
+            adds.append(want)
+        elif _needs_update(have, want):
+            updates.append((have, want))
+
+    if not add_only:
+        for key, have in current_by_key.items():
+            if key in locked_keys:
+                continue
+            if key not in desired_by_key:
+                deletes.append(have)
+
+    return Diff(adds=adds, updates=updates, deletes=deletes, locked=locked)
+
+
+def _needs_update(have: LiveInterfaceAssignment, want: InterfaceAssignmentConfig) -> bool:
+    """Decide whether a live assignment differs enough from desired to warrant setItem.
+
+    The spike checks the fields that the controller can reasonably write
+    server-side: ``device`` and ``description``. The IPv4/IPv6 raw dicts
+    aren't compared field-for-field here because the live representation
+    (from ``interfacesInfo``) and the desired representation (typed config)
+    have different schemas; that's a deliberate spike scope choice. The
+    findings doc captures this as an open question — ADR-0014 will need a
+    decision about deep IPv4/IPv6 equality before this graduates to
+    production.
+    """
+    return (have.device, have.description) != (want.device, want.description)
+
+
+# ---------------------------------------------------------------------------
+# Lockout-prevention
+# ---------------------------------------------------------------------------
+
+
+def find_lockout_conflicts(diff: Diff, current: list[LiveInterfaceAssignment]) -> list[str]:
+    """Return human-readable messages for any apply-time lockout risks.
+
+    Refuses to apply if a planned ``add`` targets a ``device`` that is
+    already bound to another logical interface (mirrors #714's design).
+    The ``setItem`` path already lets the controller server-side check
+    do this; we still pre-flight on the spike side so the operator gets a
+    coherent failure mode before any REST calls fire.
+
+    For ``setItem`` (updates), we only complain if the device is changing
+    AND the new device is bound to a *different* interface than the one
+    being updated.
+    """
+    msgs: list[str] = []
+    by_device: dict[str, str] = {entry.device: entry.identifier for entry in current}
+
+    for want in diff.adds:
+        existing_holder = by_device.get(want.device)
+        if existing_holder is not None:
+            msgs.append(
+                f"add {want.name!r}: device '{want.device}' is already bound to "
+                f"'{existing_holder}'. Refusing to apply."
+            )
+
+    for live, want in diff.updates:
+        if live.device == want.device:
+            continue  # device isn't changing
+        existing_holder = by_device.get(want.device)
+        if existing_holder is not None and existing_holder != want.name:
+            msgs.append(
+                f"update {want.name!r}: new device '{want.device}' is already bound "
+                f"to '{existing_holder}'. Refusing to apply."
+            )
+
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def cmd_inspect(client: OPNsenseClient) -> int:
+    """Detect controller install state, OPNsense version, and REST baseline."""
+    version: str = client.detect_version()
+    print(f"Detected OPNsense version: {version}")
+
+    # Controller install probe — best effort. SSH credentials are optional
+    # for inspect; if they're missing we just skip the checksum check.
+    try:
+        target = installer.load_ssh_target()
+    except RuntimeError as exc:
+        print(f"Controller checksum check skipped: {exc}")
+    else:
+        try:
+            matches, remote_sum, local_sum = installer.verify_installed_checksum(target)
+            local_short = local_sum[:12]
+            if matches:
+                print(f"Controller installed and current (sha256 {local_short}…).")
+            elif remote_sum is None:
+                print(f"Controller NOT installed on {target.host}. Run `install` to deploy.")
+            else:
+                print(
+                    f"Controller checksum mismatch on {target.host}: "
+                    f"remote {remote_sum[:12]}… vs local {local_short}…"
+                )
+        except RuntimeError as exc:
+            print(f"Controller checksum probe failed: {exc}")
+
+    # REST baseline — read-only call to interfacesInfo to confirm the API is reachable.
+    try:
+        live = fetch_interfaces_info(client)
+        print(f"Live assignments visible: {len(live)}")
+        for entry in live:
+            print(f"  {entry.identifier:8s} -> {entry.device}  ({entry.description})")
+    except Exception as exc:
+        print(f"interfacesInfo probe failed: {exc}")
+        return 1
+
+    return 0
+
+
+def cmd_list(client: OPNsenseClient) -> int:
+    """Print the current interface assignments on the box as YAML."""
+    live = fetch_interfaces_info(client)
+    if not live:
+        print("# (no interface assignments found on box)")
+        return 0
+    payload = [
+        {
+            "provider": "opnsense",
+            "type": "interface_assignments",
+            "name": entry.identifier,
+            "config": {
+                "device": entry.device,
+                "description": entry.description,
+                "enabled": True,
+                "ipv4": entry.ipv4,
+                "ipv6": entry.ipv6,
+            },
+        }
+        for entry in live
+    ]
+    print(yaml.safe_dump(payload, sort_keys=False))
+    return 0
+
+
+def cmd_plan(client: OPNsenseClient, yaml_path: Path, *, add_only: bool = False) -> int:
+    """Compute and print the diff between YAML and live state."""
+    desired = load_assignments_from_yaml(yaml_path)
+    current = fetch_interfaces_info(client)
+    diff = compute_diff(desired, current, add_only=add_only)
+    _print_diff(diff, add_only=add_only)
+    return 0
+
+
+def cmd_apply(
+    client: OPNsenseClient,
+    yaml_path: Path,
+    *,
+    confirm: bool,
+    add_only: bool = False,
+    print_rollback: bool = False,
+    no_rollback: bool = False,
+    backup_snapshot_id: str | None = None,
+) -> int:
+    """Execute the diff via REST. ``--confirm`` is required for actual mutations."""
+    desired = load_assignments_from_yaml(yaml_path)
+    current = fetch_interfaces_info(client)
+    diff = compute_diff(desired, current, add_only=add_only)
+    _print_diff(diff, add_only=add_only)
+
+    if diff.is_empty:
+        return 0
+
+    # Pre-flight lockout check before mutating.
+    conflicts = find_lockout_conflicts(diff, current)
+    if conflicts:
+        print("\nLockout risk detected — refusing to apply:")
+        for msg in conflicts:
+            print(f"  ! {msg}")
+        return 1
+
+    if not confirm:
+        print("\nDry run — pass --confirm to apply these changes.")
+        return 0
+
+    # Capture (or accept override) of pre-apply snapshot id for auto-rollback.
+    if backup_snapshot_id is not None:
+        snapshot_id: str | None = backup_snapshot_id
+        print(f"\nUsing operator-supplied backup snapshot id: {snapshot_id}")
+    elif no_rollback:
+        snapshot_id = None
+        print("\nAuto-rollback disabled (--no-rollback).")
+    else:
+        try:
+            snapshot_id = capture_latest_backup_id(client)
+        except Exception as exc:
+            print(f"WARNING: failed to capture pre-apply backup id: {exc}")
+            snapshot_id = None
+        if snapshot_id:
+            print(f"\nCaptured pre-apply backup id: {snapshot_id}")
+        else:
+            print("\nWARNING: no backup snapshot captured; auto-rollback unavailable.")
+
+    if print_rollback and snapshot_id:
+        print(f"  (rollback command: revert to backup id '{snapshot_id}')")
+
+    print("\nApplying changes via REST...")
+    try:
+        for cfg in diff.adds:
+            result = add_assignment(client, cfg)
+            print(
+                f"  + add  {cfg.name:8s} device={cfg.device:14s} -> {result.get('result', result)}"
+            )
+            _raise_on_failure(result, f"add {cfg.name}")
+
+        for live, want in diff.updates:
+            result = update_assignment(client, live.identifier, want)
+            print(
+                f"  ~ set  {want.name:8s} device={want.device:14s} -> "
+                f"{result.get('result', result)}"
+            )
+            _raise_on_failure(result, f"setItem {want.name}")
+
+        for live in diff.deletes:
+            result = delete_assignment(client, live.identifier)
+            print(
+                f"  - del  {live.identifier:8s} device={live.device:14s} -> "
+                f"{result.get('result', result)}"
+            )
+            _raise_on_failure(result, f"delItem {live.identifier}")
+    except RuntimeError as exc:
+        print(f"\nApply failed: {exc}")
+        if snapshot_id and not no_rollback:
+            print(f"Auto-rollback: reverting to backup id {snapshot_id}...")
+            try:
+                rollback_result = revert_to_backup(client, snapshot_id)
+                print(f"  rollback -> {rollback_result.get('status', rollback_result)}")
+            except Exception as rb_exc:
+                print(f"  rollback FAILED: {rb_exc}")
+                print("  Manual recovery required.")
+        return 1
+
+    print("\nApply complete.")
+    return 0
+
+
+def _raise_on_failure(response: dict[str, Any], action: str) -> None:
+    """Convert a controller failure response into a RuntimeError.
+
+    The PHP controller returns ``{"result": "failed", "errorMessage": "..."}``
+    on validation failures. We surface that as a Python exception so the
+    apply loop can short-circuit and trigger auto-rollback.
+    """
+    result_value = response.get("result")
+    if result_value not in ("saved", "deleted", "ok"):
+        msg = response.get("errorMessage", str(response))
+        raise RuntimeError(f"{action}: {msg}")
+
+
+def cmd_install(*, force: bool = False) -> int:
+    """Idempotent install of the controller PHP via the bundled installer."""
+    target = installer.load_ssh_target()
+    installer.install_controller(target, force=force)
+    return 0
+
+
+def cmd_verify_install() -> int:
+    """Compare the on-box controller checksum to the local source."""
+    target = installer.load_ssh_target()
+    matches, remote_sum, local_sum = installer.verify_installed_checksum(target)
+    local_short = local_sum[:12]
+    if matches:
+        print(f"OK: on-box and local checksums match (sha256 {local_short}…).")
+        return 0
+    if remote_sum is None:
+        print(f"MISSING: controller not installed on {target.host}.")
+    else:
+        print(f"MISMATCH: remote {remote_sum[:12]}… vs local {local_short}…")
+    return 1
+
+
+def _print_diff(diff: Diff, *, add_only: bool = False) -> None:
+    """Render a Diff for the operator."""
+    if diff.is_empty and not diff.locked:
+        print("No changes.")
+        return
+    mode_suffix = " (add-only mode — deletes suppressed)" if add_only else ""
+    print(
+        f"Plan: {len(diff.adds)} to add, {len(diff.updates)} to update, "
+        f"{len(diff.deletes)} to delete, {len(diff.locked)} locked.{mode_suffix}"
+    )
+    for cfg in diff.adds:
+        print(
+            f"  + {cfg.name:8s} device={cfg.device:14s} desc={cfg.description!r} "
+            f"ipv4={cfg.ipv4_type} ipv6={cfg.ipv6_type}"
+        )
+    for live, want in diff.updates:
+        print(
+            f"  ~ {want.name:8s} device={live.device}->{want.device} "
+            f"desc={live.description!r}->{want.description!r}"
+        )
+    for live in diff.deletes:
+        print(f"  - {live.identifier:8s} device={live.device:14s} desc={live.description!r}")
+    for want, have in diff.locked:
+        if have is None:
+            print(f"  L {want.name:8s} (locked, declared but not present on box)")
+        else:
+            print(
+                f"  L {have.identifier:8s} device={have.device} (locked) — no action will be taken"
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argparse CLI."""
+    parser = argparse.ArgumentParser(
+        prog="interface_assignment_gist_rest",
+        description=(
+            "Gist-based REST spike for OPNsense interface_assignments — informs ADR-0014 (#715)."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("inspect", help="Detect controller install state, version, REST baseline.")
+    sub.add_parser("list", help="Dump current interface assignments via interfacesInfo.")
+
+    plan_parser = sub.add_parser("plan", help="Diff a YAML file against live state.")
+    plan_parser.add_argument("yaml_path", type=Path, help="Path to interface-assignments YAML.")
+    plan_parser.add_argument(
+        "--add-only",
+        action="store_true",
+        help=(
+            "Suppress deletes for live assignments not in the YAML. Useful for "
+            "partial migrations where the YAML doesn't yet describe everything."
+        ),
+    )
+
+    apply_parser = sub.add_parser("apply", help="Apply a YAML file's diff via REST.")
+    apply_parser.add_argument("yaml_path", type=Path, help="Path to interface-assignments YAML.")
+    apply_parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Actually dispatch mutations. Without this flag, apply is a dry run.",
+    )
+    apply_parser.add_argument(
+        "--add-only",
+        action="store_true",
+        help="Suppress deletes for live assignments not in the YAML.",
+    )
+    apply_parser.add_argument(
+        "--print-rollback",
+        action="store_true",
+        help="Print the rollback command/id before applying.",
+    )
+    apply_parser.add_argument(
+        "--no-rollback",
+        action="store_true",
+        help="Disable the auto-rollback on apply failure.",
+    )
+    apply_parser.add_argument(
+        "--backup-snapshot-id",
+        type=str,
+        default=None,
+        help="Override the auto-captured pre-apply snapshot id.",
+    )
+
+    install_parser = sub.add_parser("install", help="Install the controller PHP on the box.")
+    install_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-install even when the on-box checksum already matches.",
+    )
+    sub.add_parser("verify-install", help="Check the on-box controller checksum.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns a process exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # ``install`` and ``verify-install`` are SSH-only — no REST credentials needed.
+    if args.command == "install":
+        return cmd_install(force=bool(args.force))
+    if args.command == "verify-install":
+        return cmd_verify_install()
+
+    credentials = load_env_credentials()
+    client = build_client(credentials)
+
+    try:
+        if args.command == "inspect":
+            return cmd_inspect(client)
+        if args.command == "list":
+            return cmd_list(client)
+        if args.command == "plan":
+            return cmd_plan(client, args.yaml_path, add_only=bool(args.add_only))
+        if args.command == "apply":
+            return cmd_apply(
+                client,
+                args.yaml_path,
+                confirm=bool(args.confirm),
+                add_only=bool(args.add_only),
+                print_rollback=bool(args.print_rollback),
+                no_rollback=bool(args.no_rollback),
+                backup_snapshot_id=args.backup_snapshot_id,
+            )
+    finally:
+        client.close()
+
+    parser.error(f"Unknown command: {args.command}")  # NoReturn — argparse exits
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Description

Spike PR. Pivots from #714 — whose SSH+PHP `config.xml`-edit write path was rejected on safety grounds (silent-bad-XML risk, bypassed `Config::save()` validation, no audit log, no auto-snapshot) — to a server-side-validated REST write path for OPNsense `interface_assignments`.

The spike installs a forked + patched + extended copy of `szymczag`'s community PHP controller (`AssignSettingsController.php`, BSD-2-Clause) on the OPNsense box, then drives it via REST. Server-side `Config::getInstance()->save()` rejects bad input loudly, fires the standard audit log, and triggers an auto-snapshot — three properties #714 couldn't deliver.

What the fork changes vs. the upstream gist:

| Concern | Base gist | This fork |
| :--- | :--- | :--- |
| `addItem` (auto-numbered) | yes | yes |
| `delItem` | yes | yes |
| `setItem` (in-place update) | NO | yes (added) |
| `getItem` (single fetch) | NO | yes (added) |
| `searchItem` (list all) | NO | yes (added) |
| IPv6 fields on add/set | NO | yes (`ipv6Type`, `ipv6Address`, `ipv6Subnet`, `ipv6Track`) |
| Explicit `name: optN` on `addItem` | NO | yes (load-bearing for cutover continuity) |
| `sessionClose()` calls | yes (breaks on modern OPNsense) | removed (Paradoxis 2026-02-25 community patch) |

This is a **research artifact only**. Nothing under `src/` is touched. The findings document is the artifact a future ADR-0014 amendment will cite; the production conversion of `OPNsenseDirectRunner.apply()` for `interface_assignments` lives in separate issues.

## Related Issue

Addresses #715

## Type of Change

- [x] New feature (non-breaking change which adds functionality) — research spike, no production code touched
- [x] Documentation update — full findings doc with verbatim live-run transcripts

## Changes Made

**New files (4 paths, ~10 files):**

- `tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php` (~778 LoC) — forked + patched + extended PHP controller. Both `$this->sessionClose();` calls removed (community patch). New methods: `setItemAction`, `getItemAction`, `searchItemAction`. New IPv6 fields. Optional explicit `name: optN` on `addItem`. Validation extracted into reusable private helpers.
- `tools/spikes/interface_assignment_gist_rest/install.py` (~340 LoC) — idempotent SCP + service restart + checksum verify. Standalone-runnable plus importable from spike's `inspect`/`install`/`verify-install` subcommands.
- `tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py` (~1080 LoC) — Python spike with `inspect`, `list`, `plan`, `apply`, `install`, `verify-install` subcommands. Diff engine keyed on logical interface name. Lockout-prevention pre-flight. `apply` flags: `--confirm`, `--add-only`, `--print-rollback`, `--no-rollback`, `--backup-snapshot-id`.
- `tools/spikes/interface_assignment_gist_rest/example-interface-assignments.yaml` — fixture targeting spare `igc0` named `opt9` with static IPv4 + track-interface IPv6.
- `tools/spikes/interface_assignment_gist_rest/README.md` (~150 LoC) — install/usage instructions.
- `tools/spikes/interface_assignment_gist_rest/__init__.py` — package marker.
- `tests/spikes/test_interface_assignment_gist_rest.py` — 118 unit tests, 88.28% coverage on the spike Python module (89.15% combined including `install.py`).
- `docs/development/opnsense-spike-interface-assignment-gist-findings.md` — fully-filled findings doc with verbatim live-run transcripts. ADR-0014 amendment will cite this.

**Modified files (1):**

- `tools/spikes/README.md` — appended a section for the new spike.

## Live verification results

All scenarios green against `opnsense-a` (staging, OPNsense `26.1.6_2`) on 2026-05-02 — verbatim transcripts in the findings doc:

| Scenario | Result |
| :--- | :--- |
| Install + verify (idempotent SCP + configd/php_fpm restart + checksum) | ✅ |
| `inspect` reports controller installed and current | ✅ |
| `list` baseline = 4 logical interfaces (`lan`/`lo0`/`wan`/`opt1`) | ✅ |
| `plan` against fixture | ✅ |
| `apply --add-only --confirm` add cycle: `opt9` on `igc0` with explicit name + IPv4 static + IPv6 track-interface | ✅ |
| Round-trip 1: `No changes.` | ✅ |
| `setItem` re-bind: `opt9.device` `igc0`→`igc1` IN PLACE (logical name preserved — load-bearing for cutover) | ✅ |
| Round-trip 2: `No changes.` | ✅ |
| Server-side validation: bad IP / bad type / no device | ✅ all HTTP 400 |
| Lockout-prevention: fixture targeting `ixl1` (LAN's NIC) refused before any REST call, exit 1 | ✅ |
| Delete cycle | ✅ |
| Round-trip final | ✅ end-of-spike box state matches start |
| **Auto-rollback via `/api/core/backup/{backups,download}`** | ⚠️ **HTTP 404** on `26.1.6_2` (see gate (1) below) |

## Real bug fixes during verification

The implementor's initial code had three issues caught and fixed live during the run. Framing matters: these are **caught and fixed** problems, not test rigging — in case (2) and (3) the failing tests were validating the *wrong* behavior and the requirement itself changed.

1. **Two `int(subnet)` sites** in `interface_assignment_gist_rest.py:393, 439` lacked `None`-narrowing before the cast (Pyright flagged). Runtime was correct via try/except, but added explicit `if subnet is None: raise ValueError(...)` for safety + type narrowing.

2. **`install.py` env-loading was too strict.** The original code required explicit `OPNSENSE_SSH_HOST` AND `OPNSENSE_SSH_KEY`; the operator's homelab uses `~/.ssh/config` + ssh-agent without setting either. Fixed: host falls back to `OPNSENSE_API_URL` hostname; key is optional. Tests updated: `test_missing_key_raises` removed; replaced with `test_missing_key_is_optional`, `test_host_derived_from_api_url`, `test_explicit_ssh_host_wins_over_api_url`. The `test_inspect_skips_checksum_when_ssh_env_missing` test also updated to strip `OPNSENSE_API_URL` so the fallback path doesn't kick in. The previous strictness was wrong vs. the plan's design.

3. **`install.py` remote-checksum command used `2>/dev/null`** which is invalid in OPNsense's root shell `/usr/local/sbin/opnsense-shell` (csh-derived → "Ambiguous output redirect"). Fixed: `test -f <path> && sha256 -q <path> || echo MISSING` — portable across both shells. **General principle for any future SSH-into-OPNsense work:** avoid stderr redirection in the remote command; use `&&`/`||` chaining instead.

## Gate (1) — auto-rollback unavailable on `26.1.6_2`

`/api/core/backup/backups` and `/api/core/backup/download` return HTTP 404 on `26.1.6_2` despite both being in the OpenAPI spec. Same finding as #714's REST probe.

This means the auto-rollback design specified in the spike is **unavailable on this OPNsense version**. The spike correctly degrades — captures the failure, warns loudly, and proceeds without rollback armed. ADR-0014's amendment must specify an alternative rollback strategy:
- (a) find a different snapshot endpoint on this version (none surfaced during the spike), or
- (b) shell out via SSH to a `configctl` snapshot command (re-introduces SSH dependency for safety), or
- (c) accept "no transactional rollback" and rely on server-side per-call validation as the safety net (defensible because OPNsense's standard save flow already auto-snapshots before each `Config::save()`, visible in the GUI's config history; operator can manually revert from there).

This is documented as gate (1) of the recommendation's three open items in the findings doc.

## Testing

- [x] All existing tests pass — `doit check` clean
- [x] Added new tests for new functionality — 118 unit tests
- [x] Manually tested the changes — full live run against `opnsense-a` documented in findings doc

**Test count:** 118 tests
**Spike-module coverage:** 88.28% (`tools/spikes/interface_assignment_gist_rest/interface_assignment_gist_rest.py`)
**Combined spike-package coverage:** 89.15% (includes `install.py` at 92.02%)
**Project-wide:** all checks pass clean (`doit check`)

## What this enables (out of scope here)

- ADR-0014 amendment citing this findings doc — separate issue/PR (mirrors the #707/#708 chain).
- Production conversion of `OPNsenseDirectRunner.apply()` for `interface_assignments` from no-op to live — separate issue, gated on the amendment's gate-(1) decision.
- Other GUI-only resource types (gateways, virtual_ips, NAT legacy) — each gets its own spike before production.

## Out of scope

- Production code under `src/` — untouched in this PR.
- ADR-0014 amendment — intentionally a separate issue/PR.
- ADR-0013 update — intentionally a separate issue/PR.
- Production conversion — separate issue.
- PHP linting in CI — punt to production-conversion issue (PHP can't be CI-linted in this Python project today).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — findings doc fully filled, spike README updated
- [ ] I have updated the CHANGELOG.md — N/A for spike PR
- [x] My changes generate no new warnings

## Additional Notes

- The PHP controller is community-authored and now ours to maintain (BSD-2-Clause). Net-new PHP in this fork: ~225 LoC. A real security review of the patched + extended file is gate (3) for the production lift; tracked in the issue's "Maintenance ownership" section.
- The `--add-only` flag and `lock: true` resource-level marker carry the same semantics as the VLAN spike (#705/#706). Cutover fixtures should lock `lan`/`lo0`/`wan`/`opt1` until the migration is complete.
- The findings doc's "Friction points" section is intentionally amendment-ready — every open item lists concrete options for ADR-0014 to choose from.
