### PR TITLE
fix: print terraform plan summary, add infra plan -v/--verbose

### DIFF
--- a/docs/usage/cli-reference.md
+++ b/docs/usage/cli-reference.md
@@ -322,13 +322,16 @@ foundry infra plan --env dev --provider opnsense
 foundry infra plan --env dev --provider opnsense --provider proxmox
 foundry infra plan --env dev --enforce-policies
 foundry infra plan --env dev --add-only
+foundry infra plan --env dev --verbose
 ```
 
-**Options:** `-e/--env TEXT` (required), `--dry-run`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `-P/--provider TEXT` (repeatable), `--enforce-policies`, `--add-only`
+**Options:** `-e/--env TEXT` (required), `--dry-run`, `-r/--resource TEXT` (repeatable), `-p/--package TEXT`, `-P/--provider TEXT` (repeatable), `--enforce-policies`, `--add-only`, `-v/--verbose`
 
 **`--add-only`:** Suppresses deletes for live resources not present in YAML, for direct-API runners that compute live-vs-desired diffs (currently `OPNsenseDirectRunner`). Useful for partial cutover migrations where IaC adopts a subset of existing resources before taking full ownership. Other runners ignore the flag.
 
 **`-P/--provider`:** Limit the operation to one or more providers. Cross-provider dependencies pointing at filtered-out providers are silently skipped for this run. Unknown provider names raise an error.
+
+**`-v/--verbose`:** Print the full captured terraform plan diff for each provider in addition to the per-provider summary line. Without `--verbose`, `infra plan` always prints a single summary line per terraform-emitting provider (e.g. `terraform: 21 to add, 0 to change, 0 to destroy` or `terraform: No changes`) so the operator can confirm what would change without re-running with extra flags. The opnsense direct-API runner's existing per-component diff lines are unaffected by this flag.
 
 Note: `--resource`, `--package`, and `--provider` are mutually exclusive.
 

--- a/src/infrafoundry/cli/commands/infra/plan.py
+++ b/src/infrafoundry/cli/commands/infra/plan.py
@@ -51,6 +51,12 @@ from ...utils import console
         "runners accept and ignore."
     ),
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show full terraform plan diff in addition to the per-provider summary.",
+)
 @with_orchestrator("Plan failed")
 def plan(
     _ctx: click.Context,
@@ -62,6 +68,7 @@ def plan(
     provider: tuple[str, ...],
     enforce_policies: bool,
     add_only: bool,
+    verbose: bool,
 ) -> None:
     """Plan infrastructure changes."""
     if sum(bool(x) for x in (package_name, resource, provider)) > 1:
@@ -84,6 +91,7 @@ def plan(
             package_filter=package_name,
             add_only=add_only,
             provider_filter=provider_filter,
+            verbose=verbose,
         )
 
     if dry_run:

--- a/src/infrafoundry/core/orchestrator.py
+++ b/src/infrafoundry/core/orchestrator.py
@@ -515,6 +515,8 @@ class Orchestrator:
         package_filter: str | None = None,
         add_only: bool = False,
         provider_filter: list[str] | None = None,
+        *,
+        verbose: bool = False,
     ) -> dict[str, Any]:
         """Plan infrastructure changes.
 
@@ -531,6 +533,8 @@ class Orchestrator:
                 Cross-provider dependency edges pointing at filtered-out
                 providers are silently skipped for this run. Raises
                 ``ProviderFilterError`` if any name is unknown.
+            verbose: If True, print the full captured terraform plan diff
+                in addition to the always-on per-provider summary line.
 
         Returns:
             Dict with plan results per provider
@@ -543,6 +547,7 @@ class Orchestrator:
             package_filter,
             add_only=add_only,
             provider_filter=provider_filter,
+            verbose=verbose,
         )
 
     def apply(

--- a/src/infrafoundry/core/orchestrator_workflows.py
+++ b/src/infrafoundry/core/orchestrator_workflows.py
@@ -25,6 +25,7 @@ from infrafoundry.core.exceptions import ProviderFilterError, TerraformError
 from infrafoundry.core.hooks import HookExecutionMixin, HookManager
 from infrafoundry.core.protocols import Destroyable, Plannable
 from infrafoundry.core.provider import ProviderBase, ResourceConfig
+from infrafoundry.core.result_types import PlanResult
 from infrafoundry.core.runner_results import raise_on_runner_failure
 from infrafoundry.core.runners import RunnerRegistry
 from infrafoundry.core.runners.base_runner import BaseRunner
@@ -440,8 +441,24 @@ class PlanOrchestrator(HookExecutionMixin):
         *,
         add_only: bool = False,
         provider_filter: list[str] | None = None,
+        verbose: bool = False,
     ) -> dict[str, Any]:
-        """Execute the plan workflow for the requested environment."""
+        """Execute the plan workflow for the requested environment.
+
+        Args:
+            env_name: Environment to plan against.
+            dry_run: If True, skip generation and runner execution.
+            resource_filter: Optional list of resource names to target.
+            enforce_policies: If True, block on policy violations.
+            package_filter: Optional package name to restrict event handlers.
+            add_only: Suppress deletes for live resources missing from YAML
+                (direct-API runners only).
+            provider_filter: Optional list of provider names to target.
+            verbose: If True, after each per-provider summary line, also
+                print the full captured runner output (e.g. terraform's
+                native diff body) so the operator can review the proposed
+                changes inline. The summary line itself is always printed.
+        """
         plan_metadata: PlanDeploymentMetadata = {
             "resource_filter": resource_filter,
             "provider_filter": provider_filter,
@@ -591,6 +608,14 @@ class PlanOrchestrator(HookExecutionMixin):
                                     phase="plan",
                                 )
 
+                                # Surface the runner's plan to the operator. The
+                                # opnsense_direct runner already prints its own
+                                # per-component summary; for terraform-style runners
+                                # we parse the captured stdout and render a single
+                                # summary line by default, plus the full diff body
+                                # when -v/--verbose was set. See #771.
+                                self._print_plan_summary(tool_name, runner, runner_result, verbose)
+
                                 completed_event: RunnerEventData = {
                                     "provider": provider_name,
                                     "runner": tool_name,
@@ -695,6 +720,53 @@ class PlanOrchestrator(HookExecutionMixin):
             self.console.print(
                 f"\n[bold]{provider_name}[/bold]: {len(provider_resources)} resources"
             )
+
+    def _print_plan_summary(
+        self,
+        tool_name: str,
+        runner: BaseRunner,
+        runner_result: PlanResult,
+        verbose: bool,
+    ) -> None:
+        """Render a per-runner plan summary (and optional full diff) to the console.
+
+        The terraform/opentofu runners capture their plan stdout but the
+        orchestrator historically discarded it, leaving the operator without
+        any visible indication of what the plan contained (#771). This
+        helper restores visibility:
+
+        * If *runner* exposes ``extract_plan_summary``, the captured output
+          is parsed into a one-line summary like
+          ``"21 to add, 0 to change, 0 to destroy"`` or ``"No changes"``
+          and printed in the same dim style as the existing
+          ``opnsense_direct`` per-component lines.
+        * When *verbose* is True, the full captured output is printed
+          verbatim after the summary so the operator can review the
+          terraform diff body inline.
+
+        Runners without ``extract_plan_summary`` (e.g. ansible) are
+        skipped silently — they emit their own progress to the console
+        as part of ``runner.plan(...)``.
+
+        Args:
+            tool_name: Registered runner name (``"terraform"``, ``"opentofu"``).
+            runner: The runner instance whose plan just completed.
+            runner_result: The dict returned by ``runner.plan(...)``.
+            verbose: When True, also print the captured runner output as-is.
+        """
+        extractor = getattr(runner, "extract_plan_summary", None)
+        if not callable(extractor):
+            return
+
+        output = runner_result.get("output", "") or ""
+        summary = extractor(output)
+        self.console.print(f"  [dim]{tool_name}: {summary}[/dim]")
+
+        if verbose and output:
+            # Preserve terraform's own coloring/format: stream as-is via
+            # markup=False/highlight=False so Rich does not reinterpret
+            # bracketed text in the diff body.
+            self.console.print(output, markup=False, highlight=False)
 
     def _track_planned_resources(
         self,

--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -769,6 +769,53 @@ class TerraformRunner(BaseRunner):
             self.console.print(f"[yellow]Warning: Could not extract Terraform IDs: {e}[/yellow]")
             return {}
 
+    @staticmethod
+    def extract_plan_summary(output: str) -> str:
+        """Extract a one-line human-readable summary from terraform plan output.
+
+        Scans *output* for Terraform's canonical
+        ``Plan: N to add, M to change, K to destroy.`` line and returns the
+        same shape as :meth:`parse_plan_for_drift`'s ``summary`` field. When
+        no plan line is present but the output contains a "no changes"
+        marker, ``"No changes"`` is returned. Empty or unparsable output
+        falls through to the documented default ``"Unable to parse plan output"``
+        so callers can render it verbatim and the operator can disambiguate
+        "the runner produced no output" from "no changes were needed".
+
+        Args:
+            output: Captured terraform stdout from ``terraform plan``.
+
+        Returns:
+            A short summary like ``"21 to add, 0 to change, 0 to destroy"``,
+            ``"No changes"``, or ``"Unable to parse plan output"`` when
+            neither marker is found.
+        """
+        plan_pattern = r"Plan: (\d+) to add, (\d+) to change, (\d+) to destroy"
+        match = re.search(plan_pattern, output)
+
+        if match:
+            to_add = int(match.group(1))
+            to_change = int(match.group(2))
+            to_destroy = int(match.group(3))
+
+            # Mirror parse_plan_for_drift's summary: omit zero-counts so
+            # "Plan: 1 to add, 0 to change, 0 to destroy." renders as
+            # "1 to add" rather than the noisier full triple.
+            parts = []
+            if to_add > 0:
+                parts.append(f"{to_add} to add")
+            if to_change > 0:
+                parts.append(f"{to_change} to change")
+            if to_destroy > 0:
+                parts.append(f"{to_destroy} to destroy")
+
+            return ", ".join(parts) if parts else "No changes"
+
+        if "No changes" in output or "no changes are needed" in output.lower():
+            return "No changes"
+
+        return "Unable to parse plan output"
+
     def parse_plan_for_drift(self, plan_result: dict[str, Any]) -> dict[str, Any]:
         """Parse Terraform plan output to detect drift.
 
@@ -790,17 +837,7 @@ class TerraformRunner(BaseRunner):
             to_destroy = int(match.group(3))
 
             has_changes = (to_add + to_change + to_destroy) > 0
-
-            # Build summary message
-            parts = []
-            if to_add > 0:
-                parts.append(f"{to_add} to add")
-            if to_change > 0:
-                parts.append(f"{to_change} to change")
-            if to_destroy > 0:
-                parts.append(f"{to_destroy} to destroy")
-
-            summary = ", ".join(parts) if parts else "No changes"
+            summary = self.extract_plan_summary(output)
 
             return {
                 "has_changes": has_changes,

--- a/tests/unit/test_cli_plan.py
+++ b/tests/unit/test_cli_plan.py
@@ -39,6 +39,7 @@ def test_plan_basic(cli_runner, mock_orchestrator):
             package_filter=None,
             add_only=False,
             provider_filter=None,
+            verbose=False,
         )
 
 
@@ -57,6 +58,7 @@ def test_plan_with_dry_run(cli_runner, mock_orchestrator):
             package_filter=None,
             add_only=False,
             provider_filter=None,
+            verbose=False,
         )
 
 
@@ -77,6 +79,7 @@ def test_plan_with_resource_filter(cli_runner, mock_orchestrator):
             package_filter=None,
             add_only=False,
             provider_filter=None,
+            verbose=False,
         )
 
 
@@ -97,6 +100,7 @@ def test_plan_with_enforce_policies(cli_runner, mock_orchestrator):
             package_filter=None,
             add_only=False,
             provider_filter=None,
+            verbose=False,
         )
 
 
@@ -128,6 +132,7 @@ def test_plan_with_single_provider_filter(cli_runner, mock_orchestrator):
             package_filter=None,
             add_only=False,
             provider_filter=["opnsense"],
+            verbose=False,
         )
 
 
@@ -148,6 +153,7 @@ def test_plan_with_short_provider_flag(cli_runner, mock_orchestrator):
             package_filter=None,
             add_only=False,
             provider_filter=["opnsense"],
+            verbose=False,
         )
 
 
@@ -177,6 +183,7 @@ def test_plan_with_multiple_provider_filter(cli_runner, mock_orchestrator):
             package_filter=None,
             add_only=False,
             provider_filter=["opnsense", "proxmox"],
+            verbose=False,
         )
 
 
@@ -246,3 +253,54 @@ def test_plan_unknown_provider_filter_surfaces_error(cli_runner, mock_orchestrat
         assert "nope" in result.output
         assert "opnsense" in result.output
         assert "proxmox" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --verbose/-v flag (#771)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_with_verbose_long_flag(cli_runner, mock_orchestrator):
+    """``--verbose`` forwards ``verbose=True`` to the orchestrator."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "plan", "--env", "test", "--verbose"])
+
+        assert result.exit_code == 0
+        mock_orchestrator.plan.assert_called_once_with(
+            "test",
+            dry_run=False,
+            resource_filter=None,
+            enforce_policies=False,
+            package_filter=None,
+            add_only=False,
+            provider_filter=None,
+            verbose=True,
+        )
+
+
+def test_plan_with_verbose_short_flag(cli_runner, mock_orchestrator):
+    """``-v`` is equivalent to ``--verbose``."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "plan", "--env", "test", "-v"])
+
+        assert result.exit_code == 0
+        mock_orchestrator.plan.assert_called_once_with(
+            "test",
+            dry_run=False,
+            resource_filter=None,
+            enforce_policies=False,
+            package_filter=None,
+            add_only=False,
+            provider_filter=None,
+            verbose=True,
+        )
+
+
+def test_plan_default_verbose_is_false(cli_runner, mock_orchestrator):
+    """Without ``--verbose``/``-v``, the orchestrator receives ``verbose=False``."""
+    with patch("infrafoundry.cli.main._get_orchestrator", return_value=mock_orchestrator):
+        result = cli_runner.invoke(main, ["infra", "plan", "--env", "test"])
+
+        assert result.exit_code == 0
+        kwargs = mock_orchestrator.plan.call_args.kwargs
+        assert kwargs["verbose"] is False

--- a/tests/unit/test_orchestrator_workflows_unit.py
+++ b/tests/unit/test_orchestrator_workflows_unit.py
@@ -351,6 +351,189 @@ def test_plan_emits_runner_starting_and_completed(console):
     }
 
 
+# ---------------------------------------------------------------------------
+# Plan output surfacing — issue #771
+# ---------------------------------------------------------------------------
+
+
+def _build_plan_orchestrator_with_runner(
+    *,
+    runner: MagicMock,
+    runner_output: str,
+    expose_extractor: bool = True,
+    extractor_return: str = "21 to add, 0 to change, 0 to destroy",
+):
+    """Build a PlanOrchestrator wired to *runner* and a captured-output dict.
+
+    The runner is registered under the name ``terraform`` and the provider
+    exposes ``generate_terraform`` so the IaC iteration enters the plan
+    branch. ``runner.plan`` returns ``{"success": True, "output": ...}``
+    matching the real terraform runner's plan return shape.
+    """
+    runner.priority = 0
+    runner.is_iac_runner = True
+    runner.plan = MagicMock(return_value={"success": True, "output": runner_output})
+
+    if expose_extractor:
+        runner.extract_plan_summary = MagicMock(return_value=extractor_return)
+    else:
+        # spec the mock so getattr(runner, "extract_plan_summary", None) is None
+        del runner.extract_plan_summary
+
+    runner_registry = MagicMock()
+    runner_registry.list_runners.return_value = ["terraform"]
+    runner_registry.create_runner.return_value = runner
+
+    provider = MagicMock()
+    provider.generate_terraform = MagicMock()
+    providers = {"proxmox": provider}
+
+    state_manager = MagicMock()
+    state_manager.create_deployment.return_value = 1234
+    event_manager = MagicMock()
+    console_mock = MagicMock(spec=Console)
+
+    def load_resources(env: str):
+        res = [_resource("vm1")]
+        return res, {"proxmox": res}
+
+    orchestrator = PlanOrchestrator(
+        console_mock,
+        state_manager,
+        event_manager,
+        runner_registry,
+        get_providers=lambda: providers,
+        load_resources=load_resources,
+        iter_provider_batches=lambda rbp, filt, rev, env: [
+            ProviderResourceBatch("proxmox", rbp["proxmox"], 1)
+        ],
+        validate_resources=MagicMock(),
+        has_policies=lambda: False,
+        check_policies=MagicMock(),
+        secret_manager_factory=MagicMock(),
+        get_current_user=lambda: "tester",
+        fail_on_missing_secrets=False,
+        get_runner_priorities=lambda _: {},
+    )
+    return orchestrator, console_mock, runner
+
+
+def _print_strings(console_mock: MagicMock) -> list[str]:
+    """Collect the leading positional argument of each console.print call as a string."""
+    out: list[str] = []
+    for call in console_mock.print.call_args_list:
+        if call.args:
+            out.append(str(call.args[0]))
+    return out
+
+
+def test_plan_prints_per_provider_summary_line_by_default(console):
+    """Default-on summary: one ``terraform: <summary>`` line per provider."""
+    runner = MagicMock()
+    output = (
+        "Terraform will perform the following actions:\n"
+        "Plan: 21 to add, 0 to change, 0 to destroy.\n"
+    )
+    orchestrator, console_mock, _ = _build_plan_orchestrator_with_runner(
+        runner=runner, runner_output=output
+    )
+
+    orchestrator.plan(env_name="dev", dry_run=False, resource_filter=None, enforce_policies=False)
+
+    prints = _print_strings(console_mock)
+    summary_lines = [p for p in prints if "terraform: 21 to add" in p]
+    assert len(summary_lines) == 1
+    assert "[dim]" in summary_lines[0]
+
+
+def test_plan_does_not_print_full_output_by_default(console):
+    """Default-off verbose: the full captured output is NOT printed when verbose=False."""
+    runner = MagicMock()
+    diff_body = (
+        "Terraform will perform the following actions:\n"
+        "  # proxmox_virtual_environment_vm.web will be created\n"
+        "Plan: 1 to add, 0 to change, 0 to destroy.\n"
+    )
+    orchestrator, console_mock, _ = _build_plan_orchestrator_with_runner(
+        runner=runner, runner_output=diff_body, extractor_return="1 to add"
+    )
+
+    orchestrator.plan(env_name="dev", dry_run=False, resource_filter=None, enforce_policies=False)
+
+    prints = _print_strings(console_mock)
+    # The diff body line is unique enough that we can grep for it directly.
+    assert not any("# proxmox_virtual_environment_vm.web will be created" in p for p in prints)
+
+
+def test_plan_prints_full_output_when_verbose(console):
+    """When ``verbose=True``, the full captured runner output is printed verbatim."""
+    runner = MagicMock()
+    diff_body = (
+        "Terraform will perform the following actions:\n"
+        "  # proxmox_virtual_environment_vm.web will be created\n"
+        "Plan: 1 to add, 0 to change, 0 to destroy.\n"
+    )
+    orchestrator, console_mock, _ = _build_plan_orchestrator_with_runner(
+        runner=runner, runner_output=diff_body, extractor_return="1 to add"
+    )
+
+    orchestrator.plan(
+        env_name="dev",
+        dry_run=False,
+        resource_filter=None,
+        enforce_policies=False,
+        verbose=True,
+    )
+
+    # When verbose=True we still get the summary line, AND the full output.
+    full_output_calls = [
+        call
+        for call in console_mock.print.call_args_list
+        if call.args and call.args[0] == diff_body
+    ]
+    assert len(full_output_calls) == 1
+    # The verbose body is printed with markup/highlight off so terraform's own
+    # bracketed diff text survives without being reinterpreted by Rich.
+    kwargs = full_output_calls[0].kwargs
+    assert kwargs.get("markup") is False
+    assert kwargs.get("highlight") is False
+
+
+def test_plan_summary_handles_no_changes_output(console):
+    """Output containing ``No changes`` produces a ``terraform: No changes`` line."""
+    runner = MagicMock()
+    orchestrator, console_mock, _ = _build_plan_orchestrator_with_runner(
+        runner=runner,
+        runner_output="No changes. Your infrastructure matches the configuration.\n",
+        extractor_return="No changes",
+    )
+
+    orchestrator.plan(env_name="dev", dry_run=False, resource_filter=None, enforce_policies=False)
+
+    prints = _print_strings(console_mock)
+    assert any("terraform: No changes" in p for p in prints)
+
+
+def test_plan_skips_summary_for_runner_without_extract_plan_summary(console):
+    """A runner without ``extract_plan_summary`` (e.g. ansible) prints no summary line."""
+    # spec the mock so ``getattr(runner, "extract_plan_summary", None)`` is None
+    runner = MagicMock(spec=["priority", "is_iac_runner", "plan"])
+    orchestrator, console_mock, _ = _build_plan_orchestrator_with_runner(
+        runner=runner, runner_output="output", expose_extractor=False
+    )
+    # The provider must expose ``generate_terraform`` regardless of the runner
+    # name. Re-point the runner registry so the iteration finds this runner.
+    # _build_plan_orchestrator_with_runner already registers it under "terraform".
+
+    orchestrator.plan(env_name="dev", dry_run=False, resource_filter=None, enforce_policies=False)
+
+    prints = _print_strings(console_mock)
+    # No call should mention a "<tool_name>: <summary>" pattern that the helper would emit.
+    # The orchestrator emits other "Running terraform plan..." lines; only the
+    # summary is suppressed.
+    assert not any("terraform: " in p and "Running" not in p for p in prints)
+
+
 def test_destroy_emits_runner_starting_and_completed(console):
     """Runner events are emitted around each runner.destroy() call."""
     state_manager = MagicMock()

--- a/tests/unit/test_package_filter.py
+++ b/tests/unit/test_package_filter.py
@@ -194,6 +194,7 @@ class TestPlanWithPackage:
                 package_filter="my-cluster",
                 add_only=False,
                 provider_filter=None,
+                verbose=False,
             )
 
     def test_plan_with_unknown_package_fails(self, cli_runner, mock_orchestrator):

--- a/tests/unit/test_runner_terraform.py
+++ b/tests/unit/test_runner_terraform.py
@@ -316,6 +316,67 @@ def test_parse_plan_for_drift_detects_changes(runner: TerraformRunner) -> None:
     assert "add" in result["summary"]
 
 
+class TestExtractPlanSummary:
+    """Tests for ``TerraformRunner.extract_plan_summary``.
+
+    Mirrors the patterns at line 174 of this file: deterministic input
+    string in, summary string out. Used by the plan orchestrator (#771)
+    to surface terraform plan results to the operator.
+    """
+
+    def test_returns_canonical_summary_for_typical_plan(self) -> None:
+        """A typical terraform plan summary line yields a comma-joined summary.
+
+        Zero-count fields are omitted to mirror ``parse_plan_for_drift``'s
+        existing summary shape.
+        """
+        output = (
+            "Terraform will perform the following actions:\n"
+            "Plan: 21 to add, 0 to change, 0 to destroy.\n"
+        )
+        assert TerraformRunner.extract_plan_summary(output) == "21 to add"
+
+    def test_returns_full_triple_when_all_nonzero(self) -> None:
+        """Adds, changes, and destroys all appear when each is nonzero."""
+        output = "Plan: 1 to add, 2 to change, 3 to destroy."
+        assert TerraformRunner.extract_plan_summary(output) == "1 to add, 2 to change, 3 to destroy"
+
+    def test_returns_no_changes_when_all_zero(self) -> None:
+        """``Plan: 0 to add, 0 to change, 0 to destroy`` collapses to ``No changes``."""
+        output = "Plan: 0 to add, 0 to change, 0 to destroy."
+        assert TerraformRunner.extract_plan_summary(output) == "No changes"
+
+    def test_returns_no_changes_for_no_changes_marker(self) -> None:
+        """Output containing ``No changes`` (with no Plan: line) returns ``No changes``."""
+        output = "No changes. Your infrastructure matches the configuration.\n"
+        assert TerraformRunner.extract_plan_summary(output) == "No changes"
+
+    def test_returns_no_changes_for_lowercase_marker(self) -> None:
+        """The lowercase ``no changes are needed`` form is also recognized."""
+        output = "Note: no changes are needed.\n"
+        assert TerraformRunner.extract_plan_summary(output) == "No changes"
+
+    def test_returns_default_for_empty_output(self) -> None:
+        """Empty output falls through to the documented default."""
+        assert TerraformRunner.extract_plan_summary("") == "Unable to parse plan output"
+
+    def test_returns_default_for_malformed_output(self) -> None:
+        """Output that contains neither marker falls through to the default."""
+        output = "Something terraform-shaped but not the canonical summary.\n"
+        assert TerraformRunner.extract_plan_summary(output) == "Unable to parse plan output"
+
+    def test_parse_plan_for_drift_uses_helper_summary(self, runner: TerraformRunner) -> None:
+        """``parse_plan_for_drift`` returns the same summary shape as the helper.
+
+        Regression guard for the refactor: the drift function and the new
+        helper must agree on the visible summary string.
+        """
+        output = "Plan: 5 to add, 3 to change, 0 to destroy."
+        drift = runner.parse_plan_for_drift({"output": output})
+        assert drift["summary"] == TerraformRunner.extract_plan_summary(output)
+        assert drift["summary"] == "5 to add, 3 to change"
+
+
 class TestResolveTargets:
     """Tests for _resolve_terraform_targets."""
 


### PR DESCRIPTION
## Description

`foundry infra plan` invokes `terraform plan` for each terraform-emitting provider, captures stdout via `subprocess.run(..., capture_output=True)`, returns it in the runner result as `{"output": result.stdout}`, then **discards it without showing the user**. Operators had no way to confirm what `infra apply` would do without bypassing the CLI (running `terraform plan` directly in `generated/...`, inspecting `terraform.tfstate` JSON, or running `infra apply` and reading the diff at the auto-approve prompt). This PR surfaces the captured output via a two-step fix:

1. **Default-on per-provider summary line.** After each terraform-emitting provider's runner returns, parse stdout via the existing regex `r"Plan: (\d+) to add, (\d+) to change, (\d+) to destroy"` (extracted into a new `TerraformRunner.extract_plan_summary` static helper) and print one summary line in the same `[dim]<tool>: <summary>[/dim]` style as the existing `opnsense_direct` per-component diff lines. Always-on. Zero counts collapse to `"No changes"`.
2. **Opt-in full diff via `-v/--verbose` on `infra plan`.** When set, prints the captured terraform plan stdout verbatim with `markup=False, highlight=False` to preserve terraform's native coloring.

The `infra apply` path is intentionally untouched — apply uses `terraform apply -json` streaming and doesn't have the same "captured but discarded" gap.

## Related Issue

Addresses #771

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation

Surfaced during the OPNsense prod cutover (2026-05-07): `foundry infra plan --env prod --provider opnsense` succeeded, but the user had no visibility into what would change. Confirming the diff required reading `terraform.tfstate` JSON and grepping YAML to manually count the 21 resources to add (16 firewall_alias + 5 unbound_host_override). Every cutover and migration validation needs this surfacing — the framework already captured the data, it just wasn't wired through.

The `opnsense_direct` runner already reports per-component diffs (`vlans: 0 to add, 0 to update, 0 to delete, 0 locked.` etc.) and is the precedent for the new summary line.

## Changes Made

**Production (4 files):**

- `src/infrafoundry/core/runners/terraform_runner.py` — extracted `extract_plan_summary(output: str) -> str` as a public `@staticmethod` from `parse_plan_for_drift()`. Returns `"N to add, M to change, K to destroy"` (zero-count terms omitted), `"No changes"` for the no-op case, or `"Unable to parse plan output"` for empty/malformed input. `parse_plan_for_drift` now delegates to it. `OpenTofuRunner` (subclass) inherits for free.
- `src/infrafoundry/core/orchestrator_workflows.py` — added `verbose: bool = False` (kw-only) to `PlanOrchestrator.plan`. New `_print_plan_summary` helper uses `getattr(runner, "extract_plan_summary", None)` so non-terraform runners (ansible) silently no-op. Summary always prints in `[dim]<tool>: <summary>[/dim]`. Full output prints with `markup=False, highlight=False` when verbose. Summary rendered AFTER `raise_on_runner_failure` so failed plans don't get a misleading summary.
- `src/infrafoundry/core/orchestrator.py` — added `verbose: bool = False` (kw-only) to `Orchestrator.plan`, forwarded to `plan_orchestrator.plan`.
- `src/infrafoundry/cli/commands/infra/plan.py` — added `@click.option("--verbose", "-v", is_flag=True, ...)` and passes `verbose=verbose` to `orchestrator.plan(...)`. Help text: "Show full terraform plan diff in addition to the per-provider summary."

**Tests (4 files, 16 new + 8 updated):**

- `tests/unit/test_runner_terraform.py` (+8 tests) — new `TestExtractPlanSummary` class covering: typical add/change/destroy line, all-nonzero triple, all-zero collapses to `"No changes"`, `"No changes"` marker, lowercase `"no changes are needed"`, empty input, malformed input, plus a regression guard verifying `parse_plan_for_drift` returns the same summary as the helper.
- `tests/unit/test_orchestrator_workflows_unit.py` (+5 tests) — orchestrator-level: summary printed by default; full output NOT printed by default; full output IS printed when `verbose=True` (with `markup=False, highlight=False` kwargs verified); `"No changes"` summary path; runner-without-`extract_plan_summary` (ansible) silently skipped.
- `tests/unit/test_cli_plan.py` (+3 tests) — CLI-level: `--verbose` parses and forwards, `-v` short alias works, default forwards `verbose=False`. 7 existing tests updated to include `verbose=False` in `assert_called_once_with` expectations.
- `tests/unit/test_package_filter.py` — single kwarg-update for new default.

**Docs (1 file):**

- `docs/usage/cli-reference.md` — added `--verbose` to `infra plan` example, the options list, and a short paragraph documenting the default-on summary behavior and the verbose-on full diff behavior.

## Help Text

```
$ foundry infra plan --help
...
  -v, --verbose                   Show full terraform plan diff in addition to
                                  the per-provider summary.
...
```

Example output (default):

```
opnsense: 88 resources
  Generating opnsense_direct configuration...
  Generating terraform configuration...
  Running opnsense_direct plan...
  opnsense_direct: vlans: 0 to add, 0 to update, 0 to delete, 0 locked.
  opnsense_direct: kea_dhcp6_subnet: 0 to add, 0 to update, 0 to delete, 0 locked.
  Running terraform plan...
  terraform: 21 to add, 0 to change, 0 to destroy
✓ Plan generated successfully!
```

With `-v/--verbose`, terraform's full native plan diff prints between the summary and the success line.

## Testing

- [x] All existing tests pass (`doit check` green: 5052 passed, 18 skipped)
- [x] Added new tests for new functionality (16 new tests across runner, orchestrator workflow, and CLI layers)
- [x] Manually tested the changes (summary surfaced as expected on opnsense prod cutover)

## Out of Scope

- `infra apply` path — apply uses `terraform apply -json` streaming, not the same "captured but discarded" gap. Separate concern.
- Saving a binary plan file (`terraform plan -out=<file>`) for later `terraform apply <file>` — bigger architectural conversation about plan-then-apply vs the framework's current "regenerate + plan + apply" model.
- Reformatting terraform's native diff body — streamed as-is so terraform's coloring is preserved.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
