### PR TITLE
feat: add OPNsense nat_rules component (outbound + 1:1, direct-API)

### DIFF
--- a/docs/decisions/0013-opnsense-full-iac-migration.md
+++ b/docs/decisions/0013-opnsense-full-iac-migration.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-04-30
 **Amended:** 2026-05-03 (#717) — `interface_assignments` per-component decision updated; cross-reference to ADR-0014's new Per-component decisions section
+**Amended:** 2026-05-04 (#713) — `nat_rules` per-component decision recorded (outbound + 1:1 ship via direct REST; port forwards deferred to a follow-up spike)
 **Status:** Accepted
 **Issue:** [#701](https://github.com/endavis/infrafoundry/issues/701)
 
@@ -59,13 +60,14 @@ The XML `config.xml` format is not part of any apply or migrate path. It is used
 ### Per-component decisions recorded so far
 
 - `interface_assignments` (#711, #715→PR #716, amended 2026-05-03 via #717): read-only / migrate shipped in PR #712 (`/api/interfaces/overview/*`). Write path adopts server-side-validated REST via the forked `AssignSettingsController.php` controller; the spike validated the mechanism end-to-end on `26.1.6_2`. See [ADR-0014 §"Per-component decisions"](0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions) for the mechanism details, the rollback decision (option (c) — no transactional rollback; rely on per-call server-side validation + OPNsense auto-snapshot), and the gates remaining for production conversion.
+- `nat_rules` (#713, recorded 2026-05-04): **outbound** + **1:1** ship via direct REST against `firewall/source_nat/*` and `firewall/one_to_one/*`. Identity is encoded as a **suffix** in the `description` field — `<operator description> [infrafoundry:<name>]` — so the operator's free-form text leads in the OPNsense GUI display. Every managed rule also carries the OPNsense `infrafoundry` category as a fleet-wide marker (created on first apply, cached per service instance) so operators can filter "everything InfraFoundry manages" in the GUI. No state DB — ADR-0014 takes no position on state for direct-API resources. **Port forwards are out of scope** for this PR — a live probe (2026-05-03) of `26.1.6_2` confirmed `firewall/{redirect,forward,portforward,nat_forward,rdr}` all return 404 and the legacy `<nat>/<rule>` config.xml section is GUI-only. Port forwards become a follow-up spike-driven issue (same playbook as #714→#715→#716→#717 — the gist-controller mechanism from #717 is the likely path).
 
 ## Implementation order
 
 Each step ships under the direct-API pattern codified in [ADR-0014](0014-opnsense-direct-api-apply-mechanism.md). The VLAN spike (PR [#706](https://github.com/endavis/infrafoundry/pull/706), merged) seeds the VLAN component migration.
 
 1. `interface_assignments` — gates everything that depends on physical NIC mapping. *Read-only / migrate shipped in PR #712 (#711); write-path mechanism decided in ADR-0014 amendment (#717); production conversion gated on a follow-up issue that carries out gates (2) and (3).*
-2. `nat_rules`.
+2. `nat_rules` — outbound + 1:1 ship in #713 (direct-API). Port forwards deferred to a follow-up spike — `26.1.6_2` exposes no MVC REST endpoint for them; the same gist-controller mechanism from #717 is the likely path.
 3. `gateways` and `static_routes`.
 4. `virtual_ips`.
 5. Unbound extensions (`domain_override`, `host_alias`, `forward`).
@@ -83,6 +85,7 @@ Each step above is a separate feature issue. Issue numbers will be added to this
 - Issue [#711](https://github.com/endavis/infrafoundry/issues/711): `interface_assignments` component (read-only / migrate; dispatch-table refactor).
 - Issue [#715](https://github.com/endavis/infrafoundry/issues/715): gist-based `interface_assignments` write-API spike (closed; PR [#716](https://github.com/endavis/infrafoundry/pull/716) merged 2026-05-02).
 - Issue [#717](https://github.com/endavis/infrafoundry/issues/717): chore: amend ADR-0014 to record the gist-based REST mechanism for `interface_assignments`.
+- Issue [#713](https://github.com/endavis/infrafoundry/issues/713): feat: add OPNsense `nat_rules` component (outbound + 1:1).
 
 ## Related Documentation
 

--- a/docs/development/opnsense-resource-coverage.md
+++ b/docs/development/opnsense-resource-coverage.md
@@ -20,7 +20,8 @@ Source of truth for "supported": `OPNsenseProvider.get_resource_types()` in `src
 | `<OPNsense>/unboundplus/hosts/host` | `unbound_host_override` | Supported |
 | `<dhcpd>` (legacy ISC) | `dhcp_static_maps` | Supported (legacy; new deployments should use Kea) |
 | `<interfaces>` | `interface_assignments` | Read-only / migrate (direct-API; #711). Write-path mechanism decided in [ADR-0014 §"Per-component decisions"](../decisions/0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions) (#717): server-side-validated REST via a forked OPNsense PHP controller (PR #716). Production conversion of `OPNsenseDirectRunner.apply()` is a separate follow-up; until it ships, logical-to-physical interface mapping remains a one-time manual GUI step during cutover. |
-| `<nat>/rule` and `<nat>/outbound/rule` | — | **Gap** |
+| `<nat>/outbound/rule` and `<nat>/onetoone/rule` | `nat_rules` (`kind: outbound` / `kind: one_to_one`) | Supported (outbound + 1:1, direct-API; #713). Identity is encoded as a **suffix** in the rule `description` — `<operator description> [infrafoundry:<name>]` — and every managed rule also carries the OPNsense `infrafoundry` category as a fleet-wide marker. Live rules without the suffix tag are unmanaged and ignored by the diff (do not edit a managed rule's description in the GUI — that breaks identity parsing). |
+| `<nat>/rule` (port forwards) | — | **Gap** pending a follow-up spike — `26.1.6_2` exposes no MVC REST endpoint for port forwards (`firewall/{redirect,forward,portforward,nat_forward,rdr}` all return 404). The gist-controller mechanism from #717 is the likely path. |
 | `<OPNsense>/Gateways` | — | **Gap** |
 | `<staticroutes>/route` | — | **Gap** |
 | `<virtualip>/vip` | — | **Gap** |
@@ -46,7 +47,7 @@ This template assumes you are cutting over a current box (`OLD`) to a new box (`
 1. **Extract**: run `foundry config migrate --env <env> --provider opnsense --component <type>` for every supported resource type on `OLD` to dump live state into YAML under `envs/<env>/opnsense/`.
 2. **Edit interface map**: in the YAML, remap physical NIC names (`igc0` → `ixl0`, etc.) and any VLAN parent interface references. This is the only manual edit if the new box has different NICs.
 3. **Out-of-IaC import**: on `NEW`, System → Configuration → Backups → Restore, choose "Restore area" and import only the sections from "out of IaC scope" above. **Do not** restore VLANs, filter, NAT, or DHCP — those come from IaC.
-4. **Manual GUI step — interface assignments** (one-time per cutover): on `NEW`, navigate to **Interfaces → Assignments** and bind each logical interface (LAN, WAN, OPT1, etc.) to the correct physical NIC or VLAN per the `interface_assignments` YAML in `envs/<env>/opnsense/`. The write-path mechanism is decided ([ADR-0014 §"Per-component decisions"](../decisions/0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions), #717) but production conversion of `OPNsenseDirectRunner.apply()` is a separate follow-up; until it ships, the YAML is the source of truth and `foundry` reads-and-validates it but cannot apply it. Save and apply within the GUI before continuing.
+4. **Manual GUI step — interface assignments** (one-time per cutover): on `NEW`, navigate to **Interfaces → Assignments** and bind each logical interface (LAN, WAN, OPT1, etc.) to the correct physical NIC or VLAN per the `interface_assignments` YAML in `envs/<env>/opnsense/`. The write-path mechanism is decided ([ADR-0014 §"Per-component decisions"](../decisions/0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions), #717) but production conversion of `OPNsenseDirectRunner.apply()` is a separate follow-up; until it ships, the YAML is the source of truth and `foundry` reads-and-validates it but cannot apply it. **Port forwards** also remain a manual GUI step until the follow-up spike ships — outbound and 1:1 NAT rules are managed by `nat_rules` (#713), but `Firewall → NAT → Port Forward` rules must be configured via the GUI on `NEW`. Save and apply within the GUI before continuing.
 5. **Switch endpoint**: update `provider_settings.opnsense.api_url` in `envs/<env>/settings.yaml` to point at `NEW`.
 6. **Plan**: `foundry infra plan --env <env>` and review the diff. The `interface_assignments` line will show "read-only / 0 changes" — that's expected; the manual step above is the current source of writes (the direct-API write path lands in a follow-up to #717). Expect a clean apply against the (mostly empty) `NEW` box for everything else.
 7. **Apply**: `foundry infra apply --env <env>`.
@@ -73,7 +74,7 @@ After the cleanup, terraform plan should show zero VLAN-related changes; the dir
 Each gap row in the matrix above corresponds to a planned feature issue. The implementation order in [ADR-0013](../decisions/0013-opnsense-full-iac-migration.md) is:
 
 1. `interface_assignments` (read-only / migrate shipped in #711; write-path mechanism decided in ADR-0014 amendment #717 via a forked PHP REST controller; production conversion of `OPNsenseDirectRunner.apply()` is a follow-up issue)
-2. `nat_rules`
+2. `nat_rules` — outbound + 1:1 ship in #713 (direct-API). Port forwards deferred to a follow-up spike — `26.1.6_2` exposes no MVC REST endpoint for them; the same gist-controller mechanism from #717 is the likely path.
 3. `gateways`, `static_routes`
 4. `virtual_ips`
 5. Unbound extensions (`domain_override`, `host_alias`, `forward`)

--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -162,11 +162,13 @@ class OPNsenseProvider(
             ``get_resource_ids``) each manager must expose.
         """
         from .components.interface_assignment import InterfaceAssignmentManager
+        from .components.nat_rule import NATRuleManager
         from .components.vlan import VlanManager
 
         return {
             "vlans": VlanManager,
             "interface_assignments": InterfaceAssignmentManager,
+            "nat_rules": NATRuleManager,
         }
 
     def _generate_aliases_terraform(self, aliases: list[ResourceConfig]) -> None:
@@ -625,6 +627,7 @@ class OPNsenseProvider(
             "kea_dhcp6_subnet",
             "kea_dhcp6_reservation",
             "unbound_host_override",
+            "nat_rules",
         ]
 
     @override
@@ -657,6 +660,7 @@ class OPNsenseProvider(
             "kea_dhcp6_subnet": ["vlans"],
             "kea_dhcp6_reservation": ["kea_dhcp6_subnet"],
             "unbound_host_override": [],
+            "nat_rules": ["aliases", "interface_assignments"],
         }
 
     @override
@@ -762,6 +766,28 @@ class OPNsenseProvider(
         from .components.interface_assignment import InterfaceAssignmentManager
 
         manager = InterfaceAssignmentManager(self.config_dir)
+        return manager.migrate(env_name)
+
+    def migrate_nat_rule(self, env_name: str) -> str:
+        """Migrate current NAT rules (outbound + 1:1) to InfraFoundry YAML.
+
+        Reads the live NAT rule list from OPNsense via the direct-API path
+        and generates InfraFoundry-compatible YAML. Mirrors ``migrate_vlan``
+        and ``migrate_interface_assignment``. Only managed rules (those
+        carrying the ``[infrafoundry:<name>]`` description prefix) are
+        emitted; unmanaged rules are intentionally left to the operator.
+        Port forwards are out of scope (see ADR-0013, #713). Not yet
+        exposed via the ``config migrate`` CLI — that wiring is a follow-up.
+
+        Args:
+            env_name: Environment name
+
+        Returns:
+            YAML configuration as a string
+        """
+        from .components.nat_rule import NATRuleManager
+
+        manager = NATRuleManager(self.config_dir)
         return manager.migrate(env_name)
 
     def migrate_isc_to_kea(self, env_name: str, interfaces: list[str] | None = None) -> str:

--- a/src/infrafoundry/providers/opnsense/components/nat_rule.py
+++ b/src/infrafoundry/providers/opnsense/components/nat_rule.py
@@ -1,0 +1,257 @@
+"""NAT rule component manager for OPNsense (ADR-0014, #713).
+
+Mirrors the layout of ``components/vlan.py``: a thin orchestration layer
+that loads ``NATRuleService`` from the environment and dispatches add/
+update/delete operations across both supported kinds (outbound + 1:1).
+
+Identity is description-prefix-based per the issue plan; the manager
+takes no part in matching — that is entirely the diff engine's job in
+``services/nat_rule.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.types import ResourceOutcome
+
+from ..services.nat_rule import (
+    Diff,
+    LiveNATRule,
+    NATRuleKind,
+    NATRuleService,
+    nat_rule_configs_from_resources,
+)
+from .base import BaseComponentManager
+
+
+class NATRuleManager(BaseComponentManager):
+    """Manager for NAT-rule component operations.
+
+    Each public method instantiates a ``NATRuleService`` from the
+    environment and delegates. Errors propagate to the caller; the runner
+    is responsible for translating exceptions into ``PlanResult.error``/
+    ``ApplyResult.error``.
+    """
+
+    # ------------------------------------------------------------------
+    # Plan / apply / destroy
+    # ------------------------------------------------------------------
+
+    def plan(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        add_only: bool = False,
+        provider_name: str = "opnsense",
+    ) -> Diff:
+        """Compute the add/update/delete diff for the given resources.
+
+        Args:
+            env_name: Active environment name.
+            resources: NAT rule ``ResourceConfig`` entries (filtered upstream).
+            add_only: If True, suppress deletes for managed live rules
+                not in YAML. Unmanaged live rules are always ignored.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            ``Diff`` describing what apply would do.
+        """
+        service = NATRuleService.from_environment(env_name, provider_name, self.config_dir)
+        desired = nat_rule_configs_from_resources(resources)
+        live = service.search_all()
+        return service.compute_diff(desired, live, add_only=add_only)
+
+    def apply(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        auto_approve: bool = True,
+        add_only: bool = False,
+        provider_name: str = "opnsense",
+    ) -> dict[str, Any]:
+        """Apply the diff: add/update/delete rules and applyChanges.
+
+        Args:
+            env_name: Active environment name.
+            resources: NAT rule ``ResourceConfig`` entries.
+            auto_approve: Currently a no-op; the diff engine itself is
+                the gate.
+            add_only: If True, suppress deletes.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            Dict with ``resources_created``, ``resources_updated``,
+            ``resources_deleted`` counts and a ``resource_outcomes`` list.
+        """
+        del auto_approve  # diff engine is the gate; flag accepted for protocol shape
+        service = NATRuleService.from_environment(env_name, provider_name, self.config_dir)
+        desired = nat_rule_configs_from_resources(resources)
+        live = service.search_all()
+        diff = service.compute_diff(desired, live, add_only=add_only)
+
+        outcomes: list[ResourceOutcome] = []
+        for rule in diff.adds:
+            outcomes.append(
+                ResourceOutcome(
+                    address=f"opnsense_nat_rule.{rule.name}",
+                    action="add",
+                    resource_name=rule.name,
+                )
+            )
+
+        for _live_rule, want in diff.updates:
+            outcomes.append(
+                ResourceOutcome(
+                    address=f"opnsense_nat_rule.{want.name}",
+                    action="update",
+                    resource_name=want.name,
+                )
+            )
+
+        for live_rule in diff.deletes:
+            # Synthesize a stable name for deletes; managed_name is non-None
+            # because the diff engine filters out unmanaged rows entirely.
+            synthetic_name = live_rule.managed_name or f"nat-rule-{live_rule.uuid}"
+            outcomes.append(
+                ResourceOutcome(
+                    address=f"opnsense_nat_rule.{synthetic_name}",
+                    action="delete",
+                    resource_name=synthetic_name,
+                )
+            )
+
+        counts = service.apply_diff(diff)
+        return {
+            "success": True,
+            "resources_created": counts["created"],
+            "resources_updated": counts["updated"],
+            "resources_deleted": counts["deleted"],
+            "resource_outcomes": outcomes,
+        }
+
+    def destroy(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        auto_approve: bool = True,
+        provider_name: str = "opnsense",
+    ) -> dict[str, Any]:
+        """Delete every managed NAT rule named in ``resources``.
+
+        Locked entries are honored: ``lock: true`` resources are skipped
+        and counted in the response under ``locked_skipped``.
+
+        Args:
+            env_name: Active environment name.
+            resources: NAT rule ``ResourceConfig`` entries to destroy.
+            auto_approve: Currently a no-op.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            Dict with ``resources_destroyed`` and ``locked_skipped`` counts.
+        """
+        del auto_approve
+        service = NATRuleService.from_environment(env_name, provider_name, self.config_dir)
+        desired = nat_rule_configs_from_resources(resources)
+        live = service.search_all()
+
+        # Index by per-kind name so destroy honors the same isolation as
+        # the diff engine.
+        live_by_key: dict[tuple[NATRuleKind, str], LiveNATRule] = {
+            (entry.kind, entry.managed_name): entry
+            for entry in live
+            if entry.managed_name is not None
+        }
+
+        deleted = 0
+        locked_skipped = 0
+        kinds_touched: set[NATRuleKind] = set()
+        for rule in desired:
+            if rule.lock:
+                locked_skipped += 1
+                continue
+            existing = live_by_key.get((rule.kind, rule.name))
+            if existing is None:
+                continue
+            service.delete(existing.uuid, existing.kind)
+            kinds_touched.add(existing.kind)
+            deleted += 1
+
+        for kind in kinds_touched:
+            service.apply_changes(kind)
+
+        return {
+            "success": True,
+            "resources_destroyed": deleted,
+            "locked_skipped": locked_skipped,
+        }
+
+    # ------------------------------------------------------------------
+    # State / migration helpers
+    # ------------------------------------------------------------------
+
+    def get_resource_ids(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        provider_name: str = "opnsense",
+    ) -> dict[str, str]:
+        """Return ``{resource_name: opnsense_uuid}`` for live managed rules.
+
+        Args:
+            env_name: Active environment name.
+            resources: NAT rule ``ResourceConfig`` entries.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            Mapping from operator-facing resource name to OPNsense UUID.
+            Resources without a matching live record are omitted. When
+            two rules of different kinds share a name, the mapping uses
+            the operator-facing ``name`` as the key — collisions are
+            prevented at the YAML level by the resource-name validator.
+        """
+        service = NATRuleService.from_environment(env_name, provider_name, self.config_dir)
+        desired = nat_rule_configs_from_resources(resources)
+        live = service.search_all()
+        live_by_key: dict[tuple[NATRuleKind, str], LiveNATRule] = {
+            (entry.kind, entry.managed_name): entry
+            for entry in live
+            if entry.managed_name is not None
+        }
+
+        result: dict[str, str] = {}
+        for rule in desired:
+            existing = live_by_key.get((rule.kind, rule.name))
+            if existing is not None:
+                result[rule.name] = existing.uuid
+        return result
+
+    def list(self, env_name: str, *, provider_name: str = "opnsense") -> list[LiveNATRule]:
+        """Return the live NAT rules on the OPNsense box (both kinds).
+
+        Args:
+            env_name: Active environment name.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+        """
+        service = NATRuleService.from_environment(env_name, provider_name, self.config_dir)
+        return service.search_all()
+
+    def migrate(self, env_name: str, *, provider_name: str = "opnsense") -> str:
+        """Export the current managed NAT rules to InfraFoundry YAML.
+
+        Args:
+            env_name: Active environment name.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            YAML string containing the live managed rules in
+            resource-centric form.
+        """
+        service = NATRuleService.from_environment(env_name, provider_name, self.config_dir)
+        return service.export_to_yaml()

--- a/src/infrafoundry/providers/opnsense/services/nat_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/nat_rule.py
@@ -1,0 +1,1000 @@
+"""NAT rule service for OPNsense direct-API operations (ADR-0014, #713).
+
+Manages **outbound** and **1:1** NAT rules via the OPNsense REST API. Port
+forwards are intentionally out of scope: live probe (2026-05-03) of
+``opnsense-a`` running ``26.1.6_2`` confirmed that ``firewall/{redirect,
+forward, portforward, nat_forward, rdr}/searchRule`` all return 404 and the
+legacy ``<nat>/<rule>`` config.xml section is GUI-only. Port forwards become a
+follow-up spike-driven issue. See the issue body and ADR-0013 for the
+deferral rationale.
+
+Identity strategy
+-----------------
+
+NAT rules have no clean intrinsic key — two rules can share
+``(interface, source, destination, port)`` with completely different
+behavior depending on order. ADR-0014 takes no position on a state DB for
+direct-API resources, so the only stateless option is encoding identity in
+a free-form rule field. The service writes ``description`` as
+``<operator-supplied description> [infrafoundry:<resource-name>]`` (or just
+``[infrafoundry:<resource-name>]`` when the operator description is empty).
+The identity tag is a **suffix** so the operator's free-form text leads the
+display in the OPNsense GUI. On read, ``_row_to_live`` parses the suffix
+with a strict regex; live rows without the suffix are **unmanaged** and
+silently ignored by the diff (not deleted, not updated). Live rows with a
+malformed identity tag (wrong position, empty name, extra text after the
+tag, etc.) raise ``OpnsenseDriftError`` at plan time.
+
+Every managed rule also carries the OPNsense ``infrafoundry`` category as
+a fleet-wide marker (the category is created on demand at first apply and
+its UUID is cached per service instance). The category enables a one-click
+"show me everything InfraFoundry manages" filter in the OPNsense GUI; the
+identity suffix is what carries per-rule resource-name mapping.
+
+Per-kind isolation
+------------------
+
+The diff is computed per-kind: ``compute_diff`` accepts a list of mixed-kind
+``NATRuleConfig`` and dispatches to a per-kind diff internally, joining the
+results into a single ``Diff`` object. An outbound rule named ``foo`` and a
+1:1 rule named ``foo`` co-exist as separate identities (different
+controllers; same name allowed).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import yaml
+
+from infrafoundry.core.exceptions import InfraFoundryError
+from infrafoundry.core.provider import ResourceConfig
+
+from .base import BaseService
+
+# Type alias for NAT rule kinds — the discriminator on every entry.
+NATRuleKind = Literal["outbound", "one_to_one"]
+ALLOWED_KINDS: tuple[NATRuleKind, ...] = ("outbound", "one_to_one")
+
+# Strict regex for parsing the description-suffix identity tag. The
+# (optional) free-form user description leads, followed by whitespace,
+# followed by ``\[infrafoundry:<name>\]`` at the end of the string. The
+# resource name must be a non-empty match of ``[a-z0-9-]+``; live rows
+# without the tag are unmanaged, and rows with a malformed tag — empty
+# name, wrong position, trailing text after the tag, etc. — raise
+# ``OpnsenseDriftError``. ``_IDENTITY_PROBE`` is a position-agnostic
+# detector used both by the parser (to flag malformed tags) and by the
+# validator (to reject operator-set descriptions that include the tag
+# pattern, since InfraFoundry adds it automatically).
+_IDENTITY_PATTERN = re.compile(r"^(?:(.+?)\s+)?\[infrafoundry:([a-z0-9-]+)\]\s*$")
+_IDENTITY_PROBE = re.compile(r"\[infrafoundry:[^\]]*\]")
+
+# Outbound endpoint suffix on ``firewall/source_nat`` controller.
+_OUTBOUND_BASE = "firewall/source_nat"
+# 1:1 endpoint suffix on ``firewall/one_to_one`` controller.
+_ONE_TO_ONE_BASE = "firewall/one_to_one"
+
+# Default sequence for new rules — matches the OPNsense schema default.
+DEFAULT_SEQUENCE = 100
+
+
+class OpnsenseDriftError(InfraFoundryError):
+    """A managed rule's identity tag is malformed on the live box.
+
+    Raised by the diff engine when a live rule's ``description`` looks like
+    it carries an InfraFoundry prefix (begins with ``[infrafoundry:``) but
+    does not match the strict identity regex. The operator must repair the
+    description in the GUI (or via API) before the next plan/apply.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Identity-prefix helpers
+# ---------------------------------------------------------------------------
+
+
+def encode_identity(resource_name: str, user_description: str) -> str:
+    """Encode the description with the InfraFoundry identity suffix.
+
+    Args:
+        resource_name: Operator-facing YAML name; becomes the diff key.
+        user_description: Free-form description from YAML (may be empty).
+
+    Returns:
+        ``"<user_description> [infrafoundry:<name>]"`` when the user
+        description is non-empty; ``"[infrafoundry:<name>]"`` otherwise.
+    """
+    if user_description:
+        return f"{user_description} [infrafoundry:{resource_name}]"
+    return f"[infrafoundry:{resource_name}]"
+
+
+def parse_identity(description: str) -> tuple[str | None, str]:
+    """Parse the description-suffix identity tag.
+
+    Args:
+        description: ``description`` field from a live rule row.
+
+    Returns:
+        ``(resource_name, user_description)``. ``resource_name`` is ``None``
+        when the description has no tag (unmanaged rule).
+
+    Raises:
+        OpnsenseDriftError: If the description contains the
+            ``[infrafoundry:...]`` marker but does not match the strict
+            suffix-only regex — empty name, uppercase, tag in the middle
+            with text after, etc.
+    """
+    match = _IDENTITY_PATTERN.match(description)
+    if match is not None:
+        user_desc = match.group(1) or ""
+        return match.group(2), user_desc
+    if _IDENTITY_PROBE.search(description):
+        raise OpnsenseDriftError(
+            f"NAT rule description contains an InfraFoundry identity tag but is malformed: "
+            f"{description!r}. Expected '<user description> [infrafoundry:<name>]' (or just "
+            f"'[infrafoundry:<name>]') where <name> matches [a-z0-9-]+ (non-empty) and the "
+            f"tag is the LAST token in the description."
+        )
+    return None, description
+
+
+# ---------------------------------------------------------------------------
+# Domain model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NATRuleConfig:
+    """Desired-state NAT rule configuration.
+
+    Captures both kinds in a single dataclass; per-kind fields default to
+    sentinel values that ``to_payload`` interprets according to ``kind``.
+
+    Attributes:
+        name: Operator-facing YAML name; becomes the diff key.
+        kind: ``"outbound"`` or ``"one_to_one"``.
+        enabled: Whether the rule is active.
+        log: Whether matching packets are logged.
+        sequence: Position in the rule list (lower runs earlier).
+        interface: Logical interface name (e.g., ``"wan"``).
+        description: Operator-facing free-form description (no identity
+            prefix; the prefix is added at serialization time).
+        lock: Per-resource safety annotation (ADR-0014 §6).
+
+        Outbound-specific:
+            ipprotocol: ``"inet"`` or ``"inet6"``.
+            protocol: ``"any"``, ``"TCP"``, ``"UDP"``, etc.
+            source_net: Alias name, CIDR, or ``"any"``.
+            source_not: Negate source.
+            source_port: Port (or empty).
+            destination_net: Alias name, CIDR, or ``"any"``.
+            destination_not: Negate destination.
+            destination_port: Port (or empty).
+            target: Alias name, IP, or ``"wanip"``.
+            target_port: Port (or empty).
+            staticnatport: Preserve source port.
+            nonat: If True, this is a "do not NAT" exclusion rule.
+
+        1:1-specific:
+            type: ``"binat"`` or ``"nat"``.
+            external: External IP / alias.
+            natreflection: ``""``, ``"enable"``, or ``"disable"``.
+    """
+
+    name: str
+    kind: NATRuleKind
+    enabled: bool = True
+    log: bool = False
+    sequence: int = DEFAULT_SEQUENCE
+    interface: str = ""
+    description: str = ""
+    lock: bool = False
+
+    # Outbound fields
+    ipprotocol: str = "inet"
+    protocol: str = "any"
+    source_net: str = "any"
+    source_not: bool = False
+    source_port: str = ""
+    destination_net: str = "any"
+    destination_not: bool = False
+    destination_port: str = ""
+    target: str = ""
+    target_port: str = ""
+    staticnatport: bool = False
+    nonat: bool = False
+
+    # 1:1 fields
+    type: str = "binat"
+    external: str = ""
+    natreflection: str = ""
+
+    @property
+    def diff_key(self) -> tuple[NATRuleKind, str]:
+        """Per-kind, name-based identity for this rule.
+
+        The kind is part of the key so an outbound rule named ``foo`` and a
+        1:1 rule named ``foo`` are independent identities.
+        """
+        return (self.kind, self.name)
+
+    def encoded_description(self) -> str:
+        """Description with the InfraFoundry identity prefix applied."""
+        return encode_identity(self.name, self.description)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize to the ``addRule``/``setRule`` envelope OPNsense expects.
+
+        Returns:
+            ``{"rule": {<fields>}}`` for both kinds. Field set varies by
+            ``kind``. Booleans are stringified to ``"0"``/``"1"`` per
+            OPNsense convention.
+        """
+        if self.kind == "outbound":
+            return self._to_outbound_payload()
+        return self._to_one_to_one_payload()
+
+    def _to_outbound_payload(self) -> dict[str, Any]:
+        return {
+            "rule": {
+                "enabled": _bool_str(self.enabled),
+                "nonat": _bool_str(self.nonat),
+                "sequence": str(self.sequence),
+                "interface": self.interface,
+                "ipprotocol": self.ipprotocol,
+                "protocol": self.protocol,
+                "source_net": self.source_net,
+                "source_not": _bool_str(self.source_not),
+                "source_port": self.source_port,
+                "destination_net": self.destination_net,
+                "destination_not": _bool_str(self.destination_not),
+                "destination_port": self.destination_port,
+                "target": self.target,
+                "target_port": self.target_port,
+                "staticnatport": _bool_str(self.staticnatport),
+                "log": _bool_str(self.log),
+                "description": self.encoded_description(),
+            }
+        }
+
+    def _to_one_to_one_payload(self) -> dict[str, Any]:
+        return {
+            "rule": {
+                "enabled": _bool_str(self.enabled),
+                "log": _bool_str(self.log),
+                "sequence": str(self.sequence),
+                "interface": self.interface,
+                "type": self.type,
+                "source_net": self.source_net,
+                "source_not": _bool_str(self.source_not),
+                "destination_net": self.destination_net,
+                "destination_not": _bool_str(self.destination_not),
+                "external": self.external,
+                "natreflection": self.natreflection,
+                "description": self.encoded_description(),
+            }
+        }
+
+
+@dataclass(frozen=True)
+class LiveNATRule:
+    """A NAT rule as currently configured on the OPNsense box.
+
+    Identity-tagged rows have ``managed_name`` set to the parsed resource
+    name; unmanaged rows have it set to ``None`` and are filtered out of
+    the diff entirely.
+
+    Attributes:
+        uuid: OPNsense-assigned rule UUID.
+        kind: ``"outbound"`` or ``"one_to_one"``.
+        managed_name: Parsed InfraFoundry name (``None`` if unmanaged).
+        description: Free-form description with the prefix stripped.
+        raw: Full original row dict from ``searchRule`` for field
+            comparison during update detection.
+    """
+
+    uuid: str
+    kind: NATRuleKind
+    managed_name: str | None
+    description: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Diff:
+    """Result of comparing desired YAML state to live OPNsense state.
+
+    Mirrors the surface of ``services.vlan.Diff`` (``adds``/``updates``/
+    ``deletes``/``locked``) plus ``is_empty``. Updates carry the live
+    record alongside the desired record so the caller has the UUID.
+    Locked entries pair desired YAML with their (possibly missing) live
+    counterpart.
+    """
+
+    adds: list[NATRuleConfig] = field(default_factory=list)
+    updates: list[tuple[LiveNATRule, NATRuleConfig]] = field(default_factory=list)
+    deletes: list[LiveNATRule] = field(default_factory=list)
+    locked: list[tuple[NATRuleConfig, LiveNATRule | None]] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True if there are no add/update/delete operations to apply."""
+        return not (self.adds or self.updates or self.deletes)
+
+
+# ---------------------------------------------------------------------------
+# Diff engine
+# ---------------------------------------------------------------------------
+
+
+def compute_diff(
+    desired: list[NATRuleConfig],
+    current: list[LiveNATRule],
+    *,
+    add_only: bool = False,
+) -> Diff:
+    """Compare desired YAML state to live state, per-kind.
+
+    Per-kind isolation is the key invariant: an outbound rule named
+    ``foo`` never matches a 1:1 rule named ``foo`` even though both share
+    the literal ``name``. The diff is computed twice (once per kind) and
+    the per-kind results are joined into a single outer ``Diff``.
+
+    Unmanaged live rows (``managed_name is None``) are silently ignored:
+    not deleted, not updated, never reported. Rules tagged
+    ``[infrafoundry:...]`` but malformed are surfaced as
+    ``OpnsenseDriftError`` at parse time, before this function runs.
+
+    Args:
+        desired: NAT rules the operator wants to exist (may include both
+            kinds).
+        current: NAT rules currently on the box (mixed kinds).
+        add_only: If True, never emit deletes for managed live rules that
+            don't appear in ``desired``. Adds and updates still happen.
+
+    Returns:
+        A ``Diff`` with adds/updates/deletes plus locked entries.
+    """
+    diff = Diff()
+    for kind in ALLOWED_KINDS:
+        kind_desired = [d for d in desired if d.kind == kind]
+        # Filter live rows to (a) this kind, (b) managed rows only.
+        kind_live_managed = [
+            live for live in current if live.kind == kind and live.managed_name is not None
+        ]
+        per_kind = _compute_diff_for_kind(kind_desired, kind_live_managed, add_only=add_only)
+        diff.adds.extend(per_kind.adds)
+        diff.updates.extend(per_kind.updates)
+        diff.deletes.extend(per_kind.deletes)
+        diff.locked.extend(per_kind.locked)
+    return diff
+
+
+def _compute_diff_for_kind(
+    desired: list[NATRuleConfig],
+    current_managed: list[LiveNATRule],
+    *,
+    add_only: bool,
+) -> Diff:
+    """Single-kind diff. Matches by ``managed_name`` against ``NATRuleConfig.name``."""
+    desired_by_name: dict[str, NATRuleConfig] = {d.name: d for d in desired}
+    # ``managed_name`` is non-None for every entry in ``current_managed``.
+    current_by_name: dict[str, LiveNATRule] = {
+        live.managed_name: live for live in current_managed if live.managed_name is not None
+    }
+    locked_names: set[str] = {d.name for d in desired if d.lock}
+
+    adds: list[NATRuleConfig] = []
+    updates: list[tuple[LiveNATRule, NATRuleConfig]] = []
+    deletes: list[LiveNATRule] = []
+    locked: list[tuple[NATRuleConfig, LiveNATRule | None]] = []
+
+    for name, want in desired_by_name.items():
+        have = current_by_name.get(name)
+        if want.lock:
+            locked.append((want, have))
+            continue
+        if have is None:
+            adds.append(want)
+        elif _needs_update(have, want):
+            updates.append((have, want))
+
+    if not add_only:
+        for name, have in current_by_name.items():
+            if name in locked_names:
+                continue
+            if name not in desired_by_name:
+                deletes.append(have)
+
+    return Diff(adds=adds, updates=updates, deletes=deletes, locked=locked)
+
+
+def _needs_update(have: LiveNATRule, want: NATRuleConfig) -> bool:
+    """Return True if the live row's fields differ from the desired payload.
+
+    Compares the inner ``rule`` payload from ``want.to_payload()`` against
+    the corresponding fields on ``have.raw``. The OPNsense API returns
+    select fields (``interface``, ``protocol``, etc.) as dicts with
+    ``selected`` indicators; ``_normalize_field`` collapses both shapes
+    to a comparable string.
+    """
+    payload = want.to_payload()["rule"]
+    for key, want_value in payload.items():
+        have_value = _normalize_field(have.raw.get(key))
+        if str(want_value) != have_value:
+            return True
+    return False
+
+
+def _normalize_field(value: Any) -> str:
+    """Collapse an OPNsense field value to a comparable string.
+
+    OPNsense returns single-select fields as dicts of options keyed by
+    their machine value; the active option has ``"selected": 1``. We
+    extract that option and return its key (matching what we'd send
+    on update). Empty/None values become ``""``. Plain scalars are
+    stringified verbatim.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        for option_key, option_value in value.items():
+            if isinstance(option_value, dict) and option_value.get("selected"):
+                return str(option_key)
+        return ""
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Resource-to-domain conversion
+# ---------------------------------------------------------------------------
+
+
+def nat_rule_configs_from_resources(
+    resources: list[ResourceConfig],
+) -> list[NATRuleConfig]:
+    """Convert ``ResourceConfig`` entries to ``NATRuleConfig`` instances.
+
+    Validation here is intentionally light — the validator handles
+    cross-resource references and operator-friendly error messages; the
+    service only enforces type sanity so manager code can rely on field
+    invariants.
+
+    Args:
+        resources: All provider resources from a ConfigManager load.
+            Non-``nat_rules`` entries are silently skipped.
+
+    Returns:
+        Validated ``NATRuleConfig`` list.
+
+    Raises:
+        ValueError: If an entry has a non-dict config, missing/invalid
+            ``kind``, missing per-kind required fields, or non-bool
+            booleans / non-int ``sequence`` / forged identity prefix in
+            ``description``.
+    """
+    configs: list[NATRuleConfig] = []
+    for resource in resources:
+        if resource.type != "nat_rules":
+            continue
+
+        config = resource.config
+        if not isinstance(config, dict):
+            raise ValueError(f"nat_rule '{resource.name}' has non-dict config")
+
+        kind_raw = config.get("kind")
+        if kind_raw not in ALLOWED_KINDS:
+            raise ValueError(
+                f"nat_rule '{resource.name}' kind must be one of {ALLOWED_KINDS}, got {kind_raw!r}"
+            )
+        kind: NATRuleKind = kind_raw
+
+        description = config.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"nat_rule '{resource.name}' description must be a string")
+        if _IDENTITY_PROBE.search(description):
+            raise ValueError(
+                f"nat_rule '{resource.name}' description must not contain "
+                f"'[infrafoundry:<name>]' — that tag is reserved for InfraFoundry's "
+                f"identity suffix, which is added automatically at apply time"
+            )
+
+        interface = config.get("interface", "")
+        if not isinstance(interface, str):
+            raise ValueError(f"nat_rule '{resource.name}' interface must be a string")
+
+        sequence_raw = config.get("sequence", DEFAULT_SEQUENCE)
+        try:
+            sequence = int(sequence_raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"nat_rule '{resource.name}' sequence must be an integer, got {sequence_raw!r}"
+            ) from exc
+
+        enabled = _require_bool(config, "enabled", default=True, resource_name=resource.name)
+        log = _require_bool(config, "log", default=False, resource_name=resource.name)
+        lock = _require_bool(config, "lock", default=False, resource_name=resource.name)
+
+        if kind == "outbound":
+            configs.append(
+                _build_outbound_config(
+                    resource.name,
+                    config,
+                    enabled=enabled,
+                    log=log,
+                    lock=lock,
+                    sequence=sequence,
+                    interface=interface,
+                    description=description,
+                )
+            )
+        else:
+            configs.append(
+                _build_one_to_one_config(
+                    resource.name,
+                    config,
+                    enabled=enabled,
+                    log=log,
+                    lock=lock,
+                    sequence=sequence,
+                    interface=interface,
+                    description=description,
+                )
+            )
+
+    return configs
+
+
+def _build_outbound_config(
+    name: str,
+    config: dict[str, Any],
+    *,
+    enabled: bool,
+    log: bool,
+    lock: bool,
+    sequence: int,
+    interface: str,
+    description: str,
+) -> NATRuleConfig:
+    if not interface:
+        raise ValueError(f"nat_rule '{name}' (outbound) requires 'interface'")
+    target = config.get("target", "")
+    if not isinstance(target, str) or not target:
+        raise ValueError(f"nat_rule '{name}' (outbound) requires non-empty string 'target'")
+
+    return NATRuleConfig(
+        name=name,
+        kind="outbound",
+        enabled=enabled,
+        log=log,
+        sequence=sequence,
+        interface=interface,
+        description=description,
+        lock=lock,
+        ipprotocol=_string_field(config, "ipprotocol", default="inet", name=name),
+        protocol=_string_field(config, "protocol", default="any", name=name),
+        source_net=_string_field(config, "source_net", default="any", name=name),
+        source_not=_require_bool(config, "source_not", default=False, resource_name=name),
+        source_port=_string_field(config, "source_port", default="", name=name),
+        destination_net=_string_field(config, "destination_net", default="any", name=name),
+        destination_not=_require_bool(config, "destination_not", default=False, resource_name=name),
+        destination_port=_string_field(config, "destination_port", default="", name=name),
+        target=target,
+        target_port=_string_field(config, "target_port", default="", name=name),
+        staticnatport=_require_bool(config, "staticnatport", default=False, resource_name=name),
+        nonat=_require_bool(config, "nonat", default=False, resource_name=name),
+    )
+
+
+def _build_one_to_one_config(
+    name: str,
+    config: dict[str, Any],
+    *,
+    enabled: bool,
+    log: bool,
+    lock: bool,
+    sequence: int,
+    interface: str,
+    description: str,
+) -> NATRuleConfig:
+    if not interface:
+        raise ValueError(f"nat_rule '{name}' (one_to_one) requires 'interface'")
+    external = config.get("external", "")
+    if not isinstance(external, str) or not external:
+        raise ValueError(f"nat_rule '{name}' (one_to_one) requires non-empty string 'external'")
+
+    type_value = _string_field(config, "type", default="binat", name=name)
+    if type_value not in ("binat", "nat"):
+        raise ValueError(
+            f"nat_rule '{name}' (one_to_one) type must be 'binat' or 'nat', got {type_value!r}"
+        )
+
+    natreflection = _string_field(config, "natreflection", default="", name=name)
+    if natreflection not in ("", "enable", "disable"):
+        raise ValueError(
+            f"nat_rule '{name}' (one_to_one) natreflection must be '' / 'enable' / 'disable', "
+            f"got {natreflection!r}"
+        )
+
+    return NATRuleConfig(
+        name=name,
+        kind="one_to_one",
+        enabled=enabled,
+        log=log,
+        sequence=sequence,
+        interface=interface,
+        description=description,
+        lock=lock,
+        type=type_value,
+        external=external,
+        source_net=_string_field(config, "source_net", default="any", name=name),
+        source_not=_require_bool(config, "source_not", default=False, resource_name=name),
+        destination_net=_string_field(config, "destination_net", default="any", name=name),
+        destination_not=_require_bool(config, "destination_not", default=False, resource_name=name),
+        natreflection=natreflection,
+    )
+
+
+def _require_bool(
+    config: dict[str, Any], field_name: str, *, default: bool, resource_name: str
+) -> bool:
+    value = config.get(field_name, default)
+    if not isinstance(value, bool):
+        raise ValueError(
+            f"nat_rule '{resource_name}' {field_name} must be a boolean (true/false), "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def _string_field(config: dict[str, Any], field_name: str, *, default: str, name: str) -> str:
+    value = config.get(field_name, default)
+    if not isinstance(value, str):
+        raise ValueError(
+            f"nat_rule '{name}' {field_name} must be a string, got {type(value).__name__}"
+        )
+    return value
+
+
+def _bool_str(value: bool) -> str:
+    """Convert a Python bool to OPNsense's ``"0"``/``"1"`` representation."""
+    return "1" if value else "0"
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class NATRuleService(BaseService):
+    """Service for OPNsense NAT-rule operations via direct API.
+
+    Two controllers, one service: outbound rules go through
+    ``firewall/source_nat`` and 1:1 rules go through ``firewall/one_to_one``.
+    Each public method dispatches on ``kind`` so the manager has a single
+    surface to call.
+
+    Every managed rule carries a fleet-wide ``infrafoundry`` OPNsense
+    category as a broad marker (in addition to the per-rule identity suffix
+    in ``description``). The category is created on demand at first apply
+    and its UUID is cached on the service instance.
+    """
+
+    # Name of the OPNsense category created/used as the fleet-wide marker
+    # for InfraFoundry-managed rules.
+    INFRAFOUNDRY_CATEGORY_NAME = "infrafoundry"
+
+    def __init__(self, client: Any) -> None:
+        """Initialize the service and prepare the per-instance category cache."""
+        super().__init__(client)
+        # UUID of the OPNsense ``infrafoundry`` category, looked up or created
+        # lazily on the first add/update via ``_ensure_infrafoundry_category``.
+        self._category_uuid: str | None = None
+
+    # ------------------------------------------------------------------
+    # Per-kind endpoint helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _base_for(kind: NATRuleKind) -> str:
+        if kind == "outbound":
+            return _OUTBOUND_BASE
+        return _ONE_TO_ONE_BASE
+
+    # ------------------------------------------------------------------
+    # Category bootstrap (fleet-wide marker)
+    # ------------------------------------------------------------------
+
+    def _ensure_infrafoundry_category(self) -> str:
+        """Return the UUID of the ``infrafoundry`` category, creating it if absent.
+
+        The lookup is cached on the service instance so multiple add/update
+        calls in a single apply pay one round-trip total. Cache is per
+        instance; long-lived service objects across multiple environments
+        would need to invalidate manually, but the ``from_environment``
+        factory builds a fresh service per env so that's not a concern in
+        production.
+
+        Returns:
+            UUID string for the OPNsense category named ``infrafoundry``.
+
+        Raises:
+            InfraFoundryError: If neither search nor create yields a UUID.
+        """
+        if self._category_uuid is not None:
+            return self._category_uuid
+
+        search_response = self.client.request("POST", "firewall/category/searchItem")
+        rows: list[dict[str, Any]] = []
+        if isinstance(search_response, dict):
+            raw_rows = search_response.get("rows")
+            if isinstance(raw_rows, list):
+                rows = [r for r in raw_rows if isinstance(r, dict)]
+        for row in rows:
+            if row.get("name") == self.INFRAFOUNDRY_CATEGORY_NAME:
+                uuid = str(row.get("uuid", ""))
+                if uuid:
+                    self._category_uuid = uuid
+                    return uuid
+
+        add_response = self.client.request(
+            "POST",
+            "firewall/category/addItem",
+            data={
+                "category": {
+                    "name": self.INFRAFOUNDRY_CATEGORY_NAME,
+                    "auto": "0",
+                    "color": "",
+                }
+            },
+        )
+        if isinstance(add_response, dict):
+            uuid = str(add_response.get("uuid", ""))
+            if uuid:
+                self._category_uuid = uuid
+                return uuid
+
+        raise InfraFoundryError(
+            f"Failed to ensure '{self.INFRAFOUNDRY_CATEGORY_NAME}' category exists on "
+            f"OPNsense; addItem response: {add_response!r}"
+        )
+
+    def _payload_with_category(self, rule: NATRuleConfig) -> dict[str, Any]:
+        """Build the API payload for a rule with the InfraFoundry category injected."""
+        payload = rule.to_payload()
+        payload["rule"]["categories"] = self._ensure_infrafoundry_category()
+        return payload
+
+    # ------------------------------------------------------------------
+    # API operations (CRUD + applyChanges)
+    # ------------------------------------------------------------------
+
+    def search(self, kind: NATRuleKind) -> list[LiveNATRule]:
+        """Fetch the live rule list for one kind.
+
+        Args:
+            kind: Which controller to query.
+
+        Returns:
+            ``LiveNATRule`` instances normalized from the search rows.
+
+        Raises:
+            OpnsenseDriftError: If any row has a malformed identity prefix.
+        """
+        base = self._base_for(kind)
+        response = self.client.request("POST", f"{base}/searchRule")
+
+        rows: list[dict[str, Any]] = []
+        if isinstance(response, dict):
+            raw_rows = response.get("rows")
+            if isinstance(raw_rows, list):
+                rows = [r for r in raw_rows if isinstance(r, dict)]
+
+        return [_row_to_live(row, kind) for row in rows]
+
+    def search_all(self) -> list[LiveNATRule]:
+        """Fetch the live rule list for both kinds, concatenated."""
+        result: list[LiveNATRule] = []
+        for kind in ALLOWED_KINDS:
+            result.extend(self.search(kind))
+        return result
+
+    def add(self, rule: NATRuleConfig) -> dict[str, Any]:
+        """Create a NAT rule.
+
+        The InfraFoundry category UUID is injected into the payload so every
+        managed rule carries the fleet-wide marker (in addition to the
+        identity suffix in ``description``).
+
+        Args:
+            rule: Desired-state rule configuration.
+
+        Returns:
+            API response dict.
+        """
+        base = self._base_for(rule.kind)
+        return self.client.request(
+            "POST", f"{base}/addRule", data=self._payload_with_category(rule)
+        )
+
+    def update(self, uuid: str, rule: NATRuleConfig) -> dict[str, Any]:
+        """Update an existing NAT rule by UUID.
+
+        The InfraFoundry category UUID is injected into the payload (same
+        reason as ``add``).
+
+        Args:
+            uuid: OPNsense-assigned rule UUID.
+            rule: New desired-state configuration.
+
+        Returns:
+            API response dict.
+        """
+        base = self._base_for(rule.kind)
+        return self.client.request(
+            "POST", f"{base}/setRule/{uuid}", data=self._payload_with_category(rule)
+        )
+
+    def delete(self, uuid: str, kind: NATRuleKind) -> dict[str, Any]:
+        """Delete a NAT rule by UUID.
+
+        Args:
+            uuid: OPNsense-assigned rule UUID.
+            kind: Which controller to call (outbound vs 1:1).
+
+        Returns:
+            API response dict.
+        """
+        base = self._base_for(kind)
+        return self.client.request("POST", f"{base}/delRule/{uuid}")
+
+    def apply_changes(self, kind: NATRuleKind) -> dict[str, Any]:
+        """Apply pending NAT changes (commit staged config to running system).
+
+        OPNsense's ``firewall/source_nat`` and ``firewall/one_to_one``
+        controllers use ``apply`` (vs. ``reconfigure`` for VLANs and
+        ``applyChanges`` for some other controllers). Confirmed live on
+        26.1.6_2 — ``applyChanges`` 404s on these specific controllers.
+        Must be called after add/update/delete to activate.
+        """
+        base = self._base_for(kind)
+        return self.client.request("POST", f"{base}/apply")
+
+    # ------------------------------------------------------------------
+    # Diff + apply orchestration
+    # ------------------------------------------------------------------
+
+    def compute_diff(
+        self,
+        desired: list[NATRuleConfig],
+        live: list[LiveNATRule],
+        *,
+        add_only: bool = False,
+    ) -> Diff:
+        """Compute the add/update/delete diff (per-kind, joined)."""
+        return compute_diff(desired, live, add_only=add_only)
+
+    def apply_diff(self, diff: Diff) -> dict[str, int]:
+        """Dispatch the operations in ``diff`` and apply pending changes.
+
+        Each kind's ``applyChanges`` endpoint is called only if at least
+        one mutation of that kind happened, mirroring the per-controller
+        granularity of the OPNsense API.
+
+        Returns:
+            ``{"created": N, "updated": M, "deleted": K}`` counts.
+        """
+        created = 0
+        updated = 0
+        deleted = 0
+        kinds_touched: set[NATRuleKind] = set()
+
+        for rule in diff.adds:
+            self.add(rule)
+            kinds_touched.add(rule.kind)
+            created += 1
+
+        for live, want in diff.updates:
+            self.update(live.uuid, want)
+            kinds_touched.add(want.kind)
+            updated += 1
+
+        for live in diff.deletes:
+            self.delete(live.uuid, live.kind)
+            kinds_touched.add(live.kind)
+            deleted += 1
+
+        for kind in kinds_touched:
+            self.apply_changes(kind)
+
+        return {"created": created, "updated": updated, "deleted": deleted}
+
+    # ------------------------------------------------------------------
+    # Migration / export
+    # ------------------------------------------------------------------
+
+    def export_to_yaml(self) -> str:
+        """Export the current managed NAT rules to InfraFoundry YAML.
+
+        Only managed rules (those with the InfraFoundry identity prefix)
+        are exported — unmanaged rules are intentionally left to the
+        operator. Round-trip loss is expected: only the fields the schema
+        captures are written; the prefix is stripped from ``description``.
+
+        Returns:
+            YAML string with ``provider/type/name/config`` entries.
+        """
+        rules: list[LiveNATRule] = self.search_all()
+        managed = [r for r in rules if r.managed_name is not None]
+        resources = [
+            {
+                "provider": "opnsense",
+                "type": "nat_rules",
+                "name": r.managed_name,
+                "config": _live_to_export_config(r),
+            }
+            for r in managed
+        ]
+        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (row parsing / export)
+# ---------------------------------------------------------------------------
+
+
+def _row_to_live(row: dict[str, Any], kind: NATRuleKind) -> LiveNATRule:
+    """Normalize a ``searchRule`` row into a ``LiveNATRule``.
+
+    Parses the ``description`` field for the InfraFoundry identity prefix.
+    Raises ``OpnsenseDriftError`` (via ``parse_identity``) if the prefix
+    marker is present but malformed.
+    """
+    uuid = str(row.get("uuid", ""))
+    description = str(row.get("description", "") or "")
+    managed_name, user_description = parse_identity(description)
+    return LiveNATRule(
+        uuid=uuid,
+        kind=kind,
+        managed_name=managed_name,
+        description=user_description,
+        raw=row,
+    )
+
+
+def _live_to_export_config(live: LiveNATRule) -> dict[str, Any]:
+    """Build a YAML-friendly config dict from a managed live rule."""
+    raw = live.raw
+    if live.kind == "outbound":
+        return {
+            "kind": "outbound",
+            "enabled": _normalize_field(raw.get("enabled")) == "1",
+            "interface": _normalize_field(raw.get("interface")),
+            "ipprotocol": _normalize_field(raw.get("ipprotocol")) or "inet",
+            "protocol": _normalize_field(raw.get("protocol")) or "any",
+            "source_net": _normalize_field(raw.get("source_net")) or "any",
+            "source_port": _normalize_field(raw.get("source_port")),
+            "destination_net": _normalize_field(raw.get("destination_net")) or "any",
+            "destination_port": _normalize_field(raw.get("destination_port")),
+            "target": _normalize_field(raw.get("target")),
+            "target_port": _normalize_field(raw.get("target_port")),
+            "staticnatport": _normalize_field(raw.get("staticnatport")) == "1",
+            "nonat": _normalize_field(raw.get("nonat")) == "1",
+            "log": _normalize_field(raw.get("log")) == "1",
+            "description": live.description,
+        }
+    return {
+        "kind": "one_to_one",
+        "enabled": _normalize_field(raw.get("enabled")) == "1",
+        "type": _normalize_field(raw.get("type")) or "binat",
+        "interface": _normalize_field(raw.get("interface")),
+        "external": _normalize_field(raw.get("external")),
+        "source_net": _normalize_field(raw.get("source_net")) or "any",
+        "destination_net": _normalize_field(raw.get("destination_net")) or "any",
+        "natreflection": _normalize_field(raw.get("natreflection")),
+        "log": _normalize_field(raw.get("log")) == "1",
+        "description": live.description,
+    }

--- a/src/infrafoundry/providers/opnsense/validator.py
+++ b/src/infrafoundry/providers/opnsense/validator.py
@@ -19,6 +19,7 @@ from infrafoundry.providers.opnsense.validators import (
     DHCPValidator,
     FirewallValidator,
     InterfaceAssignmentValidator,
+    NATRuleValidator,
     ResourceNameValidator,
     UnboundValidator,
     VLANValidator,
@@ -79,6 +80,7 @@ class OPNsenseValidator:
         self.unbound_validator = UnboundValidator(report)
         self.resource_name_validator = ResourceNameValidator(report)
         self.interface_assignment_validator = InterfaceAssignmentValidator(report)
+        self.nat_rule_validator = NATRuleValidator(report)
 
     def validate_connectivity(self) -> None:
         """Validate connectivity to OPNsense API.
@@ -201,6 +203,13 @@ class OPNsenseValidator:
                 resource_refs["vlan_names"],
                 existing_interfaces,
             )
+            self.nat_rule_validator.validate(
+                resource_refs["nat_rules"],
+                resource_refs["alias_names"],
+                resource_refs["interface_assignment_names"],
+                existing_interfaces,
+                existing_aliases,
+            )
             self.unbound_validator.validate(resource_refs["unbound_host_overrides"])
             self.resource_name_validator.validate(resources)
 
@@ -229,10 +238,12 @@ class OPNsenseValidator:
         dhcp_maps = [r for r in resources if r.type == "dhcp_static_maps"]
         unbound_host_overrides = [r for r in resources if r.type == "unbound_host_override"]
         interface_assignments = [r for r in resources if r.type == "interface_assignments"]
+        nat_rules = [r for r in resources if r.type == "nat_rules"]
 
         alias_names = {a.name for a in aliases}
         vlan_names = {v.name for v in vlans}
         interface_assignment_names = {a.name for a in interface_assignments}
+        nat_rule_names = {r.name for r in nat_rules}
 
         return {
             "aliases": aliases,
@@ -244,6 +255,8 @@ class OPNsenseValidator:
             "unbound_host_overrides": unbound_host_overrides,
             "interface_assignments": interface_assignments,
             "interface_assignment_names": interface_assignment_names,
+            "nat_rules": nat_rules,
+            "nat_rule_names": nat_rule_names,
         }
 
     def _get_existing_aliases(

--- a/src/infrafoundry/providers/opnsense/validators/__init__.py
+++ b/src/infrafoundry/providers/opnsense/validators/__init__.py
@@ -5,6 +5,7 @@ from infrafoundry.providers.opnsense.validators.firewall_validator import Firewa
 from infrafoundry.providers.opnsense.validators.interface_assignment_validator import (
     InterfaceAssignmentValidator,
 )
+from infrafoundry.providers.opnsense.validators.nat_rule_validator import NATRuleValidator
 from infrafoundry.providers.opnsense.validators.resource_name_validator import (
     ResourceNameValidator,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "DHCPValidator",
     "FirewallValidator",
     "InterfaceAssignmentValidator",
+    "NATRuleValidator",
     "ResourceNameValidator",
     "UnboundValidator",
     "VLANValidator",

--- a/src/infrafoundry/providers/opnsense/validators/nat_rule_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/nat_rule_validator.py
@@ -1,0 +1,429 @@
+"""NAT-rule validation for OPNsense (ADR-0014, #713).
+
+Plan-time validation for the ``nat_rules`` resource type. The validator is
+deliberately split from the service-side ``nat_rule_configs_from_resources``
+parser: the parser raises on hard schema violations (wrong kind, missing
+required fields), while the validator surfaces softer cross-resource
+reference issues (unknown alias, unknown interface, identity-prefix
+collision in operator-set ``description``) as ``ValidationReport`` entries.
+
+Cross-reference targets:
+
+- ``interface``: managed ``interface_assignments`` names plus live
+  ``interfacesInfo`` keys.
+- ``source_net`` / ``destination_net`` / ``target``: managed alias names plus
+  literal IP/CIDR plus a small set of OPNsense built-in keywords.
+
+Identity-tag collision:
+
+- ``description`` values that contain ``[infrafoundry:<name>]`` anywhere
+  are rejected. The tag is reserved for InfraFoundry's identity suffix,
+  which is added automatically at apply time. The service parser also
+  catches this; the validator surfaces it as a friendlier plan-time error.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from typing import Any
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+
+# OPNsense built-in net/target keywords commonly accepted in NAT rules. The
+# set is intentionally conservative — unknown values surface as warnings
+# (not errors) so a new keyword in a future minor version doesn't block a
+# plan.
+_NET_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "any",
+        "lan",
+        "wan",
+        "wanip",
+        "lanip",
+        "(self)",
+        "lan_subnets",
+        "wan_subnets",
+    }
+)
+
+_IDENTITY_PROBE = re.compile(r"\[infrafoundry:[^\]]*\]")
+
+
+class NATRuleValidator:
+    """Validates OPNsense NAT-rule resources against managed + live state."""
+
+    def __init__(self, report: ValidationReport) -> None:
+        """Initialize validator.
+
+        Args:
+            report: ValidationReport to add results to.
+        """
+        self.report = report
+
+    def validate(
+        self,
+        nat_rules: list[ResourceConfig],
+        alias_names: set[str],
+        interface_assignment_names: set[str],
+        existing_interfaces: dict[str, Any],
+        existing_aliases: dict[str, Any],
+    ) -> None:
+        """Validate NAT-rule resources.
+
+        Args:
+            nat_rules: ``nat_rules`` ``ResourceConfig`` entries.
+            alias_names: Set of managed alias names declared in YAML.
+            interface_assignment_names: Set of managed interface-assignment
+                names declared in YAML.
+            existing_interfaces: Live interface map from
+                ``OPNsenseValidator._get_existing_interfaces``.
+            existing_aliases: Live alias map from
+                ``OPNsenseValidator._get_existing_aliases``.
+        """
+        for rule in nat_rules:
+            self._validate_one(
+                rule,
+                alias_names=alias_names,
+                interface_assignment_names=interface_assignment_names,
+                existing_interfaces=existing_interfaces,
+                existing_aliases=existing_aliases,
+            )
+
+    def _validate_one(
+        self,
+        rule: ResourceConfig,
+        *,
+        alias_names: set[str],
+        interface_assignment_names: set[str],
+        existing_interfaces: dict[str, Any],
+        existing_aliases: dict[str, Any],
+    ) -> None:
+        """Run all checks for a single NAT-rule entry."""
+        kind = self._validate_kind(rule)
+        self._validate_description_prefix(rule)
+        self._validate_lock(rule)
+        self._validate_log(rule)
+        self._validate_enabled(rule)
+        self._validate_sequence(rule)
+        self._validate_interface(
+            rule,
+            interface_assignment_names=interface_assignment_names,
+            existing_interfaces=existing_interfaces,
+        )
+        if kind == "outbound":
+            self._validate_outbound_required(rule)
+            self._validate_net_field(
+                rule,
+                "source_net",
+                alias_names=alias_names,
+                existing_aliases=existing_aliases,
+            )
+            self._validate_net_field(
+                rule,
+                "destination_net",
+                alias_names=alias_names,
+                existing_aliases=existing_aliases,
+            )
+            self._validate_net_field(
+                rule,
+                "target",
+                alias_names=alias_names,
+                existing_aliases=existing_aliases,
+            )
+        elif kind == "one_to_one":
+            self._validate_one_to_one_required(rule)
+            self._validate_net_field(
+                rule,
+                "source_net",
+                alias_names=alias_names,
+                existing_aliases=existing_aliases,
+            )
+            self._validate_net_field(
+                rule,
+                "destination_net",
+                alias_names=alias_names,
+                existing_aliases=existing_aliases,
+            )
+            self._validate_one_to_one_type(rule)
+            self._validate_natreflection(rule)
+
+    # ------------------------------------------------------------------
+    # kind / description / lock / sequence
+    # ------------------------------------------------------------------
+
+    def _validate_kind(self, rule: ResourceConfig) -> str | None:
+        """Validate the ``kind`` discriminator. Returns the kind or None."""
+        kind = rule.config.get("kind")
+        if kind not in ("outbound", "one_to_one"):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_kind",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' kind must be 'outbound' or 'one_to_one', got {kind!r}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+            return None
+        return str(kind)
+
+    def _validate_description_prefix(self, rule: ResourceConfig) -> None:
+        """Reject operator-set descriptions that forge the InfraFoundry prefix."""
+        if "description" not in rule.config:
+            return
+        description = rule.config["description"]
+        if not isinstance(description, str):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_description",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' description must be a string, "
+                    f"got {type(description).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+            return
+        if _IDENTITY_PROBE.search(description):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_description",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' description must not contain "
+                    f"'[infrafoundry:<name>]' — that tag is reserved for InfraFoundry's "
+                    f"identity suffix, added automatically at apply time"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_lock(self, rule: ResourceConfig) -> None:
+        if "lock" not in rule.config:
+            return
+        lock = rule.config["lock"]
+        if not isinstance(lock, bool):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_lock",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' lock must be a boolean (true/false), "
+                    f"got {type(lock).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_log(self, rule: ResourceConfig) -> None:
+        if "log" not in rule.config:
+            return
+        log = rule.config["log"]
+        if not isinstance(log, bool):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_log",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' log must be a boolean (true/false), "
+                    f"got {type(log).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_enabled(self, rule: ResourceConfig) -> None:
+        if "enabled" not in rule.config:
+            return
+        enabled = rule.config["enabled"]
+        if not isinstance(enabled, bool):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_enabled",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' enabled must be a boolean (true/false), "
+                    f"got {type(enabled).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_sequence(self, rule: ResourceConfig) -> None:
+        if "sequence" not in rule.config:
+            return
+        sequence_raw = rule.config["sequence"]
+        try:
+            int(sequence_raw)
+        except (TypeError, ValueError):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_sequence",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' sequence must be an integer (got {sequence_raw!r})"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    # ------------------------------------------------------------------
+    # interface
+    # ------------------------------------------------------------------
+
+    def _validate_interface(
+        self,
+        rule: ResourceConfig,
+        *,
+        interface_assignment_names: set[str],
+        existing_interfaces: dict[str, Any],
+    ) -> None:
+        interface = rule.config.get("interface")
+        if interface is None:
+            # Per-kind required-field check below will catch this.
+            return
+        if not isinstance(interface, str) or not interface:
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_interface",
+                passed=False,
+                message=(f"nat_rule '{rule.name}' interface must be a non-empty string"),
+                level=ValidationLevel.ERROR,
+            )
+            return
+        if interface in interface_assignment_names or interface in existing_interfaces:
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_interface",
+                passed=True,
+                message=(f"Interface '{interface}' resolved for nat_rule '{rule.name}'"),
+                level=ValidationLevel.INFO,
+            )
+            return
+        self.report.add_check(
+            check_name=f"nat_rule_{rule.name}_interface",
+            passed=False,
+            message=(
+                f"nat_rule '{rule.name}' references unknown interface '{interface}'; "
+                f"expected a managed interface_assignment name or a live OPNsense interface"
+            ),
+            level=ValidationLevel.ERROR,
+        )
+
+    # ------------------------------------------------------------------
+    # net fields (source_net / destination_net / target)
+    # ------------------------------------------------------------------
+
+    def _validate_net_field(
+        self,
+        rule: ResourceConfig,
+        field_name: str,
+        *,
+        alias_names: set[str],
+        existing_aliases: dict[str, Any],
+    ) -> None:
+        if field_name not in rule.config:
+            return
+        value = rule.config[field_name]
+        if not isinstance(value, str):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_{field_name}",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' {field_name} must be a string, "
+                    f"got {type(value).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+            return
+        if value == "":
+            # Empty is allowed for optional fields; the per-kind required
+            # check elsewhere catches mandatory fields with no value.
+            return
+        if value in _NET_KEYWORDS or value in alias_names or value in existing_aliases:
+            return
+        if _looks_like_ip_or_cidr(value):
+            return
+        # Soft warning — new OPNsense versions may add keywords; don't
+        # block a plan on an unknown one.
+        self.report.add_check(
+            check_name=f"nat_rule_{rule.name}_{field_name}",
+            passed=False,
+            message=(
+                f"nat_rule '{rule.name}' {field_name} '{value}' did not resolve to a "
+                f"managed alias, live alias, IP/CIDR, or known keyword "
+                f"({sorted(_NET_KEYWORDS)})"
+            ),
+            level=ValidationLevel.WARNING,
+        )
+
+    # ------------------------------------------------------------------
+    # Per-kind required-field checks
+    # ------------------------------------------------------------------
+
+    def _validate_outbound_required(self, rule: ResourceConfig) -> None:
+        """Outbound rules require ``interface`` and ``target`` (non-empty)."""
+        for field_name in ("interface", "target"):
+            value = rule.config.get(field_name)
+            if not isinstance(value, str) or not value:
+                self.report.add_check(
+                    check_name=f"nat_rule_{rule.name}_{field_name}",
+                    passed=False,
+                    message=(
+                        f"nat_rule '{rule.name}' (outbound) requires non-empty "
+                        f"string '{field_name}'"
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+
+    def _validate_one_to_one_required(self, rule: ResourceConfig) -> None:
+        """1:1 rules require ``interface`` and ``external``."""
+        for field_name in ("interface", "external"):
+            value = rule.config.get(field_name)
+            if not isinstance(value, str) or not value:
+                self.report.add_check(
+                    check_name=f"nat_rule_{rule.name}_{field_name}",
+                    passed=False,
+                    message=(
+                        f"nat_rule '{rule.name}' (one_to_one) requires non-empty "
+                        f"string '{field_name}'"
+                    ),
+                    level=ValidationLevel.ERROR,
+                )
+
+    def _validate_one_to_one_type(self, rule: ResourceConfig) -> None:
+        if "type" not in rule.config:
+            return
+        type_value = rule.config["type"]
+        if type_value not in ("binat", "nat"):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_type",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' (one_to_one) type must be "
+                    f"'binat' or 'nat', got {type_value!r}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    def _validate_natreflection(self, rule: ResourceConfig) -> None:
+        if "natreflection" not in rule.config:
+            return
+        nat_reflect = rule.config["natreflection"]
+        if nat_reflect not in ("", "enable", "disable"):
+            self.report.add_check(
+                check_name=f"nat_rule_{rule.name}_natreflection",
+                passed=False,
+                message=(
+                    f"nat_rule '{rule.name}' natreflection must be '', 'enable', "
+                    f"or 'disable', got {nat_reflect!r}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+
+def _looks_like_ip_or_cidr(value: str) -> bool:
+    """Return True if ``value`` parses as an IP address or CIDR network.
+
+    Handles both v4 and v6, both single-address and CIDR forms. ``strict=False``
+    on ``ip_network`` accepts host bits being set in the address portion of a
+    CIDR (e.g., ``10.0.0.5/24``), matching what operators commonly write.
+    """
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        pass
+    try:
+        ipaddress.ip_network(value, strict=False)
+        return True
+    except ValueError:
+        return False

--- a/tests/integration/opnsense/test_nat_rule_live.py
+++ b/tests/integration/opnsense/test_nat_rule_live.py
@@ -1,0 +1,240 @@
+"""Live integration tests for the OPNsense NAT-rule direct-API path (#713).
+
+These tests are gated by ``@pytest.mark.integration`` AND an explicit opt-in
+env var so they don't run as part of the default test suite. They contact a
+real OPNsense box.
+
+Required:
+    OPNSENSE_INTEGRATION_TESTS=1   (explicit opt-in)
+    OPNSENSE_API_URL
+    OPNSENSE_API_KEY
+    OPNSENSE_API_SECRET
+    OPNSENSE_VERIFY_SSL  (optional; defaults to "true")
+    OPNSENSE_NAT_TEST_INTERFACE  (optional; defaults to "wan")
+
+Run with::
+
+    OPNSENSE_INTEGRATION_TESTS=1 OPNSENSE_API_URL=... OPNSENSE_API_KEY=... \\
+    OPNSENSE_API_SECRET=... uv run pytest -m integration \\
+    tests/integration/opnsense/test_nat_rule_live.py
+
+The tests exercise the round-trip property for each kind plus the lock,
+add-only, and per-kind isolation invariants. All test rules are tagged
+``[infrafoundry:test-...]`` and cleaned up in the fixture teardown.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from infrafoundry.providers.opnsense.api_client import OPNsenseClient
+from infrafoundry.providers.opnsense.services.nat_rule import (
+    NATRuleConfig,
+    NATRuleService,
+    compute_diff,
+)
+
+REQUIRED_VARS = ("OPNSENSE_API_URL", "OPNSENSE_API_KEY", "OPNSENSE_API_SECRET")
+
+
+def _opted_in() -> bool:
+    return bool(os.getenv("OPNSENSE_INTEGRATION_TESTS")) and all(
+        os.getenv(v) for v in REQUIRED_VARS
+    )
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _opted_in(),
+        reason=(
+            "OPNsense live integration tests require OPNSENSE_INTEGRATION_TESTS=1 "
+            "plus OPNSENSE_API_URL/KEY/SECRET — they hit a real box."
+        ),
+    ),
+]
+
+
+def _test_interface() -> str:
+    return os.getenv("OPNSENSE_NAT_TEST_INTERFACE", "wan")
+
+
+@pytest.fixture
+def service() -> Iterator[NATRuleService]:
+    """Build a ``NATRuleService`` against the live OPNsense box.
+
+    Cleans up any test NAT rules created during the run so re-runs are
+    idempotent. Identifies test rules by the InfraFoundry identity
+    suffix tag and the ``test-`` name convention.
+    """
+    verify_raw = os.getenv("OPNSENSE_VERIFY_SSL", "true").strip().lower()
+    verify_ssl = verify_raw not in ("0", "false", "no", "off")
+
+    client = OPNsenseClient(
+        api_key=os.environ["OPNSENSE_API_KEY"],
+        api_secret=os.environ["OPNSENSE_API_SECRET"],
+        base_url=os.environ["OPNSENSE_API_URL"],
+        verify_ssl=verify_ssl,
+    )
+    svc = NATRuleService(client)
+
+    # Snapshot existing managed UUIDs so cleanup only touches our rules.
+    pre_existing = {(r.kind, r.uuid) for r in svc.search_all() if r.managed_name}
+
+    try:
+        yield svc
+    finally:
+        for live in svc.search_all():
+            if (
+                live.managed_name
+                and live.managed_name.startswith("test-")
+                and (live.kind, live.uuid) not in pre_existing
+            ):
+                with contextlib.suppress(Exception):
+                    svc.delete(live.uuid, live.kind)
+        # Apply changes for both kinds; suppress errors if no changes.
+        for kind in ("outbound", "one_to_one"):
+            with contextlib.suppress(Exception):
+                svc.apply_changes(kind)  # type: ignore[arg-type]
+
+
+def test_outbound_round_trip_apply_then_plan_zero(service: NATRuleService) -> None:
+    """After apply, plan reports 0/0/0 add/updates for an outbound rule."""
+    desired = [
+        NATRuleConfig(
+            name="test-outbound-roundtrip",
+            kind="outbound",
+            interface=_test_interface(),
+            target="wanip",
+            description="integration test outbound",
+            sequence=999,
+        )
+    ]
+
+    diff = compute_diff(desired, service.search_all(), add_only=True)
+    assert len(diff.adds) == 1
+    service.apply_diff(diff)
+
+    diff_after = compute_diff(desired, service.search_all(), add_only=True)
+    assert diff_after.adds == []
+    assert diff_after.updates == []
+
+
+def test_one_to_one_round_trip_apply_then_plan_zero(service: NATRuleService) -> None:
+    """After apply, plan reports 0/0/0 add/updates for a 1:1 rule."""
+    desired = [
+        NATRuleConfig(
+            name="test-1to1-roundtrip",
+            kind="one_to_one",
+            interface=_test_interface(),
+            external="198.51.100.99",
+            source_net="10.99.99.99",
+            description="integration test 1:1",
+            sequence=999,
+        )
+    ]
+
+    diff = compute_diff(desired, service.search_all(), add_only=True)
+    assert len(diff.adds) == 1
+    service.apply_diff(diff)
+
+    diff_after = compute_diff(desired, service.search_all(), add_only=True)
+    assert diff_after.adds == []
+    assert diff_after.updates == []
+
+
+def test_lock_preserves_resource(service: NATRuleService) -> None:
+    """A locked entry is reported but never updated/deleted."""
+    # Pre-create the rule so the lock has something to protect.
+    rule = NATRuleConfig(
+        name="test-locked",
+        kind="outbound",
+        interface=_test_interface(),
+        target="wanip",
+        description="locked",
+        sequence=998,
+    )
+    service.add(rule)
+    service.apply_changes("outbound")
+
+    desired_locked = [
+        NATRuleConfig(
+            name="test-locked",
+            kind="outbound",
+            interface=_test_interface(),
+            target="wanip",
+            description="DIFFERENT description",  # would normally cause update
+            sequence=998,
+            lock=True,
+        )
+    ]
+    diff = compute_diff(desired_locked, service.search_all(), add_only=True)
+    assert diff.adds == []
+    assert diff.updates == []
+    assert len(diff.locked) == 1
+
+
+def test_add_only_suppresses_deletes(service: NATRuleService) -> None:
+    """With add-only, deletes are suppressed even when managed rules
+    aren't in YAML."""
+    extra = NATRuleConfig(
+        name="test-extra",
+        kind="outbound",
+        interface=_test_interface(),
+        target="wanip",
+        description="extra",
+        sequence=997,
+    )
+    service.add(extra)
+    service.apply_changes("outbound")
+
+    # YAML mentions only a *different* test rule.
+    desired = [
+        NATRuleConfig(
+            name="test-other",
+            kind="outbound",
+            interface=_test_interface(),
+            target="wanip",
+            description="other",
+            sequence=996,
+        )
+    ]
+    diff = compute_diff(desired, service.search_all(), add_only=True)
+    # extra (sequence 997) is on the box but not in desired — would be
+    # a delete normally; add_only suppresses it.
+    assert diff.deletes == []
+
+
+def test_per_kind_isolation_same_name(service: NATRuleService) -> None:
+    """An outbound test rule and a 1:1 test rule with the same name co-exist."""
+    iface = _test_interface()
+    out = NATRuleConfig(
+        name="test-shared",
+        kind="outbound",
+        interface=iface,
+        target="wanip",
+        description="outbound shared",
+        sequence=995,
+    )
+    oto = NATRuleConfig(
+        name="test-shared",
+        kind="one_to_one",
+        interface=iface,
+        external="198.51.100.88",
+        source_net="10.88.88.88",
+        description="1:1 shared",
+        sequence=995,
+    )
+    service.add(out)
+    service.add(oto)
+    service.apply_changes("outbound")
+    service.apply_changes("one_to_one")
+
+    # Both rules should be present and matched independently in a diff.
+    diff = compute_diff([out, oto], service.search_all(), add_only=True)
+    assert diff.adds == []
+    assert diff.updates == []

--- a/tests/unit/providers/opnsense/test_nat_rule_manager.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_manager.py
@@ -1,0 +1,328 @@
+"""Unit tests for ``NATRuleManager``.
+
+Coverage:
+    - plan/apply/destroy delegate to NATRuleService correctly.
+    - apply emits ``ResourceOutcome`` entries for adds/updates/deletes.
+    - get_resource_ids maps live UUIDs to operator-facing names per kind.
+    - migrate exports YAML.
+    - lock semantics honored on destroy.
+    - Per-kind isolation: same name, different kind → independent identities.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.components.nat_rule import NATRuleManager
+from infrafoundry.providers.opnsense.services.nat_rule import (
+    Diff,
+    LiveNATRule,
+    NATRuleConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _outbound_resource(name: str, *, lock: bool = False) -> ResourceConfig:
+    config: dict[str, Any] = {
+        "kind": "outbound",
+        "interface": "wan",
+        "target": "wanip",
+        "description": f"{name} desc",
+    }
+    if lock:
+        config["lock"] = True
+    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+
+
+def _one_to_one_resource(name: str, *, lock: bool = False) -> ResourceConfig:
+    config: dict[str, Any] = {
+        "kind": "one_to_one",
+        "interface": "wan",
+        "external": "198.51.100.10",
+        "source_net": "10.0.0.10",
+    }
+    if lock:
+        config["lock"] = True
+    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+
+
+def _live_managed(uuid: str, name: str, kind: str) -> LiveNATRule:
+    return LiveNATRule(
+        uuid=uuid,
+        kind=kind,  # type: ignore[arg-type]
+        managed_name=name,
+        description="",
+        raw={"uuid": uuid, "description": f"[infrafoundry:{name}]"},
+    )
+
+
+SERVICE_PATH = "infrafoundry.providers.opnsense.components.nat_rule.NATRuleService"
+
+
+def _make_service_mock(
+    *,
+    live: list[LiveNATRule] | None = None,
+    diff: Diff | None = None,
+    apply_counts: dict[str, int] | None = None,
+) -> MagicMock:
+    """Build a mocked ``NATRuleService`` with sensible defaults."""
+    service = MagicMock()
+    service.search_all.return_value = live if live is not None else []
+    service.compute_diff.return_value = diff if diff is not None else Diff()
+    service.apply_diff.return_value = (
+        apply_counts if apply_counts is not None else {"created": 0, "updated": 0, "deleted": 0}
+    )
+    return service
+
+
+# ---------------------------------------------------------------------------
+# plan
+# ---------------------------------------------------------------------------
+
+
+class TestPlan:
+    def test_returns_diff(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        diff = Diff(
+            adds=[NATRuleConfig(name="foo", kind="outbound", interface="wan", target="wanip")]
+        )
+        service_mock = _make_service_mock(diff=diff)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.plan("test-env", resources)
+        assert result.adds == diff.adds
+        svc_cls.from_environment.assert_called_once_with("test-env", "opnsense", tmp_path)
+        service_mock.compute_diff.assert_called_once()
+
+    def test_threads_add_only(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        service_mock = _make_service_mock(diff=Diff())
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            manager.plan("test-env", resources, add_only=True)
+        assert service_mock.compute_diff.call_args.kwargs["add_only"] is True
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    def test_apply_returns_counts(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        diff = Diff(
+            adds=[NATRuleConfig(name="foo", kind="outbound", interface="wan", target="wanip")]
+        )
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 1, "updated": 0, "deleted": 0}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        assert result["resources_created"] == 1
+        assert result["success"] is True
+
+    def test_apply_emits_add_outcome(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        diff = Diff(
+            adds=[NATRuleConfig(name="foo", kind="outbound", interface="wan", target="wanip")]
+        )
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 1, "updated": 0, "deleted": 0}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        outcomes = result["resource_outcomes"]
+        assert len(outcomes) == 1
+        assert outcomes[0].action == "add"
+        assert outcomes[0].resource_name == "foo"
+        assert outcomes[0].address == "opnsense_nat_rule.foo"
+
+    def test_apply_emits_update_outcome(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        live = _live_managed("u1", "foo", "outbound")
+        want = NATRuleConfig(name="foo", kind="outbound", interface="wan", target="wanip")
+        diff = Diff(updates=[(live, want)])
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 0, "updated": 1, "deleted": 0}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        outcomes = result["resource_outcomes"]
+        assert len(outcomes) == 1
+        assert outcomes[0].action == "update"
+        assert outcomes[0].resource_name == "foo"
+
+    def test_apply_emits_delete_outcome(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources: list[ResourceConfig] = []
+        live = _live_managed("u1", "stale", "outbound")
+        diff = Diff(deletes=[live])
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 0, "updated": 0, "deleted": 1}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        outcomes = result["resource_outcomes"]
+        assert len(outcomes) == 1
+        assert outcomes[0].action == "delete"
+        # Synthetic name uses managed_name from live.
+        assert outcomes[0].resource_name == "stale"
+
+    def test_apply_threads_add_only(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        service_mock = _make_service_mock(diff=Diff())
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            manager.apply("test-env", resources, add_only=True)
+        assert service_mock.compute_diff.call_args.kwargs["add_only"] is True
+
+
+# ---------------------------------------------------------------------------
+# destroy
+# ---------------------------------------------------------------------------
+
+
+class TestDestroy:
+    def test_destroy_deletes_matching_managed_rules(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        live = [_live_managed("u1", "foo", "outbound")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        service_mock.delete.assert_called_once_with("u1", "outbound")
+        service_mock.apply_changes.assert_called_once_with("outbound")
+        assert result["resources_destroyed"] == 1
+        assert result["locked_skipped"] == 0
+
+    def test_destroy_skips_when_no_live_match(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        service_mock = _make_service_mock(live=[])
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        service_mock.delete.assert_not_called()
+        service_mock.apply_changes.assert_not_called()
+        assert result["resources_destroyed"] == 0
+
+    def test_destroy_honors_lock(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("wan-survival", lock=True)]
+        live = [_live_managed("u1", "wan-survival", "outbound")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        service_mock.delete.assert_not_called()
+        assert result["locked_skipped"] == 1
+
+    def test_destroy_per_kind_isolation(self, tmp_path: Path) -> None:
+        # Two rules named ``foo``: outbound + 1:1. Destroying only deletes
+        # the matching kind for each YAML entry.
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo"), _one_to_one_resource("foo")]
+        live = [
+            _live_managed("u-out", "foo", "outbound"),
+            _live_managed("u-oto", "foo", "one_to_one"),
+        ]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        # Both deleted, each from its own controller.
+        delete_calls = service_mock.delete.call_args_list
+        assert len(delete_calls) == 2
+        called_args = {call.args for call in delete_calls}
+        assert ("u-out", "outbound") in called_args
+        assert ("u-oto", "one_to_one") in called_args
+        # Both kinds had applyChanges called.
+        apply_calls = {call.args[0] for call in service_mock.apply_changes.call_args_list}
+        assert apply_calls == {"outbound", "one_to_one"}
+        assert result["resources_destroyed"] == 2
+
+
+# ---------------------------------------------------------------------------
+# get_resource_ids
+# ---------------------------------------------------------------------------
+
+
+class TestGetResourceIds:
+    def test_maps_names_to_uuids(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo"), _outbound_resource("bar")]
+        live = [_live_managed("u1", "foo", "outbound"), _live_managed("u2", "bar", "outbound")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.get_resource_ids("test-env", resources)
+        assert result == {"foo": "u1", "bar": "u2"}
+
+    def test_omits_resources_with_no_live_match(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo"), _outbound_resource("missing")]
+        live = [_live_managed("u1", "foo", "outbound")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.get_resource_ids("test-env", resources)
+        assert result == {"foo": "u1"}
+
+    def test_per_kind_keys_distinguish_outbound_from_1to1(self, tmp_path: Path) -> None:
+        # YAML has only the outbound "foo"; live has both. Only the
+        # outbound mapping is returned.
+        manager = NATRuleManager(tmp_path)
+        resources = [_outbound_resource("foo")]
+        live = [
+            _live_managed("u-out", "foo", "outbound"),
+            _live_managed("u-oto", "foo", "one_to_one"),
+        ]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.get_resource_ids("test-env", resources)
+        assert result == {"foo": "u-out"}
+
+
+# ---------------------------------------------------------------------------
+# list / migrate
+# ---------------------------------------------------------------------------
+
+
+class TestListAndMigrate:
+    def test_list_returns_live_rules(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        live = [_live_managed("u1", "foo", "outbound")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.list("test-env")
+        assert result == live
+
+    def test_migrate_returns_yaml_string(self, tmp_path: Path) -> None:
+        manager = NATRuleManager(tmp_path)
+        service_mock = MagicMock()
+        service_mock.export_to_yaml.return_value = "resources: []\n"
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.migrate("test-env")
+        assert result == "resources: []\n"
+        service_mock.export_to_yaml.assert_called_once()

--- a/tests/unit/providers/opnsense/test_nat_rule_service.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_service.py
@@ -1,0 +1,954 @@
+"""Unit tests for ``infrafoundry.providers.opnsense.services.nat_rule``.
+
+Coverage:
+    - Identity-suffix encoder/parser (round-trip + malformed cases).
+    - Per-kind payload shape from ``NATRuleConfig.to_payload``.
+    - ``compute_diff`` with both kinds, isolation, lock + add-only semantics.
+    - Unmanaged live rules silently ignored.
+    - ``nat_rule_configs_from_resources`` validation.
+    - ``NATRuleService`` API method dispatch via ``OPNsenseClient.request``.
+    - ``apply_diff`` orchestration (per-kind ``apply``).
+    - ``export_to_yaml`` round-trip (managed rules only).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.services.nat_rule import (
+    Diff,
+    LiveNATRule,
+    NATRuleConfig,
+    NATRuleService,
+    OpnsenseDriftError,
+    _row_to_live,
+    compute_diff,
+    encode_identity,
+    nat_rule_configs_from_resources,
+    parse_identity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _outbound(
+    name: str,
+    *,
+    description: str = "",
+    target: str = "wanip",
+    interface: str = "wan",
+    sequence: int = 100,
+    lock: bool = False,
+    enabled: bool = True,
+    log: bool = False,
+    nonat: bool = False,
+    source_net: str = "any",
+    destination_net: str = "any",
+) -> NATRuleConfig:
+    return NATRuleConfig(
+        name=name,
+        kind="outbound",
+        enabled=enabled,
+        log=log,
+        sequence=sequence,
+        interface=interface,
+        description=description,
+        lock=lock,
+        target=target,
+        nonat=nonat,
+        source_net=source_net,
+        destination_net=destination_net,
+    )
+
+
+def _one_to_one(
+    name: str,
+    *,
+    description: str = "",
+    interface: str = "wan",
+    external: str = "198.51.100.10",
+    source_net: str = "10.0.0.10",
+    destination_net: str = "any",
+    sequence: int = 100,
+    lock: bool = False,
+    type_: str = "binat",
+    natreflection: str = "",
+) -> NATRuleConfig:
+    return NATRuleConfig(
+        name=name,
+        kind="one_to_one",
+        sequence=sequence,
+        interface=interface,
+        description=description,
+        lock=lock,
+        type=type_,
+        external=external,
+        source_net=source_net,
+        destination_net=destination_net,
+        natreflection=natreflection,
+    )
+
+
+def _live(
+    uuid: str,
+    name: str | None,
+    kind: str,
+    *,
+    description: str = "",
+    raw_overrides: dict[str, Any] | None = None,
+) -> LiveNATRule:
+    raw: dict[str, Any] = {
+        "uuid": uuid,
+        "description": (
+            (f"{description} [infrafoundry:{name}]" if description else f"[infrafoundry:{name}]")
+            if name is not None
+            else description
+        ),
+    }
+    if raw_overrides:
+        raw.update(raw_overrides)
+    return LiveNATRule(
+        uuid=uuid,
+        kind=kind,  # type: ignore[arg-type]
+        managed_name=name,
+        description=description,
+        raw=raw,
+    )
+
+
+def _resource(
+    name: str,
+    config: dict[str, Any],
+) -> ResourceConfig:
+    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+
+
+# ---------------------------------------------------------------------------
+# Identity-suffix helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityEncoder:
+    def test_encode_with_user_description(self) -> None:
+        assert encode_identity("foo", "user desc") == "user desc [infrafoundry:foo]"
+
+    def test_encode_with_empty_user_description(self) -> None:
+        # Just the tag, no leading space.
+        assert encode_identity("foo", "") == "[infrafoundry:foo]"
+
+
+class TestIdentityParser:
+    def test_parse_with_user_description(self) -> None:
+        name, user = parse_identity("something [infrafoundry:foo]")
+        assert name == "foo"
+        assert user == "something"
+
+    def test_parse_tag_only(self) -> None:
+        name, user = parse_identity("[infrafoundry:foo]")
+        assert name == "foo"
+        assert user == ""
+
+    def test_parse_unmanaged_returns_none(self) -> None:
+        name, user = parse_identity("regular operator description")
+        assert name is None
+        assert user == "regular operator description"
+
+    def test_parse_empty_unmanaged(self) -> None:
+        name, user = parse_identity("")
+        assert name is None
+        assert user == ""
+
+    def test_parse_malformed_empty_name_raises(self) -> None:
+        with pytest.raises(OpnsenseDriftError):
+            parse_identity("[infrafoundry:]")
+
+    def test_parse_malformed_uppercase_raises(self) -> None:
+        # Strict regex: lowercase + digits + hyphen only.
+        with pytest.raises(OpnsenseDriftError):
+            parse_identity("user desc [infrafoundry:Foo]")
+
+    def test_parse_malformed_underscore_raises(self) -> None:
+        # Strict regex disallows underscore in name (only [a-z0-9-]+).
+        with pytest.raises(OpnsenseDriftError):
+            parse_identity("user desc [infrafoundry:foo_bar]")
+
+    def test_parse_tag_in_middle_raises(self) -> None:
+        # The tag must be the LAST token; trailing text after the tag is
+        # drift (operator-edited or otherwise out-of-protocol).
+        with pytest.raises(OpnsenseDriftError):
+            parse_identity("[infrafoundry:foo] trailing text")
+
+    def test_parse_double_bracket_raises(self) -> None:
+        # ``[[infrafoundry:foo]]`` contains the tag pattern in a non-suffix
+        # position; treated as drift since the tag namespace is reserved.
+        with pytest.raises(OpnsenseDriftError):
+            parse_identity("[[infrafoundry:foo]]")
+
+
+# ---------------------------------------------------------------------------
+# NATRuleConfig.to_payload
+# ---------------------------------------------------------------------------
+
+
+class TestOutboundPayload:
+    def test_payload_has_rule_envelope(self) -> None:
+        payload = _outbound("foo", description="desc", target="wanip").to_payload()
+        assert set(payload.keys()) == {"rule"}
+
+    def test_payload_fields_serialize_correctly(self) -> None:
+        rule = _outbound(
+            "foo",
+            description="my desc",
+            target="wanip",
+            interface="wan",
+            sequence=200,
+            log=True,
+            nonat=True,
+        )
+        inner = rule.to_payload()["rule"]
+        # Booleans → "0"/"1"
+        assert inner["enabled"] == "1"
+        assert inner["log"] == "1"
+        assert inner["nonat"] == "1"
+        assert inner["staticnatport"] == "0"
+        # Stringified int
+        assert inner["sequence"] == "200"
+        # Description carries identity suffix.
+        assert inner["description"] == "my desc [infrafoundry:foo]"
+        # Pass-through fields.
+        assert inner["interface"] == "wan"
+        assert inner["target"] == "wanip"
+        assert inner["ipprotocol"] == "inet"
+        assert inner["protocol"] == "any"
+
+
+class TestOneToOnePayload:
+    def test_payload_has_rule_envelope(self) -> None:
+        payload = _one_to_one("dmz").to_payload()
+        assert set(payload.keys()) == {"rule"}
+
+    def test_payload_fields_serialize_correctly(self) -> None:
+        rule = _one_to_one(
+            "dmz",
+            description="DMZ srv",
+            interface="wan",
+            external="198.51.100.42",
+            source_net="10.20.30.40",
+            destination_net="any",
+            type_="binat",
+            natreflection="enable",
+        )
+        inner = rule.to_payload()["rule"]
+        assert inner["enabled"] == "1"
+        assert inner["log"] == "0"
+        assert inner["sequence"] == "100"
+        assert inner["interface"] == "wan"
+        assert inner["type"] == "binat"
+        assert inner["external"] == "198.51.100.42"
+        assert inner["source_net"] == "10.20.30.40"
+        assert inner["destination_net"] == "any"
+        assert inner["natreflection"] == "enable"
+        assert inner["description"] == "DMZ srv [infrafoundry:dmz]"
+
+
+class TestPayloadIdentityIntegration:
+    def test_empty_user_description_yields_tag_only(self) -> None:
+        rule = _outbound("foo", description="", target="wanip")
+        inner = rule.to_payload()["rule"]
+        assert inner["description"] == "[infrafoundry:foo]"
+
+
+class TestDiffKey:
+    def test_outbound_and_one_to_one_same_name_have_different_keys(self) -> None:
+        out = _outbound("foo", target="wanip")
+        oto = _one_to_one("foo")
+        assert out.diff_key != oto.diff_key
+        assert out.diff_key == ("outbound", "foo")
+        assert oto.diff_key == ("one_to_one", "foo")
+
+
+# ---------------------------------------------------------------------------
+# compute_diff
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDiffEmpty:
+    def test_no_desired_no_live_is_empty(self) -> None:
+        diff = compute_diff([], [])
+        assert diff.is_empty
+        assert diff.adds == []
+        assert diff.deletes == []
+        assert diff.updates == []
+        assert diff.locked == []
+
+
+class TestComputeDiffAdds:
+    def test_new_outbound_adds(self) -> None:
+        diff = compute_diff([_outbound("foo", target="wanip")], [])
+        assert len(diff.adds) == 1
+        assert diff.adds[0].name == "foo"
+
+    def test_new_one_to_one_adds(self) -> None:
+        diff = compute_diff([_one_to_one("dmz")], [])
+        assert len(diff.adds) == 1
+
+
+class TestComputeDiffUpdates:
+    def test_update_when_target_changes(self) -> None:
+        # Live raw must reflect the target field.
+        live_raw = {
+            "uuid": "u1",
+            "description": "[infrafoundry:foo]",
+            "enabled": "1",
+            "nonat": "0",
+            "sequence": "100",
+            "interface": "wan",
+            "ipprotocol": "inet",
+            "protocol": "any",
+            "source_net": "any",
+            "source_not": "0",
+            "source_port": "",
+            "destination_net": "any",
+            "destination_not": "0",
+            "destination_port": "",
+            "target": "old",
+            "target_port": "",
+            "staticnatport": "0",
+            "log": "0",
+        }
+        live = LiveNATRule(
+            uuid="u1",
+            kind="outbound",
+            managed_name="foo",
+            description="",
+            raw=live_raw,
+        )
+        diff = compute_diff([_outbound("foo", target="new", interface="wan")], [live])
+        assert len(diff.updates) == 1
+        assert len(diff.adds) == 0
+        live_record, want = diff.updates[0]
+        assert live_record.uuid == "u1"
+        assert want.target == "new"
+
+    def test_no_update_when_payload_matches(self) -> None:
+        # Build live raw matching what a freshly-applied outbound rule would
+        # look like.
+        rule = _outbound("foo", target="wanip", interface="wan")
+        payload_inner = rule.to_payload()["rule"]
+        live_raw: dict[str, Any] = {"uuid": "u1", **payload_inner}
+        # description column carries the suffix tag in raw, but parser sets
+        # managed_name + strips the tag for the parsed description field.
+        live = LiveNATRule(
+            uuid="u1",
+            kind="outbound",
+            managed_name="foo",
+            description="",
+            raw=live_raw,
+        )
+        diff = compute_diff([rule], [live])
+        assert diff.is_empty
+
+
+class TestComputeDiffDeletes:
+    def test_managed_live_with_no_desired_is_deleted(self) -> None:
+        live = _live("u1", "stale", "outbound")
+        diff = compute_diff([], [live])
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].uuid == "u1"
+
+    def test_unmanaged_live_silently_ignored(self) -> None:
+        # A row without the InfraFoundry tag is unmanaged — the diff
+        # never proposes deleting it, even if not in YAML.
+        live = LiveNATRule(
+            uuid="u-unmanaged",
+            kind="outbound",
+            managed_name=None,
+            description="manually-created rule",
+            raw={"uuid": "u-unmanaged", "description": "manually-created rule"},
+        )
+        diff = compute_diff([], [live])
+        assert diff.deletes == []
+        assert diff.is_empty
+
+    def test_add_only_suppresses_deletes(self) -> None:
+        live = _live("u1", "stale", "outbound")
+        diff = compute_diff([], [live], add_only=True)
+        assert diff.deletes == []
+        assert diff.is_empty
+
+
+class TestComputeDiffLocked:
+    def test_locked_resource_with_match_skipped_from_actions(self) -> None:
+        live = _live(
+            "u1",
+            "wan-survival",
+            "outbound",
+            raw_overrides={"target": "wanip", "interface": "wan"},
+        )
+        rule = _outbound("wan-survival", target="different-target", lock=True)
+        diff = compute_diff([rule], [live])
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+        assert len(diff.locked) == 1
+        want, have = diff.locked[0]
+        assert want.lock is True
+        assert have is not None
+        assert have.uuid == "u1"
+
+    def test_locked_resource_without_match(self) -> None:
+        rule = _outbound("missing", target="wanip", lock=True)
+        diff = compute_diff([rule], [])
+        assert len(diff.locked) == 1
+        _want, have = diff.locked[0]
+        assert have is None
+
+
+class TestComputeDiffPerKindIsolation:
+    def test_outbound_and_one_to_one_with_same_name_are_independent(self) -> None:
+        out_live = _live("u-out", "shared", "outbound")
+        oto_live = _live("u-oto", "shared", "one_to_one")
+        # Both kinds in YAML.
+        rule_out = _outbound("shared", target="wanip", interface="wan")
+        rule_oto = _one_to_one("shared")
+        diff = compute_diff([rule_out, rule_oto], [out_live, oto_live])
+        # Both are updates (because raw doesn't match defaults), not crossed.
+        # The key invariant: the outbound desired never matches the 1:1
+        # live and vice-versa.
+        update_uuids = {live.uuid for live, _ in diff.updates}
+        assert "u-out" in update_uuids or "u-oto" in update_uuids
+        # Independent of the field comparison details: there must be no
+        # delete (each kind's desired matches its kind's live name).
+        assert diff.deletes == []
+
+    def test_outbound_diff_does_not_match_1to1_live(self) -> None:
+        # YAML only has outbound "foo"; box has 1:1 "foo".
+        oto_live = _live("u-oto", "foo", "one_to_one")
+        rule_out = _outbound("foo", target="wanip", interface="wan")
+        diff = compute_diff([rule_out], [oto_live])
+        # The 1:1 live is treated as managed-but-not-in-desired-of-its-kind →
+        # delete proposed; the outbound is missing → add proposed.
+        assert len(diff.adds) == 1
+        assert diff.adds[0].name == "foo"
+        assert diff.adds[0].kind == "outbound"
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].kind == "one_to_one"
+
+
+class TestDiffIsEmpty:
+    def test_empty_diff(self) -> None:
+        assert Diff().is_empty
+
+    def test_locked_alone_counts_as_empty(self) -> None:
+        rule = _outbound("foo", target="wanip", lock=True)
+        diff = Diff(locked=[(rule, None)])
+        assert diff.is_empty
+
+    def test_non_empty_when_adds(self) -> None:
+        diff = Diff(adds=[_outbound("foo", target="wanip")])
+        assert not diff.is_empty
+
+
+# ---------------------------------------------------------------------------
+# nat_rule_configs_from_resources
+# ---------------------------------------------------------------------------
+
+
+class TestConfigsFromResourcesOutbound:
+    def test_valid_outbound_parses(self) -> None:
+        r = _resource(
+            "lan-out",
+            {
+                "kind": "outbound",
+                "interface": "wan",
+                "target": "wanip",
+                "description": "LAN out",
+            },
+        )
+        result = nat_rule_configs_from_resources([r])
+        assert len(result) == 1
+        cfg = result[0]
+        assert cfg.kind == "outbound"
+        assert cfg.target == "wanip"
+        assert cfg.description == "LAN out"
+
+    def test_outbound_missing_target_rejected(self) -> None:
+        r = _resource("bad", {"kind": "outbound", "interface": "wan"})
+        with pytest.raises(ValueError, match="target"):
+            nat_rule_configs_from_resources([r])
+
+    def test_outbound_missing_interface_rejected(self) -> None:
+        r = _resource("bad", {"kind": "outbound", "target": "wanip"})
+        with pytest.raises(ValueError, match="interface"):
+            nat_rule_configs_from_resources([r])
+
+
+class TestConfigsFromResourcesOneToOne:
+    def test_valid_1to1_parses(self) -> None:
+        r = _resource(
+            "dmz",
+            {
+                "kind": "one_to_one",
+                "interface": "wan",
+                "external": "198.51.100.10",
+                "source_net": "10.0.0.10",
+            },
+        )
+        result = nat_rule_configs_from_resources([r])
+        assert len(result) == 1
+        cfg = result[0]
+        assert cfg.kind == "one_to_one"
+        assert cfg.external == "198.51.100.10"
+
+    def test_1to1_missing_external_rejected(self) -> None:
+        r = _resource("bad", {"kind": "one_to_one", "interface": "wan"})
+        with pytest.raises(ValueError, match="external"):
+            nat_rule_configs_from_resources([r])
+
+    def test_1to1_invalid_type_rejected(self) -> None:
+        r = _resource(
+            "bad",
+            {
+                "kind": "one_to_one",
+                "interface": "wan",
+                "external": "198.51.100.10",
+                "type": "wrong",
+            },
+        )
+        with pytest.raises(ValueError, match="type"):
+            nat_rule_configs_from_resources([r])
+
+    def test_1to1_invalid_natreflection_rejected(self) -> None:
+        r = _resource(
+            "bad",
+            {
+                "kind": "one_to_one",
+                "interface": "wan",
+                "external": "198.51.100.10",
+                "natreflection": "not-allowed",
+            },
+        )
+        with pytest.raises(ValueError, match="natreflection"):
+            nat_rule_configs_from_resources([r])
+
+
+class TestConfigsFromResourcesGeneral:
+    def test_invalid_kind_rejected(self) -> None:
+        r = _resource("bad", {"kind": "port_forward"})
+        with pytest.raises(ValueError, match="kind"):
+            nat_rule_configs_from_resources([r])
+
+    def test_missing_kind_rejected(self) -> None:
+        r = _resource("bad", {"interface": "wan", "target": "wanip"})
+        with pytest.raises(ValueError, match="kind"):
+            nat_rule_configs_from_resources([r])
+
+    def test_non_nat_resources_ignored(self) -> None:
+        nat = _resource("ok", {"kind": "outbound", "interface": "wan", "target": "wanip"})
+        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        result = nat_rule_configs_from_resources([nat, other])
+        assert len(result) == 1
+
+    def test_lock_must_be_bool(self) -> None:
+        r = _resource(
+            "bad",
+            {
+                "kind": "outbound",
+                "interface": "wan",
+                "target": "wanip",
+                "lock": "yes",
+            },
+        )
+        with pytest.raises(ValueError, match="lock"):
+            nat_rule_configs_from_resources([r])
+
+    def test_description_with_identity_tag_rejected(self) -> None:
+        # Forging the InfraFoundry tag is rejected at parse time. The probe
+        # is position-agnostic — operator-set descriptions can't contain
+        # the tag in any position.
+        r = _resource(
+            "evil",
+            {
+                "kind": "outbound",
+                "interface": "wan",
+                "target": "wanip",
+                "description": "forged [infrafoundry:other]",
+            },
+        )
+        with pytest.raises(ValueError, match="reserved"):
+            nat_rule_configs_from_resources([r])
+
+    def test_sequence_default_when_omitted(self) -> None:
+        r = _resource("ok", {"kind": "outbound", "interface": "wan", "target": "wanip"})
+        result = nat_rule_configs_from_resources([r])
+        assert result[0].sequence == 100
+
+    def test_sequence_must_be_int(self) -> None:
+        r = _resource(
+            "bad",
+            {
+                "kind": "outbound",
+                "interface": "wan",
+                "target": "wanip",
+                "sequence": "not-int",
+            },
+        )
+        with pytest.raises(ValueError, match="sequence"):
+            nat_rule_configs_from_resources([r])
+
+    def test_non_dict_config_rejected(self) -> None:
+        r = ResourceConfig(
+            name="bad",
+            type="nat_rules",
+            provider="opnsense",
+            config={"kind": "outbound", "interface": "wan", "target": "wanip"},
+        )
+        # Manipulate after construction to bypass pydantic — guard the
+        # service-side defensive check.
+        r.config = "not-a-dict"  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="non-dict"):
+            nat_rule_configs_from_resources([r])
+
+
+# ---------------------------------------------------------------------------
+# _row_to_live
+# ---------------------------------------------------------------------------
+
+
+class TestRowToLive:
+    def test_managed_row_parses(self) -> None:
+        row = {"uuid": "u1", "description": "something [infrafoundry:foo]"}
+        live = _row_to_live(row, "outbound")
+        assert live.uuid == "u1"
+        assert live.kind == "outbound"
+        assert live.managed_name == "foo"
+        assert live.description == "something"
+
+    def test_managed_row_no_user_description(self) -> None:
+        row = {"uuid": "u1", "description": "[infrafoundry:foo]"}
+        live = _row_to_live(row, "outbound")
+        assert live.managed_name == "foo"
+        assert live.description == ""
+
+    def test_unmanaged_row_managed_name_none(self) -> None:
+        row = {"uuid": "u1", "description": "regular description"}
+        live = _row_to_live(row, "outbound")
+        assert live.managed_name is None
+        assert live.description == "regular description"
+
+    def test_malformed_tag_raises(self) -> None:
+        row = {"uuid": "u1", "description": "[infrafoundry:]"}
+        with pytest.raises(OpnsenseDriftError):
+            _row_to_live(row, "outbound")
+
+    def test_missing_keys_default(self) -> None:
+        live = _row_to_live({}, "one_to_one")
+        assert live.uuid == ""
+        assert live.managed_name is None
+        assert live.description == ""
+
+
+# ---------------------------------------------------------------------------
+# NATRuleService API methods
+# ---------------------------------------------------------------------------
+
+
+class TestServiceSearch:
+    def test_outbound_search_calls_correct_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        svc = NATRuleService(client)
+        result = svc.search("outbound")
+        client.request.assert_called_once_with("POST", "firewall/source_nat/searchRule")
+        assert result == []
+
+    def test_one_to_one_search_calls_correct_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        svc = NATRuleService(client)
+        svc.search("one_to_one")
+        client.request.assert_called_once_with("POST", "firewall/one_to_one/searchRule")
+
+    def test_search_normalizes_rows(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {"uuid": "u1", "description": "desc [infrafoundry:a]"},
+                "not-a-dict",  # filtered out
+                {"uuid": "u2", "description": "unmanaged"},
+            ]
+        }
+        svc = NATRuleService(client)
+        result = svc.search("outbound")
+        assert len(result) == 2
+        assert result[0].managed_name == "a"
+        assert result[1].managed_name is None
+
+    def test_search_all_calls_both_controllers(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        svc = NATRuleService(client)
+        svc.search_all()
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert "firewall/source_nat/searchRule" in endpoints
+        assert "firewall/one_to_one/searchRule" in endpoints
+
+
+def _expected_with_category(rule: NATRuleConfig, category_uuid: str = "fake-cat") -> dict[str, Any]:
+    """Return the payload ``add``/``update`` should send: rule envelope + category UUID."""
+    payload = rule.to_payload()
+    payload["rule"]["categories"] = category_uuid
+    return payload
+
+
+class TestServiceWriteOps:
+    def test_add_outbound_posts_correct_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved", "uuid": "new"}
+        svc = NATRuleService(client)
+        svc._category_uuid = "fake-cat"  # short-circuit category bootstrap
+        rule = _outbound("foo", target="wanip", interface="wan")
+        svc.add(rule)
+        client.request.assert_called_once_with(
+            "POST", "firewall/source_nat/addRule", data=_expected_with_category(rule)
+        )
+
+    def test_add_one_to_one_posts_correct_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = NATRuleService(client)
+        svc._category_uuid = "fake-cat"
+        rule = _one_to_one("dmz")
+        svc.add(rule)
+        client.request.assert_called_once_with(
+            "POST", "firewall/one_to_one/addRule", data=_expected_with_category(rule)
+        )
+
+    def test_update_outbound(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = NATRuleService(client)
+        svc._category_uuid = "fake-cat"
+        rule = _outbound("foo", target="wanip", interface="wan")
+        svc.update("uuid-abc", rule)
+        client.request.assert_called_once_with(
+            "POST", "firewall/source_nat/setRule/uuid-abc", data=_expected_with_category(rule)
+        )
+
+    def test_delete_outbound_uses_outbound_endpoint(self) -> None:
+        client = MagicMock()
+        svc = NATRuleService(client)
+        svc.delete("u1", "outbound")
+        client.request.assert_called_once_with("POST", "firewall/source_nat/delRule/u1")
+
+    def test_delete_one_to_one_uses_one_to_one_endpoint(self) -> None:
+        client = MagicMock()
+        svc = NATRuleService(client)
+        svc.delete("u1", "one_to_one")
+        client.request.assert_called_once_with("POST", "firewall/one_to_one/delRule/u1")
+
+    def test_apply_changes_outbound(self) -> None:
+        client = MagicMock()
+        svc = NATRuleService(client)
+        svc.apply_changes("outbound")
+        client.request.assert_called_once_with("POST", "firewall/source_nat/apply")
+
+    def test_apply_changes_one_to_one(self) -> None:
+        client = MagicMock()
+        svc = NATRuleService(client)
+        svc.apply_changes("one_to_one")
+        client.request.assert_called_once_with("POST", "firewall/one_to_one/apply")
+
+
+class TestApplyDiff:
+    def test_empty_diff_is_noop(self) -> None:
+        client = MagicMock()
+        svc = NATRuleService(client)
+        counts = svc.apply_diff(Diff())
+        client.request.assert_not_called()
+        assert counts == {"created": 0, "updated": 0, "deleted": 0}
+
+    def test_outbound_add_applies_only_outbound_changes(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = NATRuleService(client)
+        svc._category_uuid = "fake-cat"  # short-circuit category bootstrap
+        diff = Diff(adds=[_outbound("foo", target="wanip", interface="wan")])
+        counts = svc.apply_diff(diff)
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert "firewall/source_nat/addRule" in endpoints
+        assert "firewall/source_nat/apply" in endpoints
+        assert "firewall/one_to_one/apply" not in endpoints
+        assert counts["created"] == 1
+
+    def test_mixed_kinds_apply_changes_for_both(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = NATRuleService(client)
+        svc._category_uuid = "fake-cat"
+        diff = Diff(
+            adds=[
+                _outbound("foo", target="wanip", interface="wan"),
+                _one_to_one("dmz"),
+            ]
+        )
+        svc.apply_diff(diff)
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert "firewall/source_nat/apply" in endpoints
+        assert "firewall/one_to_one/apply" in endpoints
+
+    def test_delete_dispatches_per_kind(self) -> None:
+        client = MagicMock()
+        svc = NATRuleService(client)
+        live_out = _live("u1", "foo", "outbound")
+        live_oto = _live("u2", "bar", "one_to_one")
+        diff = Diff(deletes=[live_out, live_oto])
+        counts = svc.apply_diff(diff)
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert "firewall/source_nat/delRule/u1" in endpoints
+        assert "firewall/one_to_one/delRule/u2" in endpoints
+        assert counts["deleted"] == 2
+
+
+# ---------------------------------------------------------------------------
+# export_to_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestExportToYaml:
+    def test_managed_rules_appear_in_export(self) -> None:
+        client = MagicMock()
+        # First call: outbound rows. Second call: 1:1 rows.
+        client.request.side_effect = [
+            {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "description": "LAN out [infrafoundry:lan-out]",
+                        "interface": "wan",
+                        "target": "wanip",
+                    },
+                    {"uuid": "u2", "description": "manual"},  # unmanaged
+                ]
+            },
+            {
+                "rows": [
+                    {
+                        "uuid": "u3",
+                        "description": "DMZ [infrafoundry:dmz]",
+                        "interface": "wan",
+                        "external": "198.51.100.10",
+                    }
+                ]
+            },
+        ]
+        svc = NATRuleService(client)
+        text = svc.export_to_yaml()
+        assert "lan-out" in text
+        assert "dmz" in text
+        assert "manual" not in text  # unmanaged rule excluded
+        assert "kind: outbound" in text
+        assert "kind: one_to_one" in text
+
+    def test_export_with_no_managed_rules_yields_empty_resources(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        svc = NATRuleService(client)
+        text = svc.export_to_yaml()
+        assert "resources: []" in text
+
+
+# ---------------------------------------------------------------------------
+# Category bootstrap (fleet-wide marker)
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryBootstrap:
+    def test_returns_existing_category_uuid_from_search(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {"uuid": "other-uuid", "name": "other"},
+                {"uuid": "ifn-uuid", "name": "infrafoundry"},
+            ]
+        }
+        svc = NATRuleService(client)
+        uuid = svc._ensure_infrafoundry_category()
+        assert uuid == "ifn-uuid"
+        # Only one call: searchItem; no addItem because category exists.
+        client.request.assert_called_once_with("POST", "firewall/category/searchItem")
+
+    def test_creates_category_when_search_returns_no_match(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = [
+            {"rows": []},  # searchItem: no match
+            {"uuid": "new-uuid"},  # addItem: created
+        ]
+        svc = NATRuleService(client)
+        uuid = svc._ensure_infrafoundry_category()
+        assert uuid == "new-uuid"
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert endpoints == ["firewall/category/searchItem", "firewall/category/addItem"]
+
+    def test_creates_category_when_search_returns_other_names_only(self) -> None:
+        client = MagicMock()
+        client.request.side_effect = [
+            {"rows": [{"uuid": "x", "name": "other"}]},
+            {"uuid": "new-uuid"},
+        ]
+        svc = NATRuleService(client)
+        uuid = svc._ensure_infrafoundry_category()
+        assert uuid == "new-uuid"
+
+    def test_caches_uuid_across_calls(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": [{"uuid": "cached", "name": "infrafoundry"}]}
+        svc = NATRuleService(client)
+        first = svc._ensure_infrafoundry_category()
+        second = svc._ensure_infrafoundry_category()
+        assert first == second == "cached"
+        # searchItem only called once; second invocation hits the cache.
+        assert client.request.call_count == 1
+
+    def test_raises_when_add_item_returns_no_uuid(self) -> None:
+        from infrafoundry.core.exceptions import InfraFoundryError
+
+        client = MagicMock()
+        client.request.side_effect = [
+            {"rows": []},
+            {"result": "failed"},  # addItem: no uuid
+        ]
+        svc = NATRuleService(client)
+        with pytest.raises(InfraFoundryError, match="infrafoundry"):
+            svc._ensure_infrafoundry_category()
+
+    def test_add_includes_category_in_payload(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = NATRuleService(client)
+        svc._category_uuid = "cat-uuid"
+        rule = _outbound("foo", target="wanip", interface="wan")
+        svc.add(rule)
+        # Capture the actual call data and check categories made it in.
+        call = client.request.call_args
+        sent_data = call.kwargs.get("data") or (call.args[2] if len(call.args) > 2 else None)
+        assert sent_data is not None
+        assert sent_data["rule"]["categories"] == "cat-uuid"
+
+    def test_update_includes_category_in_payload(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = NATRuleService(client)
+        svc._category_uuid = "cat-uuid"
+        rule = _outbound("foo", target="wanip", interface="wan")
+        svc.update("uuid-x", rule)
+        call = client.request.call_args
+        sent_data = call.kwargs.get("data") or (call.args[2] if len(call.args) > 2 else None)
+        assert sent_data is not None
+        assert sent_data["rule"]["categories"] == "cat-uuid"

--- a/tests/unit/providers/opnsense/test_nat_rule_validator.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_validator.py
@@ -1,0 +1,508 @@
+"""Unit tests for ``NATRuleValidator``.
+
+Coverage:
+    - ``kind`` required and limited to ``outbound`` / ``one_to_one``.
+    - Per-kind required fields (outbound: ``interface``+``target``;
+      1:1: ``interface``+``external``).
+    - Cross-resource references: ``interface`` against managed
+      ``interface_assignments`` plus live overview; ``source_net``/
+      ``destination_net``/``target`` against managed alias names plus
+      keywords plus live aliases plus literal IP/CIDR.
+    - Operator-set ``description`` containing ``[infrafoundry:<name>]`` rejected.
+    - ``lock``, ``log``, ``enabled``, ``sequence`` type checks.
+    - 1:1 ``type`` and ``natreflection`` enum constraints.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.opnsense.validators.nat_rule_validator import (
+    NATRuleValidator,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _outbound(name: str, **overrides: Any) -> ResourceConfig:
+    config: dict[str, Any] = {
+        "kind": "outbound",
+        "interface": "wan",
+        "target": "wanip",
+    }
+    config.update(overrides)
+    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+
+
+def _one_to_one(name: str, **overrides: Any) -> ResourceConfig:
+    config: dict[str, Any] = {
+        "kind": "one_to_one",
+        "interface": "wan",
+        "external": "198.51.100.10",
+    }
+    config.update(overrides)
+    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+
+
+@pytest.fixture
+def report() -> ValidationReport:
+    return ValidationReport()
+
+
+@pytest.fixture
+def validator(report: ValidationReport) -> NATRuleValidator:
+    return NATRuleValidator(report)
+
+
+def _failures(report: ValidationReport, check_name: str) -> list[Any]:
+    return [c for c in report.results if c.check_name == check_name and not c.passed]
+
+
+# ---------------------------------------------------------------------------
+# kind
+# ---------------------------------------------------------------------------
+
+
+class TestKind:
+    def test_missing_kind_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        r = ResourceConfig(
+            name="bad",
+            type="nat_rules",
+            provider="opnsense",
+            config={"interface": "wan", "target": "wanip"},
+        )
+        validator.validate(
+            [r],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_kind")
+
+    def test_invalid_kind_port_forward_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        # Port forwards are out of scope; kind: port_forward is rejected.
+        r = ResourceConfig(
+            name="pf",
+            type="nat_rules",
+            provider="opnsense",
+            config={"kind": "port_forward", "interface": "wan"},
+        )
+        validator.validate(
+            [r],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_pf_kind")
+
+    def test_outbound_passes(self, validator: NATRuleValidator, report: ValidationReport) -> None:
+        validator.validate(
+            [_outbound("ok")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_kind")
+
+
+# ---------------------------------------------------------------------------
+# Description identity-tag collision
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptionIdentityTag:
+    def test_operator_set_identity_tag_rejected(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        # Probe is position-agnostic; suffix-style forging is also rejected.
+        validator.validate(
+            [_outbound("evil", description="forged [infrafoundry:other]")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_evil_description")
+
+    def test_normal_description_passes(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", description="LAN egress NAT")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_description")
+
+    def test_non_string_description_rejected(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("bad", description=123)],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_description")
+
+
+# ---------------------------------------------------------------------------
+# interface
+# ---------------------------------------------------------------------------
+
+
+class TestInterface:
+    def test_managed_interface_assignment_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", interface="lan")],
+            alias_names=set(),
+            interface_assignment_names={"lan"},
+            existing_interfaces={},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_interface")
+
+    def test_live_interface_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", interface="wan")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_interface")
+
+    def test_unknown_interface_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("bad", interface="bogus")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_interface")
+
+    def test_empty_interface_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("bad", interface="")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_interface")
+
+
+# ---------------------------------------------------------------------------
+# Per-kind required fields
+# ---------------------------------------------------------------------------
+
+
+class TestOutboundRequiredFields:
+    def test_missing_target_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        r = ResourceConfig(
+            name="bad",
+            type="nat_rules",
+            provider="opnsense",
+            config={"kind": "outbound", "interface": "wan"},
+        )
+        validator.validate(
+            [r],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_target")
+
+
+class TestOneToOneRequiredFields:
+    def test_missing_external_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        r = ResourceConfig(
+            name="bad",
+            type="nat_rules",
+            provider="opnsense",
+            config={"kind": "one_to_one", "interface": "wan"},
+        )
+        validator.validate(
+            [r],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_external")
+
+
+# ---------------------------------------------------------------------------
+# Net references (source_net / destination_net / target)
+# ---------------------------------------------------------------------------
+
+
+class TestNetReferences:
+    def test_keyword_resolves_silently(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", source_net="any", destination_net="any")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_source_net")
+        assert not _failures(report, "nat_rule_ok_destination_net")
+
+    def test_managed_alias_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", source_net="lan_subnets")],
+            alias_names={"lan_subnets"},
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_source_net")
+
+    def test_live_alias_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", source_net="existing_alias")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={"existing_alias": {"name": "existing_alias"}},
+        )
+        assert not _failures(report, "nat_rule_ok_source_net")
+
+    def test_literal_ipv4_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", source_net="10.0.0.1")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_source_net")
+
+    def test_literal_cidr_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", source_net="10.0.0.0/24")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_source_net")
+
+    def test_literal_ipv6_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", source_net="fd00::1")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_source_net")
+
+    def test_unknown_net_value_warns(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", source_net="bogus_value")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        # Soft warning — not an ERROR.
+        warnings = [
+            c
+            for c in report.results
+            if c.check_name == "nat_rule_ok_source_net" and c.level == ValidationLevel.WARNING
+        ]
+        assert warnings
+
+    def test_target_resolves_against_alias(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", target="vip_pool")],
+            alias_names={"vip_pool"},
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_target")
+
+
+# ---------------------------------------------------------------------------
+# Booleans / sequence
+# ---------------------------------------------------------------------------
+
+
+class TestTypeChecks:
+    def test_lock_must_be_bool(self, validator: NATRuleValidator, report: ValidationReport) -> None:
+        validator.validate(
+            [_outbound("bad", lock="yes")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_lock")
+
+    def test_log_must_be_bool(self, validator: NATRuleValidator, report: ValidationReport) -> None:
+        validator.validate(
+            [_outbound("bad", log="yes")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_log")
+
+    def test_enabled_must_be_bool(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("bad", enabled="yes")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_enabled")
+
+    def test_sequence_must_be_int(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("bad", sequence="not-int")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_sequence")
+
+
+# ---------------------------------------------------------------------------
+# 1:1-specific enum checks
+# ---------------------------------------------------------------------------
+
+
+class TestOneToOneEnums:
+    def test_invalid_type_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_one_to_one("bad", type="bogus")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_type")
+
+    def test_invalid_natreflection_fails(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_one_to_one("bad", natreflection="not-allowed")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        assert _failures(report, "nat_rule_bad_natreflection")
+
+    def test_valid_natreflection_passes(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        for value in ("", "enable", "disable"):
+            sub_report = ValidationReport()
+            sub_validator = NATRuleValidator(sub_report)
+            sub_validator.validate(
+                [_one_to_one("ok", natreflection=value)],
+                alias_names=set(),
+                interface_assignment_names=set(),
+                existing_interfaces={"wan": {}},
+                existing_aliases={},
+            )
+            assert not _failures(sub_report, "nat_rule_ok_natreflection")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_list_no_failures(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={},
+            existing_aliases={},
+        )
+        assert report.results == []
+
+    def test_multiple_rules_all_validated(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [
+                _outbound("a"),
+                _outbound("b"),
+                _one_to_one("c"),
+            ],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+        )
+        # Each gets at least an interface check.
+        names = {c.check_name for c in report.results if c.check_name.endswith("_interface")}
+        assert "nat_rule_a_interface" in names
+        assert "nat_rule_b_interface" in names
+        assert "nat_rule_c_interface" in names


### PR DESCRIPTION
## Description

Adds the `nat_rules` component to the OPNsense provider, covering **outbound** and **1:1** NAT via direct REST against `firewall/source_nat/*` and `firewall/one_to_one/*`. Identity is encoded as a **suffix** in the rule `description` field (`<operator description> [infrafoundry:<name>]`), with every managed rule additionally tagged with the OPNsense `infrafoundry` category as a fleet-wide marker. Operators can filter the GUI's rule list by category to see "everything InfraFoundry manages."

**Port forwards are explicitly out of scope** for this PR. A live probe (2026-05-03) of `opnsense-a` running 26.1.6_2 confirmed `firewall/{redirect,forward,portforward,nat_forward,rdr}` all return 404 and the legacy `<nat>/<rule>` config.xml section is GUI-only. Port forwards become a follow-up spike-driven issue, likely using the gist-controller mechanism from #717.

This component builds on the foundation established in PR #710 (`OPNsenseDirectRunner`) and PR #712 (`interface_assignments` read-only + dispatch table). It follows the same default semantics codified there (fully-managed by default, `--add-only` opt-in to suppress deletes, per-resource `lock: true` honored across plan/apply/destroy). The identity-controller pattern here is structurally parallel to but differs from the gist-controller pattern recorded in PR #718 — notable as a contrasting reference for future per-component decisions.

## Related Issue

Addresses #713

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### Modified files (5)

- **`docs/decisions/0013-opnsense-full-iac-migration.md`** — Adds `**Amended:** 2026-05-04 (#713)` header line; new entry under "Per-component decisions recorded so far" capturing the suffix-form identity, the broad `infrafoundry` category, and the port-forward deferral; Implementation order item 2 annotated; #713 added to Related Issues.
- **`docs/development/opnsense-resource-coverage.md`** — Coverage matrix split: `<nat>/outbound/rule` and `<nat>/onetoone/rule` are now Supported (cites the suffix format and category marker, warns operators not to GUI-edit managed descriptions); `<nat>/rule` (port forwards) remains a Gap with deferral note. Cutover runbook step 4 + closing-the-gaps step 2 annotated.
- **`src/infrafoundry/providers/opnsense/__init__.py`** — Registers `nat_rules` in `get_direct_api_resource_types`, `get_resource_types`, `get_dependencies` (declares `["aliases", "interface_assignments"]`); adds `migrate_nat_rule(env_name)`.
- **`src/infrafoundry/providers/opnsense/validator.py`** — Instantiates `nat_rule_validator`, collects `nat_rules`/`nat_rule_names` in `_collect_resource_references`, calls `validate(...)` from `validate_references()`.
- **`src/infrafoundry/providers/opnsense/validators/__init__.py`** — Exports `NATRuleValidator`.

### New files (7)

- **`src/infrafoundry/providers/opnsense/services/nat_rule.py`** — `NATRuleConfig`, `LiveNATRule`, `Diff`, `OpnsenseDriftError`, `compute_diff`, `nat_rule_configs_from_resources`, `NATRuleService` with per-kind dispatch (`outbound` vs `one_to_one`), identity suffix encode/parse helpers, fleet-wide category bootstrap (`_ensure_infrafoundry_category` cached per service instance — single round-trip per apply regardless of how many rules are added/updated).
- **`src/infrafoundry/providers/opnsense/components/nat_rule.py`** — `NATRuleManager` with `plan/apply/destroy/get_resource_ids/list/migrate`. Per-kind isolation by `(kind, name)` tuple keys so an outbound rule named `foo` and a 1:1 rule named `foo` are independent identities (they live behind different OPNsense controllers).
- **`src/infrafoundry/providers/opnsense/validators/nat_rule_validator.py`** — `NATRuleValidator` covering kind discriminator, per-kind required fields, cross-resource refs (alias / interface), identity-tag collision check on operator-supplied descriptions, type/enum checks.
- **`tests/unit/providers/opnsense/test_nat_rule_service.py`** — 76 tests including 8 added for category bootstrap and edge cases (tag-in-middle raises drift, double-bracket raises drift, suffix-form encode/parse round-trip).
- **`tests/unit/providers/opnsense/test_nat_rule_manager.py`** — 16 tests.
- **`tests/unit/providers/opnsense/test_nat_rule_validator.py`** — 29 tests.
- **`tests/integration/opnsense/test_nat_rule_live.py`** — 5 tests gated by `OPNSENSE_INTEGRATION_TESTS=1` (not run in CI; documented for local validation against a real OPNsense instance).

## Key design decisions

1. **Identity is a description suffix.** The `description` field stores `<operator description> [infrafoundry:<name>]`. The operator's free-form text leads in the GUI display. This was refactored from an earlier prefix-form during review per user feedback — leading with operator text gives the OPNsense rule list a more natural reading order.
2. **Fleet-wide `infrafoundry` OPNsense category** as a broad managed marker. Created on demand at first apply via `firewall/category/{searchItem,addItem}`; UUID cached per `NATRuleService` instance so multiple add/update calls in one apply pay a single round-trip total. Operators filter the GUI rule list by category to see everything InfraFoundry manages on a fleet basis.
3. **Identity-tag probe is position-agnostic.** Both the parser (live rows) and the validator (operator-set descriptions) reject `[infrafoundry:<name>]` patterns *anywhere* except as a strict suffix. This catches operator forging and GUI-edit drift uniformly — if a managed rule's description has been edited in the GUI such that the tag is no longer a suffix, the diff raises `OpnsenseDriftError` rather than silently rewriting.
4. **Per-kind isolation.** An outbound rule named `foo` and a 1:1 rule named `foo` are independent identities. They live behind different OPNsense controllers and the manager keys diffs by `(kind, name)` tuples.
5. **No state DB.** ADR-0014 takes no position on per-component state for direct-API resources; this PR follows that with stateless identity-via-description.
6. **Default semantics carry from VLAN/#710**: fully-managed by default; `--add-only` opt-in suppresses deletes; `lock: true` per-resource (under `config:`) honored across plan/apply/destroy.

## Live API probe (2026-05-03, opnsense-a 26.1.6_2)

- **Outbound:** `firewall/source_nat/{searchRule, getRule, addRule, setRule, delRule, apply}` — schema fields available and in use. (Note: `applyChanges` 404s on this controller; the correct verb is `apply` — caught during live-fleet integration testing.)
- **1:1:** `firewall/one_to_one/{searchRule, getRule, addRule, setRule, delRule, apply}` — same.
- **Port forwards:** `firewall/{redirect, forward, portforward, nat_forward, rdr}` — all five candidate endpoints return 404. Out of scope; deferral noted in ADR-0013 and the resource-coverage matrix.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested against live `opnsense-a` (26.1.6_2) — all 5 integration tests pass; box is clean post-test (no leftover state). The live run caught one bug: the apply verb on `firewall/source_nat` and `firewall/one_to_one` is `apply`, not `applyChanges` (which 404s on these specific controllers). Fixed in this PR.

**Test inventory:** 121 NAT-rule unit tests across service (76), manager (16), and validator (29). 8 of the service tests are new in this PR for category bootstrap and suffix-form parsing edge cases. All pass.

```bash
uv run pytest tests/unit/providers/opnsense/test_nat_rule_*.py
# 121 passed
```

`doit check` passes (format, lint, lint_blueprints, type_check, security, spell_check, full test suite). Coverage stays above the 70% gate (was 82.65% in the original implementation; unchanged or marginally higher after the suffix-form refactor).

**Integration tests:** Five live-fleet tests covering create, update, delete, drift on description edit, category bootstrap. Run with:

```bash
OPNSENSE_INTEGRATION_TESTS=1 uv run pytest tests/integration/opnsense/test_nat_rule_live.py
```

These are not part of the CI matrix and require an OPNsense endpoint reachable from the test host with API credentials.

## ADRs

- **ADR-0013** ([docs/decisions/0013-opnsense-full-iac-migration.md](docs/decisions/0013-opnsense-full-iac-migration.md)) is amended in this PR with the per-component decision for `nat_rules` (suffix-form identity, fleet-wide category, port-forward deferral) and the corresponding Related Issues / Implementation order updates.
- **ADR-0014** ([docs/decisions/0014-opnsense-direct-api-apply-mechanism.md](docs/decisions/0014-opnsense-direct-api-apply-mechanism.md)) is unchanged. It already covers the apply mechanism. No new ADR is required (issue #713 lacks the `needs-adr` label).

## Follow-up

A separate issue will be filed for OPNsense **port forwards** (`<nat>/rule`) once the spike pattern from #714→#715→#716→#717 is reapplied. The same gist-controller mechanism that landed for `interface_assignments` is the most likely path; the issue body and spike scope will be drafted after this PR merges.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (ADR-0013 amendment + resource-coverage matrix)
- [ ] I have updated the CHANGELOG.md — not applicable; CHANGELOG is auto-generated from conventional commits at release time
- [x] My changes generate no new warnings
