### PR TITLE
fix: tolerate per-controller 404s in opnsense nat_rules / firewall_rules migrate

### DIFF
--- a/src/infrafoundry/providers/opnsense/services/firewall_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/firewall_rule.py
@@ -45,18 +45,21 @@ use the underscored form in YAML.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import yaml
 
-from infrafoundry.core.exceptions import InfraFoundryError
+from infrafoundry.core.exceptions import APIError, InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
 
 from ._category_marker import INFRAFOUNDRY_CATEGORY_NAME as _SHARED_CATEGORY_NAME
 from ._category_marker import ensure_infrafoundry_category
 from .base import BaseService
+
+logger = logging.getLogger(__name__)
 
 # Regex for parsing the description-suffix identity tag. Operator-supplied
 # free-form text leads, followed by whitespace, followed by
@@ -902,6 +905,37 @@ class FirewallRuleService(BaseService):
                 rows = [r for r in raw_rows if isinstance(r, dict)]
         return [_row_to_live(row) for row in rows]
 
+    def search_tolerant(self) -> list[LiveFirewallRule]:
+        """Migrate-only variant of :meth:`search` that tolerates a missing controller.
+
+        Some OPNsense builds may ship without the ``firewall/filter`` MVC
+        controller. For ``export_to_yaml`` — which feeds
+        ``foundry config migrate`` — a missing controller must not abort
+        the entire extraction; instead, the migrate should produce an
+        empty resource list and log a WARNING so the operator knows what
+        was skipped. Other ``APIError`` status codes (5xx, 401/403, etc.)
+        propagate unchanged.
+
+        The strict :meth:`search` (used by apply-time logic) keeps
+        loud-fail semantics: a missing controller at apply time is a
+        real error.
+
+        Returns:
+            ``LiveFirewallRule`` instances from the box, or ``[]`` when
+            the controller responds with HTTP 404.
+        """
+        try:
+            return self.search()
+        except APIError as exc:
+            if exc.status_code == 404:
+                logger.warning(
+                    "OPNsense firewall filter controller is not available "
+                    "(HTTP 404 on %s/searchRule); skipping during migrate.",
+                    _FILTER_BASE,
+                )
+                return []
+            raise
+
     def add(self, rule: FirewallRuleConfig) -> dict[str, Any]:
         """Create a firewall rule.
 
@@ -999,10 +1033,14 @@ class FirewallRuleService(BaseService):
         of ``categories`` so the round-tripped YAML reflects the
         operator's view (any operator-supplied UUIDs survive).
 
+        Uses :meth:`search_tolerant` so a missing ``firewall/filter``
+        controller (HTTP 404) does not abort the entire migrate — the
+        export degrades to an empty resource list with a WARNING log.
+
         Returns:
             YAML string with ``provider/type/name/config`` entries.
         """
-        rules: list[LiveFirewallRule] = self.search()
+        rules: list[LiveFirewallRule] = self.search_tolerant()
         managed = [r for r in rules if r.managed_name is not None]
         marker_uuid = self._category_uuid  # may be None if cache cold
         resources = [

--- a/src/infrafoundry/providers/opnsense/services/nat_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/nat_rule.py
@@ -46,18 +46,21 @@ controllers; same name allowed).
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import yaml
 
-from infrafoundry.core.exceptions import InfraFoundryError
+from infrafoundry.core.exceptions import APIError, InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
 
 from ._category_marker import INFRAFOUNDRY_CATEGORY_NAME as _SHARED_CATEGORY_NAME
 from ._category_marker import ensure_infrafoundry_category
 from .base import BaseService
+
+logger = logging.getLogger(__name__)
 
 # Type alias for NAT rule kinds — the discriminator on every entry.
 NATRuleKind = Literal["outbound", "one_to_one", "port_forward"]
@@ -981,6 +984,44 @@ class NATRuleService(BaseService):
 
         return [_row_to_live(row, kind) for row in rows]
 
+    def search_all_tolerant(self) -> list[LiveNATRule]:
+        """Migrate-only variant of :meth:`search_all` that tolerates per-kind 404s.
+
+        Some OPNsense builds ship without one or more of the NAT MVC
+        controllers (e.g., an older or stripped image lacking the
+        ``firewall/d_nat`` port-forward controller). For ``export_to_yaml``
+        — which feeds ``foundry config migrate`` — a single missing
+        controller must not abort the entire extraction; the operator
+        should still be able to migrate whichever kinds the box exposes.
+        On a 404 from one kind, this method logs a WARNING naming the
+        skipped kind and continues with the remaining kinds. Other
+        ``APIError`` status codes (5xx, 401/403, etc.) propagate
+        unchanged.
+
+        The strict :meth:`search_all` (used by apply-time logic) keeps
+        loud-fail semantics: a missing controller at apply time is a
+        real error.
+
+        Returns:
+            ``LiveNATRule`` instances from every kind that responded
+            without a 404; kinds that 404'd contribute zero rows.
+        """
+        result: list[LiveNATRule] = []
+        for kind in ALLOWED_KINDS:
+            try:
+                result.extend(self.search(kind))
+            except APIError as exc:
+                if exc.status_code == 404:
+                    logger.warning(
+                        "OPNsense NAT controller for kind %r is not available "
+                        "(HTTP 404 on %s/searchRule); skipping during migrate.",
+                        kind,
+                        self._base_for(kind),
+                    )
+                    continue
+                raise
+        return result
+
     def search_all(self) -> list[LiveNATRule]:
         """Fetch the live rule list for both kinds, concatenated."""
         result: list[LiveNATRule] = []
@@ -1110,10 +1151,15 @@ class NATRuleService(BaseService):
         operator. Round-trip loss is expected: only the fields the schema
         captures are written; the prefix is stripped from ``description``.
 
+        Uses :meth:`search_all_tolerant` so a missing per-kind controller
+        (HTTP 404) does not abort the entire migrate — the kinds that
+        respond cleanly are still extracted, with a WARNING log naming
+        any kind that was skipped.
+
         Returns:
             YAML string with ``provider/type/name/config`` entries.
         """
-        rules: list[LiveNATRule] = self.search_all()
+        rules: list[LiveNATRule] = self.search_all_tolerant()
         managed = [r for r in rules if r.managed_name is not None]
         resources = [
             {

--- a/tests/unit/providers/opnsense/test_firewall_rule_service.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_service.py
@@ -20,12 +20,13 @@ Coverage:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
-from infrafoundry.core.exceptions import InfraFoundryError
+from infrafoundry.core.exceptions import APIError, AuthenticationError, InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.providers.opnsense.services._category_marker import (
     reset_cache_for_tests as _reset_marker_cache,
@@ -784,6 +785,97 @@ class TestServiceSearch:
         svc = FirewallRuleService(client)
         with pytest.raises(OpnsenseDriftError):
             svc.search()
+
+
+# ---------------------------------------------------------------------------
+# search_tolerant — migrate-only 404 tolerance (#754)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchTolerant:
+    """``search_tolerant`` swallows 404 with WARNING; non-404s raise; success matches strict."""
+
+    def test_404_returns_empty_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        # 404 from the filter controller must not abort migrate; result
+        # is ``[]`` and a single WARNING is emitted.
+        client = MagicMock()
+        client.request.side_effect = APIError(
+            "Not Found",
+            status_code=404,
+            response="Controller missing",
+            provider="opnsense",
+        )
+        svc = FirewallRuleService(client)
+
+        with caplog.at_level(logging.WARNING):
+            result = svc.search_tolerant()
+
+        assert result == []
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "404" in message
+        assert "firewall/filter" in message
+
+    def test_non_404_api_error_propagates(self) -> None:
+        # 500 errors must not be swallowed.
+        client = MagicMock()
+        client.request.side_effect = APIError("Internal Server Error", status_code=500)
+        svc = FirewallRuleService(client)
+        with pytest.raises(APIError) as exc_info:
+            svc.search_tolerant()
+        assert exc_info.value.status_code == 500
+
+    def test_authentication_error_propagates(self) -> None:
+        # AuthenticationError (401/403) is a subclass of APIError; it
+        # must NOT be swallowed even though it is an APIError.
+        client = MagicMock()
+        client.request.side_effect = AuthenticationError("Unauthorized", status_code=401)
+        svc = FirewallRuleService(client)
+        with pytest.raises(AuthenticationError) as exc_info:
+            svc.search_tolerant()
+        assert exc_info.value.status_code == 401
+
+    def test_success_matches_search(self, caplog: pytest.LogCaptureFixture) -> None:
+        # When search() returns rows normally, search_tolerant returns
+        # the exact same list and does not emit any warning.
+        rows = [
+            {"uuid": "u1", "description": "desc [infrafoundry:a]"},
+            {"uuid": "u2", "description": "unmanaged"},
+        ]
+
+        client_a = MagicMock()
+        client_a.request.return_value = {"rows": rows}
+        svc_a = FirewallRuleService(client_a)
+        with caplog.at_level(logging.WARNING):
+            tolerant = svc_a.search_tolerant()
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert warnings == []
+
+        client_b = MagicMock()
+        client_b.request.return_value = {"rows": rows}
+        svc_b = FirewallRuleService(client_b)
+        strict = svc_b.search()
+
+        assert [(r.uuid, r.managed_name) for r in tolerant] == [
+            (r.uuid, r.managed_name) for r in strict
+        ]
+
+    def test_export_to_yaml_yields_empty_resources_on_404(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # End-to-end: when the controller is missing, ``export_to_yaml``
+        # produces ``resources: []`` and logs a WARNING.
+        client = MagicMock()
+        client.request.side_effect = APIError("Not Found", status_code=404)
+        svc = FirewallRuleService(client)
+
+        with caplog.at_level(logging.WARNING):
+            text = svc.export_to_yaml()
+
+        assert "resources: []" in text
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert len(warnings) == 1
 
 
 class TestServiceCRUD:

--- a/tests/unit/providers/opnsense/test_nat_rule_service.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_service.py
@@ -13,11 +13,13 @@ Coverage:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
+from infrafoundry.core.exceptions import APIError, AuthenticationError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.providers.opnsense.services._category_marker import (
     reset_cache_for_tests as _reset_marker_cache,
@@ -1160,6 +1162,231 @@ class TestServiceSearch:
         assert "firewall/source_nat/searchRule" in endpoints
         assert "firewall/one_to_one/searchRule" in endpoints
         assert "firewall/d_nat/searchRule" in endpoints
+
+
+def _make_per_kind_request(
+    *,
+    outbound_response: Any = None,
+    one_to_one_response: Any = None,
+    port_forward_response: Any = None,
+) -> Any:
+    """Build a ``client.request`` side-effect that routes by URL substring.
+
+    Returns a callable that, when invoked with ``(method, url, **kwargs)``,
+    inspects ``url`` and returns (or raises) the response configured for
+    the matching NAT kind. Each ``*_response`` may be either a value to
+    return or an ``Exception`` instance to raise. ``None`` causes an
+    ``AssertionError`` (which surfaces as an unexpected call).
+
+    The URL substrings are the per-kind controller bases used by
+    :class:`NATRuleService`: ``firewall/source_nat`` (outbound),
+    ``firewall/one_to_one`` (1:1), ``firewall/d_nat`` (port_forward).
+    """
+
+    def side_effect(method: str, url: str, **_kwargs: Any) -> Any:
+        if "firewall/source_nat" in url:
+            response = outbound_response
+        elif "firewall/one_to_one" in url:
+            response = one_to_one_response
+        elif "firewall/d_nat" in url:
+            response = port_forward_response
+        else:  # pragma: no cover - defensive: unexpected URL
+            raise AssertionError(f"Unexpected URL routed to mock client: {url!r}")
+        if isinstance(response, BaseException):
+            raise response
+        if response is None:  # pragma: no cover - defensive
+            raise AssertionError(f"No mock response configured for URL {url!r}")
+        return response
+
+    return side_effect
+
+
+# ---------------------------------------------------------------------------
+# search_all_tolerant — migrate-only per-kind 404 tolerance (#754)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchAllTolerant:
+    """``search_all_tolerant`` skips per-kind 404s with WARNING; non-404s raise."""
+
+    def test_only_port_forward_404s(self, caplog: pytest.LogCaptureFixture) -> None:
+        # outbound + 1:1 return rows; port_forward 404s. Result should
+        # contain rows from the two surviving kinds only, and a single
+        # WARNING should fire naming ``port_forward``.
+        client = MagicMock()
+        client.request.side_effect = _make_per_kind_request(
+            outbound_response={"rows": [{"uuid": "u-out", "description": "out [infrafoundry:o1]"}]},
+            one_to_one_response={
+                "rows": [{"uuid": "u-oto", "description": "oto [infrafoundry:t1]"}]
+            },
+            port_forward_response=APIError(
+                "Not Found",
+                status_code=404,
+                response="Controller missing",
+                provider="opnsense",
+            ),
+        )
+        svc = NATRuleService(client)
+
+        with caplog.at_level(logging.WARNING):
+            result = svc.search_all_tolerant()
+
+        managed_names = sorted(r.managed_name for r in result if r.managed_name is not None)
+        assert managed_names == ["o1", "t1"]
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "port_forward" in message
+        assert "404" in message
+
+    def test_two_kinds_404(self, caplog: pytest.LogCaptureFixture) -> None:
+        # outbound + port_forward 404; only 1:1 survives. Two warnings.
+        client = MagicMock()
+        client.request.side_effect = _make_per_kind_request(
+            outbound_response=APIError("404", status_code=404),
+            one_to_one_response={
+                "rows": [{"uuid": "u-oto", "description": "oto [infrafoundry:t1]"}]
+            },
+            port_forward_response=APIError("404", status_code=404),
+        )
+        svc = NATRuleService(client)
+
+        with caplog.at_level(logging.WARNING):
+            result = svc.search_all_tolerant()
+
+        managed_names = [r.managed_name for r in result]
+        assert managed_names == ["t1"]
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert len(warnings) == 2
+        kinds_in_messages = {
+            kind
+            for rec in warnings
+            for kind in ("outbound", "one_to_one", "port_forward")
+            if kind in rec.getMessage()
+        }
+        assert kinds_in_messages == {"outbound", "port_forward"}
+
+    def test_all_three_kinds_404(self, caplog: pytest.LogCaptureFixture) -> None:
+        # All three controllers 404. Result is empty; three warnings.
+        client = MagicMock()
+        client.request.side_effect = _make_per_kind_request(
+            outbound_response=APIError("404", status_code=404),
+            one_to_one_response=APIError("404", status_code=404),
+            port_forward_response=APIError("404", status_code=404),
+        )
+        svc = NATRuleService(client)
+
+        with caplog.at_level(logging.WARNING):
+            result = svc.search_all_tolerant()
+
+        assert result == []
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert len(warnings) == 3
+
+    def test_non_404_api_error_propagates(self) -> None:
+        # 500 errors must not be swallowed — apply-time and migrate
+        # alike should fail loudly on a real server-side error.
+        client = MagicMock()
+        client.request.side_effect = _make_per_kind_request(
+            outbound_response={"rows": []},
+            one_to_one_response=APIError("Internal Server Error", status_code=500),
+            port_forward_response={"rows": []},
+        )
+        svc = NATRuleService(client)
+        with pytest.raises(APIError) as exc_info:
+            svc.search_all_tolerant()
+        assert exc_info.value.status_code == 500
+
+    def test_authentication_error_propagates(self) -> None:
+        # AuthenticationError is a subclass of APIError with 401/403 —
+        # it must NOT be swallowed even though it is an APIError.
+        client = MagicMock()
+        client.request.side_effect = _make_per_kind_request(
+            outbound_response=AuthenticationError("Unauthorized", status_code=401),
+            one_to_one_response={"rows": []},
+            port_forward_response={"rows": []},
+        )
+        svc = NATRuleService(client)
+        with pytest.raises(AuthenticationError) as exc_info:
+            svc.search_all_tolerant()
+        assert exc_info.value.status_code == 401
+
+    def test_success_path_matches_search_all(self, caplog: pytest.LogCaptureFixture) -> None:
+        # When no kind 404s, the tolerant variant returns the same rows
+        # as ``search_all`` (same input data) and emits no warnings.
+        rows_outbound = [{"uuid": "u-out", "description": "out [infrafoundry:o1]"}]
+        rows_one_to_one = [{"uuid": "u-oto", "description": "oto [infrafoundry:t1]"}]
+        rows_port_forward = [{"uuid": "u-pf", "descr": "pf [infrafoundry:p1]"}]
+
+        # Run search_all_tolerant.
+        client_a = MagicMock()
+        client_a.request.side_effect = _make_per_kind_request(
+            outbound_response={"rows": rows_outbound},
+            one_to_one_response={"rows": rows_one_to_one},
+            port_forward_response={"rows": rows_port_forward},
+        )
+        svc_a = NATRuleService(client_a)
+        with caplog.at_level(logging.WARNING):
+            tolerant = svc_a.search_all_tolerant()
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert warnings == []
+
+        # Run search_all on a separate client/instance with the same
+        # configured responses to compare outputs.
+        client_b = MagicMock()
+        client_b.request.side_effect = _make_per_kind_request(
+            outbound_response={"rows": rows_outbound},
+            one_to_one_response={"rows": rows_one_to_one},
+            port_forward_response={"rows": rows_port_forward},
+        )
+        svc_b = NATRuleService(client_b)
+        strict = svc_b.search_all()
+
+        # Same managed-name sequence and per-kind ordering.
+        assert [(r.kind, r.managed_name) for r in tolerant] == [
+            (r.kind, r.managed_name) for r in strict
+        ]
+
+    def test_export_to_yaml_uses_tolerant_path(self, caplog: pytest.LogCaptureFixture) -> None:
+        # End-to-end: when port_forward 404s, ``export_to_yaml`` produces
+        # YAML containing the outbound + 1:1 managed rules and a
+        # WARNING is logged naming ``port_forward``.
+        client = MagicMock()
+        client.request.side_effect = _make_per_kind_request(
+            outbound_response={
+                "rows": [
+                    {
+                        "uuid": "u-out",
+                        "description": "LAN out [infrafoundry:lan-out]",
+                        "interface": "wan",
+                        "target": "wanip",
+                    }
+                ]
+            },
+            one_to_one_response={
+                "rows": [
+                    {
+                        "uuid": "u-oto",
+                        "description": "DMZ [infrafoundry:dmz]",
+                        "interface": "wan",
+                        "external": "198.51.100.10",
+                    }
+                ]
+            },
+            port_forward_response=APIError("404", status_code=404),
+        )
+        svc = NATRuleService(client)
+
+        with caplog.at_level(logging.WARNING):
+            text = svc.export_to_yaml()
+
+        assert "lan-out" in text
+        assert "dmz" in text
+        # No port-forward managed rules emitted.
+        assert "kind: port_forward" not in text
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "port_forward" in warnings[0].getMessage()
 
 
 def _expected_with_category(rule: NATRuleConfig, category_uuid: str = "fake-cat") -> dict[str, Any]:


### PR DESCRIPTION
## Description

`foundry config migrate --provider opnsense --component nat_rules` aborted with HTTP 404 on a 25.7.x box that lacks the `firewall/d_nat` (port-forward) MVC controller, even though the outbound and 1:1 controllers were present and would have extracted cleanly. A single missing controller blocked the entire migrate.

This change adds migrate-only, per-controller 404 tolerance to the OPNsense `nat_rules` and `firewall_rules` extractors. Apply-time strict paths are unchanged — a missing controller at apply time is still a real error and still propagates. The tolerance is read-side only (`export_to_yaml`), so `foundry config migrate` can extract whichever kinds the box exposes and warn loudly about the kinds it had to skip.

## Related Issue

Addresses #754

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `NATRuleService.search_all_tolerant()` — new migrate-only method that loops `ALLOWED_KINDS` (`outbound`, `one_to_one`, `port_forward`) calling per-kind `search(kind)`. On `APIError(status_code=404)` for a single kind, it logs a WARNING naming the kind and the endpoint and continues with the other kinds. Other status codes (5xx, 401/403, etc.) propagate. `export_to_yaml` now calls `search_all_tolerant()`; the strict `search_all()` is unchanged and still used by apply-time logic.
- `FirewallRuleService.search_tolerant()` — same shape, single-controller variant. On `APIError(status_code=404)` from `search()`, returns `[]` with a WARNING log. `export_to_yaml` now calls `search_tolerant()`; the strict `search()` is unchanged. `firewall/filter/searchRule` works on current 25.7.x but the same defensive shape future-proofs the framework against fleet/version skew.
- Module-level `logger = logging.getLogger(__name__)` added to both services (matches the `_credentials.py` precedent), and `APIError` added to the existing `infrafoundry.core.exceptions` import.
- The WARNING surfaces in CLI output via stderr (standard logging propagation) so the operator sees, e.g., `OPNsense NAT controller for kind 'port_forward' is not available (HTTP 404 on firewall/d_nat/searchRule); skipping during migrate.`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

12 new tests added:

`tests/unit/providers/opnsense/test_nat_rule_service.py::TestSearchAllTolerant` (7):
- only `port_forward` 404s — outbound + 1:1 rows returned, single WARNING naming `port_forward`
- two kinds 404 — surviving kind's rows returned, two WARNINGs
- all three kinds 404 — empty list returned, three WARNINGs
- non-404 `APIError` (500) propagates
- `AuthenticationError` (401) propagates
- success path (no 404s) matches `search_all()` exactly with no WARNINGs
- `export_to_yaml` round-trip when `port_forward` 404s — produces YAML using only the surviving kinds

`tests/unit/providers/opnsense/test_firewall_rule_service.py::TestSearchTolerant` (5):
- 404 returns `[]` with one WARNING
- non-404 `APIError` (500) propagates
- `AuthenticationError` (401) propagates
- success matches `search()` exactly with no WARNINGs
- `export_to_yaml` yields `resources: []` on 404

**Live verification against the user's prod box (OPNsense 25.7.11_1):**
- `foundry config migrate ... --component nat_rules` succeeded with the WARNING `OPNsense NAT controller for kind 'port_forward' is not available (HTTP 404 on firewall/d_nat/searchRule); skipping during migrate.` and produced `migrated-nat_rules.yaml` with `resources: []` (outbound + 1:1 are 0 rows on this box; port_forward skipped).
- `foundry config migrate ... --component firewall_rules` succeeded as before (regression-clean), `resources: []`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

Documentation: no doc changes required. The fix is a localized error-handling refinement with no architectural change. Issue #754 is `bug`, not `needs-adr`. ADR-0014 amendment was considered as a one-line note but rejected as light-touch and not strictly required (per the plan on the issue). No runbook changes.

## Additional Notes

- Apply-time strict paths (`search_all`, `search`, diff/list) are intentionally **unchanged**. A missing controller at apply time on a box that can't host the resource is a real error and should still fail loudly.
- The WARNING wording is intentionally explicit about kind, endpoint, and that the skip is migrate-scoped, so an operator scanning logs can immediately tell what was extracted vs. what was skipped.
- Sibling PR context: PR #752 (env-var override for OPNsense direct-API credentials) just merged; #754 surfaced during the ensuing pre-cutover migrate run against the user's prod box.
