### PR TITLE
fix: rename unbound host overrides output to avoid terraform reserved *_override.tf suffix

### DIFF
--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -343,7 +343,7 @@ class OPNsenseProvider(
         self.render_and_write_terraform(
             "opnsense/unbound_host_override.tf.j2",
             context={"overrides": overrides},
-            output_name="unbound_host_override.tf",
+            output_name="unbound_host_overrides.tf",
         )
 
     # DHCPv6 subnet / reservation management lives on

--- a/tests/unit/providers/opnsense/test_unbound_host_override.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_override.py
@@ -53,8 +53,13 @@ class TestUnboundHostOverrideTemplates:
         """Test basic host override Terraform generation."""
         provider.generate_terraform([basic_override])
 
-        override_tf = provider.terraform_dir / "unbound_host_override.tf"
+        override_tf = provider.terraform_dir / "unbound_host_overrides.tf"
         assert override_tf.exists()
+        # Terraform reserves the ``*_override.tf`` filename suffix for override
+        # files (resource blocks must reference resources defined elsewhere).
+        # See #763 — using the singular form caused "Missing resource to
+        # override" errors during plan/init.
+        assert not override_tf.name.endswith("_override.tf")
 
         content = override_tf.read_text()
         assert 'resource "opnsense_unbound_host_override"' in content
@@ -69,7 +74,7 @@ class TestUnboundHostOverrideTemplates:
         """Test host override with description renders correctly."""
         provider.generate_terraform([override_with_description])
 
-        content = (provider.terraform_dir / "unbound_host_override.tf").read_text()
+        content = (provider.terraform_dir / "unbound_host_overrides.tf").read_text()
         assert 'description = "Mail server override"' in content
 
     def test_generate_override_without_optional_fields(self, provider: OPNsenseProvider) -> None:
@@ -86,7 +91,7 @@ class TestUnboundHostOverrideTemplates:
 
         provider.generate_terraform([override])
 
-        content = (provider.terraform_dir / "unbound_host_override.tf").read_text()
+        content = (provider.terraform_dir / "unbound_host_overrides.tf").read_text()
         assert 'hostname = "app"' in content
         assert 'domain   = "internal.local"' in content
         assert "server" not in content
@@ -110,7 +115,7 @@ class TestUnboundHostOverrideTemplates:
 
         provider.generate_terraform(overrides)
 
-        content = (provider.terraform_dir / "unbound_host_override.tf").read_text()
+        content = (provider.terraform_dir / "unbound_host_overrides.tf").read_text()
         assert "host_0" in content
         assert "host_1" in content
         assert "host_2" in content
@@ -129,7 +134,7 @@ class TestUnboundHostOverrideTemplates:
 
         provider.generate_terraform([override])
 
-        content = (provider.terraform_dir / "unbound_host_override.tf").read_text()
+        content = (provider.terraform_dir / "unbound_host_overrides.tf").read_text()
         assert "my_web_server" in content
         assert (
             "my-web-server"


### PR DESCRIPTION
## Description

Terraform reserves the `*_override.tf` filename suffix for [override files](https://developer.hashicorp.com/terraform/language/files/override): resource blocks in those files merge into resources defined elsewhere, and Terraform raises `Missing resource to override` at init/plan if no matching base resource exists. The OPNsense provider was emitting its Unbound host overrides into `generated/{env}/terraform/opnsense/unbound_host_override.tf`, which collided head-on with that reserved suffix.

The fix is a single-site filename rename in the provider: the output file is now `unbound_host_overrides.tf` (plural). The Terraform resource type (`opnsense_unbound_host_override`) and the YAML config schema are unchanged — only the filename inside the generated `terraform/opnsense/` directory differs.

This bug was latent until today. Activating a previously-parked `migrated-unbound_host_override.yaml` in `endavis-infra` (preparation for the OPNsense box-to-box cutover snapshot direction tracked under #758) was the first time `_generate_unbound_host_override_terraform` produced a non-empty file with concrete `resource` blocks, which is when Terraform's override-file semantics kick in.

## Related Issue

Addresses #763

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/infrafoundry/providers/opnsense/__init__.py`: rename the output filename in `_generate_unbound_host_override_terraform` from `unbound_host_override.tf` to `unbound_host_overrides.tf` (single line, no other behavior change).
- `tests/unit/providers/opnsense/test_unbound_host_override.py`: update five hardcoded filename strings to match the new output, and add one new defensive assertion in `test_generate_basic_host_override`:
  ```python
  assert not override_tf.name.endswith("_override.tf")
  ```
  with an inline comment naming Terraform's reserved-suffix constraint and citing #763. This documents the constraint in code so a future revert (e.g., a "make it singular for consistency" refactor) cannot silently re-introduce the bug — the test will fail loudly.
- Jinja template name (`templates/opnsense/unbound_host_override.tf.j2`) is unchanged on purpose: Terraform never sees template names, only the rendered output file.

## Testing

- [x] All existing tests pass (`doit check` — full suite green: format, lint, type, security, spell, tests).
- [x] Added a new defensive assertion that documents Terraform's reserved-suffix constraint in code.
- [x] Manually verified the changed code path matches the issue: line 346 of `src/infrafoundry/providers/opnsense/__init__.py` now passes `output_name="unbound_host_overrides.tf"`.

## Scope

This PR is deliberately narrow:

- **No codebase-wide AST guardrail.** A general-purpose check that scans every provider for output filenames ending in `_override.tf`, `_data.tf`, etc. is a reasonable follow-up but out of scope here. The new defensive assertion covers the one site that hit the bug.
- **No automatic stale-file purging.** The framework does not currently delete previously-generated `.tf` files when their producer is renamed/removed. That is a separate concern with broader implications for any provider that drops a resource type. See post-merge cleanup note below.
- **Jinja template name unchanged.** Renaming the template is gratuitous churn — Terraform doesn't see template names, only rendered output filenames.

## Post-merge operator cleanup

Operators whose environment generated the now-renamed file before this fix landed need to delete the stale file once. The framework does not purge stale generated files on its own:

```bash
rm generated/<env>/terraform/opnsense/unbound_host_override.tf
```

Run this for any environment that hit the failed `terraform plan` / `terraform init` after activating an Unbound host override YAML. New environments and environments that never had a non-empty Unbound host overrides file are unaffected.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective (the rename is verified by all five updated filename assertions, and the new defensive assertion guards against regression)
- [x] All new and existing tests pass (`doit test`)
- [x] No documentation changes required — no doc references the old filename, and no user-facing behavior (resource type, YAML schema) changes
- [x] My changes generate no new warnings
