### PR TITLE
feat: add OPNsense static_routes component (direct-API)

### DIFF
--- a/docs/decisions/0013-opnsense-full-iac-migration.md
+++ b/docs/decisions/0013-opnsense-full-iac-migration.md
@@ -4,6 +4,7 @@
 **Amended:** 2026-05-03 (#717) — `interface_assignments` per-component decision updated; cross-reference to ADR-0014's new Per-component decisions section
 **Amended:** 2026-05-04 (#713) — `nat_rules` per-component decision recorded (outbound + 1:1 ship via direct REST; port forwards deferred to a follow-up spike)
 **Amended:** 2026-05-03 (#721) — `gateways` per-component decision recorded (direct REST against `routing/settings/*Gateway`; natural-key identity)
+**Amended:** 2026-05-04 (#722) — `static_routes` per-component decision recorded (direct REST against `routes/routes/*route`; natural-key identity tuple); implementation order #3 completed
 **Status:** Accepted
 **Issue:** [#701](https://github.com/endavis/infrafoundry/issues/701)
 
@@ -63,6 +64,7 @@ The XML `config.xml` format is not part of any apply or migrate path. It is used
 - `interface_assignments` (#711, #715→PR #716, amended 2026-05-03 via #717): read-only / migrate shipped in PR #712 (`/api/interfaces/overview/*`). Write path adopts server-side-validated REST via the forked `AssignSettingsController.php` controller; the spike validated the mechanism end-to-end on `26.1.6_2`. See [ADR-0014 §"Per-component decisions"](0014-opnsense-direct-api-apply-mechanism.md#per-component-decisions) for the mechanism details, the rollback decision (option (c) — no transactional rollback; rely on per-call server-side validation + OPNsense auto-snapshot), and the gates remaining for production conversion.
 - `nat_rules` (#713, recorded 2026-05-04): **outbound** + **1:1** ship via direct REST against `firewall/source_nat/*` and `firewall/one_to_one/*`. Identity is encoded as a **suffix** in the `description` field — `<operator description> [infrafoundry:<name>]` — so the operator's free-form text leads in the OPNsense GUI display. Every managed rule also carries the OPNsense `infrafoundry` category as a fleet-wide marker (created on first apply, cached per service instance) so operators can filter "everything InfraFoundry manages" in the GUI. No state DB — ADR-0014 takes no position on state for direct-API resources. **Port forwards are out of scope** for this PR — a live probe (2026-05-03) of `26.1.6_2` confirmed `firewall/{redirect,forward,portforward,nat_forward,rdr}` all return 404 and the legacy `<nat>/<rule>` config.xml section is GUI-only. Port forwards become a follow-up spike-driven issue (same playbook as #714→#715→#716→#717 — the gist-controller mechanism from #717 is the likely path).
 - `gateways` (#721, recorded 2026-05-03): ships via direct REST against `routing/settings/{searchGateway, getGateway, addGateway, setGateway, delGateway, reconfigure}`. Identity is the **natural key** `name` — OPNsense enforces uniqueness server-side, so the operator-facing YAML `name` maps 1:1 to the live `name` field. **No description-suffix tag** and **no `infrafoundry` category bootstrap** (gateways have no categories). This is a deliberate divergence from `nat_rules`, which needed the description-suffix scheme because firewall rules have no stable name field. **Dynamic / virtual gateways** (those synthesized by OPNsense from interface DHCP state — e.g., `WAN_DHCP`, `WAN_DHCP6`) appear in `searchGateway` rows with `dynamic: true`/`virtual: true` and are silently filtered out of the diff entirely; they cannot be added/updated/deleted via the gateway controller and must not be listed in YAML. Cutover semantics same as VLAN: operator either lists every gateway in YAML or uses `--add-only` to suppress deletes during partial migration. Apply mechanism unchanged from ADR-0014 (stock direct-REST); no new ADR.
+- `static_routes` (#722, recorded 2026-05-04): ships via direct REST against `routes/routes/{searchroute, getroute, addroute, setroute, delroute, reconfigure}`. Identity is the **natural key tuple** `(network, gateway)` — OPNsense exposes no server-unique `name` field on routes. The operator-facing YAML `name` is metadata only (used for cross-resource references and `ResourceOutcome` addressing) and never travels on the wire. **No description-suffix tag** and **no `infrafoundry` category bootstrap** (routes have no categories). The `gateway` field cross-references either a managed `gateways` resource declared in YAML *or* a live system gateway (e.g., `WAN_DHCP`, `WAN_DHCP6`) — the validator accepts both, mirroring the gateway validator's interface-acceptance pattern. Cross-protocol mismatch (e.g., an IPv4 CIDR routed through an IPv6 gateway) is enforced at validation time before the request lands; the live API does not always reject the mismatch itself. Cutover semantics same as VLAN/gateways: list every route in YAML or use `--add-only` during partial migration. Apply mechanism unchanged from ADR-0014 (stock direct-REST); no new ADR.
 
 ## Implementation order
 
@@ -70,7 +72,7 @@ Each step ships under the direct-API pattern codified in [ADR-0014](0014-opnsens
 
 1. `interface_assignments` — gates everything that depends on physical NIC mapping. *Read-only / migrate shipped in PR #712 (#711); write-path mechanism decided in ADR-0014 amendment (#717); production conversion gated on a follow-up issue that carries out gates (2) and (3).*
 2. `nat_rules` — outbound + 1:1 ship in #713 (direct-API). Port forwards deferred to a follow-up spike — `26.1.6_2` exposes no MVC REST endpoint for them; the same gist-controller mechanism from #717 is the likely path.
-3. `gateways` (#721 — direct-API, natural-key identity) and `static_routes`.
+3. `gateways` (#721 — direct-API, natural-key identity) and `static_routes` (#722 — direct-API, natural-key tuple identity). *Both shipped 2026-05-04.*
 4. `virtual_ips`.
 5. Unbound extensions (`domain_override`, `host_alias`, `forward`).
 6. `config migrate` extractors for the full set, in any order once each component lands.
@@ -89,6 +91,7 @@ Each step above is a separate feature issue. Issue numbers will be added to this
 - Issue [#717](https://github.com/endavis/infrafoundry/issues/717): chore: amend ADR-0014 to record the gist-based REST mechanism for `interface_assignments`.
 - Issue [#713](https://github.com/endavis/infrafoundry/issues/713): feat: add OPNsense `nat_rules` component (outbound + 1:1).
 - Issue [#721](https://github.com/endavis/infrafoundry/issues/721): feat: add OPNsense `gateways` component (direct-API, natural-key identity).
+- Issue [#722](https://github.com/endavis/infrafoundry/issues/722): feat: add OPNsense `static_routes` component (direct-API, natural-key tuple identity).
 
 ## Related Documentation
 

--- a/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
+++ b/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
@@ -3,6 +3,7 @@
 **Date:** 2026-04-30
 **Amended:** 2026-05-03 (#717, PR #718) — added second internal write path for resources with no native REST CRUD; records `interface_assignments` per-component decision
 **Amended:** 2026-05-03 (#720, PR #N) — Gates (2) and (3) cleared; production conversion of `interface_assignments` from no-op to live complete (full CRUD via the in-tree `AssignSettingsController.php` fork at `src/infrafoundry/providers/opnsense/extensions/interface_assignments/`). Spike deleted.
+**Amended:** 2026-05-04 (#722) — `static_routes` per-component decision recorded (stock direct-REST against `routes/routes/*route`; natural-key identity tuple `(network, gateway)`)
 **Status:** Accepted
 
 ## Status
@@ -106,6 +107,19 @@ The spike empirically established that `/api/core/backup/{backups,download}` ret
 
 **Cross-reference:** [ADR-0013 §"Per-component decisions recorded so far"](0013-opnsense-full-iac-migration.md#per-component-decisions-recorded-so-far) updated to reflect this resolution. See also [`docs/development/opnsense-spike-interface-assignment-gist-findings.md`](../development/opnsense-spike-interface-assignment-gist-findings.md) for the load-bearing evidence.
 
+### `static_routes` (#722, 2026-05-04)
+
+**Mechanism:** Stock direct-REST against the `routes/routes/*route` controller — no controller fork required (this component falls under §1's default).
+
+- **Endpoints:** `POST routes/routes/searchroute` (list), `GET routes/routes/getroute/<uuid>` (full record under `{"route": {...}}` envelope, with `gateway` rendered as a select option dict), `POST routes/routes/addroute` and `POST routes/routes/setroute/<uuid>` (body envelope `{"route": {...}}`), `POST routes/routes/delroute/<uuid>`, `POST routes/routes/reconfigure`.
+- **Identity:** natural key tuple `(network, gateway)`. OPNsense exposes no server-unique `name` field on routes; the operator-facing YAML `name` is metadata only (used for cross-resource references and `ResourceOutcome` addressing) and never travels on the wire. Two routes with the same `(network, gateway)` tuple are the same record by the diff engine. Updating either field is a delete + add (the diff engine emits both); updating only `descr` or `disabled` is an in-place `setroute` (preserves UUID).
+- **Wire schema:** `network` (CIDR), `gateway` (next-hop gateway name), `descr` (operator description), `disabled` (`"0"`/`"1"` string). The probe (live on `opnsense-a` running `26.1.6_2`, 2026-05-04) confirmed those four fields plus the auto-assigned `uuid` exhaust the schema — no metric / mtu / interface override knobs exist on this OPNsense version.
+- **Gateway reference scope:** validator accepts both managed `gateways` resources declared in YAML *and* live system gateways (e.g., `WAN_DHCP`, `WAN_DHCP6`) returned by `searchGateway`. Mirrors the gateway validator's interface-acceptance pattern — operators can route through dynamic gateways without first declaring them as managed.
+- **Cross-protocol enforcement:** the live API empirically does *not* always reject an IPv4 CIDR routed through an IPv6 gateway (the probe accepted `203.0.113.0/24` → `WAN_DHCP6` without error), so the validator enforces the family match before the request lands. For managed gateways the protocol is read from YAML; for live system gateways the heuristic is the trailing-`6` convention (e.g., `WAN_DHCP6` → IPv6).
+- **No description-suffix tag** and **no `infrafoundry` category bootstrap** (routes have no categories). Different from `nat_rules` (which uses suffix tags because firewall rules have no stable name field) and same as `gateways` (which has a server-unique `name` field).
+
+**Rollback strategy:** Same as the rest of §1's default mechanism — rely on per-call server-side validation; OPNsense's auto-snapshot in `/conf/backup/` (System → Configuration → Backups) is the residual safety net. No transactional rollback (option (c) from the `interface_assignments` rollback discussion applies fleet-wide for direct-REST mechanisms).
+
 ## Rationale
 
 The VLAN spike supplied the load-bearing evidence:
@@ -142,6 +156,7 @@ The runner integration via ADR-0010 protocols keeps the CLI surface consistent: 
 - Issue [#715](https://github.com/endavis/infrafoundry/issues/715): feat: spike + extend OPNsense gist-based `interface_assignments` write API (closed; PR [#716](https://github.com/endavis/infrafoundry/pull/716) merged 2026-05-02). Load-bearing evidence for this amendment.
 - Issue [#717](https://github.com/endavis/infrafoundry/issues/717): chore: amend ADR-0014 to record gist-based REST mechanism for `interface_assignments` (this amendment).
 - Issue [#720](https://github.com/endavis/infrafoundry/issues/720): feat: convert `OPNsenseDirectRunner.apply()` for `interface_assignments` from no-op to live. Carries out gates (2) and (3); recorded as cleared in the 2026-05-03 amendment line above and in the per-component decisions section.
+- Issue [#722](https://github.com/endavis/infrafoundry/issues/722): feat: add OPNsense `static_routes` component (direct-API, natural-key tuple identity).
 
 ## Related Documentation
 

--- a/docs/development/opnsense-resource-coverage.md
+++ b/docs/development/opnsense-resource-coverage.md
@@ -23,7 +23,7 @@ Source of truth for "supported": `OPNsenseProvider.get_resource_types()` in `src
 | `<nat>/outbound/rule` and `<nat>/onetoone/rule` | `nat_rules` (`kind: outbound` / `kind: one_to_one`) | Supported (outbound + 1:1, direct-API; #713). Identity is encoded as a **suffix** in the rule `description` — `<operator description> [infrafoundry:<name>]` — and every managed rule also carries the OPNsense `infrafoundry` category as a fleet-wide marker. Live rules without the suffix tag are unmanaged and ignored by the diff (do not edit a managed rule's description in the GUI — that breaks identity parsing). |
 | `<nat>/rule` (port forwards) | — | **Gap** pending a follow-up spike — `26.1.6_2` exposes no MVC REST endpoint for port forwards (`firewall/{redirect,forward,portforward,nat_forward,rdr}` all return 404). The gist-controller mechanism from #717 is the likely path. |
 | `<OPNsense>/Gateways` | `gateways` | Supported (direct-API; #721). Identity is the natural-key `name` (OPNsense enforces uniqueness server-side). Dynamic/virtual gateways synthesized from interface DHCP state (e.g., `WAN_DHCP`, `WAN_DHCP6`) are silently excluded from the diff — they're recreated from interface state on reconfigure and must not appear in YAML. |
-| `<staticroutes>/route` | — | **Gap** |
+| `<staticroutes>/route` | `static_routes` | Supported (direct-API; #722). Identity is the natural-key tuple `(network, gateway)` (OPNsense exposes no server-unique `name` field on routes — operator-facing YAML `name` is metadata only and never travels on the wire). The `gateway` field cross-references either a managed `gateways` resource declared in YAML or a live system gateway (e.g., `WAN_DHCP`, `WAN_DHCP6`); the validator enforces protocol-family match (IPv4 CIDR → IPv4 gateway, IPv6 CIDR → IPv6 gateway). |
 | `<virtualip>/vip` | — | **Gap** |
 | `<OPNsense>/unboundplus/hosts/host/alias` | — | **Gap** (Unbound host alias) |
 | `<OPNsense>/unboundplus/domains/domain` | — | **Gap** (Unbound domain override) |
@@ -75,7 +75,7 @@ Each gap row in the matrix above corresponds to a planned feature issue. The imp
 
 1. `interface_assignments` (read-only / migrate shipped in #711; write-path mechanism decided in ADR-0014 amendment #717 via a forked PHP REST controller; production conversion of `OPNsenseDirectRunner.apply()` is a follow-up issue)
 2. `nat_rules` — outbound + 1:1 ship in #713 (direct-API). Port forwards deferred to a follow-up spike — `26.1.6_2` exposes no MVC REST endpoint for them; the same gist-controller mechanism from #717 is the likely path.
-3. `gateways`, `static_routes`
+3. `gateways` (#721, completed) and `static_routes` (#722, completed)
 4. `virtual_ips`
 5. Unbound extensions (`domain_override`, `host_alias`, `forward`)
 6. `config migrate` extractors for every supported and newly-added resource type

--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -164,6 +164,7 @@ class OPNsenseProvider(
         from .components.gateway import GatewayManager
         from .components.interface_assignment import InterfaceAssignmentManager
         from .components.nat_rule import NATRuleManager
+        from .components.static_route import StaticRouteManager
         from .components.vlan import VlanManager
 
         return {
@@ -171,6 +172,7 @@ class OPNsenseProvider(
             "interface_assignments": InterfaceAssignmentManager,
             "nat_rules": NATRuleManager,
             "gateways": GatewayManager,
+            "static_routes": StaticRouteManager,
         }
 
     def _generate_aliases_terraform(self, aliases: list[ResourceConfig]) -> None:
@@ -631,6 +633,7 @@ class OPNsenseProvider(
             "unbound_host_override",
             "nat_rules",
             "gateways",
+            "static_routes",
         ]
 
     @override
@@ -665,6 +668,7 @@ class OPNsenseProvider(
             "unbound_host_override": [],
             "nat_rules": ["aliases", "interface_assignments"],
             "gateways": ["interface_assignments"],
+            "static_routes": ["gateways"],
         }
 
     @override
@@ -815,6 +819,29 @@ class OPNsenseProvider(
         from .components.gateway import GatewayManager
 
         manager = GatewayManager(self.config_dir)
+        return manager.migrate(env_name)
+
+    def migrate_static_route(self, env_name: str) -> str:
+        """Migrate current static routes to InfraFoundry YAML.
+
+        Reads the live static-route list from OPNsense via the direct-API
+        path and generates InfraFoundry-compatible YAML. Mirrors
+        ``migrate_gateway`` and the other migrate-* methods. The operator-
+        facing ``name`` is synthesized from the ``(network, gateway)``
+        natural-key tuple — the operator can rename freely after import,
+        since identity is the tuple, not the name. Not yet exposed via
+        the ``config migrate`` CLI — that wiring is a follow-up (per
+        ADR-0014 §8).
+
+        Args:
+            env_name: Environment name
+
+        Returns:
+            YAML configuration as a string
+        """
+        from .components.static_route import StaticRouteManager
+
+        manager = StaticRouteManager(self.config_dir)
         return manager.migrate(env_name)
 
     def migrate_isc_to_kea(self, env_name: str, interfaces: list[str] | None = None) -> str:

--- a/src/infrafoundry/providers/opnsense/components/static_route.py
+++ b/src/infrafoundry/providers/opnsense/components/static_route.py
@@ -1,0 +1,267 @@
+"""Static-route component manager for OPNsense (ADR-0014, #722).
+
+Mirrors the layout of ``components/gateway.py`` and ``components/nat_rule.py``:
+a thin orchestration layer that loads ``StaticRouteService`` from the
+environment and dispatches add/update/delete operations.
+
+Identity is the natural-key ``(network, gateway)`` tuple per the issue plan;
+the manager takes no part in matching — that is entirely the diff engine's
+job in ``services/static_route.py``. The operator-facing ``name`` is metadata
+only and is used for ``ResourceOutcome.address`` synthesis.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.types import ResourceOutcome
+
+from ..services.static_route import (
+    Diff,
+    LiveStaticRoute,
+    StaticRouteService,
+    static_route_configs_from_resources,
+)
+from .base import BaseComponentManager
+
+
+class StaticRouteManager(BaseComponentManager):
+    """Manager for static-route component operations.
+
+    Each public method instantiates a ``StaticRouteService`` from the
+    environment and delegates. Errors propagate to the caller; the runner
+    is responsible for translating exceptions into ``PlanResult.error``/
+    ``ApplyResult.error``.
+    """
+
+    # ------------------------------------------------------------------
+    # Plan / apply / destroy
+    # ------------------------------------------------------------------
+
+    def plan(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        add_only: bool = False,
+        provider_name: str = "opnsense",
+    ) -> Diff:
+        """Compute the add/update/delete diff for the given resources.
+
+        Args:
+            env_name: Active environment name.
+            resources: Static-route ``ResourceConfig`` entries (filtered upstream).
+            add_only: If True, suppress deletes for live routes not in YAML.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            ``Diff`` describing what apply would do.
+        """
+        service = StaticRouteService.from_environment(env_name, provider_name, self.config_dir)
+        desired = static_route_configs_from_resources(resources)
+        live = service.search()
+        return service.compute_diff(desired, live, add_only=add_only)
+
+    def apply(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        auto_approve: bool = True,
+        add_only: bool = False,
+        provider_name: str = "opnsense",
+    ) -> dict[str, Any]:
+        """Apply the diff: add/update/delete static routes and reconfigure.
+
+        Args:
+            env_name: Active environment name.
+            resources: Static-route ``ResourceConfig`` entries.
+            auto_approve: Currently a no-op; the diff engine itself is
+                the gate.
+            add_only: If True, suppress deletes.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            Dict with ``resources_created``, ``resources_updated``,
+            ``resources_deleted`` counts and a ``resource_outcomes`` list.
+        """
+        del auto_approve  # diff engine is the gate; flag accepted for protocol shape
+        service = StaticRouteService.from_environment(env_name, provider_name, self.config_dir)
+        desired = static_route_configs_from_resources(resources)
+        live = service.search()
+        diff = service.compute_diff(desired, live, add_only=add_only)
+
+        outcomes: list[ResourceOutcome] = []
+        for route in diff.adds:
+            outcomes.append(
+                ResourceOutcome(
+                    address=f"opnsense_static_route.{route.name}",
+                    action="add",
+                    resource_name=route.name,
+                )
+            )
+
+        for _live_route, want in diff.updates:
+            outcomes.append(
+                ResourceOutcome(
+                    address=f"opnsense_static_route.{want.name}",
+                    action="update",
+                    resource_name=want.name,
+                )
+            )
+
+        for live_route in diff.deletes:
+            # Live routes carry no operator-facing name; synthesize a
+            # stable address from the natural key so the outcome is
+            # readable in plan output.
+            synthetic_name = _synthetic_name(live_route)
+            outcomes.append(
+                ResourceOutcome(
+                    address=f"opnsense_static_route.{synthetic_name}",
+                    action="delete",
+                    resource_name=synthetic_name,
+                )
+            )
+
+        counts = service.apply_diff(diff)
+        return {
+            "success": True,
+            "resources_created": counts["created"],
+            "resources_updated": counts["updated"],
+            "resources_deleted": counts["deleted"],
+            "resource_outcomes": outcomes,
+        }
+
+    def destroy(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        auto_approve: bool = True,
+        provider_name: str = "opnsense",
+    ) -> dict[str, Any]:
+        """Delete every live route whose ``(network, gateway)`` tuple is in ``resources``.
+
+        Locked entries are honored: ``lock: true`` resources are skipped
+        and counted in the response under ``locked_skipped``.
+
+        Args:
+            env_name: Active environment name.
+            resources: Static-route ``ResourceConfig`` entries to destroy.
+            auto_approve: Currently a no-op.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            Dict with ``resources_destroyed`` and ``locked_skipped`` counts.
+        """
+        del auto_approve
+        service = StaticRouteService.from_environment(env_name, provider_name, self.config_dir)
+        desired = static_route_configs_from_resources(resources)
+        live = service.search()
+
+        # Index live by natural-key tuple.
+        live_by_key: dict[tuple[str, str], LiveStaticRoute] = {
+            entry.diff_key: entry for entry in live
+        }
+
+        deleted = 0
+        locked_skipped = 0
+        any_action = False
+        for route in desired:
+            if route.lock:
+                locked_skipped += 1
+                continue
+            existing = live_by_key.get(route.diff_key)
+            if existing is None:
+                continue
+            service.delete(existing.uuid)
+            deleted += 1
+            any_action = True
+
+        if any_action:
+            service.reconfigure()
+
+        return {
+            "success": True,
+            "resources_destroyed": deleted,
+            "locked_skipped": locked_skipped,
+        }
+
+    # ------------------------------------------------------------------
+    # State / migration helpers
+    # ------------------------------------------------------------------
+
+    def get_resource_ids(
+        self,
+        env_name: str,
+        resources: list[ResourceConfig],
+        *,
+        provider_name: str = "opnsense",
+    ) -> dict[str, str]:
+        """Return ``{resource_name: opnsense_uuid}`` for live routes matching YAML.
+
+        Matches by the natural-key ``(network, gateway)`` tuple — the
+        operator-facing ``name`` is only used as the dict key in the
+        return value.
+
+        Args:
+            env_name: Active environment name.
+            resources: Static-route ``ResourceConfig`` entries.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            Mapping from operator-facing resource name to OPNsense UUID.
+            Resources without a matching live record are omitted.
+        """
+        service = StaticRouteService.from_environment(env_name, provider_name, self.config_dir)
+        desired = static_route_configs_from_resources(resources)
+        live = service.search()
+        live_by_key: dict[tuple[str, str], LiveStaticRoute] = {
+            entry.diff_key: entry for entry in live
+        }
+
+        result: dict[str, str] = {}
+        for route in desired:
+            existing = live_by_key.get(route.diff_key)
+            if existing is not None:
+                result[route.name] = existing.uuid
+        return result
+
+    def list(self, env_name: str, *, provider_name: str = "opnsense") -> list[LiveStaticRoute]:
+        """Return the live static routes on the OPNsense box.
+
+        Args:
+            env_name: Active environment name.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+        """
+        service = StaticRouteService.from_environment(env_name, provider_name, self.config_dir)
+        return service.search()
+
+    def migrate(self, env_name: str, *, provider_name: str = "opnsense") -> str:
+        """Export the current static routes to InfraFoundry YAML.
+
+        Args:
+            env_name: Active environment name.
+            provider_name: Provider identifier (defaults to ``opnsense``).
+
+        Returns:
+            YAML string containing the live routes in resource-centric form.
+            Operator-facing ``name`` is synthesized from the
+            ``(network, gateway)`` tuple — the operator can rename freely
+            after import, since identity is the tuple, not the name.
+        """
+        service = StaticRouteService.from_environment(env_name, provider_name, self.config_dir)
+        return service.export_to_yaml()
+
+
+def _synthetic_name(route: LiveStaticRoute) -> str:
+    """Build a stable synthetic name for a live route.
+
+    Used when emitting ``ResourceOutcome`` for deletes — the live record
+    carries no operator-facing name. Mirrors ``services.static_route.
+    _synthesize_name`` so plan output and migrated YAML use the same
+    convention.
+    """
+    sanitized = route.network.replace("/", "-").replace(":", "-").replace(".", "-")
+    return f"route-{sanitized}-via-{route.gateway}".lower()

--- a/src/infrafoundry/providers/opnsense/services/static_route.py
+++ b/src/infrafoundry/providers/opnsense/services/static_route.py
@@ -1,0 +1,583 @@
+"""Static-route service for OPNsense direct-API operations (ADR-0014, #722).
+
+Manages OPNsense static routes via the ``routes/routes/*route`` controller.
+Identity is the natural key tuple ``(network, gateway)`` — OPNsense does not
+expose a server-unique ``name`` field on routes (the YAML ``name`` is operator
+metadata for cross-resource references only and never appears on the wire).
+The diff engine matches by the natural-key tuple. No description-suffix tag,
+no ``infrafoundry`` category bootstrap (routes have no categories).
+
+Endpoint surface (confirmed live on ``opnsense-a`` running ``26.1.6_2``,
+2026-05-04 probe; corroborated by the bundled ``opnsense_openapi==0.4.0``
+spec for 26.1.6):
+
+- ``POST routes/routes/searchroute`` — list rows for the dataTable view.
+  Response shape ``{"rows": [...], "rowCount": N, "total": N, "current": 1}``;
+  rows expose the flat ``gateway`` (selected key) plus ``%gateway`` (display
+  string) — only ``gateway`` is read by the diff engine.
+- ``GET  routes/routes/getroute/<uuid>`` — full record under ``{"route": {...}}``
+  envelope, with ``gateway`` rendered as an option dict
+  (``{<gw_name>: {"value": "<display>", "selected": 0|1}, ...}``).
+- ``POST routes/routes/addroute`` — body envelope ``{"route": {...}}``;
+  response ``{"result": "saved", "uuid": "..."}`` on success or
+  ``{"result": "failed", "validations": {<field>: <message>}}`` on
+  server-side validation failure.
+- ``POST routes/routes/setroute/<uuid>`` — same body envelope as add.
+- ``POST routes/routes/delroute/<uuid>`` — response ``{"result": "deleted"}``.
+- ``POST routes/routes/toggleroute/<uuid>`` — flips ``disabled`` (not used by
+  this service; the operator-facing ``enabled`` is set via add/set instead).
+- ``POST routes/routes/reconfigure`` — typed response ``{"status": "ok"|"failed"}``.
+
+Field schema (probe-derived, recorded here so a follow-up doesn't need to
+re-probe). All write fields are simple strings on the wire:
+
+- Required: ``network`` (CIDR matching the gateway's IP protocol),
+  ``gateway`` (the next-hop gateway name — must reference a gateway that
+  exists on the box; managed gateways listed in YAML or live system gateways
+  like ``WAN_DHCP``/``WAN_DHCP6`` are both accepted at the validator level
+  and at the API level).
+- Booleans serialized as ``"0"``/``"1"`` strings: ``disabled``.
+- Strings: ``descr``.
+
+The wire surface is intentionally narrow — OPNsense's ``<staticroutes>/route``
+schema in ``config.xml`` only exposes those four fields plus the auto-assigned
+``uuid``. The probe confirmed no additional knobs (no metric / mtu / interface
+override etc.) on ``26.1.6_2``. If a future OPNsense release exposes new
+fields, the schema here grows in lockstep.
+
+Cross-protocol mismatch (e.g., an IPv4 CIDR routed through an IPv6 gateway)
+is *not* always rejected at the API level — empirically the box accepted
+``203.0.113.0/24`` → ``WAN_DHCP6`` during the probe — so the validator
+enforces the family match before the request lands.
+
+Identity contract recap:
+
+- Two routes with the same ``(network, gateway)`` tuple are considered the
+  same record by the diff engine; updating either of those fields is a
+  delete + add (the diff engine emits both). Updating ``descr`` or
+  ``disabled`` only is an in-place ``setroute`` (preserves UUID).
+- Operator-facing YAML ``name`` is metadata only — used for cross-resource
+  reference lookups and ``ResourceOutcome.address``-style addressing — and
+  is never sent on the wire as identity.
+- ``lock: true`` is honored: locked entries appear in ``Diff.locked`` and
+  are never added, updated, or deleted.
+
+The operator-facing YAML uses ``enabled: bool`` (matches the rest of the
+provider's resources); on serialization that's flipped to OPNsense's
+``disabled`` field. Same applies to ``description`` (YAML) → ``descr`` (API).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+from infrafoundry.core.provider import ResourceConfig
+
+from .base import BaseService
+
+# Controller base for all static-route CRUD + reconfigure endpoints.
+_ROUTE_BASE = "routes/routes"
+
+
+# ---------------------------------------------------------------------------
+# Domain model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StaticRouteConfig:
+    """Desired-state static-route configuration.
+
+    The operator-facing YAML ``name`` is metadata only — used for cross-
+    resource references and ``ResourceOutcome`` addresses — and never
+    travels on the wire. The diff engine matches on the natural-key
+    tuple ``(network, gateway)``.
+
+    ``lock`` is a per-resource safety annotation (ADR-0014 §6) — locked
+    entries appear in ``Diff.locked`` but are never added, updated, or
+    deleted.
+
+    Attributes:
+        name: Operator-facing YAML name; metadata only.
+        network: Destination CIDR (IPv4 or IPv6).
+        gateway: Next-hop gateway name (managed or live system gateway).
+        enabled: Whether the route is active. Inverted to ``disabled``
+            on the wire.
+        description: Operator-facing free-form description (mapped to
+            ``descr`` on the wire).
+        lock: Per-resource safety annotation (ADR-0014 §6).
+    """
+
+    name: str
+    network: str
+    gateway: str
+    enabled: bool = True
+    description: str = ""
+    lock: bool = False
+
+    @property
+    def diff_key(self) -> tuple[str, str]:
+        """Identity of this route: the ``(network, gateway)`` natural-key tuple."""
+        return (self.network, self.gateway)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize to the ``addroute``/``setroute`` envelope.
+
+        Returns:
+            ``{"route": {<fields>}}``. Booleans are stringified to
+            ``"0"``/``"1"``; ``enabled`` is inverted to ``disabled``;
+            ``description`` maps to ``descr``. The operator-facing
+            ``name`` is intentionally NOT sent — it is metadata only.
+        """
+        return {
+            "route": {
+                "network": self.network,
+                "gateway": self.gateway,
+                "disabled": _bool_str(not self.enabled),
+                "descr": self.description,
+            }
+        }
+
+
+@dataclass(frozen=True)
+class LiveStaticRoute:
+    """A static route as currently configured on the OPNsense box.
+
+    ``raw`` is the ``searchroute`` row, which exposes the flat ``gateway``
+    field (the selected key, not the option dict) plus ``%gateway``
+    (display string) — only ``gateway`` is read by the diff engine. The
+    ``getroute`` envelope is read separately during ``export_to_yaml``
+    to recover the option-dict-rendered fields.
+
+    Attributes:
+        uuid: OPNsense-assigned UUID.
+        network: Destination CIDR.
+        gateway: Next-hop gateway name.
+        raw: Full original ``searchroute`` row for field comparison
+            during update detection.
+    """
+
+    uuid: str
+    network: str
+    gateway: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def diff_key(self) -> tuple[str, str]:
+        """Identity of this route: the ``(network, gateway)`` natural-key tuple."""
+        return (self.network, self.gateway)
+
+
+@dataclass
+class Diff:
+    """Result of comparing desired YAML state to live OPNsense state.
+
+    Mirrors ``services.gateway.Diff`` and ``services.nat_rule.Diff``: adds /
+    updates / deletes / locked, plus ``is_empty``. Updates carry the live
+    record alongside the desired record so the caller has the UUID. Locked
+    entries pair desired YAML with their (possibly missing) live record.
+
+    Note that changing ``network`` or ``gateway`` (the identity tuple) on
+    a YAML resource produces a delete + add, not an update — the live
+    record's tuple no longer matches anything in YAML and a new tuple
+    appears with no live counterpart.
+    """
+
+    adds: list[StaticRouteConfig] = field(default_factory=list)
+    updates: list[tuple[LiveStaticRoute, StaticRouteConfig]] = field(default_factory=list)
+    deletes: list[LiveStaticRoute] = field(default_factory=list)
+    locked: list[tuple[StaticRouteConfig, LiveStaticRoute | None]] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True if there are no add/update/delete operations to apply."""
+        return not (self.adds or self.updates or self.deletes)
+
+
+# ---------------------------------------------------------------------------
+# Diff engine
+# ---------------------------------------------------------------------------
+
+
+def compute_diff(
+    desired: list[StaticRouteConfig],
+    current: list[LiveStaticRoute],
+    *,
+    add_only: bool = False,
+) -> Diff:
+    """Compare desired YAML state to live state, keyed by ``(network, gateway)``.
+
+    Args:
+        desired: Routes the operator wants to exist.
+        current: Routes currently on the box.
+        add_only: If True, never emit deletes for live routes that don't
+            appear in ``desired``. Adds and updates still happen.
+
+    Returns:
+        ``Diff`` with adds / updates / deletes plus locked entries.
+    """
+    desired_by_key: dict[tuple[str, str], StaticRouteConfig] = {r.diff_key: r for r in desired}
+    current_by_key: dict[tuple[str, str], LiveStaticRoute] = {r.diff_key: r for r in current}
+    locked_keys: set[tuple[str, str]] = {r.diff_key for r in desired if r.lock}
+
+    adds: list[StaticRouteConfig] = []
+    updates: list[tuple[LiveStaticRoute, StaticRouteConfig]] = []
+    deletes: list[LiveStaticRoute] = []
+    locked: list[tuple[StaticRouteConfig, LiveStaticRoute | None]] = []
+
+    for key, want in desired_by_key.items():
+        have = current_by_key.get(key)
+        if want.lock:
+            locked.append((want, have))
+            continue
+        if have is None:
+            adds.append(want)
+        elif _needs_update(have, want):
+            updates.append((have, want))
+
+    if not add_only:
+        for key, have in current_by_key.items():
+            if key in locked_keys:
+                continue
+            if key not in desired_by_key:
+                deletes.append(have)
+
+    return Diff(adds=adds, updates=updates, deletes=deletes, locked=locked)
+
+
+def _needs_update(have: LiveStaticRoute, want: StaticRouteConfig) -> bool:
+    """Return True if the live row's fields differ from the desired payload.
+
+    Compares the inner ``route`` payload from ``want.to_payload()`` against
+    the corresponding fields on ``have.raw``. ``searchroute`` returns
+    ``gateway`` as a flat string (the selected option key) — same shape as
+    ``want.to_payload()`` — so ``_normalize_field`` is mostly pass-through,
+    but it keeps update detection robust if the API surface changes.
+    """
+    payload = want.to_payload()["route"]
+    for key, want_value in payload.items():
+        have_value = _normalize_field(have.raw.get(key))
+        if str(want_value) != have_value:
+            return True
+    return False
+
+
+def _normalize_field(value: Any) -> str:
+    """Collapse an OPNsense field value to a comparable string.
+
+    Booleans (returned from ``searchroute``'s post-processed view) are
+    serialized as ``"1"`` / ``"0"`` to match what we'd send. Select fields
+    returned as option dicts (from ``getroute``) extract the selected key.
+    Plain scalars are stringified verbatim. ``None`` becomes ``""``.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, dict):
+        for option_key, option_value in value.items():
+            if isinstance(option_value, dict) and option_value.get("selected"):
+                return str(option_key)
+        return ""
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Resource-to-domain conversion
+# ---------------------------------------------------------------------------
+
+
+def static_route_configs_from_resources(
+    resources: list[ResourceConfig],
+) -> list[StaticRouteConfig]:
+    """Convert ``ResourceConfig`` entries to ``StaticRouteConfig`` instances.
+
+    Validation here is intentionally minimal — the validator handles
+    cross-resource references (gateway ref) and operator-friendly error
+    messages; this parser only enforces type sanity so manager code can
+    rely on field invariants.
+
+    Args:
+        resources: All provider resources from a ConfigManager load.
+            Non-``static_routes`` entries are silently skipped.
+
+    Returns:
+        Validated ``StaticRouteConfig`` list.
+
+    Raises:
+        ValueError: If an entry has a non-dict config, missing required
+            fields, or non-bool booleans / non-string fields.
+    """
+    configs: list[StaticRouteConfig] = []
+    for resource in resources:
+        if resource.type != "static_routes":
+            continue
+
+        config = resource.config
+        if not isinstance(config, dict):
+            raise ValueError(f"static_route '{resource.name}' has non-dict config")
+
+        network = config.get("network", "")
+        if not isinstance(network, str) or not network:
+            raise ValueError(
+                f"static_route '{resource.name}' requires a non-empty string 'network'"
+            )
+
+        gateway = config.get("gateway", "")
+        if not isinstance(gateway, str) or not gateway:
+            raise ValueError(
+                f"static_route '{resource.name}' requires a non-empty string 'gateway'"
+            )
+
+        description = config.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"static_route '{resource.name}' description must be a string")
+
+        enabled = _require_bool(config, "enabled", default=True, resource_name=resource.name)
+        lock = _require_bool(config, "lock", default=False, resource_name=resource.name)
+
+        configs.append(
+            StaticRouteConfig(
+                name=resource.name,
+                network=network,
+                gateway=gateway,
+                enabled=enabled,
+                description=description,
+                lock=lock,
+            )
+        )
+
+    return configs
+
+
+def _require_bool(
+    config: dict[str, Any], field_name: str, *, default: bool, resource_name: str
+) -> bool:
+    value = config.get(field_name, default)
+    if not isinstance(value, bool):
+        raise ValueError(
+            f"static_route '{resource_name}' {field_name} must be a boolean (true/false), "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def _bool_str(value: bool) -> str:
+    """Convert a Python bool to OPNsense's ``"0"``/``"1"`` representation."""
+    return "1" if value else "0"
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class StaticRouteService(BaseService):
+    """Service for OPNsense static-route operations via direct API.
+
+    Single controller, single endpoint family — no per-kind dispatch.
+    Identity is the natural-key ``(network, gateway)`` tuple, so the diff
+    engine matches operator YAML directly to live records by tuple. The
+    operator-facing ``name`` never travels on the wire.
+    """
+
+    # ------------------------------------------------------------------
+    # API operations (CRUD + reconfigure)
+    # ------------------------------------------------------------------
+
+    def search(self) -> list[LiveStaticRoute]:
+        """Fetch the live static-route list.
+
+        Returns:
+            ``LiveStaticRoute`` instances normalized from the search rows.
+        """
+        response = self.client.request("POST", f"{_ROUTE_BASE}/searchroute")
+
+        rows: list[dict[str, Any]] = []
+        if isinstance(response, dict):
+            raw_rows = response.get("rows")
+            if isinstance(raw_rows, list):
+                rows = [r for r in raw_rows if isinstance(r, dict)]
+
+        return [_row_to_live(row) for row in rows]
+
+    def get(self, uuid: str) -> dict[str, Any]:
+        """Fetch the full static-route record by UUID.
+
+        Used by ``export_to_yaml`` to read the option-dict-rendered fields
+        that ``searchroute`` doesn't expose. Returns the raw envelope
+        ``{"route": {...}}``.
+        """
+        return self.client.request("GET", f"{_ROUTE_BASE}/getroute/{uuid}")
+
+    def add(self, route: StaticRouteConfig) -> dict[str, Any]:
+        """Create a static route.
+
+        Args:
+            route: Desired-state static-route configuration.
+
+        Returns:
+            API response dict (typically ``{"result": "saved", "uuid": ...}``).
+        """
+        return self.client.request(
+            "POST",
+            f"{_ROUTE_BASE}/addroute",
+            data=route.to_payload(),
+        )
+
+    def update(self, uuid: str, route: StaticRouteConfig) -> dict[str, Any]:
+        """Update an existing static route by UUID.
+
+        Args:
+            uuid: OPNsense-assigned route UUID.
+            route: New desired-state configuration.
+
+        Returns:
+            API response dict.
+        """
+        return self.client.request(
+            "POST",
+            f"{_ROUTE_BASE}/setroute/{uuid}",
+            data=route.to_payload(),
+        )
+
+    def delete(self, uuid: str) -> dict[str, Any]:
+        """Delete a static route by UUID.
+
+        Args:
+            uuid: OPNsense-assigned route UUID.
+
+        Returns:
+            API response dict (typically ``{"result": "deleted"}``).
+        """
+        return self.client.request("POST", f"{_ROUTE_BASE}/delroute/{uuid}")
+
+    def reconfigure(self) -> dict[str, Any]:
+        """Apply pending route changes (commit staged config to running system).
+
+        Must be called after add/update/delete operations to activate them.
+        Response shape per the OpenAPI spec is ``{"status": "ok" | "failed"}``.
+        """
+        return self.client.request("POST", f"{_ROUTE_BASE}/reconfigure")
+
+    # ------------------------------------------------------------------
+    # Diff + apply orchestration
+    # ------------------------------------------------------------------
+
+    def compute_diff(
+        self,
+        desired: list[StaticRouteConfig],
+        live: list[LiveStaticRoute],
+        *,
+        add_only: bool = False,
+    ) -> Diff:
+        """Compute the add/update/delete diff between desired and live state.
+
+        Thin wrapper over the module-level ``compute_diff`` for callers
+        that prefer the service-method form.
+        """
+        return compute_diff(desired, live, add_only=add_only)
+
+    def apply_diff(self, diff: Diff) -> dict[str, int]:
+        """Dispatch the operations described by ``diff``, then reconfigure.
+
+        Returns:
+            Counts of operations actually performed:
+            ``{"created": N, "updated": M, "deleted": K}``. ``reconfigure``
+            is called once at the end if any mutation happened.
+        """
+        created = 0
+        updated = 0
+        deleted = 0
+
+        for route in diff.adds:
+            self.add(route)
+            created += 1
+
+        for live, want in diff.updates:
+            self.update(live.uuid, want)
+            updated += 1
+
+        for live in diff.deletes:
+            self.delete(live.uuid)
+            deleted += 1
+
+        if created or updated or deleted:
+            self.reconfigure()
+
+        return {"created": created, "updated": updated, "deleted": deleted}
+
+    # ------------------------------------------------------------------
+    # Migration / export
+    # ------------------------------------------------------------------
+
+    def export_to_yaml(self) -> str:
+        """Export the current static-route configuration to InfraFoundry YAML.
+
+        For each live route we issue a ``getroute/<uuid>`` to capture the
+        option-dict-rendered ``gateway`` field at full fidelity. Operator-
+        facing ``name`` is synthesized from ``(network, gateway)`` since
+        OPNsense has no name field — the operator can rename freely after
+        import; identity is the tuple, not the name.
+
+        Returns:
+            YAML string with ``provider/type/name/config`` entries.
+        """
+        live = self.search()
+        resources = [
+            {
+                "provider": "opnsense",
+                "type": "static_routes",
+                "name": _synthesize_name(route),
+                "config": _live_to_export_config(self.get(route.uuid)),
+            }
+            for route in live
+        ]
+        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (row parsing / export)
+# ---------------------------------------------------------------------------
+
+
+def _row_to_live(row: dict[str, Any]) -> LiveStaticRoute:
+    """Normalize a ``searchroute`` row into a ``LiveStaticRoute``."""
+    uuid = str(row.get("uuid", ""))
+    network = str(row.get("network", ""))
+    # ``searchroute`` returns ``gateway`` as a flat string already (the
+    # selected option key); fall through to ``_normalize_field`` for safety.
+    gateway = _normalize_field(row.get("gateway"))
+    return LiveStaticRoute(uuid=uuid, network=network, gateway=gateway, raw=row)
+
+
+def _synthesize_name(route: LiveStaticRoute) -> str:
+    """Build a YAML-friendly synthetic name from a ``LiveStaticRoute``.
+
+    Replaces characters that don't survive YAML keys / kebab-case
+    conventions (``/``, ``:``) with hyphens. The operator can rename
+    after import; identity is the ``(network, gateway)`` tuple, not
+    the name.
+    """
+    sanitized = route.network.replace("/", "-").replace(":", "-").replace(".", "-")
+    return f"route-{sanitized}-via-{route.gateway}".lower()
+
+
+def _live_to_export_config(get_response: dict[str, Any]) -> dict[str, Any]:
+    """Build a YAML-friendly config dict from a ``getroute`` envelope.
+
+    Reads the option-dict ``gateway`` via ``_normalize_field`` to recover
+    the selected gateway name. Booleans are decoded from the
+    ``"0"``/``"1"`` strings that OPNsense returns. The operator-facing
+    ``enabled`` is the inverse of the live ``disabled``.
+    """
+    item = get_response.get("route", {}) if isinstance(get_response, dict) else {}
+    return {
+        "enabled": _normalize_field(item.get("disabled")) != "1",
+        "network": _normalize_field(item.get("network")),
+        "gateway": _normalize_field(item.get("gateway")),
+        "description": _normalize_field(item.get("descr")),
+    }

--- a/src/infrafoundry/providers/opnsense/validator.py
+++ b/src/infrafoundry/providers/opnsense/validator.py
@@ -22,6 +22,7 @@ from infrafoundry.providers.opnsense.validators import (
     InterfaceAssignmentValidator,
     NATRuleValidator,
     ResourceNameValidator,
+    StaticRouteValidator,
     UnboundValidator,
     VLANValidator,
 )
@@ -83,6 +84,7 @@ class OPNsenseValidator:
         self.interface_assignment_validator = InterfaceAssignmentValidator(report)
         self.nat_rule_validator = NATRuleValidator(report)
         self.gateway_validator = GatewayValidator(report)
+        self.static_route_validator = StaticRouteValidator(report)
 
     def validate_connectivity(self) -> None:
         """Validate connectivity to OPNsense API.
@@ -185,6 +187,9 @@ class OPNsenseValidator:
             # Get existing interfaces/VLANs
             existing_interfaces = self._get_existing_interfaces(api_url, api_key, api_secret)
 
+            # Get existing gateway names (managed + dynamic) for static-route refs
+            existing_gateways = self._get_existing_gateways(api_url, api_key, api_secret)
+
             # Validate using specialized validators
             self.firewall_validator.validate(
                 resource_refs["firewall_rules"],
@@ -217,6 +222,12 @@ class OPNsenseValidator:
                 resource_refs["interface_assignment_names"],
                 existing_interfaces,
             )
+            self.static_route_validator.validate(
+                resource_refs["static_routes"],
+                resource_refs["gateways"],
+                resource_refs["gateway_names"],
+                existing_gateways,
+            )
             self.unbound_validator.validate(resource_refs["unbound_host_overrides"])
             self.resource_name_validator.validate(resources)
 
@@ -247,12 +258,14 @@ class OPNsenseValidator:
         interface_assignments = [r for r in resources if r.type == "interface_assignments"]
         nat_rules = [r for r in resources if r.type == "nat_rules"]
         gateways = [r for r in resources if r.type == "gateways"]
+        static_routes = [r for r in resources if r.type == "static_routes"]
 
         alias_names = {a.name for a in aliases}
         vlan_names = {v.name for v in vlans}
         interface_assignment_names = {a.name for a in interface_assignments}
         nat_rule_names = {r.name for r in nat_rules}
         gateway_names = {g.name for g in gateways}
+        static_route_names = {r.name for r in static_routes}
 
         return {
             "aliases": aliases,
@@ -268,6 +281,8 @@ class OPNsenseValidator:
             "nat_rule_names": nat_rule_names,
             "gateways": gateways,
             "gateway_names": gateway_names,
+            "static_routes": static_routes,
+            "static_route_names": static_route_names,
         }
 
     def _get_existing_aliases(
@@ -386,3 +401,40 @@ class OPNsenseValidator:
             for iface in interface_list
             if (name := self._extract_interface_name(iface))
         }
+
+    def _get_existing_gateways(self, api_url: str, api_key: str, api_secret: str) -> set[str]:
+        """Get the set of live gateway names from OPNsense API.
+
+        Returns the union of managed and dynamic gateways (e.g.,
+        ``WAN_DHCP``, ``WAN_DHCP6``). Used by the static-route validator
+        to accept references to live system gateways without first
+        declaring them as managed.
+
+        Args:
+            api_url: OPNsense API base URL
+            api_key: API key
+            api_secret: API secret
+
+        Returns:
+            Set of gateway names; empty if the API call fails.
+        """
+        data = self.api_validator.fetch_json(
+            url=f"{api_url}/api/routing/settings/searchGateway",
+            auth=(api_key, api_secret),
+            verify_ssl=False,
+            timeout=10,
+            method="POST",
+            check_name="opnsense_get_gateways",
+            error_message="Could not retrieve existing gateways (status {status})",
+            error_level=ValidationLevel.WARNING,
+        )
+        if not data:
+            return set()
+        names: set[str] = set()
+        for row in data.get("rows", []):
+            if not isinstance(row, dict):
+                continue
+            name = row.get("name")
+            if isinstance(name, str) and name:
+                names.add(name)
+        return names

--- a/src/infrafoundry/providers/opnsense/validators/__init__.py
+++ b/src/infrafoundry/providers/opnsense/validators/__init__.py
@@ -10,6 +10,9 @@ from infrafoundry.providers.opnsense.validators.nat_rule_validator import NATRul
 from infrafoundry.providers.opnsense.validators.resource_name_validator import (
     ResourceNameValidator,
 )
+from infrafoundry.providers.opnsense.validators.static_route_validator import (
+    StaticRouteValidator,
+)
 from infrafoundry.providers.opnsense.validators.unbound_validator import UnboundValidator
 from infrafoundry.providers.opnsense.validators.vlan_validator import VLANValidator
 
@@ -20,6 +23,7 @@ __all__ = [
     "InterfaceAssignmentValidator",
     "NATRuleValidator",
     "ResourceNameValidator",
+    "StaticRouteValidator",
     "UnboundValidator",
     "VLANValidator",
 ]

--- a/src/infrafoundry/providers/opnsense/validators/static_route_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/static_route_validator.py
@@ -1,0 +1,271 @@
+"""Static-route validation for OPNsense (ADR-0014, #722).
+
+Plan-time validation for the ``static_routes`` resource type. The validator
+is deliberately split from the service-side ``static_route_configs_from_resources``
+parser: the parser raises on hard schema violations (missing required fields,
+non-bool booleans), while the validator surfaces softer cross-resource
+reference issues (unknown gateway) and field-shape problems (malformed CIDR,
+host-bits-set CIDR, IP-vs-protocol mismatch) as ``ValidationReport`` entries.
+
+Cross-reference targets:
+
+- ``network``: must parse as an IPv4 or IPv6 network in CIDR notation
+  (no host bits set).
+- ``gateway``: must reference either a managed ``gateways`` resource
+  declared in YAML *or* a live system gateway (e.g., ``WAN_DHCP``,
+  ``WAN_DHCP6``) returned by OPNsense's ``searchGateway``. This mirrors
+  the gateway validator's interface-acceptance pattern — operators can
+  reference dynamic gateways without first declaring them as managed.
+- Protocol match: the network's IP family must match the referenced
+  gateway's IP protocol family (IPv4 network → IPv4 gateway, IPv6 network →
+  IPv6 gateway). The validator enforces this for managed gateways (where
+  ``protocol`` is in YAML); for live system gateways the heuristic is the
+  trailing ``6`` convention (e.g., ``WAN_DHCP6`` is treated as IPv6).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationLevel, ValidationReport
+
+
+class StaticRouteValidator:
+    """Validates OPNsense static-route resources against managed + live state."""
+
+    def __init__(self, report: ValidationReport) -> None:
+        """Initialize validator.
+
+        Args:
+            report: ValidationReport to add results to.
+        """
+        self.report = report
+
+    def validate(
+        self,
+        static_routes: list[ResourceConfig],
+        managed_gateways: list[ResourceConfig],
+        gateway_names: set[str],
+        existing_gateways: set[str],
+    ) -> None:
+        """Validate static-route resources.
+
+        Args:
+            static_routes: ``static_routes`` ``ResourceConfig`` entries.
+            managed_gateways: ``gateways`` ``ResourceConfig`` entries —
+                used to resolve the gateway's IP protocol for the protocol-
+                match check.
+            gateway_names: Set of managed gateway names declared in YAML.
+            existing_gateways: Set of live gateway names returned by
+                OPNsense's ``searchGateway`` (managed + dynamic).
+        """
+        gateway_protocols = _index_managed_gateway_protocols(managed_gateways)
+        for route in static_routes:
+            self._validate_one(
+                route,
+                gateway_names=gateway_names,
+                existing_gateways=existing_gateways,
+                gateway_protocols=gateway_protocols,
+            )
+
+    def _validate_one(
+        self,
+        route: ResourceConfig,
+        *,
+        gateway_names: set[str],
+        existing_gateways: set[str],
+        gateway_protocols: dict[str, str],
+    ) -> None:
+        """Run all checks for a single static-route entry."""
+        network = self._validate_network(route)
+        gateway = self._validate_gateway(
+            route,
+            gateway_names=gateway_names,
+            existing_gateways=existing_gateways,
+        )
+        if network is not None and gateway is not None:
+            self._validate_protocol_match(route, network, gateway, gateway_protocols)
+        self._validate_bool(route, "enabled")
+        self._validate_bool(route, "lock")
+        self._validate_description(route)
+
+    # ------------------------------------------------------------------
+    # network (CIDR)
+    # ------------------------------------------------------------------
+
+    def _validate_network(
+        self, route: ResourceConfig
+    ) -> ipaddress.IPv4Network | ipaddress.IPv6Network | None:
+        """Validate the ``network`` CIDR. Returns the parsed network or None."""
+        network_raw = route.config.get("network")
+        if network_raw is None:
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_network",
+                passed=False,
+                message=f"static_route '{route.name}' missing required field 'network'",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+        if not isinstance(network_raw, str) or not network_raw:
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_network",
+                passed=False,
+                message=f"static_route '{route.name}' network must be a non-empty string",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+        try:
+            # ``strict=True`` rejects host bits set (e.g., ``10.0.0.1/24``).
+            return ipaddress.ip_network(network_raw, strict=True)
+        except ValueError as exc:
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_network",
+                passed=False,
+                message=(
+                    f"static_route '{route.name}' network {network_raw!r} "
+                    f"is not a valid CIDR: {exc}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # gateway (cross-ref into managed + live)
+    # ------------------------------------------------------------------
+
+    def _validate_gateway(
+        self,
+        route: ResourceConfig,
+        *,
+        gateway_names: set[str],
+        existing_gateways: set[str],
+    ) -> str | None:
+        """Validate the ``gateway`` cross-reference. Returns the value or None."""
+        gateway = route.config.get("gateway")
+        if gateway is None:
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_gateway",
+                passed=False,
+                message=f"static_route '{route.name}' missing required field 'gateway'",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+        if not isinstance(gateway, str) or not gateway:
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_gateway",
+                passed=False,
+                message=f"static_route '{route.name}' gateway must be a non-empty string",
+                level=ValidationLevel.ERROR,
+            )
+            return None
+        if gateway in gateway_names or gateway in existing_gateways:
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_gateway",
+                passed=True,
+                message=f"Gateway '{gateway}' resolved for static_route '{route.name}'",
+                level=ValidationLevel.INFO,
+            )
+            return gateway
+        self.report.add_check(
+            check_name=f"static_route_{route.name}_gateway",
+            passed=False,
+            message=(
+                f"static_route '{route.name}' references unknown gateway '{gateway}'; "
+                f"expected a managed 'gateways' resource name or a live OPNsense gateway"
+            ),
+            level=ValidationLevel.ERROR,
+        )
+        return None
+
+    # ------------------------------------------------------------------
+    # protocol match (network family vs gateway family)
+    # ------------------------------------------------------------------
+
+    def _validate_protocol_match(
+        self,
+        route: ResourceConfig,
+        network: ipaddress.IPv4Network | ipaddress.IPv6Network,
+        gateway: str,
+        gateway_protocols: dict[str, str],
+    ) -> None:
+        """Validate that ``network``'s family matches the gateway's protocol.
+
+        For managed gateways the protocol is read from YAML. For live
+        system gateways the heuristic is the trailing ``6`` convention
+        (e.g., ``WAN_DHCP6`` → IPv6, ``WAN_DHCP`` → IPv4).
+        """
+        gateway_protocol = gateway_protocols.get(gateway)
+        if gateway_protocol is None:
+            # Live system gateway — apply the trailing-6 heuristic.
+            gateway_protocol = "inet6" if gateway.endswith("6") else "inet"
+
+        is_v4_network = isinstance(network, ipaddress.IPv4Network)
+        wants_v4 = gateway_protocol == "inet"
+        if is_v4_network == wants_v4:
+            return
+        self.report.add_check(
+            check_name=f"static_route_{route.name}_protocol_match",
+            passed=False,
+            message=(
+                f"static_route '{route.name}' network family does not match gateway "
+                f"'{gateway}' protocol: network is {'IPv4' if is_v4_network else 'IPv6'} "
+                f"but gateway protocol is {gateway_protocol!r}"
+            ),
+            level=ValidationLevel.ERROR,
+        )
+
+    # ------------------------------------------------------------------
+    # bool fields
+    # ------------------------------------------------------------------
+
+    def _validate_bool(self, route: ResourceConfig, field_name: str) -> None:
+        if field_name not in route.config:
+            return
+        value = route.config[field_name]
+        if not isinstance(value, bool):
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_{field_name}",
+                passed=False,
+                message=(
+                    f"static_route '{route.name}' {field_name} must be a boolean (true/false), "
+                    f"got {type(value).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+    # ------------------------------------------------------------------
+    # description
+    # ------------------------------------------------------------------
+
+    def _validate_description(self, route: ResourceConfig) -> None:
+        if "description" not in route.config:
+            return
+        value = route.config["description"]
+        if not isinstance(value, str):
+            self.report.add_check(
+                check_name=f"static_route_{route.name}_description",
+                passed=False,
+                message=(
+                    f"static_route '{route.name}' description must be a string, "
+                    f"got {type(value).__name__}"
+                ),
+                level=ValidationLevel.ERROR,
+            )
+
+
+def _index_managed_gateway_protocols(
+    managed_gateways: list[ResourceConfig],
+) -> dict[str, str]:
+    """Build ``{gateway_name: protocol}`` from managed gateway resources.
+
+    Skips entries with malformed protocol values — those have their own
+    validator failures from ``GatewayValidator`` and we don't want to
+    double-report.
+    """
+    result: dict[str, str] = {}
+    for gateway in managed_gateways:
+        protocol = gateway.config.get("protocol")
+        if isinstance(protocol, str) and protocol in ("inet", "inet6"):
+            result[gateway.name] = protocol
+    return result

--- a/tests/unit/providers/opnsense/test_static_route_manager.py
+++ b/tests/unit/providers/opnsense/test_static_route_manager.py
@@ -1,0 +1,326 @@
+"""Unit tests for ``StaticRouteManager``.
+
+Coverage:
+    - plan/apply/destroy delegate to StaticRouteService correctly.
+    - apply emits ``ResourceOutcome`` entries for adds/updates/deletes.
+    - delete outcomes use the synthesized ``route-<network>-via-<gateway>`` name.
+    - get_resource_ids maps live UUIDs to operator-facing names by tuple match.
+    - migrate exports YAML.
+    - lock semantics honored on destroy.
+    - add_only flag propagated to compute_diff.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.components.static_route import StaticRouteManager
+from infrafoundry.providers.opnsense.services.static_route import (
+    Diff,
+    LiveStaticRoute,
+    StaticRouteConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resource(
+    name: str,
+    *,
+    network: str = "10.0.0.0/24",
+    gateway: str = "WAN_DHCP",
+    lock: bool = False,
+) -> ResourceConfig:
+    config: dict[str, Any] = {
+        "network": network,
+        "gateway": gateway,
+        "description": f"{name} desc",
+    }
+    if lock:
+        config["lock"] = True
+    return ResourceConfig(name=name, type="static_routes", provider="opnsense", config=config)
+
+
+def _live(
+    uuid: str,
+    *,
+    network: str = "10.0.0.0/24",
+    gateway: str = "WAN_DHCP",
+) -> LiveStaticRoute:
+    return LiveStaticRoute(
+        uuid=uuid,
+        network=network,
+        gateway=gateway,
+        raw={
+            "uuid": uuid,
+            "network": network,
+            "gateway": gateway,
+            "disabled": "0",
+            "descr": "",
+        },
+    )
+
+
+def _route(name: str, **overrides: Any) -> StaticRouteConfig:
+    return StaticRouteConfig(
+        name=name,
+        network=overrides.get("network", "10.0.0.0/24"),
+        gateway=overrides.get("gateway", "WAN_DHCP"),
+        enabled=overrides.get("enabled", True),
+    )
+
+
+SERVICE_PATH = "infrafoundry.providers.opnsense.components.static_route.StaticRouteService"
+
+
+def _make_service_mock(
+    *,
+    live: list[LiveStaticRoute] | None = None,
+    diff: Diff | None = None,
+    apply_counts: dict[str, int] | None = None,
+) -> MagicMock:
+    """Build a mocked ``StaticRouteService`` with sensible defaults."""
+    service = MagicMock()
+    service.search.return_value = live if live is not None else []
+    service.compute_diff.return_value = diff if diff is not None else Diff()
+    service.apply_diff.return_value = (
+        apply_counts if apply_counts is not None else {"created": 0, "updated": 0, "deleted": 0}
+    )
+    return service
+
+
+# ---------------------------------------------------------------------------
+# plan
+# ---------------------------------------------------------------------------
+
+
+class TestPlan:
+    def test_returns_diff(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        diff = Diff(adds=[_route("foo")])
+        service_mock = _make_service_mock(diff=diff)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.plan("test-env", resources)
+        assert result.adds == diff.adds
+        svc_cls.from_environment.assert_called_once_with("test-env", "opnsense", tmp_path)
+        service_mock.compute_diff.assert_called_once()
+
+    def test_threads_add_only(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        service_mock = _make_service_mock(diff=Diff())
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            manager.plan("test-env", resources, add_only=True)
+        assert service_mock.compute_diff.call_args.kwargs["add_only"] is True
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    def test_apply_returns_counts(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        diff = Diff(adds=[_route("foo")])
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 1, "updated": 0, "deleted": 0}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        assert result["resources_created"] == 1
+        assert result["success"] is True
+
+    def test_apply_emits_add_outcome(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        diff = Diff(adds=[_route("foo")])
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 1, "updated": 0, "deleted": 0}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        outcomes = result["resource_outcomes"]
+        assert len(outcomes) == 1
+        assert outcomes[0].action == "add"
+        assert outcomes[0].resource_name == "foo"
+        assert outcomes[0].address == "opnsense_static_route.foo"
+
+    def test_apply_emits_update_outcome(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        live = _live("u1")
+        want = _route("foo")
+        diff = Diff(updates=[(live, want)])
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 0, "updated": 1, "deleted": 0}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        outcomes = result["resource_outcomes"]
+        assert len(outcomes) == 1
+        assert outcomes[0].action == "update"
+        assert outcomes[0].resource_name == "foo"
+        assert outcomes[0].address == "opnsense_static_route.foo"
+
+    def test_apply_emits_delete_outcome_with_synthetic_name(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources: list[ResourceConfig] = []
+        live = _live("u1", network="172.16.0.0/24", gateway="WAN_DHCP")
+        diff = Diff(deletes=[live])
+        service_mock = _make_service_mock(
+            diff=diff, apply_counts={"created": 0, "updated": 0, "deleted": 1}
+        )
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.apply("test-env", resources)
+        outcomes = result["resource_outcomes"]
+        assert len(outcomes) == 1
+        assert outcomes[0].action == "delete"
+        # Live records carry no operator-facing name; address uses the
+        # synthetic ``route-<network>-via-<gateway>`` form.
+        assert outcomes[0].resource_name == "route-172-16-0-0-24-via-wan_dhcp"
+        assert outcomes[0].address == "opnsense_static_route.route-172-16-0-0-24-via-wan_dhcp"
+
+    def test_apply_threads_add_only(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        service_mock = _make_service_mock(diff=Diff())
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            manager.apply("test-env", resources, add_only=True)
+        assert service_mock.compute_diff.call_args.kwargs["add_only"] is True
+
+
+# ---------------------------------------------------------------------------
+# destroy
+# ---------------------------------------------------------------------------
+
+
+class TestDestroy:
+    def test_destroy_deletes_matching_routes(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        live = [_live("u1")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        service_mock.delete.assert_called_once_with("u1")
+        service_mock.reconfigure.assert_called_once()
+        assert result["resources_destroyed"] == 1
+        assert result["locked_skipped"] == 0
+
+    def test_destroy_skips_when_no_live_match(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo")]
+        service_mock = _make_service_mock(live=[])
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        service_mock.delete.assert_not_called()
+        service_mock.reconfigure.assert_not_called()
+        assert result["resources_destroyed"] == 0
+
+    def test_destroy_honors_lock(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("survival", lock=True)]
+        live = [_live("u1")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        service_mock.delete.assert_not_called()
+        assert result["locked_skipped"] == 1
+
+    def test_destroy_matches_by_natural_key(self, tmp_path: Path) -> None:
+        # YAML name is ``foo``, but identity matches by tuple — verify
+        # that two tuples that don't match each other don't accidentally
+        # collide on names.
+        manager = StaticRouteManager(tmp_path)
+        resources = [_resource("foo", network="10.0.0.0/24", gateway="WAN_DHCP")]
+        live = [
+            _live("u1", network="10.0.0.0/24", gateway="WAN_DHCP"),
+            _live("u2", network="172.16.0.0/24", gateway="WAN_DHCP"),
+        ]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.destroy("test-env", resources)
+        # Only the matching tuple is deleted.
+        service_mock.delete.assert_called_once_with("u1")
+        assert result["resources_destroyed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_resource_ids
+# ---------------------------------------------------------------------------
+
+
+class TestGetResourceIds:
+    def test_maps_names_to_uuids_by_tuple(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [
+            _resource("foo", network="10.0.0.0/24", gateway="WAN_DHCP"),
+            _resource("bar", network="172.16.0.0/24", gateway="WAN_DHCP"),
+        ]
+        live = [
+            _live("u1", network="10.0.0.0/24", gateway="WAN_DHCP"),
+            _live("u2", network="172.16.0.0/24", gateway="WAN_DHCP"),
+        ]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.get_resource_ids("test-env", resources)
+        assert result == {"foo": "u1", "bar": "u2"}
+
+    def test_omits_resources_with_no_live_match(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        resources = [
+            _resource("foo", network="10.0.0.0/24", gateway="WAN_DHCP"),
+            _resource("missing", network="192.168.0.0/24", gateway="WAN_DHCP"),
+        ]
+        live = [_live("u1", network="10.0.0.0/24", gateway="WAN_DHCP")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.get_resource_ids("test-env", resources)
+        assert result == {"foo": "u1"}
+
+
+# ---------------------------------------------------------------------------
+# list / migrate
+# ---------------------------------------------------------------------------
+
+
+class TestListAndMigrate:
+    def test_list_returns_live_routes(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        live = [_live("u1"), _live("u2", network="172.16.0.0/24")]
+        service_mock = _make_service_mock(live=live)
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.list("test-env")
+        assert result == live
+
+    def test_migrate_returns_yaml_string(self, tmp_path: Path) -> None:
+        manager = StaticRouteManager(tmp_path)
+        service_mock = MagicMock()
+        service_mock.export_to_yaml.return_value = "resources: []\n"
+        with patch(SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service_mock
+            result = manager.migrate("test-env")
+        assert result == "resources: []\n"
+        service_mock.export_to_yaml.assert_called_once()

--- a/tests/unit/providers/opnsense/test_static_route_service.py
+++ b/tests/unit/providers/opnsense/test_static_route_service.py
@@ -1,0 +1,788 @@
+"""Unit tests for ``infrafoundry.providers.opnsense.services.static_route``.
+
+Coverage:
+    - ``StaticRouteConfig.to_payload`` envelope + boolean inversion
+      (``enabled`` → ``disabled``) + ``description`` → ``descr`` mapping.
+    - ``compute_diff`` with adds / updates / deletes / lock + add-only.
+    - Identity is the ``(network, gateway)`` natural-key tuple — YAML
+      ``name`` changes don't trigger updates.
+    - ``static_route_configs_from_resources`` validation.
+    - ``StaticRouteService`` API method dispatch via ``OPNsenseClient.request``.
+    - ``apply_diff`` orchestration (single ``reconfigure`` if any mutation).
+    - ``_normalize_field`` for OPNsense select dicts and bool variants.
+    - ``export_to_yaml`` round-trip with synthetic name generation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.services.static_route import (
+    Diff,
+    LiveStaticRoute,
+    StaticRouteConfig,
+    StaticRouteService,
+    _live_to_export_config,
+    _normalize_field,
+    _row_to_live,
+    _synthesize_name,
+    compute_diff,
+    static_route_configs_from_resources,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _route(
+    name: str,
+    *,
+    network: str = "10.0.0.0/24",
+    gateway: str = "WAN_DHCP",
+    enabled: bool = True,
+    description: str = "",
+    lock: bool = False,
+) -> StaticRouteConfig:
+    return StaticRouteConfig(
+        name=name,
+        network=network,
+        gateway=gateway,
+        enabled=enabled,
+        description=description,
+        lock=lock,
+    )
+
+
+def _live(
+    uuid: str,
+    *,
+    network: str = "10.0.0.0/24",
+    gateway: str = "WAN_DHCP",
+    raw_overrides: dict[str, Any] | None = None,
+) -> LiveStaticRoute:
+    raw: dict[str, Any] = {
+        "uuid": uuid,
+        "network": network,
+        "gateway": gateway,
+        "disabled": "0",
+        "descr": "",
+    }
+    if raw_overrides:
+        raw.update(raw_overrides)
+    return LiveStaticRoute(uuid=uuid, network=network, gateway=gateway, raw=raw)
+
+
+def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
+    return ResourceConfig(name=name, type="static_routes", provider="opnsense", config=config)
+
+
+# ---------------------------------------------------------------------------
+# StaticRouteConfig.to_payload
+# ---------------------------------------------------------------------------
+
+
+class TestPayload:
+    def test_payload_has_envelope(self) -> None:
+        payload = _route("foo").to_payload()
+        assert set(payload.keys()) == {"route"}
+
+    def test_payload_field_set(self) -> None:
+        route = _route(
+            "lan-via-wan",
+            network="10.0.0.0/24",
+            gateway="WAN_DHCP",
+            description="reach the LAN",
+        )
+        inner = route.to_payload()["route"]
+        assert inner["network"] == "10.0.0.0/24"
+        assert inner["gateway"] == "WAN_DHCP"
+        assert inner["descr"] == "reach the LAN"
+
+    def test_enabled_true_serializes_disabled_zero(self) -> None:
+        # operator-facing ``enabled=True`` → wire ``disabled=0``.
+        inner = _route("foo", enabled=True).to_payload()["route"]
+        assert inner["disabled"] == "0"
+
+    def test_enabled_false_serializes_disabled_one(self) -> None:
+        inner = _route("foo", enabled=False).to_payload()["route"]
+        assert inner["disabled"] == "1"
+
+    def test_name_not_sent_on_wire(self) -> None:
+        # ``name`` is operator-facing only; the wire only carries
+        # ``network``, ``gateway``, ``descr``, ``disabled``.
+        inner = _route("operator-friendly-name").to_payload()["route"]
+        assert "name" not in inner
+        assert set(inner.keys()) == {"network", "gateway", "descr", "disabled"}
+
+    def test_default_description_empty(self) -> None:
+        inner = _route("foo").to_payload()["route"]
+        assert inner["descr"] == ""
+
+
+class TestDiffKey:
+    def test_diff_key_is_tuple(self) -> None:
+        route = _route("foo", network="10.0.0.0/24", gateway="WAN_DHCP")
+        assert route.diff_key == ("10.0.0.0/24", "WAN_DHCP")
+
+    def test_live_diff_key_is_tuple(self) -> None:
+        live = _live("u1", network="10.0.0.0/24", gateway="WAN_DHCP")
+        assert live.diff_key == ("10.0.0.0/24", "WAN_DHCP")
+
+    def test_yaml_name_does_not_affect_diff_key(self) -> None:
+        a = _route("name-one", network="10.0.0.0/24", gateway="WAN_DHCP")
+        b = _route("name-two", network="10.0.0.0/24", gateway="WAN_DHCP")
+        assert a.diff_key == b.diff_key
+
+
+# ---------------------------------------------------------------------------
+# compute_diff
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDiffEmpty:
+    def test_no_desired_no_live_is_empty(self) -> None:
+        diff = compute_diff([], [])
+        assert diff.is_empty
+        assert diff.adds == []
+        assert diff.deletes == []
+        assert diff.updates == []
+        assert diff.locked == []
+
+
+class TestComputeDiffAdds:
+    def test_new_route_adds(self) -> None:
+        diff = compute_diff([_route("foo")], [])
+        assert len(diff.adds) == 1
+        assert diff.adds[0].network == "10.0.0.0/24"
+        assert diff.adds[0].gateway == "WAN_DHCP"
+
+
+class TestComputeDiffUpdates:
+    def test_update_when_description_changes(self) -> None:
+        # Only ``descr`` differs; the identity tuple matches.
+        route = _route("foo", description="new description")
+        live_raw: dict[str, Any] = {
+            "uuid": "u1",
+            "network": "10.0.0.0/24",
+            "gateway": "WAN_DHCP",
+            "disabled": "0",
+            "descr": "old description",
+        }
+        live = LiveStaticRoute(
+            uuid="u1",
+            network="10.0.0.0/24",
+            gateway="WAN_DHCP",
+            raw=live_raw,
+        )
+        diff = compute_diff([route], [live])
+        assert len(diff.updates) == 1
+        live_record, want = diff.updates[0]
+        assert live_record.uuid == "u1"
+        assert want.description == "new description"
+
+    def test_update_when_disabled_flips(self) -> None:
+        route = _route("foo", enabled=False)
+        live_raw: dict[str, Any] = {
+            "uuid": "u1",
+            "network": "10.0.0.0/24",
+            "gateway": "WAN_DHCP",
+            "disabled": "0",
+            "descr": "",
+        }
+        live = LiveStaticRoute(
+            uuid="u1",
+            network="10.0.0.0/24",
+            gateway="WAN_DHCP",
+            raw=live_raw,
+        )
+        diff = compute_diff([route], [live])
+        assert len(diff.updates) == 1
+
+    def test_no_update_when_payload_matches(self) -> None:
+        route = _route("foo")
+        live_raw: dict[str, Any] = {"uuid": "u1", **route.to_payload()["route"]}
+        live = LiveStaticRoute(
+            uuid="u1",
+            network="10.0.0.0/24",
+            gateway="WAN_DHCP",
+            raw=live_raw,
+        )
+        diff = compute_diff([route], [live])
+        assert diff.is_empty
+
+    def test_yaml_name_change_alone_is_noop(self) -> None:
+        # ``name`` change with same identity tuple is a no-op (name is
+        # operator metadata, not on the wire).
+        route = _route("renamed-route")
+        live_raw: dict[str, Any] = {"uuid": "u1", **route.to_payload()["route"]}
+        live = LiveStaticRoute(
+            uuid="u1",
+            network="10.0.0.0/24",
+            gateway="WAN_DHCP",
+            raw=live_raw,
+        )
+        diff = compute_diff([route], [live])
+        assert diff.is_empty
+
+    def test_changing_gateway_is_delete_plus_add(self) -> None:
+        # Identity tuple changed — old record has no YAML counterpart
+        # (delete) and new tuple has no live counterpart (add).
+        old_live = _live("u1", network="10.0.0.0/24", gateway="WAN_DHCP")
+        new_route = _route("foo", network="10.0.0.0/24", gateway="ALT_GW")
+        diff = compute_diff([new_route], [old_live])
+        assert len(diff.adds) == 1
+        assert diff.adds[0].gateway == "ALT_GW"
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].uuid == "u1"
+
+
+class TestComputeDiffDeletes:
+    def test_live_with_no_desired_is_deleted(self) -> None:
+        diff = compute_diff([], [_live("u1")])
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].uuid == "u1"
+
+    def test_add_only_suppresses_deletes(self) -> None:
+        diff = compute_diff([], [_live("u1")], add_only=True)
+        assert diff.deletes == []
+        assert diff.is_empty
+
+    def test_add_only_still_emits_updates(self) -> None:
+        route = _route("foo", description="changed")
+        live_raw: dict[str, Any] = {
+            "uuid": "u1",
+            "network": "10.0.0.0/24",
+            "gateway": "WAN_DHCP",
+            "disabled": "0",
+            "descr": "old",
+        }
+        live = LiveStaticRoute(
+            uuid="u1",
+            network="10.0.0.0/24",
+            gateway="WAN_DHCP",
+            raw=live_raw,
+        )
+        diff = compute_diff([route], [live], add_only=True)
+        assert len(diff.updates) == 1
+
+
+class TestComputeDiffLocked:
+    def test_locked_resource_with_match_skipped_from_actions(self) -> None:
+        route = _route("survival", description="locked", lock=True)
+        live_raw: dict[str, Any] = {
+            "uuid": "u1",
+            "network": "10.0.0.0/24",
+            "gateway": "WAN_DHCP",
+            "disabled": "0",
+            "descr": "drift!",
+        }
+        live = LiveStaticRoute(
+            uuid="u1",
+            network="10.0.0.0/24",
+            gateway="WAN_DHCP",
+            raw=live_raw,
+        )
+        diff = compute_diff([route], [live])
+        assert diff.adds == []
+        assert diff.updates == []
+        assert diff.deletes == []
+        assert len(diff.locked) == 1
+        want, have = diff.locked[0]
+        assert want.lock is True
+        assert have is not None
+        assert have.uuid == "u1"
+
+    def test_locked_resource_without_match(self) -> None:
+        route = _route("missing", lock=True)
+        diff = compute_diff([route], [])
+        assert len(diff.locked) == 1
+        _want, have = diff.locked[0]
+        assert have is None
+
+    def test_locked_resource_does_not_appear_as_delete_when_only_in_yaml(self) -> None:
+        # Confirms locked tuples are excluded from the delete pass even
+        # when they have no live counterpart and there's another live
+        # to delete.
+        route = _route("locked-name", lock=True)
+        live_other = _live("u2", network="172.16.0.0/24", gateway="WAN_DHCP")
+        diff = compute_diff([route], [live_other])
+        # The other live (172.16/24) should still be deleted.
+        assert len(diff.deletes) == 1
+        assert diff.deletes[0].network == "172.16.0.0/24"
+
+
+class TestDiffIsEmpty:
+    def test_empty_diff(self) -> None:
+        assert Diff().is_empty
+
+    def test_locked_alone_counts_as_empty(self) -> None:
+        diff = Diff(locked=[(_route("foo", lock=True), None)])
+        assert diff.is_empty
+
+    def test_non_empty_when_adds(self) -> None:
+        diff = Diff(adds=[_route("foo")])
+        assert not diff.is_empty
+
+    def test_non_empty_when_updates(self) -> None:
+        diff = Diff(updates=[(_live("u1"), _route("foo"))])
+        assert not diff.is_empty
+
+    def test_non_empty_when_deletes(self) -> None:
+        diff = Diff(deletes=[_live("u1")])
+        assert not diff.is_empty
+
+
+# ---------------------------------------------------------------------------
+# _normalize_field
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeField:
+    def test_none_becomes_empty(self) -> None:
+        assert _normalize_field(None) == ""
+
+    def test_bool_true_becomes_one(self) -> None:
+        assert _normalize_field(True) == "1"
+
+    def test_bool_false_becomes_zero(self) -> None:
+        assert _normalize_field(False) == "0"
+
+    def test_string_passthrough(self) -> None:
+        assert _normalize_field("WAN_DHCP") == "WAN_DHCP"
+
+    def test_int_stringified(self) -> None:
+        assert _normalize_field(42) == "42"
+
+    def test_select_dict_extracts_selected_key(self) -> None:
+        # getroute returns gateway as a select dict.
+        value = {
+            "WAN_DHCP": {"value": "WAN_DHCP - 10.0.0.1", "selected": 1},
+            "WAN_DHCP6": {"value": "WAN_DHCP6 - fe80::1", "selected": 0},
+        }
+        assert _normalize_field(value) == "WAN_DHCP"
+
+    def test_select_dict_no_selection_returns_empty(self) -> None:
+        value = {"WAN_DHCP": {"value": "WAN_DHCP - 10.0.0.1", "selected": 0}}
+        assert _normalize_field(value) == ""
+
+
+# ---------------------------------------------------------------------------
+# static_route_configs_from_resources
+# ---------------------------------------------------------------------------
+
+
+class TestConfigsFromResources:
+    def test_valid_parses(self) -> None:
+        r = _resource(
+            "lan-via-wan",
+            {
+                "network": "10.0.0.0/24",
+                "gateway": "WAN_DHCP",
+                "description": "lan",
+            },
+        )
+        result = static_route_configs_from_resources([r])
+        assert len(result) == 1
+        cfg = result[0]
+        assert cfg.name == "lan-via-wan"
+        assert cfg.network == "10.0.0.0/24"
+        assert cfg.gateway == "WAN_DHCP"
+        assert cfg.description == "lan"
+
+    def test_default_enabled_true(self) -> None:
+        r = _resource(
+            "foo",
+            {"network": "10.0.0.0/24", "gateway": "WAN_DHCP"},
+        )
+        cfg = static_route_configs_from_resources([r])[0]
+        assert cfg.enabled is True
+
+    def test_explicit_enabled_false(self) -> None:
+        r = _resource(
+            "foo",
+            {"network": "10.0.0.0/24", "gateway": "WAN_DHCP", "enabled": False},
+        )
+        cfg = static_route_configs_from_resources([r])[0]
+        assert cfg.enabled is False
+
+    def test_lock_passthrough(self) -> None:
+        r = _resource(
+            "foo",
+            {"network": "10.0.0.0/24", "gateway": "WAN_DHCP", "lock": True},
+        )
+        cfg = static_route_configs_from_resources([r])[0]
+        assert cfg.lock is True
+
+    def test_missing_network_rejected(self) -> None:
+        r = _resource("bad", {"gateway": "WAN_DHCP"})
+        with pytest.raises(ValueError, match="network"):
+            static_route_configs_from_resources([r])
+
+    def test_empty_network_rejected(self) -> None:
+        r = _resource("bad", {"network": "", "gateway": "WAN_DHCP"})
+        with pytest.raises(ValueError, match="network"):
+            static_route_configs_from_resources([r])
+
+    def test_missing_gateway_rejected(self) -> None:
+        r = _resource("bad", {"network": "10.0.0.0/24"})
+        with pytest.raises(ValueError, match="gateway"):
+            static_route_configs_from_resources([r])
+
+    def test_empty_gateway_rejected(self) -> None:
+        r = _resource("bad", {"network": "10.0.0.0/24", "gateway": ""})
+        with pytest.raises(ValueError, match="gateway"):
+            static_route_configs_from_resources([r])
+
+    def test_non_string_description_rejected(self) -> None:
+        r = _resource(
+            "bad",
+            {"network": "10.0.0.0/24", "gateway": "WAN_DHCP", "description": 12345},
+        )
+        with pytest.raises(ValueError, match="description"):
+            static_route_configs_from_resources([r])
+
+    def test_non_bool_enabled_rejected(self) -> None:
+        r = _resource(
+            "bad",
+            {"network": "10.0.0.0/24", "gateway": "WAN_DHCP", "enabled": "yes"},
+        )
+        with pytest.raises(ValueError, match="enabled"):
+            static_route_configs_from_resources([r])
+
+    def test_non_bool_lock_rejected(self) -> None:
+        r = _resource(
+            "bad",
+            {"network": "10.0.0.0/24", "gateway": "WAN_DHCP", "lock": "yes"},
+        )
+        with pytest.raises(ValueError, match="lock"):
+            static_route_configs_from_resources([r])
+
+    def test_non_dict_config_rejected(self) -> None:
+        r = ResourceConfig(
+            name="bad",
+            type="static_routes",
+            provider="opnsense",
+            config={"network": "10.0.0.0/24", "gateway": "WAN_DHCP"},
+        )
+        # Bypass pydantic — guard the service-side defensive check.
+        r.config = "not-a-dict"  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="non-dict"):
+            static_route_configs_from_resources([r])
+
+    def test_non_static_routes_resources_ignored(self) -> None:
+        sr = _resource("ok", {"network": "10.0.0.0/24", "gateway": "WAN_DHCP"})
+        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        result = static_route_configs_from_resources([sr, other])
+        assert len(result) == 1
+        assert result[0].name == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _row_to_live
+# ---------------------------------------------------------------------------
+
+
+class TestRowToLive:
+    def test_basic_row(self) -> None:
+        row = {
+            "uuid": "u1",
+            "network": "10.0.0.0/24",
+            "gateway": "WAN_DHCP",
+            "descr": "lan",
+            "disabled": "0",
+        }
+        live = _row_to_live(row)
+        assert live.uuid == "u1"
+        assert live.network == "10.0.0.0/24"
+        assert live.gateway == "WAN_DHCP"
+        assert live.raw == row
+
+    def test_missing_keys_default(self) -> None:
+        live = _row_to_live({})
+        assert live.uuid == ""
+        assert live.network == ""
+        assert live.gateway == ""
+
+    def test_gateway_as_select_dict_normalizes(self) -> None:
+        # Defensive — search rows currently return flat strings, but
+        # the helper handles the option-dict case if it ever changes.
+        row = {
+            "uuid": "u1",
+            "network": "10.0.0.0/24",
+            "gateway": {"WAN_DHCP": {"value": "x", "selected": 1}},
+        }
+        live = _row_to_live(row)
+        assert live.gateway == "WAN_DHCP"
+
+
+# ---------------------------------------------------------------------------
+# _synthesize_name
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeName:
+    def test_v4_cidr(self) -> None:
+        live = _live("u1", network="10.0.0.0/24", gateway="WAN_DHCP")
+        assert _synthesize_name(live) == "route-10-0-0-0-24-via-wan_dhcp"
+
+    def test_v6_cidr(self) -> None:
+        live = _live("u1", network="2001:db8::/32", gateway="WAN_DHCP6")
+        # ``:`` is replaced with ``-`` and lowercased.
+        assert _synthesize_name(live) == "route-2001-db8---32-via-wan_dhcp6"
+
+    def test_lowercase(self) -> None:
+        live = _live("u1", network="10.0.0.0/24", gateway="MyGW")
+        assert _synthesize_name(live) == "route-10-0-0-0-24-via-mygw"
+
+
+# ---------------------------------------------------------------------------
+# StaticRouteService API methods
+# ---------------------------------------------------------------------------
+
+
+class TestServiceSearch:
+    def test_search_calls_correct_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        svc = StaticRouteService(client)
+        result = svc.search()
+        client.request.assert_called_once_with("POST", "routes/routes/searchroute")
+        assert result == []
+
+    def test_search_normalizes_rows(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {"uuid": "u1", "network": "10.0.0.0/24", "gateway": "WAN_DHCP"},
+                "not-a-dict",  # filtered out
+                {"uuid": "u2", "network": "172.16.0.0/24", "gateway": "WAN_DHCP"},
+            ]
+        }
+        svc = StaticRouteService(client)
+        result = svc.search()
+        assert len(result) == 2
+        assert result[0].uuid == "u1"
+        assert result[1].uuid == "u2"
+
+    def test_search_handles_non_dict_response(self) -> None:
+        client = MagicMock()
+        client.request.return_value = "not-a-dict"
+        svc = StaticRouteService(client)
+        assert svc.search() == []
+
+    def test_search_handles_missing_rows_key(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {}
+        svc = StaticRouteService(client)
+        assert svc.search() == []
+
+
+class TestServiceGet:
+    def test_get_uses_get_verb(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"route": {"network": "10.0.0.0/24"}}
+        svc = StaticRouteService(client)
+        result = svc.get("u1")
+        client.request.assert_called_once_with("GET", "routes/routes/getroute/u1")
+        assert result == {"route": {"network": "10.0.0.0/24"}}
+
+
+class TestServiceWriteOps:
+    def test_add_posts_correct_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved", "uuid": "new"}
+        svc = StaticRouteService(client)
+        route = _route("foo")
+        svc.add(route)
+        client.request.assert_called_once_with(
+            "POST", "routes/routes/addroute", data=route.to_payload()
+        )
+
+    def test_update_posts_correct_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = StaticRouteService(client)
+        route = _route("foo")
+        svc.update("uuid-abc", route)
+        client.request.assert_called_once_with(
+            "POST", "routes/routes/setroute/uuid-abc", data=route.to_payload()
+        )
+
+    def test_delete_posts_correct_endpoint(self) -> None:
+        client = MagicMock()
+        svc = StaticRouteService(client)
+        svc.delete("u1")
+        client.request.assert_called_once_with("POST", "routes/routes/delroute/u1")
+
+    def test_reconfigure_posts_correct_endpoint(self) -> None:
+        client = MagicMock()
+        svc = StaticRouteService(client)
+        svc.reconfigure()
+        client.request.assert_called_once_with("POST", "routes/routes/reconfigure")
+
+
+class TestApplyDiff:
+    def test_empty_diff_is_noop(self) -> None:
+        client = MagicMock()
+        svc = StaticRouteService(client)
+        counts = svc.apply_diff(Diff())
+        client.request.assert_not_called()
+        assert counts == {"created": 0, "updated": 0, "deleted": 0}
+
+    def test_add_calls_reconfigure_once(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = StaticRouteService(client)
+        diff = Diff(adds=[_route("foo"), _route("bar", network="172.16.0.0/24")])
+        counts = svc.apply_diff(diff)
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert endpoints.count("routes/routes/addroute") == 2
+        assert endpoints.count("routes/routes/reconfigure") == 1
+        assert counts == {"created": 2, "updated": 0, "deleted": 0}
+
+    def test_update_calls_reconfigure_once(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = StaticRouteService(client)
+        live = _live("u1")
+        route = _route("foo")
+        diff = Diff(updates=[(live, route)])
+        counts = svc.apply_diff(diff)
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert "routes/routes/setroute/u1" in endpoints
+        assert endpoints.count("routes/routes/reconfigure") == 1
+        assert counts == {"created": 0, "updated": 1, "deleted": 0}
+
+    def test_delete_calls_reconfigure_once(self) -> None:
+        client = MagicMock()
+        svc = StaticRouteService(client)
+        diff = Diff(
+            deletes=[
+                _live("u1"),
+                _live("u2", network="172.16.0.0/24"),
+            ]
+        )
+        counts = svc.apply_diff(diff)
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert "routes/routes/delroute/u1" in endpoints
+        assert "routes/routes/delroute/u2" in endpoints
+        assert endpoints.count("routes/routes/reconfigure") == 1
+        assert counts == {"created": 0, "updated": 0, "deleted": 2}
+
+    def test_mixed_diff_single_reconfigure(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"result": "saved"}
+        svc = StaticRouteService(client)
+        live_for_update = _live("u1")
+        live_for_delete = _live("u2", network="172.16.0.0/24")
+        new = _route("new", network="192.168.0.0/24")
+        update_target = _route("foo", description="changed")
+        diff = Diff(
+            adds=[new],
+            updates=[(live_for_update, update_target)],
+            deletes=[live_for_delete],
+        )
+        counts = svc.apply_diff(diff)
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert endpoints.count("routes/routes/reconfigure") == 1
+        assert counts == {"created": 1, "updated": 1, "deleted": 1}
+
+
+class TestComputeDiffServiceWrapper:
+    def test_service_wrapper_delegates(self) -> None:
+        client = MagicMock()
+        svc = StaticRouteService(client)
+        # Module-level compute_diff is the source of truth; just make
+        # sure the wrapper threads add_only.
+        diff = svc.compute_diff([], [_live("u1")], add_only=True)
+        assert diff.deletes == []
+
+
+# ---------------------------------------------------------------------------
+# export_to_yaml + _live_to_export_config
+# ---------------------------------------------------------------------------
+
+
+class TestExportToYaml:
+    def test_routes_appear_in_export(self) -> None:
+        client = MagicMock()
+        # First call: searchroute. Subsequent calls: per-uuid getroute.
+        client.request.side_effect = [
+            {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "network": "10.0.0.0/24",
+                        "gateway": "WAN_DHCP",
+                        "descr": "lan",
+                        "disabled": "0",
+                    },
+                ]
+            },
+            # getroute/u1
+            {
+                "route": {
+                    "network": "10.0.0.0/24",
+                    "gateway": {
+                        "WAN_DHCP": {"value": "WAN_DHCP - 10.0.0.1", "selected": 1},
+                        "WAN_DHCP6": {"value": "WAN_DHCP6 - fe80::1", "selected": 0},
+                    },
+                    "descr": "lan",
+                    "disabled": "0",
+                }
+            },
+        ]
+        svc = StaticRouteService(client)
+        text = svc.export_to_yaml()
+        # Synthetic name appears.
+        assert "route-10-0-0-0-24-via-wan_dhcp" in text
+        # Field decoding worked.
+        assert "network: 10.0.0.0/24" in text
+        assert "gateway: WAN_DHCP" in text
+        assert "description: lan" in text
+        assert "enabled: true" in text
+
+    def test_export_with_no_routes_yields_empty_resources(self) -> None:
+        client = MagicMock()
+        client.request.return_value = {"rows": []}
+        svc = StaticRouteService(client)
+        text = svc.export_to_yaml()
+        assert "resources: []" in text
+
+
+class TestLiveToExportConfig:
+    def test_decoding_select_dict_and_bools(self) -> None:
+        get_response = {
+            "route": {
+                "network": "2001:db8::/32",
+                "gateway": {
+                    "WAN_DHCP": {"value": "WAN_DHCP - 10.0.0.1", "selected": 0},
+                    "WAN_DHCP6": {"value": "WAN_DHCP6 - fe80::1", "selected": 1},
+                },
+                "descr": "v6 route",
+                "disabled": "1",
+            }
+        }
+        cfg = _live_to_export_config(get_response)
+        assert cfg["enabled"] is False  # disabled "1" → enabled False
+        assert cfg["network"] == "2001:db8::/32"
+        assert cfg["gateway"] == "WAN_DHCP6"
+        assert cfg["description"] == "v6 route"
+
+    def test_missing_envelope_yields_defaults(self) -> None:
+        cfg = _live_to_export_config({})
+        # Defensive defaults so an empty response doesn't crash.
+        assert cfg["enabled"] is True
+        assert cfg["network"] == ""
+        assert cfg["gateway"] == ""
+        assert cfg["description"] == ""
+
+    def test_non_dict_envelope_yields_defaults(self) -> None:
+        cfg = _live_to_export_config(None)  # type: ignore[arg-type]
+        assert cfg["enabled"] is True
+        assert cfg["network"] == ""

--- a/tests/unit/providers/opnsense/test_static_route_validator.py
+++ b/tests/unit/providers/opnsense/test_static_route_validator.py
@@ -1,0 +1,467 @@
+"""Unit tests for ``StaticRouteValidator``.
+
+Coverage:
+    - ``network`` field: IPv4 / IPv6 CIDRs accepted; missing / non-string /
+      malformed / host-bits-set rejected.
+    - ``gateway`` field: managed gateway ref accepted; live system gateway
+      ref accepted (``WAN_DHCP`` / ``WAN_DHCP6``); unknown gateway rejected;
+      missing / non-string rejected.
+    - Protocol match: IPv4 network with IPv4 gateway passes; v4 network
+      with v6 managed gateway fails; v4 network with ``WAN_DHCP6`` fails;
+      v6 network with v4 gateway fails.
+    - Bool type checks: ``enabled``, ``lock``.
+    - ``description`` type check.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.core.validation import ValidationReport
+from infrafoundry.providers.opnsense.validators.static_route_validator import (
+    StaticRouteValidator,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _route(name: str, **overrides: Any) -> ResourceConfig:
+    config: dict[str, Any] = {
+        "network": "10.0.0.0/24",
+        "gateway": "WAN_DHCP",
+    }
+    config.update(overrides)
+    return ResourceConfig(name=name, type="static_routes", provider="opnsense", config=config)
+
+
+def _gw(name: str, *, protocol: str = "inet") -> ResourceConfig:
+    return ResourceConfig(
+        name=name,
+        type="gateways",
+        provider="opnsense",
+        config={"interface": "wan", "protocol": protocol, "gateway": "192.0.2.1"},
+    )
+
+
+@pytest.fixture
+def report() -> ValidationReport:
+    return ValidationReport()
+
+
+@pytest.fixture
+def validator(report: ValidationReport) -> StaticRouteValidator:
+    return StaticRouteValidator(report)
+
+
+def _failures(report: ValidationReport, check_name: str) -> list[Any]:
+    return [c for c in report.results if c.check_name == check_name and not c.passed]
+
+
+# ---------------------------------------------------------------------------
+# network
+# ---------------------------------------------------------------------------
+
+
+class TestNetwork:
+    def test_v4_cidr_passes(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", network="10.0.0.0/24")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "static_route_ok_network")
+
+    def test_v6_cidr_passes(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", network="2001:db8::/32", gateway="WAN_DHCP6")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP6"},
+        )
+        assert not _failures(report, "static_route_ok_network")
+
+    def test_missing_network_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        r = ResourceConfig(
+            name="bad",
+            type="static_routes",
+            provider="opnsense",
+            config={"gateway": "WAN_DHCP"},
+        )
+        validator.validate(
+            [r],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_network")
+
+    def test_non_string_network_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", network=12345)],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_network")
+
+    def test_empty_network_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", network="")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_network")
+
+    def test_malformed_cidr_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", network="not-a-cidr")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_network")
+
+    def test_host_bits_set_v4_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        # ``10.0.0.1/24`` has host bits set; ``strict=True`` rejects it.
+        validator.validate(
+            [_route("bad", network="10.0.0.1/24")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_network")
+
+    def test_host_bits_set_v6_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", network="2001:db8::1/32", gateway="WAN_DHCP6")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP6"},
+        )
+        assert _failures(report, "static_route_bad_network")
+
+
+# ---------------------------------------------------------------------------
+# gateway (cross-ref)
+# ---------------------------------------------------------------------------
+
+
+class TestGateway:
+    def test_managed_gateway_ref_accepted(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", gateway="my-wan")],
+            managed_gateways=[_gw("my-wan")],
+            gateway_names={"my-wan"},
+            existing_gateways=set(),
+        )
+        assert not _failures(report, "static_route_ok_gateway")
+
+    def test_live_system_gateway_accepted(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        # ``WAN_DHCP`` exists live on the box but isn't declared as managed.
+        validator.validate(
+            [_route("ok", gateway="WAN_DHCP")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "static_route_ok_gateway")
+
+    def test_unknown_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", gateway="bogus-gw")],
+            managed_gateways=[],
+            gateway_names={"my-wan"},
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_gateway")
+
+    def test_missing_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        r = ResourceConfig(
+            name="bad",
+            type="static_routes",
+            provider="opnsense",
+            config={"network": "10.0.0.0/24"},
+        )
+        validator.validate(
+            [r],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_gateway")
+
+    def test_empty_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", gateway="")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_gateway")
+
+    def test_non_string_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", gateway=12345)],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways=set(),
+        )
+        assert _failures(report, "static_route_bad_gateway")
+
+
+# ---------------------------------------------------------------------------
+# protocol match
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolMatch:
+    def test_v4_network_v4_managed_gateway_passes(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", network="10.0.0.0/24", gateway="my-wan")],
+            managed_gateways=[_gw("my-wan", protocol="inet")],
+            gateway_names={"my-wan"},
+            existing_gateways=set(),
+        )
+        assert not _failures(report, "static_route_ok_protocol_match")
+
+    def test_v6_network_v6_managed_gateway_passes(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", network="2001:db8::/32", gateway="my-wan6")],
+            managed_gateways=[_gw("my-wan6", protocol="inet6")],
+            gateway_names={"my-wan6"},
+            existing_gateways=set(),
+        )
+        assert not _failures(report, "static_route_ok_protocol_match")
+
+    def test_v4_network_v6_managed_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", network="10.0.0.0/24", gateway="my-wan6")],
+            managed_gateways=[_gw("my-wan6", protocol="inet6")],
+            gateway_names={"my-wan6"},
+            existing_gateways=set(),
+        )
+        assert _failures(report, "static_route_bad_protocol_match")
+
+    def test_v6_network_v4_managed_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", network="2001:db8::/32", gateway="my-wan")],
+            managed_gateways=[_gw("my-wan", protocol="inet")],
+            gateway_names={"my-wan"},
+            existing_gateways=set(),
+        )
+        assert _failures(report, "static_route_bad_protocol_match")
+
+    def test_v4_network_v6_dynamic_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        # ``WAN_DHCP6`` is heuristically v6 (trailing ``6``).
+        validator.validate(
+            [_route("bad", network="10.0.0.0/24", gateway="WAN_DHCP6")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP6"},
+        )
+        assert _failures(report, "static_route_bad_protocol_match")
+
+    def test_v6_network_v4_dynamic_gateway_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        # ``WAN_DHCP`` is heuristically v4 (no trailing ``6``).
+        validator.validate(
+            [_route("bad", network="2001:db8::/32", gateway="WAN_DHCP")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_protocol_match")
+
+    def test_v4_network_v4_dynamic_gateway_passes(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", network="10.0.0.0/24", gateway="WAN_DHCP")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "static_route_ok_protocol_match")
+
+
+# ---------------------------------------------------------------------------
+# bool type checks
+# ---------------------------------------------------------------------------
+
+
+class TestBoolFields:
+    def test_enabled_must_be_bool(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", enabled="yes")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_enabled")
+
+    def test_lock_must_be_bool(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", lock="yes")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_lock")
+
+    def test_enabled_true_passes(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", enabled=True)],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "static_route_ok_enabled")
+
+    def test_lock_true_passes(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("ok", lock=True)],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "static_route_ok_lock")
+
+
+# ---------------------------------------------------------------------------
+# description
+# ---------------------------------------------------------------------------
+
+
+class TestDescription:
+    def test_string_passes(self, validator: StaticRouteValidator, report: ValidationReport) -> None:
+        validator.validate(
+            [_route("ok", description="my description")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "static_route_ok_description")
+
+    def test_non_string_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_route("bad", description=12345)],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert _failures(report, "static_route_bad_description")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_list_no_failures(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways=set(),
+        )
+        assert report.results == []
+
+    def test_multiple_routes_all_validated(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [
+                _route("a"),
+                _route("b", network="172.16.0.0/24"),
+                _route("c", network="192.168.0.0/24"),
+            ],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        names = {c.check_name for c in report.results if c.check_name.endswith("_gateway")}
+        assert "static_route_a_gateway" in names
+        assert "static_route_b_gateway" in names
+        assert "static_route_c_gateway" in names
+
+    def test_managed_gateway_with_invalid_protocol_skipped_in_protocol_index(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        # A managed gateway with a bogus protocol value shouldn't crash
+        # the protocol-match check — it has its own validator failures
+        # from ``GatewayValidator`` and is skipped here.
+        bad_gw = ResourceConfig(
+            name="bad-gw",
+            type="gateways",
+            provider="opnsense",
+            config={"interface": "wan", "protocol": "ipv7", "gateway": "192.0.2.1"},
+        )
+        validator.validate(
+            [_route("ok", gateway="bad-gw")],
+            managed_gateways=[bad_gw],
+            gateway_names={"bad-gw"},
+            existing_gateways=set(),
+        )
+        # Gateway ref still resolves — the protocol-match check falls
+        # through to the trailing-6 heuristic (no trailing 6 ⇒ v4),
+        # and a v4 network + heuristic-v4 ⇒ pass.
+        assert not _failures(report, "static_route_ok_protocol_match")


### PR DESCRIPTION
## Description

Adds the OPNsense `static_routes` direct-API component, closing the next gap in the ADR-0013 box-to-box migration scope. Mirrors the `gateways` pattern from #721: stock direct-REST under `OPNsenseDirectRunner` (no controller fork), Provider → Component Manager → Service Layer arrangement, full plan/apply/destroy/migrate.

Identity is the natural-key tuple `(network, gateway)` — OPNsense exposes no server-unique `name` field on routes, so the operator-facing YAML `name` is metadata only and never travels on the wire. The `gateway` field cross-references either a managed `gateways` resource declared in YAML or a live system gateway returned by `searchGateway` (e.g., `WAN_DHCP`, `WAN_DHCP6`); the validator accepts both, mirroring the gateway validator's interface-acceptance pattern. Cross-protocol mismatch (e.g., an IPv4 CIDR routed through an IPv6 gateway) is enforced at validation time before the request lands — the live API does not always reject the mismatch itself.

## Related Issue

Addresses #722

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (ADR-0013, ADR-0014, coverage matrix)

## Changes Made

- New `static_routes` resource type backed by `routes/routes/{searchroute, getroute, addroute, setroute, delroute, reconfigure}`
- Service layer (`services/static_route.py`): live-API CRUD plus a `searchroute` → `getroute` reconciliation loop. Live probe of `26.1.6_2` confirmed the field surface is narrower than initially planned (~16 fields) — only `network`, `gateway`, `descr`, `disabled`. Probe outcome and full wire schema captured in the service module docstring.
- Component manager (`components/static_route.py`): plan/apply/destroy/migrate, natural-key diff engine, `--add-only` and `lock: true` honored
- Validator (`validators/static_route_validator.py`): CIDR / gateway-name / cross-protocol checks; accepts both managed `gateway_names` and live `existing_gateways` fed in by a new `_get_existing_gateways()` helper on the parent validator (`POST routing/settings/searchGateway`)
- Provider integration (`providers/opnsense/__init__.py`): registered `StaticRouteManager` in `get_direct_api_resource_types()`, added `"static_routes": ["gateways"]` dependency, added `migrate_static_route(env_name)` (mirrors the other `migrate_*` methods; CLI wiring deferred per ADR-0014 §8)
- 118 new unit tests across three files (75 service + 13 manager + 30 validator)
- ADR-0013 amended: per-component decisions row for `static_routes`; implementation order #3 marked complete; #722 added to Related Issues; `**Amended:** 2026-05-04 (#722)` line added
- ADR-0014 amended: per-component decisions section now contains a `static_routes` entry (stock direct-REST, natural-key tuple identity, no category bootstrap, fork mechanism not used); #722 added to Related Issues
- `docs/development/opnsense-resource-coverage.md`: `<staticroutes>/route` row moved to Supported; implementation order #3 annotates both #721 and #722 as completed

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (118 unit tests total — service + manager + validator)
- [ ] Manually tested the changes — **deferred**: only the live API probe (read-only — `searchroute`, `getroute`, plus a single canary `addroute`/`delroute` pair on a throwaway `203.0.113.0/24` route) has been run against `opnsense-a` (26.1.6_2). Recommended pre-merge validation by the operator: `foundry config doctor --env <env>` → `foundry infra plan --env <env>` → `foundry infra apply --env <env>` against a small sample static-route YAML (a single managed route plus a route through `WAN_DHCP6` to exercise the live-gateway acceptance path).

`doit check` passes locally — format, lint, blueprint lint, mypy, bandit, codespell, full pytest matrix.

## Checklist

- [x] My code follows the code style of this project (`doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove the feature works
- [x] All new and existing tests pass (`doit check` green)
- [x] I have updated the documentation accordingly (ADR-0013, ADR-0014, coverage matrix)
- [ ] I have updated the CHANGELOG.md — N/A (changelog auto-generated by commitizen at release time from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

**No new ADR required.** Issue #722 is not labeled `needs-adr`. The mechanism is the stock direct-REST default codified in ADR-0014 §1, so the existing per-component decisions section there is the right place to record the variant — not a new ADR. Both ADR-0013 and ADR-0014 are amended in scope.

**Why no description-suffix tag** (unlike `nat_rules`): routes don't need stable identity smuggled through `descr` — the `(network, gateway)` tuple is server-unique on its own. This keeps the operator's `descr` field free for human-readable text and avoids the parsing footgun the NAT rules carry.

**Why no `infrafoundry` category bootstrap**: routes have no categories on this OPNsense version. Same call as `gateways` (#721).
