### PR TITLE
feat: add --provider scoping flag to infra plan/apply/destroy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,9 +162,9 @@ Key commands (`foundry` via `uv run foundry ...`):
 
 **Infra group (`infra`):**
 - `infra doctor --env <name>` – validate infrastructure against provider APIs
-- `infra plan --env <name>` – generate files only (use `--dry-run` when applicable)
-- `infra apply --env <name>` – generate and execute Terraform/Ansible
-- `infra destroy --env <name>` – tear down infrastructure
+- `infra plan --env <name>` – generate files only (use `--dry-run` when applicable). Supports `--provider/-P <name>` (repeatable) to scope to specific provider(s).
+- `infra apply --env <name>` – generate and execute Terraform/Ansible. Supports `--provider/-P <name>` (repeatable) to scope to specific provider(s).
+- `infra destroy --env <name>` – tear down infrastructure. Supports `--provider/-P <name>` (repeatable) to scope to specific provider(s).
 - `infra drift <detect|remediate|history>` – detect and remediate drift
 - `infra deployed --env <name>` – show deployment status and resources
 - `infra history [--env <name>]` – inspect past deployments

--- a/docs/usage/cli-reference.md
+++ b/docs/usage/cli-reference.md
@@ -318,15 +318,19 @@ foundry infra plan --env dev
 foundry infra plan --env dev --dry-run
 foundry infra plan --env dev --resource vm-01 --resource vm-02
 foundry infra plan --env dev --package ontap-cluster
+foundry infra plan --env dev --provider opnsense
+foundry infra plan --env dev --provider opnsense --provider proxmox
 foundry infra plan --env dev --enforce-policies
 foundry infra plan --env dev --add-only
 ```
 
-**Options:** `-e/--env TEXT` (required), `--dry-run`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `--enforce-policies`, `--add-only`
+**Options:** `-e/--env TEXT` (required), `--dry-run`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `-P/--provider TEXT` (repeatable), `--enforce-policies`, `--add-only`
 
 **`--add-only`:** Suppresses deletes for live resources not present in YAML, for direct-API runners that compute live-vs-desired diffs (currently `OPNsenseDirectRunner`). Useful for partial cutover migrations where IaC adopts a subset of existing resources before taking full ownership. Other runners ignore the flag.
 
-Note: `--resource` and `--package` are mutually exclusive.
+**`-P/--provider`:** Limit the operation to one or more providers. Cross-provider dependencies pointing at filtered-out providers are silently skipped for this run. Unknown provider names raise an error.
+
+Note: `--resource`, `--package`, and `--provider` are mutually exclusive.
 
 ### `infra apply`
 
@@ -336,14 +340,17 @@ Deploy infrastructure changes.
 foundry infra apply --env dev
 foundry infra apply --env dev --auto-approve
 foundry infra apply --env dev --package ontap-cluster --auto-approve
+foundry infra apply --env dev --provider opnsense --auto-approve
 foundry infra apply --env dev --parallel --max-workers 8
 foundry infra apply --env dev --lock-timeout 300 --lock-ttl 1800
 foundry infra apply --env dev --add-only
 ```
 
-**Options:** `-e/--env TEXT` (required), `--auto-approve`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `--parallel`, `--max-workers INTEGER` (default: 4), `--lock-timeout INTEGER` (default: 0), `--lock-ttl INTEGER` (default: 600), `--add-only`
+**Options:** `-e/--env TEXT` (required), `--auto-approve`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `-P/--provider TEXT` (repeatable), `--parallel`, `--max-workers INTEGER` (default: 4), `--lock-timeout INTEGER` (default: 0), `--lock-ttl INTEGER` (default: 600), `--add-only`
 
 **`--add-only`:** Same semantics as `infra plan --add-only` — suppresses deletes for live resources missing from YAML during apply. Direct-API runners only.
+
+**`-P/--provider`:** Same semantics as `infra plan --provider` — limit the operation to one or more providers. Mutually exclusive with `--package` and `--resource`.
 
 **Lock options:** `--lock-timeout` sets how long to wait for an existing lock before failing. `--lock-ttl` sets how long the lock is valid before considered stale (auto-extended every `ttl / 3` while running).
 
@@ -355,9 +362,12 @@ Tear down infrastructure.
 foundry infra destroy --env dev --auto-approve
 foundry infra destroy --env dev --package ontap-cluster
 foundry infra destroy --env dev --resource vm-01
+foundry infra destroy --env dev --provider opnsense --auto-approve
 ```
 
-**Options:** `-e/--env TEXT` (required), `--auto-approve`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `--lock-timeout INTEGER`, `--lock-ttl INTEGER`
+**Options:** `-e/--env TEXT` (required), `--auto-approve`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `-P/--provider TEXT` (repeatable), `--lock-timeout INTEGER`, `--lock-ttl INTEGER`
+
+**`-P/--provider`:** Same semantics as `infra plan --provider` — limit the destroy to one or more providers. Mutually exclusive with `--package` and `--resource`.
 
 ### `infra drift`
 

--- a/src/infrafoundry/cli/commands/infra/apply.py
+++ b/src/infrafoundry/cli/commands/infra/apply.py
@@ -22,7 +22,19 @@ from ...utils import console
     "--package",
     "-p",
     "package_name",
-    help="Target a specific package by name (mutually exclusive with -r)",
+    help="Target a specific package by name (mutually exclusive with -r and -P)",
+)
+@click.option(
+    "--provider",
+    "-P",
+    "provider",
+    multiple=True,
+    help=(
+        "Limit operation to specific provider(s) (can be used multiple times). "
+        "Mutually exclusive with --package and --resource. Cross-provider "
+        "dependencies pointing at filtered-out providers are silently skipped "
+        "for this run."
+    ),
 )
 @click.option(
     "--parallel",
@@ -69,6 +81,7 @@ def apply(
     auto_approve: bool,
     resource: tuple[str, ...],
     package_name: str | None,
+    provider: tuple[str, ...],
     parallel: bool,
     max_workers: int,
     lock_timeout: int,
@@ -76,8 +89,8 @@ def apply(
     add_only: bool,
 ) -> None:
     """Apply infrastructure changes."""
-    if package_name and resource:
-        raise click.UsageError("--package and --resource are mutually exclusive")
+    if sum(bool(x) for x in (package_name, resource, provider)) > 1:
+        raise click.UsageError("--package, --resource, and --provider are mutually exclusive")
 
     resource_filter: list[str] | None = None
     if package_name:
@@ -85,12 +98,16 @@ def apply(
     elif resource:
         resource_filter = list(resource)
 
+    provider_filter: list[str] | None = list(provider) if provider else None
+
     # If not auto-approve, ask for confirmation at InfraFoundry level
     if not auto_approve:
         if package_name:
             resource_desc = f" (package: {package_name})"
         elif resource:
             resource_desc = f" (resources: {', '.join(resource)})"
+        elif provider:
+            resource_desc = f" (providers: {', '.join(provider)})"
         else:
             resource_desc = ""
         console.warning(f"About to apply infrastructure for environment: {env}{resource_desc}")
@@ -114,5 +131,6 @@ def apply(
             lock_timeout=lock_timeout,
             lock_ttl=lock_ttl,
             add_only=add_only,
+            provider_filter=provider_filter,
         )
     console.success(f"Apply complete! ({timer.elapsed_str})")

--- a/src/infrafoundry/cli/commands/infra/destroy.py
+++ b/src/infrafoundry/cli/commands/infra/destroy.py
@@ -22,7 +22,19 @@ from ...utils import console
     "--package",
     "-p",
     "package_name",
-    help="Target a specific package by name (mutually exclusive with -r)",
+    help="Target a specific package by name (mutually exclusive with -r and -P)",
+)
+@click.option(
+    "--provider",
+    "-P",
+    "provider",
+    multiple=True,
+    help=(
+        "Limit operation to specific provider(s) (can be used multiple times). "
+        "Mutually exclusive with --package and --resource. Cross-provider "
+        "dependencies pointing at filtered-out providers are silently skipped "
+        "for this run."
+    ),
 )
 @click.option(
     "--lock-timeout",
@@ -48,12 +60,13 @@ def destroy(
     auto_approve: bool,
     resource: tuple[str, ...],
     package_name: str | None,
+    provider: tuple[str, ...],
     lock_timeout: int,
     lock_ttl: int,
 ) -> None:
     """Destroy infrastructure."""
-    if package_name and resource:
-        raise click.UsageError("--package and --resource are mutually exclusive")
+    if sum(bool(x) for x in (package_name, resource, provider)) > 1:
+        raise click.UsageError("--package, --resource, and --provider are mutually exclusive")
 
     resource_filter: list[str] | None = None
     if package_name:
@@ -61,11 +74,15 @@ def destroy(
     elif resource:
         resource_filter = list(resource)
 
+    provider_filter: list[str] | None = list(provider) if provider else None
+
     if not auto_approve:
         if package_name:
             resource_desc = f" (package: {package_name})"
         elif resource:
             resource_desc = f" (resources: {', '.join(resource)})"
+        elif provider:
+            resource_desc = f" (providers: {', '.join(provider)})"
         else:
             resource_desc = ""
         console.warning(f"About to DESTROY infrastructure for environment: {env}{resource_desc}")
@@ -86,5 +103,6 @@ def destroy(
             package_filter=package_name,
             lock_timeout=lock_timeout,
             lock_ttl=lock_ttl,
+            provider_filter=provider_filter,
         )
     console.success(f"Destroy complete! ({timer.elapsed_str})")

--- a/src/infrafoundry/cli/commands/infra/plan.py
+++ b/src/infrafoundry/cli/commands/infra/plan.py
@@ -22,7 +22,19 @@ from ...utils import console
     "--package",
     "-p",
     "package_name",
-    help="Target a specific package by name (mutually exclusive with -r)",
+    help="Target a specific package by name (mutually exclusive with -r and -P)",
+)
+@click.option(
+    "--provider",
+    "-P",
+    "provider",
+    multiple=True,
+    help=(
+        "Limit operation to specific provider(s) (can be used multiple times). "
+        "Mutually exclusive with --package and --resource. Cross-provider "
+        "dependencies pointing at filtered-out providers are silently skipped "
+        "for this run."
+    ),
 )
 @click.option(
     "--enforce-policies",
@@ -47,18 +59,21 @@ def plan(
     dry_run: bool,
     resource: tuple[str, ...],
     package_name: str | None,
+    provider: tuple[str, ...],
     enforce_policies: bool,
     add_only: bool,
 ) -> None:
     """Plan infrastructure changes."""
-    if package_name and resource:
-        raise click.UsageError("--package and --resource are mutually exclusive")
+    if sum(bool(x) for x in (package_name, resource, provider)) > 1:
+        raise click.UsageError("--package, --resource, and --provider are mutually exclusive")
 
     resource_filter: list[str] | None = None
     if package_name:
         resource_filter = orchestrator.config_manager.resolve_package_filter(env, package_name)
     elif resource:
         resource_filter = list(resource)
+
+    provider_filter: list[str] | None = list(provider) if provider else None
 
     with OperationTimer() as timer:
         orchestrator.plan(
@@ -68,6 +83,7 @@ def plan(
             enforce_policies=enforce_policies,
             package_filter=package_name,
             add_only=add_only,
+            provider_filter=provider_filter,
         )
 
     if dry_run:

--- a/src/infrafoundry/core/exceptions.py
+++ b/src/infrafoundry/core/exceptions.py
@@ -213,6 +213,33 @@ class PackageNotFoundError(InfraFoundryError):
     """Raised when a named package is not found in the environment."""
 
 
+class ProviderFilterError(InfraFoundryError):
+    """Raised when ``--provider`` filter references unknown provider names.
+
+    Carries both the requested names and the providers actually available
+    in the target environment so the CLI can render an actionable error.
+    """
+
+    def __init__(self, requested: list[str], available: list[str]) -> None:
+        """Initialize provider filter error.
+
+        Args:
+            requested: Provider names supplied via ``--provider``/``-P``
+                that did not match any provider in the environment.
+            available: Provider names that are present in the environment.
+        """
+        self.requested = list(requested)
+        self.available = list(available)
+        message = (
+            f"Unknown provider(s): {sorted(self.requested)}. Available: {sorted(self.available)}"
+        )
+        context: dict[str, Any] = {
+            "requested": self.requested,
+            "available": self.available,
+        }
+        super().__init__(message, context)
+
+
 class PackageMoveRollbackError(InfraFoundryError):
     """Raised when a package move fails and rollback also encounters errors.
 
@@ -399,6 +426,7 @@ __all__ = [
     "PolicyViolationError",
     # Provider
     "ProviderError",
+    "ProviderFilterError",
     "ProviderInitializationError",
     "ProviderNotFoundError",
     "ReferenceValidationError",

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -514,6 +514,7 @@ class Orchestrator:
         enforce_policies: bool = False,
         package_filter: str | None = None,
         add_only: bool = False,
+        provider_filter: list[str] | None = None,
     ) -> dict[str, Any]:
         """Plan infrastructure changes.
 
@@ -526,6 +527,10 @@ class Orchestrator:
             add_only: If True, suppress deletes for live resources not
                 described in YAML. Honored by direct-API runners; other
                 runners accept and ignore.
+            provider_filter: Optional list of provider names to target.
+                Cross-provider dependency edges pointing at filtered-out
+                providers are silently skipped for this run. Raises
+                ``ProviderFilterError`` if any name is unknown.
 
         Returns:
             Dict with plan results per provider
@@ -537,6 +542,7 @@ class Orchestrator:
             enforce_policies,
             package_filter,
             add_only=add_only,
+            provider_filter=provider_filter,
         )
 
     def apply(
@@ -550,6 +556,7 @@ class Orchestrator:
         lock_timeout: int = 0,
         lock_ttl: int = 600,
         add_only: bool = False,
+        provider_filter: list[str] | None = None,
     ) -> dict[str, Any]:
         """Apply infrastructure changes.
 
@@ -568,6 +575,10 @@ class Orchestrator:
             add_only: If True, suppress deletes for live resources not
                 described in YAML. Honored by direct-API runners; other
                 runners accept and ignore.
+            provider_filter: Optional list of provider names to target.
+                Cross-provider dependency edges pointing at filtered-out
+                providers are silently skipped for this run. Raises
+                ``ProviderFilterError`` if any name is unknown.
 
         Returns:
             Dict with apply results per provider
@@ -588,6 +599,7 @@ class Orchestrator:
                 resource_filter=resource_filter,
                 package_filter=package_filter,
                 add_only=add_only,
+                provider_filter=provider_filter,
             )
             return self.apply_orchestrator.apply(
                 env_name=env_name,
@@ -597,6 +609,7 @@ class Orchestrator:
                 max_workers=max_workers,
                 package_filter=package_filter,
                 add_only=add_only,
+                provider_filter=provider_filter,
             )
 
     def _apply_providers_serial(
@@ -691,6 +704,7 @@ class Orchestrator:
         package_filter: str | None = None,
         lock_timeout: int = 0,
         lock_ttl: int = 600,
+        provider_filter: list[str] | None = None,
     ) -> dict[str, Any]:
         """Destroy infrastructure.
 
@@ -705,6 +719,10 @@ class Orchestrator:
             lock_ttl: Lock TTL in seconds (default: 10 minutes). The lock is
                 extended automatically while the process runs, so this only
                 governs stale-lock recovery after a crash.
+            provider_filter: Optional list of provider names to target.
+                Cross-provider dependency edges pointing at filtered-out
+                providers are silently skipped for this run. Raises
+                ``ProviderFilterError`` if any name is unknown.
 
         Returns:
             Dict with destroy results per provider
@@ -719,7 +737,12 @@ class Orchestrator:
             event_manager=self.event_manager,
         ):
             return self.destroy_orchestrator.destroy(
-                env_name, resource_filter, auto_approve, confirm_callback, package_filter
+                env_name,
+                resource_filter,
+                auto_approve,
+                confirm_callback,
+                package_filter,
+                provider_filter=provider_filter,
             )
 
     def rollback(

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -21,7 +21,7 @@ from infrafoundry.core.config import ConfigManager
 from infrafoundry.core.config.models import EnvironmentConfig, IaCTool
 from infrafoundry.core.drift_detector import DriftDetector
 from infrafoundry.core.events import EventManager, EventType
-from infrafoundry.core.exceptions import TerraformError
+from infrafoundry.core.exceptions import ProviderFilterError, TerraformError
 from infrafoundry.core.hooks import HookExecutionMixin, HookManager
 from infrafoundry.core.protocols import Destroyable, Plannable
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
@@ -94,6 +94,47 @@ class ProviderResourceBatch:
     name: str
     resources: list[ResourceConfig]
     original_count: int
+
+
+def _apply_provider_filter(
+    resources_by_provider: dict[str, list[ResourceConfig]],
+    provider_filter: list[str] | None,
+) -> dict[str, list[ResourceConfig]]:
+    """Apply a provider-name filter to ``resources_by_provider``.
+
+    When ``provider_filter`` is ``None`` or empty, returns the input dict
+    unchanged. Otherwise returns a new dict containing only the requested
+    provider keys, in the same order they appeared in the input. Raises
+    :class:`ProviderFilterError` if any requested name is not present in
+    ``resources_by_provider``.
+
+    Cross-provider dependency edges that point at filtered-out providers
+    are silently dropped for the run; callers operate only on the filtered
+    set returned here.
+
+    Args:
+        resources_by_provider: Mapping of provider name to its resources.
+        provider_filter: Optional list of provider names to retain.
+
+    Returns:
+        A possibly-narrowed dict of the same shape.
+
+    Raises:
+        ProviderFilterError: If any requested provider name does not match
+            an entry in ``resources_by_provider``.
+    """
+    if not provider_filter:
+        return resources_by_provider
+
+    available = list(resources_by_provider.keys())
+    requested = list(dict.fromkeys(provider_filter))  # de-dupe, preserve order
+    available_set = set(available)
+    unknown = [name for name in requested if name not in available_set]
+    if unknown:
+        raise ProviderFilterError(requested=unknown, available=available)
+
+    requested_set = set(requested)
+    return {name: resources_by_provider[name] for name in available if name in requested_set}
 
 
 class DriftOrchestrator:
@@ -398,9 +439,13 @@ class PlanOrchestrator(HookExecutionMixin):
         package_filter: str | None = None,
         *,
         add_only: bool = False,
+        provider_filter: list[str] | None = None,
     ) -> dict[str, Any]:
         """Execute the plan workflow for the requested environment."""
-        plan_metadata: PlanDeploymentMetadata = {"resource_filter": resource_filter}
+        plan_metadata: PlanDeploymentMetadata = {
+            "resource_filter": resource_filter,
+            "provider_filter": provider_filter,
+        }
         deployment_id = self.state_manager.create_deployment(
             environment=env_name,
             command="plan",
@@ -426,6 +471,7 @@ class PlanOrchestrator(HookExecutionMixin):
         try:
             self._print_header("Planning", env_name, resource_filter, style="bold cyan")
             all_resources, resources_by_provider = self._load_resources(env_name)
+            resources_by_provider = _apply_provider_filter(resources_by_provider, provider_filter)
 
             if self._has_policies():
                 self._check_policies(env_name, all_resources, enforce_policies)
@@ -819,11 +865,13 @@ class ApplyOrchestrator(HookExecutionMixin):
         package_filter: str | None = None,
         *,
         add_only: bool = False,
+        provider_filter: list[str] | None = None,
     ) -> dict[str, Any]:
         """Apply infrastructure across providers."""
         apply_metadata: ApplyDeploymentMetadata = {
             "resource_filter": resource_filter,
             "auto_approve": auto_approve,
+            "provider_filter": provider_filter,
         }
         deployment_id = self.state_manager.create_deployment(
             environment=env_name,
@@ -865,6 +913,7 @@ class ApplyOrchestrator(HookExecutionMixin):
         try:
             self._print_header("Applying", env_name, resource_filter, "bold green")
             all_resources, resources_by_provider = self._load_resources(env_name)
+            resources_by_provider = _apply_provider_filter(resources_by_provider, provider_filter)
             self._store_rollback_snapshot(deployment_id, env_name, all_resources)
 
             # Convert to set for O(1) lookups
@@ -1031,11 +1080,14 @@ class DestroyOrchestrator(HookExecutionMixin):
         auto_approve: bool,
         confirm_callback: Callable[[], bool] | None = None,
         package_filter: str | None = None,
+        *,
+        provider_filter: list[str] | None = None,
     ) -> dict[str, Any]:
         """Destroy all requested resources."""
         destroy_metadata: DestroyDeploymentMetadata = {
             "resource_filter": resource_filter,
             "auto_approve": auto_approve,
+            "provider_filter": provider_filter,
         }
         deployment_id = self.state_manager.create_deployment(
             environment=env_name,
@@ -1085,6 +1137,7 @@ class DestroyOrchestrator(HookExecutionMixin):
                     return {"success": False, "message": "User aborted"}
 
             _, resources_by_provider = self._load_resources(env_name)
+            resources_by_provider = _apply_provider_filter(resources_by_provider, provider_filter)
             providers = self._get_providers()
 
             # Execute environment-level before_destroy hooks

--- a/src/infrafoundry/core/types.py
+++ b/src/infrafoundry/core/types.py
@@ -93,6 +93,7 @@ class PlanDeploymentMetadata(TypedDict, total=False):
     """Metadata recorded for plan deployments."""
 
     resource_filter: list[str] | None
+    provider_filter: list[str] | None
 
 
 class ApplyDeploymentMetadata(PlanDeploymentMetadata, total=False):

--- a/tests/unit/test_cli_apply.py
+++ b/tests/unit/test_cli_apply.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from infrafoundry.cli.main import main
+from infrafoundry.core.exceptions import ProviderFilterError
 from infrafoundry.core.orchestrator import Orchestrator
 
 
@@ -41,6 +42,7 @@ def test_apply_with_confirmation(cli_runner, mock_orchestrator):
             lock_timeout=0,
             lock_ttl=600,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -72,6 +74,7 @@ def test_apply_with_auto_approve(cli_runner, mock_orchestrator):
             lock_timeout=0,
             lock_ttl=600,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -94,6 +97,7 @@ def test_apply_with_resource_filter(cli_runner, mock_orchestrator):
             lock_timeout=0,
             lock_ttl=600,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -125,6 +129,7 @@ def test_apply_with_parallel(cli_runner, mock_orchestrator):
             lock_timeout=0,
             lock_ttl=600,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -137,3 +142,171 @@ def test_apply_orchestrator_failure(cli_runner, mock_orchestrator):
 
         assert result.exit_code == 1
         assert "Apply failed" in result.output
+
+
+def test_apply_with_single_provider_filter(cli_runner, mock_orchestrator):
+    """A single --provider value is passed through as a one-element list."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "apply", "--env", "test", "--auto-approve", "--provider", "opnsense"],
+        )
+
+        assert result.exit_code == 0
+        mock_orchestrator.apply.assert_called_once_with(
+            "test",
+            auto_approve=True,
+            resource_filter=None,
+            parallel=False,
+            max_workers=4,
+            package_filter=None,
+            lock_timeout=0,
+            lock_ttl=600,
+            add_only=False,
+            provider_filter=["opnsense"],
+        )
+
+
+def test_apply_with_short_provider_flag(cli_runner, mock_orchestrator):
+    """The -P short option is equivalent to --provider."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "apply", "--env", "test", "--auto-approve", "-P", "opnsense"],
+        )
+
+        assert result.exit_code == 0
+        mock_orchestrator.apply.assert_called_once_with(
+            "test",
+            auto_approve=True,
+            resource_filter=None,
+            parallel=False,
+            max_workers=4,
+            package_filter=None,
+            lock_timeout=0,
+            lock_ttl=600,
+            add_only=False,
+            provider_filter=["opnsense"],
+        )
+
+
+def test_apply_with_multiple_provider_filter(cli_runner, mock_orchestrator):
+    """Multiple --provider flags accumulate into a list."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "apply",
+                "--env",
+                "test",
+                "--auto-approve",
+                "--provider",
+                "opnsense",
+                "-P",
+                "proxmox",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_orchestrator.apply.assert_called_once_with(
+            "test",
+            auto_approve=True,
+            resource_filter=None,
+            parallel=False,
+            max_workers=4,
+            package_filter=None,
+            lock_timeout=0,
+            lock_ttl=600,
+            add_only=False,
+            provider_filter=["opnsense", "proxmox"],
+        )
+
+
+def test_apply_provider_and_package_mutually_exclusive(cli_runner, mock_orchestrator):
+    """--provider with --package raises UsageError; orchestrator is not called."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "apply",
+                "--env",
+                "test",
+                "--auto-approve",
+                "-P",
+                "opnsense",
+                "-p",
+                "core",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.apply.assert_not_called()
+
+
+def test_apply_provider_and_resource_mutually_exclusive(cli_runner, mock_orchestrator):
+    """--provider with --resource raises UsageError; orchestrator is not called."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "apply",
+                "--env",
+                "test",
+                "--auto-approve",
+                "-P",
+                "opnsense",
+                "-r",
+                "vm-01",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.apply.assert_not_called()
+
+
+def test_apply_three_way_mutex(cli_runner, mock_orchestrator):
+    """All three of --provider, --package, --resource together fail."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "apply",
+                "--env",
+                "test",
+                "--auto-approve",
+                "-P",
+                "opnsense",
+                "-p",
+                "core",
+                "-r",
+                "vm-01",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.apply.assert_not_called()
+
+
+def test_apply_unknown_provider_filter_surfaces_error(cli_runner, mock_orchestrator):
+    """Unknown provider names surface as ProviderFilterError via the orchestrator."""
+    mock_orchestrator.apply.side_effect = ProviderFilterError(
+        requested=["nope"], available=["opnsense", "proxmox"]
+    )
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "apply", "--env", "test", "--auto-approve", "--provider", "nope"],
+        )
+
+        assert result.exit_code != 0
+        assert "nope" in result.output
+        assert "opnsense" in result.output
+        assert "proxmox" in result.output

--- a/tests/unit/test_cli_destroy.py
+++ b/tests/unit/test_cli_destroy.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from infrafoundry.cli.main import main
-from infrafoundry.core.exceptions import TerraformError
+from infrafoundry.core.exceptions import ProviderFilterError, TerraformError
 from infrafoundry.core.orchestrator import Orchestrator
 
 
@@ -112,3 +112,143 @@ def test_destroy_cli_does_not_print_success_on_orchestrator_failure(cli_runner, 
     # Error is reported via the framework's error catalog (IF-RUNNER-001).
     assert "Terraform" in result.output
     assert "Destroy failed" in result.output
+
+
+def test_destroy_with_single_provider_filter(cli_runner, mock_orchestrator):
+    """A single --provider value is passed through as a one-element list."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "destroy", "--env", "test", "--auto-approve", "--provider", "opnsense"],
+        )
+
+        assert result.exit_code == 0
+        call_args = mock_orchestrator.destroy.call_args
+        assert call_args[1]["provider_filter"] == ["opnsense"]
+        assert call_args[1]["resource_filter"] is None
+        assert call_args[1]["package_filter"] is None
+
+
+def test_destroy_with_short_provider_flag(cli_runner, mock_orchestrator):
+    """The -P short option is equivalent to --provider."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "destroy", "--env", "test", "--auto-approve", "-P", "opnsense"],
+        )
+
+        assert result.exit_code == 0
+        call_args = mock_orchestrator.destroy.call_args
+        assert call_args[1]["provider_filter"] == ["opnsense"]
+
+
+def test_destroy_with_multiple_provider_filter(cli_runner, mock_orchestrator):
+    """Multiple --provider flags accumulate into a list."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "destroy",
+                "--env",
+                "test",
+                "--auto-approve",
+                "--provider",
+                "opnsense",
+                "-P",
+                "proxmox",
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_args = mock_orchestrator.destroy.call_args
+        assert call_args[1]["provider_filter"] == ["opnsense", "proxmox"]
+
+
+def test_destroy_provider_and_package_mutually_exclusive(cli_runner, mock_orchestrator):
+    """--provider with --package raises UsageError; orchestrator is not called."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "destroy",
+                "--env",
+                "test",
+                "--auto-approve",
+                "-P",
+                "opnsense",
+                "-p",
+                "core",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.destroy.assert_not_called()
+
+
+def test_destroy_provider_and_resource_mutually_exclusive(cli_runner, mock_orchestrator):
+    """--provider with --resource raises UsageError; orchestrator is not called."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "destroy",
+                "--env",
+                "test",
+                "--auto-approve",
+                "-P",
+                "opnsense",
+                "-r",
+                "vm-01",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.destroy.assert_not_called()
+
+
+def test_destroy_three_way_mutex(cli_runner, mock_orchestrator):
+    """All three of --provider, --package, --resource together fail."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "destroy",
+                "--env",
+                "test",
+                "--auto-approve",
+                "-P",
+                "opnsense",
+                "-p",
+                "core",
+                "-r",
+                "vm-01",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.destroy.assert_not_called()
+
+
+def test_destroy_unknown_provider_filter_surfaces_error(cli_runner, mock_orchestrator):
+    """Unknown provider names surface as ProviderFilterError via the orchestrator."""
+    mock_orchestrator.destroy.side_effect = ProviderFilterError(
+        requested=["nope"], available=["opnsense", "proxmox"]
+    )
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "destroy", "--env", "test", "--auto-approve", "--provider", "nope"],
+        )
+
+        assert result.exit_code != 0
+        assert "nope" in result.output
+        assert "opnsense" in result.output
+        assert "proxmox" in result.output

--- a/tests/unit/test_cli_plan.py
+++ b/tests/unit/test_cli_plan.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from infrafoundry.cli.main import main
+from infrafoundry.core.exceptions import ProviderFilterError
 from infrafoundry.core.orchestrator import Orchestrator
 
 
@@ -37,6 +38,7 @@ def test_plan_basic(cli_runner, mock_orchestrator):
             enforce_policies=False,
             package_filter=None,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -54,6 +56,7 @@ def test_plan_with_dry_run(cli_runner, mock_orchestrator):
             enforce_policies=False,
             package_filter=None,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -73,6 +76,7 @@ def test_plan_with_resource_filter(cli_runner, mock_orchestrator):
             enforce_policies=False,
             package_filter=None,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -92,6 +96,7 @@ def test_plan_with_enforce_policies(cli_runner, mock_orchestrator):
             enforce_policies=True,
             package_filter=None,
             add_only=False,
+            provider_filter=None,
         )
 
 
@@ -104,3 +109,140 @@ def test_plan_orchestrator_failure(cli_runner, mock_orchestrator):
 
         assert result.exit_code == 1
         assert "Plan failed" in result.output
+
+
+def test_plan_with_single_provider_filter(cli_runner, mock_orchestrator):
+    """A single --provider value is passed through as a one-element list."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "plan", "--env", "test", "--provider", "opnsense"],
+        )
+
+        assert result.exit_code == 0
+        mock_orchestrator.plan.assert_called_once_with(
+            "test",
+            dry_run=False,
+            resource_filter=None,
+            enforce_policies=False,
+            package_filter=None,
+            add_only=False,
+            provider_filter=["opnsense"],
+        )
+
+
+def test_plan_with_short_provider_flag(cli_runner, mock_orchestrator):
+    """The -P short option is equivalent to --provider."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "plan", "--env", "test", "-P", "opnsense"],
+        )
+
+        assert result.exit_code == 0
+        mock_orchestrator.plan.assert_called_once_with(
+            "test",
+            dry_run=False,
+            resource_filter=None,
+            enforce_policies=False,
+            package_filter=None,
+            add_only=False,
+            provider_filter=["opnsense"],
+        )
+
+
+def test_plan_with_multiple_provider_filter(cli_runner, mock_orchestrator):
+    """Multiple --provider flags accumulate into a list."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "plan",
+                "--env",
+                "test",
+                "--provider",
+                "opnsense",
+                "-P",
+                "proxmox",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_orchestrator.plan.assert_called_once_with(
+            "test",
+            dry_run=False,
+            resource_filter=None,
+            enforce_policies=False,
+            package_filter=None,
+            add_only=False,
+            provider_filter=["opnsense", "proxmox"],
+        )
+
+
+def test_plan_provider_and_package_mutually_exclusive(cli_runner, mock_orchestrator):
+    """--provider with --package raises UsageError; orchestrator is not called."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "plan", "--env", "test", "-P", "opnsense", "-p", "core"],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.plan.assert_not_called()
+
+
+def test_plan_provider_and_resource_mutually_exclusive(cli_runner, mock_orchestrator):
+    """--provider with --resource raises UsageError; orchestrator is not called."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "plan", "--env", "test", "-P", "opnsense", "-r", "vm-01"],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.plan.assert_not_called()
+
+
+def test_plan_three_way_mutex(cli_runner, mock_orchestrator):
+    """All three of --provider, --package, --resource together fail."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            [
+                "infra",
+                "plan",
+                "--env",
+                "test",
+                "-P",
+                "opnsense",
+                "-p",
+                "core",
+                "-r",
+                "vm-01",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_orchestrator.plan.assert_not_called()
+
+
+def test_plan_unknown_provider_filter_surfaces_error(cli_runner, mock_orchestrator):
+    """Unknown provider names surface as ProviderFilterError via the orchestrator."""
+    mock_orchestrator.plan.side_effect = ProviderFilterError(
+        requested=["nope"], available=["opnsense", "proxmox"]
+    )
+
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(
+            main,
+            ["infra", "plan", "--env", "test", "--provider", "nope"],
+        )
+
+        assert result.exit_code != 0
+        assert "nope" in result.output
+        assert "opnsense" in result.output
+        assert "proxmox" in result.output

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -1229,3 +1229,313 @@ def test_apply_restores_prior_warnings_env_var(monkeypatch, tmp_path):
 
     assert captured["mid"] != str(prior)
     assert os.environ.get(ENV_VAR) == str(prior)
+
+
+# ---------------------------------------------------------------------------
+# Provider scoping (--provider / -P) — issue #769
+# ---------------------------------------------------------------------------
+
+
+def test_apply_provider_filter_isolates_to_requested_provider(console):
+    """``provider_filter=["opnsense"]`` keeps Proxmox resources out of the apply path."""
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 200
+    event_manager = MagicMock()
+
+    res_proxmox = [_resource("vm1", provider="proxmox")]
+    res_opnsense = [_resource("fw1", provider="opnsense", type_="firewall_rule")]
+
+    captured: dict[str, dict[str, list[ResourceConfig]]] = {}
+
+    def apply_serial(
+        env_name,
+        deployment_id,
+        resources_by_provider,
+        resource_filter,
+        auto_approve,
+        package_filter=None,
+        *,
+        add_only=False,
+    ):
+        captured["resources_by_provider"] = resources_by_provider
+        return {"opnsense": {"success": True}}
+
+    apply_parallel = MagicMock()
+
+    orchestrator = ApplyOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        lambda env: (
+            res_proxmox + res_opnsense,
+            {"proxmox": res_proxmox, "opnsense": res_opnsense},
+        ),
+        apply_serial=apply_serial,
+        apply_parallel=apply_parallel,
+        get_current_user=lambda: "tester",
+    )
+
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+        provider_filter=["opnsense"],
+    )
+
+    apply_parallel.assert_not_called()
+    # Filter dropped proxmox; only opnsense reached the serial executor.
+    assert list(captured["resources_by_provider"].keys()) == ["opnsense"]
+    assert captured["resources_by_provider"]["opnsense"] == res_opnsense
+
+
+def test_apply_provider_filter_none_preserves_full_iteration(console):
+    """Passing ``provider_filter=None`` is equivalent to no filter (regression check)."""
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 201
+    event_manager = MagicMock()
+
+    res_proxmox = [_resource("vm1", provider="proxmox")]
+    res_opnsense = [_resource("fw1", provider="opnsense", type_="firewall_rule")]
+
+    captured: dict[str, dict[str, list[ResourceConfig]]] = {}
+
+    def apply_serial(
+        env_name,
+        deployment_id,
+        resources_by_provider,
+        resource_filter,
+        auto_approve,
+        package_filter=None,
+        *,
+        add_only=False,
+    ):
+        captured["resources_by_provider"] = resources_by_provider
+        return {}
+
+    orchestrator = ApplyOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        lambda env: (
+            res_proxmox + res_opnsense,
+            {"proxmox": res_proxmox, "opnsense": res_opnsense},
+        ),
+        apply_serial=apply_serial,
+        apply_parallel=MagicMock(),
+        get_current_user=lambda: "tester",
+    )
+
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+        provider_filter=None,
+    )
+
+    assert set(captured["resources_by_provider"].keys()) == {"proxmox", "opnsense"}
+
+
+def test_apply_provider_filter_unknown_name_raises(console):
+    """An unknown name in ``provider_filter`` raises ``ProviderFilterError``."""
+    from infrafoundry.core.exceptions import ProviderFilterError
+
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 202
+    event_manager = MagicMock()
+
+    res_proxmox = [_resource("vm1", provider="proxmox")]
+    res_opnsense = [_resource("fw1", provider="opnsense", type_="firewall_rule")]
+
+    apply_serial = MagicMock()
+
+    orchestrator = ApplyOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        lambda env: (
+            res_proxmox + res_opnsense,
+            {"proxmox": res_proxmox, "opnsense": res_opnsense},
+        ),
+        apply_serial=apply_serial,
+        apply_parallel=MagicMock(),
+        get_current_user=lambda: "tester",
+    )
+
+    with pytest.raises(ProviderFilterError) as excinfo:
+        orchestrator.apply(
+            env_name="dev",
+            resource_filter=None,
+            auto_approve=True,
+            parallel=False,
+            max_workers=1,
+            provider_filter=["nope"],
+        )
+
+    assert excinfo.value.requested == ["nope"]
+    assert sorted(excinfo.value.available) == ["opnsense", "proxmox"]
+    apply_serial.assert_not_called()
+    state_manager.update_deployment_status.assert_called_with(
+        202, DeploymentStatus.FAILED, str(excinfo.value)
+    )
+
+
+def test_apply_provider_filter_multi_provider_scoping(console):
+    """``provider_filter=["opnsense", "proxmox"]`` keeps both, drops the third."""
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 203
+    event_manager = MagicMock()
+
+    res_proxmox = [_resource("vm1", provider="proxmox")]
+    res_opnsense = [_resource("fw1", provider="opnsense", type_="firewall_rule")]
+    res_oci = [_resource("box1", provider="oci", type_="instance")]
+
+    captured: dict[str, dict[str, list[ResourceConfig]]] = {}
+
+    def apply_serial(
+        env_name,
+        deployment_id,
+        resources_by_provider,
+        resource_filter,
+        auto_approve,
+        package_filter=None,
+        *,
+        add_only=False,
+    ):
+        captured["resources_by_provider"] = resources_by_provider
+        return {}
+
+    orchestrator = ApplyOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        lambda env: (
+            res_proxmox + res_opnsense + res_oci,
+            {"proxmox": res_proxmox, "opnsense": res_opnsense, "oci": res_oci},
+        ),
+        apply_serial=apply_serial,
+        apply_parallel=MagicMock(),
+        get_current_user=lambda: "tester",
+    )
+
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+        provider_filter=["opnsense", "proxmox"],
+    )
+
+    assert set(captured["resources_by_provider"].keys()) == {"opnsense", "proxmox"}
+    assert "oci" not in captured["resources_by_provider"]
+
+
+def test_apply_provider_filter_drops_cross_provider_dependency_silently(console):
+    """When a filtered-in provider has a dep on a filtered-out provider, the run still completes.
+
+    The orchestrator-level provider filter narrows ``resources_by_provider`` to the
+    requested keys before iteration; any cross-provider dependency edges pointing at
+    the dropped providers are silently skipped for this run.
+    """
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 204
+    event_manager = MagicMock()
+
+    # Proxmox resource conceptually depends on the OPNsense firewall rule, but
+    # we filter to ["proxmox"]; the dependency target is excluded for this run.
+    res_proxmox = [_resource("vm1", provider="proxmox")]
+    res_opnsense = [_resource("fw1", provider="opnsense", type_="firewall_rule")]
+
+    captured: dict[str, dict[str, list[ResourceConfig]]] = {}
+    serial_called = MagicMock()
+
+    def apply_serial(
+        env_name,
+        deployment_id,
+        resources_by_provider,
+        resource_filter,
+        auto_approve,
+        package_filter=None,
+        *,
+        add_only=False,
+    ):
+        captured["resources_by_provider"] = resources_by_provider
+        serial_called(env_name)
+        return {"proxmox": {"success": True}}
+
+    orchestrator = ApplyOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        lambda env: (
+            res_proxmox + res_opnsense,
+            {"proxmox": res_proxmox, "opnsense": res_opnsense},
+        ),
+        apply_serial=apply_serial,
+        apply_parallel=MagicMock(),
+        get_current_user=lambda: "tester",
+    )
+
+    # Should NOT raise even though the dropped opnsense provider was a
+    # cross-provider dependency target.
+    orchestrator.apply(
+        env_name="dev",
+        resource_filter=None,
+        auto_approve=True,
+        parallel=False,
+        max_workers=1,
+        provider_filter=["proxmox"],
+    )
+
+    serial_called.assert_called_once_with("dev")
+    assert list(captured["resources_by_provider"].keys()) == ["proxmox"]
+    assert "opnsense" not in captured["resources_by_provider"]
+    state_manager.update_deployment_status.assert_called_with(204, DeploymentStatus.COMPLETED)
+
+
+def test_plan_provider_filter_unknown_name_raises(console):
+    """Plan also raises ``ProviderFilterError`` for unknown names."""
+    from infrafoundry.core.exceptions import ProviderFilterError
+
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 205
+    event_manager = MagicMock()
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = []
+    providers = {"proxmox": MagicMock()}
+
+    def load_resources(env: str):
+        res = [_resource("vm1")]
+        return res, {"proxmox": res}
+
+    orchestrator = PlanOrchestrator(
+        console,
+        state_manager,
+        event_manager,
+        runner_registry,
+        get_providers=lambda: providers,
+        load_resources=load_resources,
+        iter_provider_batches=lambda resources_by_provider, filt, reverse, env_name: [
+            ProviderResourceBatch("proxmox", resources_by_provider["proxmox"], 1)
+        ],
+        validate_resources=MagicMock(),
+        has_policies=lambda: False,
+        check_policies=MagicMock(),
+        secret_manager_factory=MagicMock(),
+        get_current_user=lambda: "tester",
+        fail_on_missing_secrets=False,
+        get_runner_priorities=lambda _: {},
+    )
+
+    with pytest.raises(ProviderFilterError):
+        orchestrator.plan(
+            env_name="dev",
+            dry_run=True,
+            resource_filter=None,
+            enforce_policies=False,
+            provider_filter=["nope"],
+        )

--- a/tests/unit/test_package_filter.py
+++ b/tests/unit/test_package_filter.py
@@ -193,6 +193,7 @@ class TestPlanWithPackage:
                 enforce_policies=False,
                 package_filter="my-cluster",
                 add_only=False,
+                provider_filter=None,
             )
 
     def test_plan_with_unknown_package_fails(self, cli_runner, mock_orchestrator):
@@ -245,6 +246,7 @@ class TestApplyWithPackage:
                 lock_timeout=0,
                 lock_ttl=600,
                 add_only=False,
+                provider_filter=None,
             )
 
     def test_apply_with_package_shows_package_in_prompt(self, cli_runner, mock_orchestrator):


### PR DESCRIPTION
## Description

Add a new additive `--provider/-P <name>` flag (repeatable) to `foundry infra plan`, `foundry infra apply`, and `foundry infra destroy` to scope an operation to one or more providers.

The filter is applied immediately after `_load_resources()` via a shared module-level helper `_apply_provider_filter()` in `orchestrator_workflows.py`. Unknown provider names raise a new domain exception `ProviderFilterError(InfraFoundryError)`, which the existing `@with_orchestrator` decorator already converts to a CLI error — no decorator changes needed. The flag is mutually exclusive with `--package` and `--resource` (three-way mutex enforced at each CLI command). Cross-provider dependency edges that point at filtered-out providers are silently dropped for the run; the help text documents this.

When the flag is not supplied, behavior is unchanged.

## Related Issue

Addresses #769

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation

The OPNsense prod cutover surfaced a need to run `infra plan/apply` against a single provider while a sibling provider (`oci`) was blocked by a latent tailscale OAuth bug (separate issue and PR). A short-term `--provider opnsense` filter unblocks the cutover without stripping the broken provider from environment config or hand-editing generated artifacts.

Beyond the immediate cutover, provider-scoping is broadly useful for:

- **Partial migrations** — adopting one provider into IaC while others remain manual.
- **Single-provider debugging** — iterating on one provider without re-planning the rest of the env.
- **Deferring known-broken providers** — temporarily skip a provider whose dependencies are being fixed in a parallel branch, instead of removing it from env YAML.

## Implementation

- **New CLI flag** on `infra plan`, `apply`, `destroy`:
  - `-P, --provider TEXT  Limit operation to specific provider(s) (can be used multiple times). Mutually exclusive with --package and --resource. Cross-provider dependencies pointing at filtered-out providers are silently skipped for this run.`
- **Three-way mutex check** on each command: `--package`, `--resource`, `--provider` — at most one may be set.
- **Filter point**: immediately after `_load_resources()` in each workflow (`PlanOrchestrator.plan`, `ApplyOrchestrator.apply`, `DestroyOrchestrator.destroy`), via a shared module-level helper `_apply_provider_filter(resources, provider_filter)` in `orchestrator_workflows.py`.
- **Unknown-name handling**: a new domain exception `ProviderFilterError(InfraFoundryError)` is raised when any name in `provider_filter` is not present in the loaded resources. The existing `@with_orchestrator` decorator already converts `InfraFoundryError` subclasses to a CLI error, so no decorator changes were required.
- **Metadata capture**: `provider_filter: list[str] | None` is added to `PlanDeploymentMetadata` (inherited by Apply/Destroy variants) so deployment audit records reflect the scope.
- **Confirmation prompt** on `apply`/`destroy` now shows `(providers: ...)` when only `--provider` is set (mirroring how `--package` and `--resource` are surfaced).
- **Cross-provider deps**: edges pointing at filtered-out providers are dropped silently for the run — documented in the help text. This keeps the filter operationally simple (no surprise errors when a fully-isolated subset is requested).

## Help Text (per-command)

```
-P, --provider TEXT  Limit operation to specific provider(s) (can be used
                     multiple times). Mutually exclusive with --package and
                     --resource. Cross-provider dependencies pointing at
                     filtered-out providers are silently skipped for this run.
```

## Changes Made

**Production (8 files):**

- `src/infrafoundry/core/exceptions.py` — add `ProviderFilterError`, export in `__all__`.
- `src/infrafoundry/core/types.py` — add `provider_filter: list[str] | None` to `PlanDeploymentMetadata`.
- `src/infrafoundry/core/orchestrator_workflows.py` — add module-level `_apply_provider_filter()` helper; thread `provider_filter` (kw-only) through `PlanOrchestrator.plan`, `ApplyOrchestrator.apply`, `DestroyOrchestrator.destroy`; capture in metadata.
- `src/infrafoundry/core/orchestrator.py` — add `provider_filter` parameter to `Orchestrator.plan/apply/destroy`; forward to workflow orchestrators.
- `src/infrafoundry/cli/commands/infra/plan.py` — add `-P/--provider` Click option, three-way mutex check, pass-through.
- `src/infrafoundry/cli/commands/infra/apply.py` — same; confirmation prompt shows `(providers: ...)` when only `--provider` is set.
- `src/infrafoundry/cli/commands/infra/destroy.py` — same; confirmation prompt shows `(providers: ...)` similarly.

**Tests (5 files):**

- `tests/unit/test_cli_plan.py` — 6 new tests: `--provider` parses, `-P` short option, multiple flags, three mutex pairs, `ProviderFilterError` surfacing.
- `tests/unit/test_cli_apply.py` — 6 new tests, mirrored.
- `tests/unit/test_cli_destroy.py` — 6 new tests, mirrored.
- `tests/unit/test_orchestrator_workflows_unit.py` — 6 orchestrator-level tests: filter applied, `None` preserves full iteration, unknown name raises (apply + plan), multi-provider scoping, cross-provider dependency drop.
- `tests/unit/test_package_filter.py` — kwarg consistency update for the new `provider_filter=None` default.

**Docs (2 files):**

- `AGENTS.md` — one-line note per command in the `Infra group` reference for `infra plan`, `apply`, `destroy` that `--provider/-P` is available.
- `docs/usage/cli-reference.md` — add `--provider` to options lists and example sections for `infra plan`, `apply`, `destroy`; add a short paragraph documenting semantics; update mutex note.

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Added new tests for new functionality (24 new tests total: 18 CLI + 6 orchestrator-level)
- [x] Manually verified the CLI surface against the new help text

`doit check` is green: tests, lint, format, type-check, security, spell-check.

### Test coverage details

- **CLI layer (6 × 3 commands = 18 tests)**: long flag, short flag, multiple uses, mutex with `--package`, mutex with `--resource`, `ProviderFilterError` surfaced as CLI error.
- **Orchestrator layer (6 tests)**: filter applied to loaded resources, `provider_filter=None` preserves full iteration, unknown provider name raises `ProviderFilterError` (verified for both apply and plan), multi-provider scoping works, cross-provider dependency edges pointing at filtered-out providers are dropped for the run.

## Out of Scope

Mirrors the issue body — these are explicitly *not* in this PR:

- Adding `--provider` to other subcommands (`drift`, `doctor`, `security`, `test`).
- The OCI tailscale OAuth fix (separate issue, separate PR — surfaced as motivation for *why* this flag is being added now, but resolved independently).
- Renaming or deprecating `--package` / `--resource`.

## Checklist

- [x] My code follows the code style of this project (`doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (`AGENTS.md`, `docs/usage/cli-reference.md`)
- [x] My changes generate no new warnings
