### PR TITLE
fix: correct tailscale terraform module source path (registry 404)

### DIFF
--- a/blueprints/k3s-cluster/providers/oci/instance.yaml
+++ b/blueprints/k3s-cluster/providers/oci/instance.yaml
@@ -4,7 +4,7 @@
 # Multi-instance safe: every outer name is templated. workers: is a list of
 # dicts with schema {name, ocpus, memory_gb}; see blueprint README.
 #
-# Tailscale is wired up via the official tailscale/cloudinit/tailscale
+# Tailscale is wired up via the official tailscale/tailscale/cloudinit
 # Terraform module (issue #212). Auth credentials live in the env's
 # sops-encrypted secrets.yaml under secrets.tailscale.* and flow into
 # Terraform via the framework's secrets→TF_VAR_* bridge — values never

--- a/example-config/envs/oci-k3s/settings.yaml
+++ b/example-config/envs/oci-k3s/settings.yaml
@@ -38,7 +38,7 @@ provider_settings:
 #     env: block via {{ secrets.tailscale.api_key }} templating.
 secrets:
   tailscale:
-    # OAuth client credentials for the official tailscale/cloudinit/tailscale
+    # OAuth client credentials for the official tailscale/tailscale/cloudinit
     # Terraform module. Generate at:
     #   https://login.tailscale.com/admin/settings/oauth
     # Required scope: Devices Core (read+write).

--- a/src/infrafoundry/core/tailscale.py
+++ b/src/infrafoundry/core/tailscale.py
@@ -32,9 +32,9 @@ from typing import Any
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.provider_mixins import sanitize_secret_ref_to_tf_var
 
-#: Pinned version of the ``tailscale/cloudinit/tailscale`` module.
+#: Pinned version of the ``tailscale/tailscale/cloudinit`` module.
 TAILSCALE_MODULE_VERSION = "0.0.11"
-TAILSCALE_MODULE_SOURCE = "tailscale/cloudinit/tailscale"
+TAILSCALE_MODULE_SOURCE = "tailscale/tailscale/cloudinit"
 
 
 class TailscaleSchemaError(ValueError):

--- a/src/infrafoundry/providers/oci/templates/oci/provider.tf.j2
+++ b/src/infrafoundry/providers/oci/templates/oci/provider.tf.j2
@@ -5,7 +5,7 @@ terraform {
       version = "~> 6.0"
     }
     # Required by the Tailscale cloud-init module
-    # (tailscale/cloudinit/tailscale). Declared unconditionally so consumers
+    # (tailscale/tailscale/cloudinit). Declared unconditionally so consumers
     # that enable the optional ``tailscale:`` resource block don't need any
     # extra wiring. Unused when no instance declares ``tailscale:``.
     cloudinit = {

--- a/src/infrafoundry/providers/proxmox/templates/proxmox/provider.tf.j2
+++ b/src/infrafoundry/providers/proxmox/templates/proxmox/provider.tf.j2
@@ -5,7 +5,7 @@ terraform {
       version = "~> 0.86"
     }
     # Required by the Tailscale cloud-init module
-    # (tailscale/cloudinit/tailscale). Declared unconditionally so consumers
+    # (tailscale/tailscale/cloudinit). Declared unconditionally so consumers
     # that enable the optional ``tailscale:`` resource block don't need any
     # extra wiring. Unused when no VM declares ``tailscale:``.
     cloudinit = {

--- a/tests/unit/core/test_tailscale.py
+++ b/tests/unit/core/test_tailscale.py
@@ -1,0 +1,45 @@
+"""Structural regression tests for the Tailscale cloud-init module constants.
+
+Guards ``TAILSCALE_MODULE_SOURCE`` against the failure mode that motivated
+issue #767: the constant was set to ``"tailscale/cloudinit/tailscale"``,
+flipping the 2nd and 3rd Terraform Registry path segments. Terraform's
+registry source format is ``<namespace>/<name>/<provider>``, and the
+canonical Tailscale cloud-init module lives at
+``https://registry.terraform.io/modules/tailscale/tailscale/cloudinit``.
+The wrong path returns HTTP 404 from the registry; ``terraform init``
+fails before any rendered output is consumed.
+
+These tests pin the constant against canonical registry coordinates
+without performing any network call.
+"""
+
+from __future__ import annotations
+
+from infrafoundry.core.tailscale import TAILSCALE_MODULE_SOURCE
+
+
+def test_module_source_has_three_segments() -> None:
+    """``TAILSCALE_MODULE_SOURCE`` must be a 3-segment slash-separated path.
+
+    Guards against accidental flattening (e.g. ``"tailscale/tailscale-cloudinit"``)
+    or an extra segment getting introduced. Terraform Registry sources are
+    always exactly ``<namespace>/<name>/<provider>``.
+    """
+    parts = TAILSCALE_MODULE_SOURCE.split("/")
+    assert len(parts) == 3, (
+        f"Expected 3 slash-separated segments, got {len(parts)}: {TAILSCALE_MODULE_SOURCE!r}"
+    )
+
+
+def test_module_source_segments_match_canonical_registry_path() -> None:
+    """``TAILSCALE_MODULE_SOURCE`` segments must equal the canonical path.
+
+    The canonical Tailscale cloud-init module is published at
+    ``https://registry.terraform.io/modules/tailscale/tailscale/cloudinit``.
+    Per Terraform Registry conventions, the module-block ``source`` is
+    ``<namespace>/<name>/<provider>``. This test would have caught the
+    original bug (#767), where the 2nd and 3rd segments were flipped
+    to ``"tailscale/cloudinit/tailscale"`` (HTTP 404).
+    """
+    namespace, name, provider = TAILSCALE_MODULE_SOURCE.split("/")
+    assert (namespace, name, provider) == ("tailscale", "tailscale", "cloudinit")

--- a/tests/unit/providers/oci/test_tailscale_module.py
+++ b/tests/unit/providers/oci/test_tailscale_module.py
@@ -68,7 +68,7 @@ class TestOCITailscaleAuthKey:
         instances_tf = _read_tf(output_dir, "instances.tf")
 
         assert 'module "tailscale_ts_control"' in instances_tf
-        assert 'source  = "tailscale/cloudinit/tailscale"' in instances_tf
+        assert 'source  = "tailscale/tailscale/cloudinit"' in instances_tf
         assert 'version = "0.0.11"' in instances_tf
         assert "auth_key = var.tailscale_auth_key" in instances_tf
         # client_id/secret should NOT appear in auth_key mode

--- a/tests/unit/providers/proxmox/test_tailscale_module.py
+++ b/tests/unit/providers/proxmox/test_tailscale_module.py
@@ -70,7 +70,7 @@ class TestProxmoxTailscaleAuthKey:
         vms_tf = _read_tf(output_dir, "vms.tf")
 
         assert 'module "tailscale_ts_control"' in vms_tf
-        assert 'source  = "tailscale/cloudinit/tailscale"' in vms_tf
+        assert 'source  = "tailscale/tailscale/cloudinit"' in vms_tf
         assert 'version = "0.0.11"' in vms_tf
         assert "auth_key = var.tailscale_auth_key" in vms_tf
 

--- a/tests/unit/test_oci_k3s_cluster_blueprint.py
+++ b/tests/unit/test_oci_k3s_cluster_blueprint.py
@@ -206,7 +206,7 @@ def test_oci_k3s_cluster_example_uses_tailscale_module(loader: PackageLoader) ->
     """Every instance declares a tailscale: block referencing the OAuth
     secrets in the env's secrets.tailscale.* dict. Issue #212 phase 2
     replaced the custom cloud-init snippet with the official
-    tailscale/cloudinit/tailscale Terraform module; this test verifies
+    tailscale/tailscale/cloudinit Terraform module; this test verifies
     every blueprint instance opted into the new schema."""
     resources, _events, _variables = loader.load_package(
         PACKAGE_DIR, provider="oci", env_name="oci-k3s"


### PR DESCRIPTION
## Description

The framework's pinned Tailscale Terraform module source path had its 2nd and 3rd registry segments flipped — `"tailscale/cloudinit/tailscale"` instead of the canonical `"tailscale/tailscale/cloudinit"`. Terraform's registry source format is `<namespace>/<name>/<provider>`, and the Tailscale cloud-init module is published at `https://registry.terraform.io/modules/tailscale/tailscale/cloudinit` (source repo: `tailscale/terraform-cloudinit-tailscale`). The wrong path returns HTTP 404 from the registry, so `terraform init` fails before any rendered output is consumed — affecting both OCI and Proxmox provider templates that include Tailscale cloud-init blocks.

The fix is a single-string correction in `TAILSCALE_MODULE_SOURCE` (`src/infrafoundry/core/tailscale.py`). All other touched files are comments, docstrings, test-assertion literals, and one user-facing comment in an example config — every site that hard-coded the old path was audited and updated for consistency. A new structural regression test pins the constant to canonical registry coordinates without requiring a network call, so this failure mode cannot regress silently.

## Related Issue

Addresses #767

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement (adds structural regression test for `TAILSCALE_MODULE_SOURCE`)

## Root cause

Terraform Registry sources are exactly `<namespace>/<name>/<provider>`. The constant transposed the 2nd and 3rd segments:

| Segment | What it should be | What was there | Notes |
| --- | --- | --- | --- |
| 1 (namespace) | `tailscale` | `tailscale` | Correct |
| 2 (name) | `tailscale` | `cloudinit` | Flipped |
| 3 (provider) | `cloudinit` | `tailscale` | Flipped |

Verification (no auth required):

```text
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" https://registry.terraform.io/v1/modules/tailscale/tailscale/cloudinit
HTTP 200
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" https://registry.terraform.io/v1/modules/tailscale/cloudinit/tailscale
HTTP 404
```

## How this surfaced

The bug was latent for any environment that didn't actually run `terraform init` against an OCI/Proxmox plan emitting a Tailscale module block. It surfaced during the OCI cutover when `[IF-RUNNER-001]` fired at `terraform init` with the registry-404 message. Existing unit tests asserted the constant matched a literal string, but the literal was the wrong literal — pure structural assertions about "is this the canonical registry path" did not exist. The new test in `tests/unit/core/test_tailscale.py` closes that gap.

## Audit summary

Eight files referenced the old path string; one new test file added. Every hit was updated:

| File | Kind of reference | Action |
| --- | --- | --- |
| `src/infrafoundry/core/tailscale.py:37` | Module constant (the actual fix) | Corrected |
| `src/infrafoundry/core/tailscale.py:35` | Docstring above constant | Corrected |
| `src/infrafoundry/providers/oci/templates/oci/provider.tf.j2:8` | Comment in rendered template | Corrected |
| `src/infrafoundry/providers/proxmox/templates/proxmox/provider.tf.j2:8` | Comment in rendered template | Corrected |
| `tests/unit/providers/oci/test_tailscale_module.py:71` | Assert literal | Corrected |
| `tests/unit/providers/proxmox/test_tailscale_module.py:73` | Assert literal | Corrected |
| `tests/unit/test_oci_k3s_cluster_blueprint.py:209` | Docstring | Corrected |
| `blueprints/k3s-cluster/providers/oci/instance.yaml:7` | Comment | Corrected |
| `example-config/envs/oci-k3s/settings.yaml:41` | User-facing comment | Corrected |

## Changes Made

### Modified (8)

- `src/infrafoundry/core/tailscale.py`: `TAILSCALE_MODULE_SOURCE = "tailscale/tailscale/cloudinit"` (was `"tailscale/cloudinit/tailscale"`); docstring updated to match.
- `src/infrafoundry/providers/oci/templates/oci/provider.tf.j2`: comment updated.
- `src/infrafoundry/providers/proxmox/templates/proxmox/provider.tf.j2`: comment updated.
- `tests/unit/providers/oci/test_tailscale_module.py`: assert literal updated to canonical path.
- `tests/unit/providers/proxmox/test_tailscale_module.py`: assert literal updated to canonical path.
- `tests/unit/test_oci_k3s_cluster_blueprint.py`: docstring updated.
- `blueprints/k3s-cluster/providers/oci/instance.yaml`: comment updated.
- `example-config/envs/oci-k3s/settings.yaml`: user-facing comment updated.

### New (1)

- `tests/unit/core/test_tailscale.py`: structural regression test with two cases:
  - `test_module_source_has_three_segments` — guards against accidental flattening or extra segments.
  - `test_module_source_segments_match_canonical_registry_path` — pins the three segments to the exact tuple `("tailscale", "tailscale", "cloudinit")`. This is what would have caught the original bug at PR-time. No network call.

## Scope

Deliberately narrow. The following are out of scope:

1. **The version pin (`TAILSCALE_MODULE_VERSION = "0.0.11"`) is not changed.** A version bump is a separate decision with its own testing surface; this PR only fixes the source path so the registry lookup resolves at all.
2. **No network-dependent integration test.** The new test is purely structural (string-shape and segment values). A live registry probe would be flaky against transient network/registry conditions and would gate `doit check` on internet access, which the project's test suite intentionally avoids. The structural test is sufficient to catch the original failure mode.
3. **User-config repositories are not touched.** Any user-config repo (e.g., a private homelab repo) that hard-codes the old path will need to be updated by its maintainer. This PR's scope is the framework repo only.

## Testing

- `doit check` clean (format, lint, lint_blueprints, type_check, security, spell_check, full test suite).
- The new structural test fails loudly without the fix:
  - `test_module_source_segments_match_canonical_registry_path` asserts `(namespace, name, provider) == ("tailscale", "tailscale", "cloudinit")`; against the pre-fix constant it would assert `("tailscale", "cloudinit", "tailscale") == ("tailscale", "tailscale", "cloudinit")` and fail.
- The two existing per-provider tests (`tests/unit/providers/{oci,proxmox}/test_tailscale_module.py`) continue to assert the literal `'source  = "tailscale/tailscale/cloudinit"'` appears in the rendered `.tf`, providing a second layer of coverage at the rendered-output boundary.

- [x] All existing tests pass
- [x] Added new tests for new functionality (structural regression suite)
- [x] Manually verified the canonical path returns HTTP 200 and the old path returns HTTP 404 from the public Terraform Registry

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective (structural regression test pins the canonical registry coordinates)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — N/A; no doc in `docs/` cited the wrong path or described the registry coordinates (verified by `grep -rn "tailscale/cloudinit\|cloudinit/tailscale" docs/`)
- [x] My changes generate no new warnings

## Additional Notes

- Issue #767 carries labels `bug, needs-triage` only — no `needs-adr`. No ADR is created or updated. The change is a single-string correction with no architectural impact, and there is no precedent ADR for the Tailscale integration that would need a link added.
- The `.claude/scheduled_tasks.lock` and `.claude/commands/{resume,snapshot}.md` files in local `git status` are pre-existing personal/local environment artifacts and are NOT part of this PR.
