### PR TITLE
fix: honor runner PlanResult.success in plan path

### DIFF
--- a/docs/decisions/0010-protocol-based-runner-interfaces.md
+++ b/docs/decisions/0010-protocol-based-runner-interfaces.md
@@ -6,7 +6,7 @@
 
 **Deciders:** Development Team
 
-**Related Issues:** #48
+**Related Issues:** #48, #761
 
 **Related PRs:** #77
 

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -533,6 +533,18 @@ class PlanOrchestrator(HookExecutionMixin):
                                 )
                                 provider_results[f"{tool_name}_plan"] = runner_result
 
+                                # Honor the runner's success flag: if the runner
+                                # returned ``success=False`` (e.g. OPNsenseDirectRunner
+                                # caught a per-component-manager exception), raise so
+                                # the CLI reports failure rather than printing a
+                                # misleading success message. The surrounding
+                                # ``except Exception`` handler emits RUNNER_FAILED.
+                                raise_on_runner_failure(
+                                    runner_result,
+                                    provider_name=provider_name,
+                                    phase="plan",
+                                )
+
                                 completed_event: RunnerEventData = {
                                     "provider": provider_name,
                                     "runner": tool_name,

--- a/src/infrafoundry/core/runner_results.py
+++ b/src/infrafoundry/core/runner_results.py
@@ -1,10 +1,11 @@
 """Helpers for interpreting runner result dictionaries.
 
 This module centralizes the logic that converts a runner's result dict
-(as returned by ``BaseRunner.apply`` / ``BaseRunner.destroy``) into a
-Python exception when the runner reports failure. Keeping this in one
-place ensures that both the apply and destroy code paths honor the
-``success`` flag identically and produce consistent error messages.
+(as returned by ``BaseRunner.plan`` / ``BaseRunner.apply`` /
+``BaseRunner.destroy``) into a Python exception when the runner reports
+failure. Keeping this in one place ensures that the plan, apply, and
+destroy code paths honor the ``success`` flag identically and produce
+consistent error messages.
 """
 
 from __future__ import annotations
@@ -28,13 +29,14 @@ def raise_on_runner_failure(
     only converts a result dict into an exception, never emits events.
 
     Args:
-        run_result: The dict returned by a runner's ``apply`` or
-            ``destroy`` method. Expected keys include ``success``,
+        run_result: The dict returned by a runner's ``plan``, ``apply``,
+            or ``destroy`` method. Expected keys include ``success``,
             ``error``, ``stderr``, ``exit_code``, and ``output``.
         provider_name: Name of the provider whose runner produced the
             result. Used in the error message.
         phase: The runner phase that produced the result, e.g.
-            ``"apply"`` or ``"destroy"``. Used in the error message.
+            ``"plan"``, ``"apply"``, or ``"destroy"``. Used in the error
+            message.
 
     Raises:
         TerraformError: If ``run_result['success']`` is False. The

--- a/tests/integration/test_orchestrator_workflows.py
+++ b/tests/integration/test_orchestrator_workflows.py
@@ -242,6 +242,64 @@ class TestPlanOrchestrator:
 
         assert EventType.PLAN_FAILED in events_received
 
+    def test_plan_runner_returning_success_false_marks_deployment_failed(self, orchestrator):
+        """Plan must mark deployment FAILED when runner returns success=False.
+
+        Mirrors ``test_plan_failure_updates_deployment_status`` but exercises
+        the path where the runner returns ``PlanResult(success=False, ...)``
+        instead of raising. Without ``raise_on_runner_failure`` in the plan
+        path, the orchestrator would silently mark the deployment COMPLETED
+        and the CLI would exit 0 despite the failure.
+        """
+        from infrafoundry.core.exceptions import TerraformError
+
+        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
+            mock_plan.return_value = {
+                "success": False,
+                "error": "boom",
+                "exit_code": 1,
+                "output": "",
+                "stderr": "boom",
+            }
+
+            with pytest.raises(TerraformError):
+                orchestrator.plan(env_name="dev", dry_run=False)
+
+            # Check deployment was marked as failed and the runner's error
+            # message propagated into the deployment record.
+            deployments = orchestrator.state_manager.get_deployment_history(environment="dev")
+            assert deployments[0].status == DeploymentStatus.FAILED
+            assert "boom" in deployments[0].error_message
+
+    def test_plan_runner_returning_success_false_emits_plan_failed_event(self, orchestrator):
+        """Plan must emit PLAN_FAILED when runner returns success=False.
+
+        Mirrors ``test_plan_emits_failure_event`` but exercises the
+        runner-returns-success-False path rather than the runner-raises path.
+        """
+        from infrafoundry.core.exceptions import TerraformError
+
+        events_received = []
+
+        def capture_event(event):
+            events_received.append(event.event_type)
+
+        orchestrator.event_manager.subscribe(EventType.PLAN_FAILED, capture_event)
+
+        with patch("infrafoundry.core.runners.terraform_runner.TerraformRunner.plan") as mock_plan:
+            mock_plan.return_value = {
+                "success": False,
+                "error": "boom",
+                "exit_code": 1,
+                "output": "",
+                "stderr": "boom",
+            }
+
+            with pytest.raises(TerraformError):
+                orchestrator.plan(env_name="dev", dry_run=False)
+
+        assert EventType.PLAN_FAILED in events_received
+
 
 class TestApplyOrchestrator:
     """Tests for apply workflow."""


### PR DESCRIPTION
## Description

Plan now honors the runner's `success` flag the same way `apply` and `destroy` already do. Previously, when a runner returned `PlanResult(success=False, error=...)` (the documented contract for non-exception failures), `PlanOrchestrator.plan()` stored the result, emitted `RUNNER_COMPLETED` with hardcoded `success=True`, marked the deployment `COMPLETED`, and exited `0`. The CLI then printed `Plan generated successfully!` despite the runner explicitly reporting failure.

This PR adds a single `raise_on_runner_failure(runner_result, provider_name=..., phase="plan")` call in `PlanOrchestrator.plan()` immediately after `runner.plan(...)` returns, mirroring the existing `phase="apply"` call in `deployment_executor.py` and the `phase="destroy"` call in `DestroyOrchestrator`. When the runner reports failure, the helper raises `TerraformError`; the surrounding `except Exception` arm then emits `RUNNER_FAILED` and `PLAN_FAILED` and marks the deployment `FAILED`, so the CLI exits non-zero and surfaces the runner's error.

This is the framework follow-up to behavior surfaced while live-verifying PR #760 (the kea_dhcp6 direct-runner refactor on issue #758). #760 added the loud `ReferenceValidationError` that gets caught and converted to `PlanResult(success=False)` by `OPNsenseDirectRunner.plan()` — which is correct per the runner contract. That made the pre-existing orchestrator gap suddenly visible: the loud-raise-at-plan-time guarantee #760 promises was being silently undone here.

## Related Issue

Addresses #761

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/infrafoundry/core/orchestrator_workflows.py` (+12): inside `PlanOrchestrator.plan()`, call `raise_on_runner_failure(runner_result, provider_name=provider_name, phase="plan")` immediately after `runner.plan(...)` returns. Located in the existing `try` block before `RUNNER_COMPLETED` is emitted, so the existing `except Exception` arm picks up the `TerraformError` and routes it through the same `RUNNER_FAILED` / `PLAN_FAILED` / `DeploymentStatus.FAILED` path that runner-raised exceptions already take.
- `src/infrafoundry/core/runner_results.py` (docstring-only): module docstring and `raise_on_runner_failure` docstring now mention `plan` alongside `apply` / `destroy`. No behavior change — the helper was already phase-agnostic; only the documented expected callers needed updating.
- `tests/integration/test_orchestrator_workflows.py` (+58): two new integration tests under `TestPlanOrchestrator`:
  - `test_plan_runner_returning_success_false_marks_deployment_failed`: mocks `TerraformRunner.plan` to return `{"success": False, "error": "boom", ...}`, asserts the orchestrator raises `TerraformError`, the deployment row is `DeploymentStatus.FAILED`, and the runner's error message is captured in `error_message`.
  - `test_plan_runner_returning_success_false_emits_plan_failed_event`: same mock, asserts `EventType.PLAN_FAILED` is published. Mirrors the existing `test_plan_emits_failure_event` test (which exercises the runner-raises path) so the runner-returns-`success=False` path now has equivalent coverage.
- `docs/decisions/0010-protocol-based-runner-interfaces.md`: added `#761` to the `Related Issues` header line. ADR-0010 defines the `Plannable` protocol and the `PlanResult.success` contract that this fix enforces in the orchestrator.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, full pytest -n auto).

The two new tests both verify the orchestrator side of the runner contract: when the runner returns a `success=False` result dict, `plan()` must raise, mark the deployment failed, and emit `PLAN_FAILED`. They sit alongside the existing tests that cover the runner-raises path, so the two failure modes documented in ADR-0010 (`Plannable.plan` may raise, **or** may return `PlanResult(success=False)`) are both exercised end-to-end.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

**Deliberate scope holds:**

- **No generalization of the `raise_on_runner_failure` error wording.** The helper still raises `TerraformError("Terraform {phase} failed for provider '{name}': {error}", ...)` even when the failing runner is `OPNsenseDirectRunner`, not Terraform. That message has been wrong for the apply/destroy paths since the helper was extracted; this PR does not fix it. Generalizing the wording (and either renaming `TerraformError` or introducing a `RunnerError` superclass) is a separate refactor with broader callsite impact and should land on its own issue.
- **No continue-vs-stop semantics changes elsewhere.** The plan path already iterates providers serially and runners in dependency order; raising on the first runner failure stops further runners for the failing provider and stops the orchestrator itself, which matches how apply and destroy already behave today. This PR does not touch the parallel-apply path, the per-provider continue/stop policy, or any drift / rollback flow.
- **No CHANGELOG.md entry.** Following the repo's existing convention (CHANGELOG is auto-generated from conventional-commit history at release time via commitizen — see `.github/CONTRIBUTING.md` "How Versioning Works"), no manual entry is added here. The `fix:` commit subject is what feeds the release notes.

**Discovered while live-verifying PR #760 (issue #758).** That PR remains the right home for the kea_dhcp6 changes; this PR is the orthogonal framework fix it depends on for its loud-failure behavior to actually reach the CLI.
