### PR TITLE
fix: serialize infrafoundry category bootstrap to close race between firewall_rules and nat_rules

### DIFF
--- a/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
+++ b/docs/decisions/0014-opnsense-direct-api-apply-mechanism.md
@@ -9,6 +9,7 @@
 **Amended:** 2026-05-04 (#725) — `port_forward` per-component decision recorded (stock direct-REST against `firewall/d_nat/*`; extends `nat_rules` with a third `kind`; identical mechanism to outbound and 1:1; no new wire mechanism)
 **Amended:** 2026-05-04 (#726) — §8 resolved: pluggable extractor registry replaces per-component dispatch on the provider and CLI; new components are reachable via `config migrate` as soon as they register an extractor
 **Amended:** 2026-05-05 (#742) — `firewall_rules` per-component decision recorded (stock direct-REST against the MVC `firewall/filter/*` controller; identity scheme matches `nat_rules`; legacy terraform path retired in the same PR — no `kind: legacy` shim). See ADR-0015 for the full driving decision.
+**Amended:** 2026-05-05 (#746) — identity-marker bootstrap mechanism amended: shared, thread-safe helper (`services/_category_marker.py`) replaces per-service-lazy lookup. Closes a theoretical race between concurrent `firewall_rules` and `nat_rules` first apply against a fresh box (OPNsense `addItem` is not idempotent by category name). The "Per-component decisions" section gets a new "Marker bootstrap" entry; no per-component decisions change.
 **Status:** Accepted
 
 ## Status
@@ -191,6 +192,12 @@ The spike empirically established that `/api/core/backup/{backups,download}` ret
 
 **Rollback strategy:** Same as the rest of §1's default mechanism — per-call server-side validation; OPNsense's auto-snapshot in `/conf/backup/` is the residual safety net. `firewall/filter/savepoint` is exposed on the service for manual rollback (15-revision retention) but is not auto-wired into apply.
 
+### Marker bootstrap (#746, amended 2026-05-05)
+
+The `infrafoundry` category UUID is resolved via a shared, thread-safe helper (`src/infrafoundry/providers/opnsense/services/_category_marker.py`) rather than per-service lazy lookup. The helper holds a process-local cache keyed by OPNsense client `base_url` and serializes the search+create critical section under a `threading.Lock`. This closes a theoretical race that would surface if `OPNsenseDirectRunner.apply()` ever dispatched components concurrently — `addItem` is not idempotent by category name on OPNsense's side, so two concurrent first-apply dispatches would create two distinct `infrafoundry` rows. The runner's responsibility is unchanged; the fix lives entirely in the service layer.
+
+Both `FirewallRuleService._ensure_infrafoundry_category` and `NATRuleService._ensure_infrafoundry_category` are now thin wrappers that delegate to the helper. Each service keeps its per-instance `_category_uuid` cache as a fast-path so an instance that already resolved the UUID does not pay even the helper's dict-lookup cost on subsequent calls.
+
 ## Secrets handling
 
 Direct-API resources can declare secret-bearing fields as `secret://env_secrets/<dotted/path>` URIs in YAML. Resolution is performed at apply time by the component manager, which:
@@ -245,6 +252,7 @@ The runner integration via ADR-0010 protocols keeps the CLI surface consistent: 
 - Issue [#724](https://github.com/endavis/infrafoundry/issues/724): feat: add OPNsense Unbound extensions — `unbound_host_alias` and `unbound_forward` (direct-API; merges domain_override into forward per live probe).
 - Issue [#725](https://github.com/endavis/infrafoundry/issues/725): feat: add OPNsense `port_forward` kind on `nat_rules` (direct-API at `firewall/d_nat`; closes ADR-0013 implementation-order item #2; the 2026-05-04 re-probe corrected the original deferral premise).
 - Issue [#726](https://github.com/endavis/infrafoundry/issues/726): refactor: extract `config migrate` extractor registry from per-component dispatch (resolves §8; breaking CLI rename `kea/dhcp` → `kea_dhcp` and `isc-to-kea` → `isc_to_kea`).
+- Issue [#746](https://github.com/endavis/infrafoundry/issues/746): bug — identity-marker race condition between concurrent `firewall_rules` and `nat_rules` first apply (closed by the shared-helper bootstrap recorded under "Marker bootstrap" above).
 
 ## Related Documentation
 

--- a/src/infrafoundry/providers/opnsense/api_client.py
+++ b/src/infrafoundry/providers/opnsense/api_client.py
@@ -27,6 +27,7 @@ class OPNsenseClient:
         verify_ssl: bool = True,
         timeout: int = 30,
     ) -> None:
+        self._base_url = base_url
         self.client = OpenAPIOPNsenseClient(
             base_url=base_url,
             api_key=api_key,
@@ -35,6 +36,17 @@ class OPNsenseClient:
             timeout=timeout,
             auto_detect_version=False,
         )
+
+    @property
+    def base_url(self) -> str:
+        """The OPNsense base URL this client targets.
+
+        Used as the per-box cache key by the shared
+        ``ensure_infrafoundry_category`` helper (#746) so that a single
+        process talking to multiple OPNsense boxes keeps separate
+        identity-marker UUID entries per box.
+        """
+        return self._base_url
 
     def request(
         self,

--- a/src/infrafoundry/providers/opnsense/services/_category_marker.py
+++ b/src/infrafoundry/providers/opnsense/services/_category_marker.py
@@ -1,0 +1,178 @@
+"""Shared bootstrap helper for the OPNsense ``infrafoundry`` identity-marker category.
+
+Both ``FirewallRuleService`` and ``NATRuleService`` tag their managed rows
+with a per-box ``infrafoundry`` OPNsense category as a fleet-wide marker.
+The category is resolved (and, on a fresh box, created) on first apply via
+``firewall/category/searchItem`` + ``firewall/category/addItem``. OPNsense's
+``addItem`` is **not idempotent by category name**: two concurrent first-
+apply dispatches against a fresh box would each see an empty
+``searchItem``, each call ``addItem``, and create two distinct
+``infrafoundry`` rows. The marker invariant ("exactly one ``infrafoundry``
+row per box") would silently break, and subsequent applies would tag
+arbitrarily-chosen rows.
+
+Today this race is theoretical because ``OPNsenseDirectRunner.apply()``
+dispatches services sequentially; the second service's ``searchItem``
+finds the first service's just-created row and the invariant holds.
+**The race becomes real the moment dispatch becomes concurrent** — a
+future change anyone might make without thinking about this contract.
+This helper closes the race at the implementation layer regardless of
+dispatch order: a process-local lock + per-box UUID cache means only
+one ``addItem`` ever fires per box per process, and concurrent callers
+serialize on the first attempt then hit the cache on every subsequent
+one.
+
+Cache key
+---------
+
+The cache is keyed by the OPNsense client's ``base_url``. One entry per
+box per process. Different environments (different ``base_url``s) get
+distinct cache entries; the same box reached via two service instances
+in the same process shares one entry.
+
+Test affordance
+---------------
+
+``reset_cache_for_tests()`` clears the module-level cache. Test suites
+that exercise the helper (or services that delegate to it) must call
+this in a ``setup_method`` / autouse fixture so each test starts from
+a clean cache state — without it, cached state from earlier tests
+leaks into later ones.
+
+References
+----------
+
+- Issue #746: bug — identity-marker race condition between concurrent
+  ``firewall_rules`` and ``nat_rules`` first apply.
+- ADR-0014 §"Per-component decisions" — records that marker bootstrap
+  is process-shared rather than per-service-lazy.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from infrafoundry.core.exceptions import InfraFoundryError
+
+# Name of the OPNsense category created/used as the fleet-wide marker
+# for InfraFoundry-managed rules. Both ``FirewallRuleService`` and
+# ``NATRuleService`` reference this value.
+INFRAFOUNDRY_CATEGORY_NAME = "infrafoundry"
+
+# Module-level lock and cache. The lock serializes the search+create
+# critical section so only one ``addItem`` ever fires per box per
+# process. The cache is a process-local dict keyed by the OPNsense
+# client's ``base_url`` (one entry per box per process).
+_lock = threading.Lock()
+_cache: dict[str, str] = {}
+
+
+def _client_base_url(client: Any) -> str:
+    """Return the cache key for an OPNsense client.
+
+    The wrapper ``OPNsenseClient`` (in ``api_client.py``) exposes
+    ``base_url`` as a top-level attribute; tests using ``MagicMock`` for
+    the client auto-generate a per-instance mock attribute when the
+    attribute is accessed. Either form is hashable and suitable as a
+    dict key.
+
+    Args:
+        client: The OPNsense API client (real or mocked).
+
+    Returns:
+        The string used as the per-box cache key.
+    """
+    return str(client.base_url)
+
+
+def ensure_infrafoundry_category(client: Any) -> str:
+    """Return the UUID of the ``infrafoundry`` category, creating it if absent.
+
+    Thread-safe and process-cached. Concurrent callers against the same
+    client serialize on a module-level lock and share a single
+    ``addItem`` call; subsequent callers (in the same process, against
+    the same ``base_url``) hit the cache without any API round-trip.
+
+    The lookup order is:
+
+    1. Cache hit → return immediately (no lock needed).
+    2. Acquire lock.
+    3. Re-check cache (double-checked locking — another thread may have
+       populated it between the cache miss and lock acquisition).
+    4. ``firewall/category/searchItem`` → if a row matches
+       ``INFRAFOUNDRY_CATEGORY_NAME``, cache and return its UUID.
+    5. ``firewall/category/addItem`` → cache and return the new UUID.
+    6. If neither yields a UUID, raise ``InfraFoundryError``.
+
+    Args:
+        client: An OPNsense API client (or mock) exposing ``request()``
+            and ``base_url``. ``request()`` must accept ``(method,
+            endpoint)`` for ``searchItem`` and ``(method, endpoint,
+            data=...)`` for ``addItem``.
+
+    Returns:
+        UUID string for the OPNsense category named ``infrafoundry``.
+
+    Raises:
+        InfraFoundryError: If neither ``searchItem`` nor ``addItem``
+            returns a usable UUID.
+    """
+    key = _client_base_url(client)
+
+    cached = _cache.get(key)
+    if cached is not None:
+        return cached
+
+    with _lock:
+        # Double-checked: another thread may have populated the cache
+        # while we were waiting for the lock.
+        cached = _cache.get(key)
+        if cached is not None:
+            return cached
+
+        search_response = client.request("POST", "firewall/category/searchItem")
+        rows: list[dict[str, Any]] = []
+        if isinstance(search_response, dict):
+            raw_rows = search_response.get("rows")
+            if isinstance(raw_rows, list):
+                rows = [r for r in raw_rows if isinstance(r, dict)]
+        for row in rows:
+            if row.get("name") == INFRAFOUNDRY_CATEGORY_NAME:
+                uuid = str(row.get("uuid", ""))
+                if uuid:
+                    _cache[key] = uuid
+                    return uuid
+
+        add_response = client.request(
+            "POST",
+            "firewall/category/addItem",
+            data={
+                "category": {
+                    "name": INFRAFOUNDRY_CATEGORY_NAME,
+                    "auto": "0",
+                    "color": "",
+                }
+            },
+        )
+        if isinstance(add_response, dict):
+            uuid = str(add_response.get("uuid", ""))
+            if uuid:
+                _cache[key] = uuid
+                return uuid
+
+        raise InfraFoundryError(
+            f"Failed to ensure '{INFRAFOUNDRY_CATEGORY_NAME}' category exists on "
+            f"OPNsense; addItem response: {add_response!r}"
+        )
+
+
+def reset_cache_for_tests() -> None:
+    """Clear the module-level cache.
+
+    Test-only affordance. Call from a ``setup_method`` or autouse
+    fixture in test suites that exercise this helper (or services that
+    delegate to it) so each test starts from a clean cache state.
+    """
+    with _lock:
+        _cache.clear()

--- a/src/infrafoundry/providers/opnsense/services/firewall_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/firewall_rule.py
@@ -54,6 +54,8 @@ import yaml
 from infrafoundry.core.exceptions import InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
 
+from ._category_marker import INFRAFOUNDRY_CATEGORY_NAME as _SHARED_CATEGORY_NAME
+from ._category_marker import ensure_infrafoundry_category
 from .base import BaseService
 
 # Regex for parsing the description-suffix identity tag. Operator-supplied
@@ -810,14 +812,19 @@ class FirewallRuleService(BaseService):
     InfraFoundry's identity model.
     """
 
-    INFRAFOUNDRY_CATEGORY_NAME = "infrafoundry"
+    # Class attribute kept for backward compatibility with existing
+    # tests and downstream references; forwards to the module-level
+    # constant in ``_category_marker``.
+    INFRAFOUNDRY_CATEGORY_NAME = _SHARED_CATEGORY_NAME
 
     def __init__(self, client: Any) -> None:
         """Initialize the service and prepare the per-instance category cache."""
         super().__init__(client)
-        # UUID of the OPNsense ``infrafoundry`` category, looked up or
-        # created lazily on the first add/update via
-        # ``_ensure_infrafoundry_category``.
+        # Per-instance fast-path cache: once an instance has resolved
+        # the category UUID via the shared helper, subsequent calls on
+        # the same instance skip even the helper's dict lookup. The
+        # process-wide cache and the search+create critical section
+        # both live in ``_category_marker``.
         self._category_uuid: str | None = None
 
     # ------------------------------------------------------------------
@@ -827,57 +834,33 @@ class FirewallRuleService(BaseService):
     def _ensure_infrafoundry_category(self) -> str:
         """Return the UUID of the ``infrafoundry`` category, creating it if absent.
 
-        Identical lazy-cached lookup as ``NATRuleService``. Note: a
-        race condition exists if ``firewall_rules`` and ``nat_rules``
-        apply concurrently on first run — both would attempt
-        ``addItem`` and OPNsense's ``addItem`` is not idempotent by
-        name. This is out of scope for #742 (would require either
-        coordination at the runner level or a tolerate-409 retry).
+        Thin wrapper around the shared
+        ``_category_marker.ensure_infrafoundry_category`` helper. The
+        helper holds the process-wide cache and the lock that
+        serializes the search+create critical section across concurrent
+        callers (#746) — both ``FirewallRuleService`` and
+        ``NATRuleService`` delegate here, so a single ``addItem`` ever
+        fires per OPNsense box per process even if dispatch ever
+        becomes concurrent.
+
+        The per-instance ``self._category_uuid`` cache is preserved as
+        a fast-path: an instance that has already resolved the UUID
+        does not pay even the helper's dict-lookup cost on subsequent
+        calls.
 
         Returns:
             UUID string for the OPNsense category named ``infrafoundry``.
 
         Raises:
             InfraFoundryError: If neither search nor create yields a
-                UUID.
+                UUID (propagated unchanged from the helper).
         """
         if self._category_uuid is not None:
             return self._category_uuid
 
-        search_response = self.client.request("POST", "firewall/category/searchItem")
-        rows: list[dict[str, Any]] = []
-        if isinstance(search_response, dict):
-            raw_rows = search_response.get("rows")
-            if isinstance(raw_rows, list):
-                rows = [r for r in raw_rows if isinstance(r, dict)]
-        for row in rows:
-            if row.get("name") == self.INFRAFOUNDRY_CATEGORY_NAME:
-                uuid = str(row.get("uuid", ""))
-                if uuid:
-                    self._category_uuid = uuid
-                    return uuid
-
-        add_response = self.client.request(
-            "POST",
-            "firewall/category/addItem",
-            data={
-                "category": {
-                    "name": self.INFRAFOUNDRY_CATEGORY_NAME,
-                    "auto": "0",
-                    "color": "",
-                }
-            },
-        )
-        if isinstance(add_response, dict):
-            uuid = str(add_response.get("uuid", ""))
-            if uuid:
-                self._category_uuid = uuid
-                return uuid
-
-        raise InfraFoundryError(
-            f"Failed to ensure '{self.INFRAFOUNDRY_CATEGORY_NAME}' category exists on "
-            f"OPNsense; addItem response: {add_response!r}"
-        )
+        uuid = ensure_infrafoundry_category(self.client)
+        self._category_uuid = uuid
+        return uuid
 
     def _payload_with_category(self, rule: FirewallRuleConfig) -> dict[str, Any]:
         """Build the API payload for a rule with the InfraFoundry category appended.

--- a/src/infrafoundry/providers/opnsense/services/nat_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/nat_rule.py
@@ -55,6 +55,8 @@ import yaml
 from infrafoundry.core.exceptions import InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
 
+from ._category_marker import INFRAFOUNDRY_CATEGORY_NAME as _SHARED_CATEGORY_NAME
+from ._category_marker import ensure_infrafoundry_category
 from .base import BaseService
 
 # Type alias for NAT rule kinds — the discriminator on every entry.
@@ -884,15 +886,19 @@ class NATRuleService(BaseService):
     and its UUID is cached on the service instance.
     """
 
-    # Name of the OPNsense category created/used as the fleet-wide marker
-    # for InfraFoundry-managed rules.
-    INFRAFOUNDRY_CATEGORY_NAME = "infrafoundry"
+    # Class attribute kept for backward compatibility with existing
+    # tests and downstream references; forwards to the module-level
+    # constant in ``_category_marker``.
+    INFRAFOUNDRY_CATEGORY_NAME = _SHARED_CATEGORY_NAME
 
     def __init__(self, client: Any) -> None:
         """Initialize the service and prepare the per-instance category cache."""
         super().__init__(client)
-        # UUID of the OPNsense ``infrafoundry`` category, looked up or created
-        # lazily on the first add/update via ``_ensure_infrafoundry_category``.
+        # Per-instance fast-path cache: once an instance has resolved
+        # the category UUID via the shared helper, subsequent calls on
+        # the same instance skip even the helper's dict lookup. The
+        # process-wide cache and the search+create critical section
+        # both live in ``_category_marker``.
         self._category_uuid: str | None = None
 
     # ------------------------------------------------------------------
@@ -914,56 +920,33 @@ class NATRuleService(BaseService):
     def _ensure_infrafoundry_category(self) -> str:
         """Return the UUID of the ``infrafoundry`` category, creating it if absent.
 
-        The lookup is cached on the service instance so multiple add/update
-        calls in a single apply pay one round-trip total. Cache is per
-        instance; long-lived service objects across multiple environments
-        would need to invalidate manually, but the ``from_environment``
-        factory builds a fresh service per env so that's not a concern in
-        production.
+        Thin wrapper around the shared
+        ``_category_marker.ensure_infrafoundry_category`` helper. The
+        helper holds the process-wide cache and the lock that
+        serializes the search+create critical section across concurrent
+        callers (#746) — both ``FirewallRuleService`` and
+        ``NATRuleService`` delegate here, so a single ``addItem`` ever
+        fires per OPNsense box per process even if dispatch ever
+        becomes concurrent.
+
+        The per-instance ``self._category_uuid`` cache is preserved as
+        a fast-path: an instance that has already resolved the UUID
+        does not pay even the helper's dict-lookup cost on subsequent
+        calls.
 
         Returns:
             UUID string for the OPNsense category named ``infrafoundry``.
 
         Raises:
-            InfraFoundryError: If neither search nor create yields a UUID.
+            InfraFoundryError: If neither search nor create yields a
+                UUID (propagated unchanged from the helper).
         """
         if self._category_uuid is not None:
             return self._category_uuid
 
-        search_response = self.client.request("POST", "firewall/category/searchItem")
-        rows: list[dict[str, Any]] = []
-        if isinstance(search_response, dict):
-            raw_rows = search_response.get("rows")
-            if isinstance(raw_rows, list):
-                rows = [r for r in raw_rows if isinstance(r, dict)]
-        for row in rows:
-            if row.get("name") == self.INFRAFOUNDRY_CATEGORY_NAME:
-                uuid = str(row.get("uuid", ""))
-                if uuid:
-                    self._category_uuid = uuid
-                    return uuid
-
-        add_response = self.client.request(
-            "POST",
-            "firewall/category/addItem",
-            data={
-                "category": {
-                    "name": self.INFRAFOUNDRY_CATEGORY_NAME,
-                    "auto": "0",
-                    "color": "",
-                }
-            },
-        )
-        if isinstance(add_response, dict):
-            uuid = str(add_response.get("uuid", ""))
-            if uuid:
-                self._category_uuid = uuid
-                return uuid
-
-        raise InfraFoundryError(
-            f"Failed to ensure '{self.INFRAFOUNDRY_CATEGORY_NAME}' category exists on "
-            f"OPNsense; addItem response: {add_response!r}"
-        )
+        uuid = ensure_infrafoundry_category(self.client)
+        self._category_uuid = uuid
+        return uuid
 
     def _payload_with_category(self, rule: NATRuleConfig) -> dict[str, Any]:
         """Build the API payload for a rule with the InfraFoundry category injected."""

--- a/tests/unit/providers/opnsense/test_category_marker.py
+++ b/tests/unit/providers/opnsense/test_category_marker.py
@@ -1,0 +1,270 @@
+"""Unit tests for ``infrafoundry.providers.opnsense.services._category_marker``.
+
+Coverage:
+    - Search-finds-existing-category short circuit (no addItem call).
+    - Search empty → addItem path (UUID returned and cached).
+    - Multi-call cache hit (subsequent calls skip both API round-trips).
+    - **Race-closure assertion** — concurrent callers across many threads
+      serialize on the module lock and trigger exactly one addItem.
+    - Distinct ``base_url``s populate distinct cache entries.
+    - ``reset_cache_for_tests`` clears the cache.
+    - Error paths: addItem returns no UUID; search returns malformed
+      shapes; search finds other categories but not the marker.
+    - Helper does not log or print on the success path.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrafoundry.core.exceptions import InfraFoundryError
+from infrafoundry.providers.opnsense.services._category_marker import (
+    INFRAFOUNDRY_CATEGORY_NAME,
+    ensure_infrafoundry_category,
+    reset_cache_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    """Clear the module-level cache before every test in this file."""
+    reset_cache_for_tests()
+
+
+def _make_client(base_url: str = "https://opnsense.example") -> MagicMock:
+    """Build a MagicMock client with a deterministic ``base_url`` attribute.
+
+    Using a string ``base_url`` keeps cache-key behavior deterministic
+    across tests; without this, ``MagicMock.base_url`` would return a
+    fresh sub-mock per access whose ``str()`` includes a unique id.
+    """
+    client = MagicMock()
+    client.base_url = base_url
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestSearchFindsExisting:
+    def test_search_finds_existing_category_uuid(self) -> None:
+        client = _make_client()
+        client.request.return_value = {
+            "rows": [
+                {"uuid": "other-uuid", "name": "other"},
+                {"uuid": "ifn-uuid", "name": "infrafoundry"},
+            ]
+        }
+        uuid = ensure_infrafoundry_category(client)
+        assert uuid == "ifn-uuid"
+        # Only one call: searchItem; no addItem because category exists.
+        client.request.assert_called_once_with("POST", "firewall/category/searchItem")
+
+    def test_search_empty_then_create(self) -> None:
+        client = _make_client()
+        client.request.side_effect = [
+            {"rows": []},  # searchItem: no match
+            {"uuid": "new-uuid"},  # addItem: created
+        ]
+        uuid = ensure_infrafoundry_category(client)
+        assert uuid == "new-uuid"
+        endpoints = [c.args[1] for c in client.request.call_args_list]
+        assert endpoints == ["firewall/category/searchItem", "firewall/category/addItem"]
+
+    def test_add_item_payload_shape(self) -> None:
+        client = _make_client()
+        client.request.side_effect = [
+            {"rows": []},
+            {"uuid": "new-uuid"},
+        ]
+        ensure_infrafoundry_category(client)
+        add_call = client.request.call_args_list[1]
+        sent = add_call.kwargs.get("data") or add_call.args[2]
+        assert sent["category"]["name"] == INFRAFOUNDRY_CATEGORY_NAME
+        assert sent["category"]["auto"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# Cache behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCacheBehavior:
+    def test_subsequent_calls_hit_cache(self) -> None:
+        client = _make_client()
+        client.request.side_effect = [
+            {"rows": []},
+            {"uuid": "cached-uuid"},
+        ]
+        first = ensure_infrafoundry_category(client)
+        second = ensure_infrafoundry_category(client)
+        assert first == second == "cached-uuid"
+        # Two calls total: searchItem + addItem from the first invocation.
+        # The second invocation hits the cache and triggers no API round-trip.
+        assert client.request.call_count == 2
+
+    def test_distinct_base_urls_dont_share_cache(self) -> None:
+        client_a = _make_client(base_url="https://box-a.example")
+        client_b = _make_client(base_url="https://box-b.example")
+        client_a.request.return_value = {"rows": [{"uuid": "uuid-a", "name": "infrafoundry"}]}
+        client_b.request.return_value = {"rows": [{"uuid": "uuid-b", "name": "infrafoundry"}]}
+        assert ensure_infrafoundry_category(client_a) == "uuid-a"
+        assert ensure_infrafoundry_category(client_b) == "uuid-b"
+        # Each box gets its own cache entry; second call against A still
+        # returns the A-side UUID.
+        assert ensure_infrafoundry_category(client_a) == "uuid-a"
+        # Total calls: one searchItem against each box.
+        assert client_a.request.call_count == 1
+        assert client_b.request.call_count == 1
+
+    def test_reset_cache_for_tests_clears_cache(self) -> None:
+        client = _make_client()
+        client.request.return_value = {"rows": [{"uuid": "first-uuid", "name": "infrafoundry"}]}
+        ensure_infrafoundry_category(client)
+        assert client.request.call_count == 1
+
+        reset_cache_for_tests()
+
+        # After reset, the next call must hit the API again rather than
+        # returning the cached UUID.
+        ensure_infrafoundry_category(client)
+        assert client.request.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Race-closure assertion (the canonical demonstration that the fix works)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_concurrent_calls_serialize_on_lock(self) -> None:
+        """Multiple threads calling helper concurrently see exactly one addItem.
+
+        This is the canonical demonstration of the fix's value (#746).
+        Without the lock, each thread's ``searchItem`` would return
+        empty rows simultaneously and each thread would issue its own
+        ``addItem`` — creating multiple ``infrafoundry`` rows on a
+        fresh OPNsense box. With the lock and double-checked cache,
+        the first thread to acquire the lock performs the
+        search+create; every subsequent thread observes the populated
+        cache (either at the cache-miss check before the lock or at
+        the double-check inside the lock) and returns the same UUID.
+        """
+        add_item_count = Counter[str]()
+        new_uuid = "shared-new-uuid"
+
+        def fake_request(
+            method: str,
+            endpoint: str,
+            data: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            if endpoint == "firewall/category/searchItem":
+                # Always return empty to maximize race pressure: every
+                # thread's pre-lock search would conclude the category
+                # is absent. Without the lock all of them would proceed
+                # to addItem.
+                return {"rows": []}
+            if endpoint == "firewall/category/addItem":
+                add_item_count[endpoint] += 1
+                return {"uuid": new_uuid}
+            raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+        client = _make_client(base_url="https://race-test.example")
+        client.request.side_effect = fake_request
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda _: ensure_infrafoundry_category(client), range(8)))
+
+        # Every thread received the same UUID.
+        assert all(r == new_uuid for r in results)
+        # And ``addItem`` fired exactly once across all threads — the
+        # lock + double-checked cache closed the race.
+        assert add_item_count["firewall/category/addItem"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Defensive / error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrorAndDefensivePaths:
+    def test_add_item_failure_raises_infrafoundry_error(self) -> None:
+        client = _make_client()
+        client.request.side_effect = [
+            {"rows": []},
+            {"result": "failed"},  # addItem: no uuid
+        ]
+        with pytest.raises(InfraFoundryError, match=INFRAFOUNDRY_CATEGORY_NAME) as excinfo:
+            ensure_infrafoundry_category(client)
+        # The response body is included in the message for debuggability.
+        assert "result" in str(excinfo.value)
+
+    def test_search_returns_non_dict_yields_create(self) -> None:
+        # Defensive: searchItem returns a list (malformed) — fall through
+        # to addItem rather than crashing.
+        client = _make_client()
+        client.request.side_effect = [
+            ["malformed"],
+            {"uuid": "fallback-uuid"},
+        ]
+        assert ensure_infrafoundry_category(client) == "fallback-uuid"
+
+    def test_search_returns_dict_without_rows_yields_create(self) -> None:
+        client = _make_client()
+        client.request.side_effect = [
+            {},
+            {"uuid": "fallback-uuid"},
+        ]
+        assert ensure_infrafoundry_category(client) == "fallback-uuid"
+
+    def test_search_finds_other_category_with_different_name(self) -> None:
+        # Search returns rows but none match "infrafoundry" — fall
+        # through to addItem.
+        client = _make_client()
+        client.request.side_effect = [
+            {"rows": [{"uuid": "x", "name": "other"}]},
+            {"uuid": "new-uuid"},
+        ]
+        assert ensure_infrafoundry_category(client) == "new-uuid"
+
+    def test_search_row_with_empty_uuid_falls_through(self) -> None:
+        # Defensive: matching row has empty UUID — must not cache the
+        # empty value and must fall through to addItem.
+        client = _make_client()
+        client.request.side_effect = [
+            {"rows": [{"uuid": "", "name": "infrafoundry"}]},
+            {"uuid": "new-uuid"},
+        ]
+        assert ensure_infrafoundry_category(client) == "new-uuid"
+
+
+# ---------------------------------------------------------------------------
+# Silence on success
+# ---------------------------------------------------------------------------
+
+
+class TestNoIncidentalLogging:
+    def test_helper_does_not_log_on_success(self, caplog: pytest.LogCaptureFixture) -> None:
+        client = _make_client()
+        client.request.side_effect = [
+            {"rows": []},
+            {"uuid": "new-uuid"},
+        ]
+        with caplog.at_level(logging.DEBUG):
+            ensure_infrafoundry_category(client)
+        # The helper itself emits nothing on the success path; downstream
+        # service logging is the caller's concern.
+        helper_records = [
+            r
+            for r in caplog.records
+            if r.name.startswith("infrafoundry.providers.opnsense.services._category_marker")
+        ]
+        assert helper_records == []

--- a/tests/unit/providers/opnsense/test_firewall_rule_service.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_service.py
@@ -27,6 +27,9 @@ import pytest
 
 from infrafoundry.core.exceptions import InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.services._category_marker import (
+    reset_cache_for_tests as _reset_marker_cache,
+)
 from infrafoundry.providers.opnsense.services.firewall_rule import (
     DEFAULT_SEQUENCE,
     Diff,
@@ -40,6 +43,19 @@ from infrafoundry.providers.opnsense.services.firewall_rule import (
     firewall_rule_configs_from_resources,
     parse_identity,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_category_marker_cache() -> None:
+    """Reset the shared identity-marker cache before each test.
+
+    Without this, cached UUIDs from earlier tests would leak into later
+    tests that share the same module-level ``_category_marker._cache``,
+    masking real assertions about ``searchItem``/``addItem`` call
+    counts.
+    """
+    _reset_marker_cache()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -942,6 +958,20 @@ class TestCategoryBootstrap:
         add_call = client.request.call_args_list[1]
         sent = add_call.kwargs.get("data") or add_call.args[2]
         assert sent["category"]["name"] == "infrafoundry"
+
+    def test_ensure_infrafoundry_category_uses_shared_cache(self) -> None:
+        # Two distinct service instances against the same client share the
+        # process-wide cache: only the first instance triggers searchItem;
+        # the second hits the cache via the shared helper (#746).
+        client = MagicMock()
+        client.request.return_value = {"rows": [{"uuid": "shared-uuid", "name": "infrafoundry"}]}
+        svc_a = FirewallRuleService(client)
+        svc_b = FirewallRuleService(client)
+        assert svc_a._ensure_infrafoundry_category() == "shared-uuid"
+        assert svc_b._ensure_infrafoundry_category() == "shared-uuid"
+        # Only one searchItem across both instances; the second hits the
+        # process-wide cache in ``_category_marker``.
+        assert client.request.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/opnsense/test_nat_rule_service.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_service.py
@@ -19,6 +19,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.services._category_marker import (
+    reset_cache_for_tests as _reset_marker_cache,
+)
 from infrafoundry.providers.opnsense.services.nat_rule import (
     Diff,
     LiveNATRule,
@@ -31,6 +34,19 @@ from infrafoundry.providers.opnsense.services.nat_rule import (
     nat_rule_configs_from_resources,
     parse_identity,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_category_marker_cache() -> None:
+    """Reset the shared identity-marker cache before each test.
+
+    Without this, cached UUIDs from earlier tests would leak into later
+    tests that share the same module-level ``_category_marker._cache``,
+    masking real assertions about ``searchItem``/``addItem`` call
+    counts.
+    """
+    _reset_marker_cache()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1477,6 +1493,20 @@ class TestCategoryBootstrap:
         svc = NATRuleService(client)
         with pytest.raises(InfraFoundryError, match="infrafoundry"):
             svc._ensure_infrafoundry_category()
+
+    def test_ensure_infrafoundry_category_uses_shared_cache(self) -> None:
+        # Two distinct service instances against the same client share the
+        # process-wide cache: only the first instance triggers searchItem;
+        # the second hits the cache via the shared helper (#746).
+        client = MagicMock()
+        client.request.return_value = {"rows": [{"uuid": "shared-uuid", "name": "infrafoundry"}]}
+        svc_a = NATRuleService(client)
+        svc_b = NATRuleService(client)
+        assert svc_a._ensure_infrafoundry_category() == "shared-uuid"
+        assert svc_b._ensure_infrafoundry_category() == "shared-uuid"
+        # Only one searchItem across both instances; the second hits the
+        # process-wide cache in ``_category_marker``.
+        assert client.request.call_count == 1
 
     def test_add_includes_category_in_payload(self) -> None:
         client = MagicMock()


### PR DESCRIPTION
## Description

Closes a theoretical race condition in the OPNsense direct-API marker bootstrap. Both `FirewallRuleService` and `NATRuleService` lazy-bootstrap the per-box `infrafoundry` category UUID via `firewall/category/addItem` on first apply against a fresh box. Each `service.from_environment()` builds a fresh service with `_category_uuid: None`, and OPNsense's `addItem` is **not idempotent by category name** — two concurrent first-apply dispatches against a fresh box would create two distinct `infrafoundry` category rows, splitting the fleet-wide identity marker.

**The race is theoretical today.** `OPNsenseDirectRunner.apply()` dispatches services sequentially (`for type_name, manager_cls in dispatch_table.items()` at `runners/opnsense_direct_runner.py:381`), so the second service finds the first service's just-created category via `searchItem` and the marker invariant holds. **The race becomes real the moment dispatch becomes concurrent** — a future change anyone might make without thinking about the marker contract. This PR closes the race at the implementation layer regardless of dispatch order, and as a bonus removes the redundant per-service `searchItem` round-trip on every fresh service instance.

## Related Issue

Addresses #746

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

**Architecture:** Shared helper with process-local lock + per-`base_url` UUID cache. Both services delegate; runner unchanged.

- **New** `src/infrafoundry/providers/opnsense/services/_category_marker.py` — single canonical `ensure_infrafoundry_category(client) -> str`. Module-level `threading.Lock` + `dict[str, str]` cache keyed by `client.base_url`. Lookup-then-create runs inside the lock with a double-checked cache read on the slow path; concurrent callers serialize on the first attempt and hit cache on every subsequent one. Errors propagate as `InfraFoundryError`. Includes `reset_cache_for_tests()` helper.
- **Modified** `services/firewall_rule.py` — `_ensure_infrafoundry_category` now a thin wrapper (per-instance fast-path → delegate to helper → store result on `self._category_uuid`). Removed ~50 lines of inline search+create logic and the stale race-condition comment. `INFRAFOUNDRY_CATEGORY_NAME` class attribute kept for backward compatibility (forwards to module constant).
- **Modified** `services/nat_rule.py` — same delegation pattern, mirrors `firewall_rule.py`.
- **Modified** `api_client.py` — added `base_url` property on the `OPNsenseClient` wrapper so the helper can key the cache. The wrapper didn't previously surface this attribute (12-line addition).
- **Documentation:** ADR-0014 amended with a new "Marker bootstrap" entry under "Per-component decisions" and a Related Issues entry for #746. The matrix doc (`docs/development/opnsense-resource-coverage.md`) was reviewed but not updated — the helper is an implementation detail; the marker pattern itself is unchanged from an operator's perspective.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes (no live verification needed — the fix is a serialization concern; sequential dispatch behavior on the live box is unchanged)

**New helper-level test file** `tests/unit/providers/opnsense/test_category_marker.py` (13 tests). The canonical demonstration is **`test_concurrent_calls_serialize_on_lock`**: 8 threads via `ThreadPoolExecutor` call `ensure_infrafoundry_category` simultaneously against a mock client whose `searchItem` always returns empty rows (maximum race pressure). Assertions: `addItem` called exactly once across all threads; every thread receives the same UUID. The pre-fix inline code would fail this test deterministically; the post-fix helper passes deterministically.

Other new coverage: cache hit/miss, multi-box (different `base_url` → distinct cache entries), `reset_cache_for_tests`, `addItem` failure error path, defensive parsing of malformed `searchItem` responses.

**Service-level tests** (`test_firewall_rule_service.py`, `test_nat_rule_service.py`):
- Added autouse `_clear_category_marker_cache` fixture (calls `reset_cache_for_tests()` between tests so each test starts clean).
- Added one new test per file: `test_ensure_infrafoundry_category_uses_shared_cache` — two distinct service instances against the same client → only one `searchItem` across both.
- Pre-existing 5 `TestCategoryBootstrap` tests in each file pass without rewrites (delegation preserves the public interface).

**Verification:**
- `doit check` passes: 4912 tests, format, lint, mypy strict, bandit, codespell.
- 228 tests in the three affected test files pass (215 pre-existing + 13 new helper tests).
- The race-closure test passes deterministically across runs.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (ADR-0014 amendment)
- [ ] I have updated the CHANGELOG.md (auto-generated at release time from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

**Deviations from the plan posted on issue #746:**

1. **`api_client.py` change** — added a `base_url` `@property` on the `OPNsenseClient` wrapper (12 lines). The plan said "keyed by `client.base_url`" without spelling out that the wrapper didn't expose it. Added as a thin property rather than reaching through the inner `opnsense_openapi` client.
2. **Test naming** — three test methods/variables initially used camelCase (e.g., `test_addItem_payload_shape`); ruff `N802`/`N806` flagged them; renamed to snake_case. No behavior change.

**ADR posture:** Issue #746 lacked the `needs-adr` label. The change is a refinement of an existing decision (ADR-0014's marker bootstrap mechanism) rather than a new architectural call, so no new ADR was created — the existing ADR-0014 was amended in place.

**No live verification needed.** The fix is a serialization concern; live behavior under sequential dispatch is identical to today's. Operators can spot-check by running `infra apply` against a fresh test box and confirming a single `infrafoundry` category row in the OPNsense GUI under Firewall → Categories, but this is not a release-gating step.
