### PR TITLE
docs: amend ADR-0014 to record gist-based REST mechanism for interface_assignments

### DIFF
--- a/docs/decisions/0013-opnsense-full-iac-migration.md
+++ b/docs/decisions/0013-opnsense-full-iac-migration.md
@@ -1,6 +1,7 @@
 # ADR-0013: OPNsense Full-IaC Migration Coverage
 
 **Date:** 2026-04-30
+**Amended:** 2026-05-03 (#717) — `interface_assignments` per-component decision updated; cross-reference to ADR-0014's new Per-component decisions section
 **Status:** Accepted
 **Issue:** [#701](https://github.com/endavis/infrafoundry/issues/701)
 
@@ -55,15 +56,15 @@ ADR-0014 takes positions on schema source, client surface, runner integration (a
 
 The XML `config.xml` format is not part of any apply or migrate path. It is used only for one-shot scoping (as in [docs/development/opnsense-resource-coverage.md](../development/opnsense-resource-coverage.md)) and remains a per-component fallback only if no stable API endpoint exists for a resource type. That decision would be made per-component and recorded in its issue.
 
-**Per-component decisions recorded so far:**
+### Per-component decisions recorded so far
 
-- `interface_assignments` (#711, 2026-05-02): no REST CRUD endpoint on OPNsense `26.1.6_2` (`/api/interfaces/overview/*` is read-only; the GUI uses legacy PHP form posts that ultimately edit `<interfaces>` in `config.xml`). Component ships read-only — `list` / `migrate` / validation work; `apply` / `destroy` are loud no-ops. The cutover runbook documents the manual GUI step. The XML-edit write path is a future concern.
+- `interface_assignments` (#711, #715→PR #716, amended 2026-05-03 via #717): read-only / migrate shipped in PR #712 (`/api/interfaces/overview/*`). Write path adopts server-side-validated REST via the forked `AssignSettingsController.php` controller; the spike validated the mechanism end-to-end on `26.1.6_2`. See [ADR-0014 §"Per-component decisions"](0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions) for the mechanism details, the rollback decision (option (c) — no transactional rollback; rely on per-call server-side validation + OPNsense auto-snapshot), and the gates remaining for production conversion.
 
 ## Implementation order
 
 Each step ships under the direct-API pattern codified in [ADR-0014](0014-opnsense-direct-api-apply-mechanism.md). The VLAN spike (PR [#706](https://github.com/endavis/infrafoundry/pull/706), merged) seeds the VLAN component migration.
 
-1. `interface_assignments` — gates everything that depends on physical NIC mapping. *Read-only / migrate shipped in #711; write path deferred per the per-component decision recorded above.*
+1. `interface_assignments` — gates everything that depends on physical NIC mapping. *Read-only / migrate shipped in PR #712 (#711); write-path mechanism decided in ADR-0014 amendment (#717); production conversion gated on a follow-up issue that carries out gates (2) and (3).*
 2. `nat_rules`.
 3. `gateways` and `static_routes`.
 4. `virtual_ips`.
@@ -80,6 +81,8 @@ Each step above is a separate feature issue. Issue numbers will be added to this
 - Issue [#707](https://github.com/endavis/infrafoundry/issues/707): ADR-0014 (closed; PR [#708](https://github.com/endavis/infrafoundry/pull/708) merged).
 - Issue [#709](https://github.com/endavis/infrafoundry/issues/709): VLAN component direct-API migration (`OPNsenseDirectRunner` seed).
 - Issue [#711](https://github.com/endavis/infrafoundry/issues/711): `interface_assignments` component (read-only / migrate; dispatch-table refactor).
+- Issue [#715](https://github.com/endavis/infrafoundry/issues/715): gist-based `interface_assignments` write-API spike (closed; PR [#716](https://github.com/endavis/infrafoundry/pull/716) merged 2026-05-02).
+- Issue [#717](https://github.com/endavis/infrafoundry/issues/717): chore: amend ADR-0014 to record the gist-based REST mechanism for `interface_assignments`.
 
 ## Related Documentation
 

--- a/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
+++ b/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
@@ -1,7 +1,7 @@
 # ADR-0014: OPNsense Direct-API Apply Mechanism
 
 **Date:** 2026-04-30
-**Amended:** 2026-05-03 (#717, PR #XXX) — added second internal write path for resources with no native REST CRUD; records `interface_assignments` per-component decision
+**Amended:** 2026-05-03 (#717, PR #718) — added second internal write path for resources with no native REST CRUD; records `interface_assignments` per-component decision
 **Status:** Accepted
 
 ## Status

--- a/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
+++ b/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
@@ -1,6 +1,7 @@
 # ADR-0014: OPNsense Direct-API Apply Mechanism
 
 **Date:** 2026-04-30
+**Amended:** 2026-05-03 (#717, PR #XXX) — added second internal write path for resources with no native REST CRUD; records `interface_assignments` per-component decision
 **Status:** Accepted
 
 ## Status
@@ -16,6 +17,8 @@ The decision answers the nine open questions deferred from [ADR-0013](0013-opnse
 ### 1. Apply mechanism for new components
 
 **Direct-API via `opnsense_openapi`.** The 736-line spike covered every operation the production path needs in a single readable Python module with one runtime dependency and zero external binaries. The Terraform + `browningluke/opnsense` + Ansible-reload pipeline is retained only until each existing component is migrated; net-new components ship under direct-API immediately.
+
+**Component-installed REST controllers** are a recognized second internal write path inside `OPNsenseDirectRunner` for resource types where OPNsense's stock API surface has no CRUD endpoint. The pattern: a small PHP controller is installed once at `/usr/local/opnsense/mvc/app/controllers/OPNsense/<Module>/Api/`; subsequent operations use REST exclusively. Install requires SSH (one-time per box; idempotent verify-and-reinstall on each `infra apply` is acceptable for production); ongoing apply does not. The first such controller is `AssignSettingsController.php` for `interface_assignments`, validated in PR #716. Each new controller-installed REST mechanism is a discrete decision recorded in this ADR's "Per-component decisions" section. Ownership: when InfraFoundry forks a community controller, the fork lives in-tree under `tools/spikes/.../` (or graduates to `src/infrafoundry/providers/<provider>/extensions/...` once production-bound), and InfraFoundry maintains it.
 
 ### 2. Schema source
 
@@ -71,7 +74,36 @@ Granular locks (`lock: { delete: true, update: false }`) are deferred to a follo
 
 The `templates/opnsense/playbook.yml.j2` Ansible service-reload playbook retires once the last Terraform-based component is gone.
 
-> **Note (interface_assignments, #711):** OPNsense `26.1.6_2` exposes only a read-only API for interface assignments (`/api/interfaces/overview/*`); there is no REST CRUD surface and the GUI uses legacy PHP form posts that ultimately edit `<interfaces>` in `config.xml`. The component ships read-only — `list` / `migrate` / validation work; `apply` and `destroy` are loud no-ops. Operators perform interface assignment manually via the OPNsense GUI as a one-time step during cutover. The XML-edit write path is a future concern. See ADR-0013 §"Per-component decisions recorded so far".
+> **Note (interface_assignments, #711, amended 2026-05-03):** OPNsense `26.1.6_2` exposes no REST CRUD for `<interfaces>`. The component shipped read-only in PR #712 (`list` / `migrate` / validation work; `apply` / `destroy` are loud no-ops). The write path is decided in this ADR's "Per-component decisions" section: server-side-validated REST via a forked, in-tree PHP controller (PR #716 spike). Production conversion (`OPNsenseDirectRunner.apply()` from no-op to live for this resource) is gated on the production conversion issue, which carries out gates (2) and (3) recorded above.
+
+## Per-component decisions
+
+Each new write mechanism that diverges from §1's default (REST via `opnsense_openapi`) is recorded here.
+
+### `interface_assignments` (PR #716, 2026-05-02 spike; production conversion gated on this amendment)
+
+**Mechanism:** Server-side-validated REST via the forked `AssignSettingsController.php` controller installed at `/usr/local/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/`.
+
+- **Read side:** `interfaces/overview/interfacesInfo` (already in production from PR #712, no controller required).
+- **Write side:** `assign_settings/{addItem, setItem, getItem, searchItem, delItem}` against the installed controller.
+- **Fork location:** in-tree at `tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php` for the spike phase; production conversion graduates it to `src/infrafoundry/providers/opnsense/extensions/...`.
+- **Patches/extensions over the upstream gist:** `sessionClose()` removed (modern-OPNsense compatibility), IPv6 fields, `setItem` / `getItem` / `searchItem`, optional explicit `name: optN`, validation helpers. ~225 LoC net-new on top of ~345 LoC inherited from szymczag's BSD-2-Clause base.
+
+**Rollback strategy:** No transactional rollback (option (c) from the findings doc).
+
+The spike empirically established that `/api/core/backup/{backups,download}` returns HTTP 404 on `26.1.6_2`, so the original auto-rollback design is unavailable on this OPNsense version. Three options surfaced; this ADR adopts (c) for the following reasons:
+
+- **Per-call server-side validation is the primary safety net.** Every `addItem`/`setItem`/`delItem` POST flows through OPNsense's standard `Config::getInstance()->save()`. Bad input (invalid IPv4, unknown `ipv4Type`, missing `device`) is rejected with HTTP 400 *before* any state change. The spike verified all three cases live.
+- **OPNsense's auto-snapshot is the residual safety net.** `Config::save()` captures a pre-write snapshot in `/conf/backup/` (visible in System → Configuration → Backups in the GUI). Operators can manually revert from there for the "correct-but-undesired apply" case that validation can't catch.
+- **Option (a) is wishful** — no alternative snapshot endpoint surfaced during the spike's REST probe.
+- **Option (b) re-introduces SSH** into the safety path for rollback. The gist-based mechanism's premise was to remove SSH from the steady-state apply path; reusing it for rollback erodes that win. Rejected.
+
+**Preconditions for production conversion** (carried out by the production conversion issue, not this amendment):
+
+- **Gate (2):** Empirically confirm that an `addItem`/`setItem`/`delItem` REST call produces a new entry in System → Configuration → Backups (auto-snapshot) AND System → Log Files → System General (audit log). The PHP controller calls OPNsense's standard `Config::save()` write path, so both should fire — but production lift can't proceed without empirical confirmation.
+- **Gate (3):** Security review of the ~225 LoC of net-new PHP in the forked controller. Community-authored code deployed to root on production firewall infrastructure requires a deliberate review pass. BSD-2-Clause is compatible.
+
+**Cross-reference:** [ADR-0013 §"Per-component decisions recorded so far"](0013-opnsense-full-iac-migration.md#per-component-decisions-recorded-so-far) updated to reflect this resolution. See also [`docs/development/opnsense-spike-interface-assignment-gist-findings.md`](../development/opnsense-spike-interface-assignment-gist-findings.md) for the load-bearing evidence.
 
 ## Rationale
 
@@ -106,9 +138,13 @@ The runner integration via ADR-0010 protocols keeps the CLI surface consistent: 
 - Upstream [`endavis/opnsense-openapi#32`](https://github.com/endavis/opnsense-openapi/issues/32): bug — spec generator emits wrong controller names for multi-word controllers (blocker for typed surface).
 - Upstream [`endavis/opnsense-openapi#33`](https://github.com/endavis/opnsense-openapi/issues/33): bug — misleading "No OpenAPI spec found" error when `openapi-python-client` is missing.
 - Upstream [`endavis/opnsense-openapi#34`](https://github.com/endavis/opnsense-openapi/issues/34): refactor — stabilize generated-client module path across patch revisions; add closest-floor spec matching.
+- Issue [#715](https://github.com/endavis/infrafoundry/issues/715): feat: spike + extend OPNsense gist-based `interface_assignments` write API (closed; PR [#716](https://github.com/endavis/infrafoundry/pull/716) merged 2026-05-02). Load-bearing evidence for this amendment.
+- Issue [#717](https://github.com/endavis/infrafoundry/issues/717): chore: amend ADR-0014 to record gist-based REST mechanism for `interface_assignments` (this amendment).
+- Production conversion of `OPNsenseDirectRunner.apply()` for `interface_assignments` from no-op to live — to be filed after this amendment merges; carries out gates (2) and (3).
 
 ## Related Documentation
 
 - [`docs/development/opnsense-spike-vlan-findings.md`](../development/opnsense-spike-vlan-findings.md) — load-bearing evidence cited throughout this ADR.
 - [ADR-0010: Protocol-Based Runner Interfaces](0010-protocol-based-runner-interfaces.md) — the contract `OPNsenseDirectRunner` implements.
 - [ADR-0013: OPNsense Full-IaC Migration](0013-opnsense-full-iac-migration.md) — the deferral this ADR closes (lands when PR [#704](https://github.com/endavis/infrafoundry/pull/704) merges).
+- [`docs/development/opnsense-spike-interface-assignment-gist-findings.md`](../development/opnsense-spike-interface-assignment-gist-findings.md) — load-bearing evidence cited by the 2026-05-03 amendment.

--- a/docs/development/opnsense-resource-coverage.md
+++ b/docs/development/opnsense-resource-coverage.md
@@ -19,7 +19,7 @@ Source of truth for "supported": `OPNsenseProvider.get_resource_types()` in `src
 | `<OPNsense>/Kea` (DHCPv6 reservations) | `kea_dhcp6_reservation` | Supported |
 | `<OPNsense>/unboundplus/hosts/host` | `unbound_host_override` | Supported |
 | `<dhcpd>` (legacy ISC) | `dhcp_static_maps` | Supported (legacy; new deployments should use Kea) |
-| `<interfaces>` | `interface_assignments` | Read-only / migrate (direct-API; #711). No write API exists on OPNsense `26.1.6_2`; logical-to-physical interface mapping is a one-time manual GUI step during cutover. |
+| `<interfaces>` | `interface_assignments` | Read-only / migrate (direct-API; #711). Write-path mechanism decided in [ADR-0014 §"Per-component decisions"](../decisions/0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions) (#717): server-side-validated REST via a forked OPNsense PHP controller (PR #716). Production conversion of `OPNsenseDirectRunner.apply()` is a separate follow-up; until it ships, logical-to-physical interface mapping remains a one-time manual GUI step during cutover. |
 | `<nat>/rule` and `<nat>/outbound/rule` | — | **Gap** |
 | `<OPNsense>/Gateways` | — | **Gap** |
 | `<staticroutes>/route` | — | **Gap** |
@@ -46,9 +46,9 @@ This template assumes you are cutting over a current box (`OLD`) to a new box (`
 1. **Extract**: run `foundry config migrate --env <env> --provider opnsense --component <type>` for every supported resource type on `OLD` to dump live state into YAML under `envs/<env>/opnsense/`.
 2. **Edit interface map**: in the YAML, remap physical NIC names (`igc0` → `ixl0`, etc.) and any VLAN parent interface references. This is the only manual edit if the new box has different NICs.
 3. **Out-of-IaC import**: on `NEW`, System → Configuration → Backups → Restore, choose "Restore area" and import only the sections from "out of IaC scope" above. **Do not** restore VLANs, filter, NAT, or DHCP — those come from IaC.
-4. **Manual GUI step — interface assignments** (one-time per cutover): on `NEW`, navigate to **Interfaces → Assignments** and bind each logical interface (LAN, WAN, OPT1, etc.) to the correct physical NIC or VLAN per the `interface_assignments` YAML in `envs/<env>/opnsense/`. OPNsense `26.1.6_2` has no REST write API for assignments (#711); the YAML is the source of truth and `foundry` reads-and-validates it but cannot apply it. Save and apply within the GUI before continuing.
+4. **Manual GUI step — interface assignments** (one-time per cutover): on `NEW`, navigate to **Interfaces → Assignments** and bind each logical interface (LAN, WAN, OPT1, etc.) to the correct physical NIC or VLAN per the `interface_assignments` YAML in `envs/<env>/opnsense/`. The write-path mechanism is decided ([ADR-0014 §"Per-component decisions"](../decisions/0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions), #717) but production conversion of `OPNsenseDirectRunner.apply()` is a separate follow-up; until it ships, the YAML is the source of truth and `foundry` reads-and-validates it but cannot apply it. Save and apply within the GUI before continuing.
 5. **Switch endpoint**: update `provider_settings.opnsense.api_url` in `envs/<env>/settings.yaml` to point at `NEW`.
-6. **Plan**: `foundry infra plan --env <env>` and review the diff. The `interface_assignments` line will show "read-only / 0 changes" — that's expected; the manual step above is the source of writes. Expect a clean apply against the (mostly empty) `NEW` box for everything else.
+6. **Plan**: `foundry infra plan --env <env>` and review the diff. The `interface_assignments` line will show "read-only / 0 changes" — that's expected; the manual step above is the current source of writes (the direct-API write path lands in a follow-up to #717). Expect a clean apply against the (mostly empty) `NEW` box for everything else.
 7. **Apply**: `foundry infra apply --env <env>`.
 8. **Verify**: confirm interfaces, VLAN trunks, and firewall connectivity. Roll DNS / Tailscale / WAN cutover as appropriate to your environment.
 9. **Decommission `OLD`**: power off after a soak period.
@@ -72,7 +72,7 @@ After the cleanup, terraform plan should show zero VLAN-related changes; the dir
 
 Each gap row in the matrix above corresponds to a planned feature issue. The implementation order in [ADR-0013](../decisions/0013-opnsense-full-iac-migration.md) is:
 
-1. `interface_assignments` (read-only / migrate shipped in #711; write path deferred pending an XML-edit or upstream-API mechanism)
+1. `interface_assignments` (read-only / migrate shipped in #711; write-path mechanism decided in ADR-0014 amendment #717 via a forked PHP REST controller; production conversion of `OPNsenseDirectRunner.apply()` is a follow-up issue)
 2. `nat_rules`
 3. `gateways`, `static_routes`
 4. `virtual_ips`


### PR DESCRIPTION
## Description

Docs-only amendment to ADR-0014 ("OPNsense direct-API apply mechanism") to record the
decision — validated by the PR #716 spike — to use a server-side-validated REST mechanism
via a forked, in-tree PHP controller (`AssignSettingsController.php`) for
`interface_assignments`, the first OPNsense resource type with no native REST CRUD.

ADR-0013 ("OPNsense full-IaC migration") and the OPNsense resource-coverage doc are
updated to cross-reference the new decision and to remove stale "no REST write API exists"
framing now that a write path is decided. No code, no tests, no behavioral change.

The spike findings that this amendment ratifies are documented in
[docs/development/opnsense-spike-interface-assignment-gist-findings.md](../blob/chore/717-amend-adr-0014-gist-rest/docs/development/opnsense-spike-interface-assignment-gist-findings.md).

## Related Issue

Addresses #717

Load-bearing prior PRs:

- PR #716 (closes #715) — gist-based `interface_assignments` REST write spike; the
  evidence this amendment ratifies.
- PR #712 (addresses #711) — `interface_assignments` read-only / migrate ship + dispatch
  table.
- PR #710 (addresses #709) — `OPNsenseDirectRunner` foundation; VLAN migration to
  direct-API.
- PR #708 (addresses #707) — original ADR-0014 record (the document this PR amends).

## Type of Change

- [x] Documentation update

## Changes Made

- **`docs/decisions/0014-opnsense-direct-api-apply-mechanism.md` (ADR-0014, primary
  amendment)**
    - Adds `**Amended:** 2026-05-03 (#717)` header line.
    - Appends a paragraph to §1 ("Decision") recognizing component-installed REST
      controllers as a second internal write path inside `OPNsenseDirectRunner` for
      resource types where stock OPNsense exposes no REST CRUD; defines the
      install-once / verify-and-reinstall-on-apply pattern; states the in-tree fork
      ownership model.
    - Adds a new top-level `## Per-component decisions` section with the
      `interface_assignments` entry: mechanism (REST via forked
      `AssignSettingsController.php`); resolution of the spike's open gate (1) on
      transactional rollback as **option (c) — no transactional rollback**, relying on
      per-call server-side validation plus OPNsense's standard `Config::save()`
      auto-snapshot for manual revert; restates gate (2) (empirical confirmation that
      audit log + auto-snapshot fire on REST mutations) and gate (3) (security review
      of the ~225 LoC of net-new PHP in the forked controller) as preconditions for
      the production-conversion follow-up.
    - Updates §9 footnote on `interface_assignments` to point at the new
      Per-component decisions section.
    - Adds three Related Issues entries (#711, #715→#716, #717) and one Related
      Documentation entry (the spike findings doc).

- **`docs/decisions/0013-opnsense-full-iac-migration.md` (ADR-0013, cross-reference)**
    - Adds `**Amended:** 2026-05-03 (#717)` header line.
    - Promotes the existing `**Per-component decisions recorded so far:**` bolded
      paragraph to a `### Per-component decisions recorded so far` heading so the
      cross-link from ADR-0014 resolves to a stable anchor.
    - Replaces the `interface_assignments` per-component bullet with a fuller summary
      pointing at ADR-0014's new Per-component decisions section.
    - Replaces Implementation order bullet 1 to reflect that the read-only / migrate
      shipped in PR #712, the write-path mechanism is decided in this amendment, and
      the production conversion remains gated on a follow-up.
    - Adds two Related Issues entries (#715, #717).

- **`docs/development/opnsense-resource-coverage.md` (resource-coverage doc cleanup)**
    - Rewrites four stale "no REST write API exists" / "read-only / migrate" framings
      (lines 22, 49, 51, 75) to point at ADR-0014's new per-component decision and to
      frame the remaining manual-GUI step as the gap-window operational reality until
      the production-conversion follow-up lands. (Scope expansion explicitly
      authorized during `/implement` review.)

## Testing

- [x] All existing tests pass (`uv run doit check` — full check suite green)
- [x] `uv run doit docs_build` completes cleanly; no warnings reference any of the
      three modified files or the new `#per-component-decisions` /
      `#per-component-decisions-recorded-so-far` anchors. (Pre-existing warnings on
      unrelated ADR-9xxx series files remain.)
- [ ] Added new tests for new functionality — N/A (docs-only)
- [x] Manually tested the changes — spot-checked rendered headings and cross-references

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A
      (docs-only, no behavioral change)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR *is* the documentation
      update)
- [ ] I have updated the CHANGELOG.md — N/A (ADR amendments are tracked via the
      `Amended:` header on the ADR itself, not CHANGELOG)
- [x] My changes generate no new warnings

## Additional Notes

**Gate (1) resolution.** The PR #716 spike left three gates open before
`interface_assignments` could be flipped from no-op to live in
`OPNsenseDirectRunner.apply()`. Gate (1) — "do we need transactional rollback across a
multi-call apply, and if so how?" — is **resolved in this amendment as option (c): no
transactional rollback.** The mechanism relies on per-call server-side validation
(controller rejects bad payloads before write) plus OPNsense's standard auto-snapshot
on `configd` reload. This is the lowest-complexity path consistent with the rest of
ADR-0014's "trust the box's atomicity story" stance.

**Gates (2) and (3) remain open** and are explicitly framed in the amended ADR as
preconditions for the production-conversion follow-up issue (to be filed after this
amendment merges; not yet numbered):

- Gate (2): empirically confirm via the OPNsense GUI that `addItem` / `setItem` /
  `delItem` REST calls produce a new entry in System → Configuration → Backups
  (auto-snapshot) and System → Log Files → System General (audit log). The PHP
  controller calls OPNsense's standard `Config::save()` so both should fire — but
  production lift can't proceed without empirical confirmation.
- Gate (3): security review of the ~225 LoC of net-new PHP in the forked controller
  (`tools/spikes/interface_assignment_gist_rest/AssignSettingsController.php`).
  Community-authored code deployed to root on production firewall infrastructure
  requires a deliberate review pass. BSD-2-Clause is compatible.

These gates are not blocked by — and do not block — this amendment. They block the
follow-up that flips `OPNsenseDirectRunner.apply()` from no-op to live for this
resource.

**No code, no behavioral change.** This PR amends three Markdown files only. The
`interface_assignments` component remains read-only / migrate at runtime exactly as
shipped in PR #712. The shipped `apply` / `destroy` no-ops are unchanged.

**Issue label note.** Issue #717 is labeled `chore` (no `needs-adr` label), which is
correct — this PR amends existing ADRs rather than creating a new one. Per
`AGENTS.md`, no ADR creation is required.
