### PR TITLE
fix: strip ansi color codes before parsing terraform plan summary

### DIFF
--- a/src/infrafoundry/core/runners/terraform_runner.py
+++ b/src/infrafoundry/core/runners/terraform_runner.py
@@ -783,13 +783,23 @@ class TerraformRunner(BaseRunner):
         "the runner produced no output" from "no changes were needed".
 
         Args:
-            output: Captured terraform stdout from ``terraform plan``.
+            output: Captured terraform stdout from ``terraform plan``. ANSI
+                color escape codes (CSI sequences like ``\x1b[1m``) are
+                stripped before parsing because real terraform invocations
+                emit colored output even when stdout is captured via a
+                pipe, and the embedded escapes block the regex match.
 
         Returns:
             A short summary like ``"21 to add, 0 to change, 0 to destroy"``,
             ``"No changes"``, or ``"Unable to parse plan output"`` when
             neither marker is found.
         """
+        # Strip ANSI color escape codes before parsing. Terraform colors its
+        # output by default (e.g. ``\x1b[1mPlan:\x1b[0m \x1b[0m32 to add, ...``)
+        # even when stdout is captured, which prevents the regex from matching.
+        # No-op on already-clean strings.
+        output = re.sub(r"\x1b\[[0-9;]*m", "", output)
+
         plan_pattern = r"Plan: (\d+) to add, (\d+) to change, (\d+) to destroy"
         match = re.search(plan_pattern, output)
 

--- a/tests/unit/test_runner_terraform.py
+++ b/tests/unit/test_runner_terraform.py
@@ -376,6 +376,22 @@ class TestExtractPlanSummary:
         assert drift["summary"] == TerraformRunner.extract_plan_summary(output)
         assert drift["summary"] == "5 to add, 3 to change"
 
+    def test_strips_ansi_escape_codes_before_parsing(self) -> None:
+        """ANSI-colored terraform output still yields the canonical summary.
+
+        Regression test for #773: real ``terraform plan`` output contains
+        CSI color escapes (``\x1b[1m``, ``\x1b[0m``, etc.) inline with the
+        ``Plan:`` line even when stdout is captured by ``subprocess.run``.
+        Without stripping, the regex never matches and the helper falls
+        through to ``"Unable to parse plan output"``. The fixture below is a
+        realistic captured-from-terraform sample.
+        """
+        output = (
+            "Terraform will perform the following actions:\n"
+            "\x1b[1mPlan:\x1b[0m \x1b[0m32 to add, 8 to change, 0 to destroy.\n"
+        )
+        assert TerraformRunner.extract_plan_summary(output) == "32 to add, 8 to change"
+
 
 class TestResolveTargets:
     """Tests for _resolve_terraform_targets."""


### PR DESCRIPTION
## Description

`TerraformRunner.extract_plan_summary` (added in #772 to back the always-on per-provider summary line from #771) failed against real-world `terraform plan` stdout. Real terraform invocations emit ANSI color escape codes inline with the summary line — even when stdout is captured via `subprocess.run(..., capture_output=True)`:

```
\x1b[1mPlan:\x1b[0m \x1b[0m32 to add, 8 to change, 0 to destroy.
```

The regex `r"Plan: (\d+) to add, (\d+) to change, (\d+) to destroy"` does not tolerate the embedded `\x1b[1m` / `\x1b[0m` sequences, so the helper never matched and always fell through to the `"Unable to parse plan output"` default in production. The unit tests added in #772 fed clean ASCII strings only and never exercised the captured-from-terraform contract.

This PR strips ANSI CSI sequences (`re.sub(r"\x1b\[[0-9;]*m", "", output)`) at the top of `extract_plan_summary` before regex matching, then adds a realistic-capture fixture to lock the contract in.

## Related Issue

Addresses #773

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation

Observed live during the OPNsense prod cutover on 2026-05-07, immediately after #772 merged:

```
opnsense: 88 resources
  ...
  Running terraform plan...
Refreshing Terraform init...
  terraform: Unable to parse plan output
Plan generated successfully! (4.4s)
```

The default-on summary line that #771 was filed to provide always said `"Unable to parse plan output"` in real environments, defeating the fix. Re-running with `-v/--verbose` revealed the captured stdout did contain the canonical `Plan:` line — just wrapped in ANSI color escapes:

```
[1mPlan:[0m [0m32 to add, 8 to change, 0 to destroy.
```

After this fix, the same plan run prints the intended summary:

```
  terraform: 32 to add, 8 to change, 0 to destroy
```

## Changes Made

**Production (1 file):**

- `src/infrafoundry/core/runners/terraform_runner.py` — single-line strip at the top of `extract_plan_summary`:
  ```python
  output = re.sub(r"\x1b\[[0-9;]*m", "", output)
  ```
  No-op on already-clean inputs. `parse_plan_for_drift` inherits the fix transparently via existing delegation. `OpenTofuRunner` (subclass) inherits for free. Docstring `Args:` block updated to document the strip and its rationale (terraform colors stdout even when piped).

**Tests (1 file):**

- `tests/unit/test_runner_terraform.py` — added `test_strips_ansi_escape_codes_before_parsing` to the existing `TestExtractPlanSummary` class. Fixture is realistic captured-from-terraform stdout (`"Terraform will perform the following actions:\n\x1b[1mPlan:\x1b[0m \x1b[0m32 to add, 8 to change, 0 to destroy.\n"`); asserts the helper returns `"32 to add, 8 to change"` (zero-destroy elided per existing zero-count behavior). 9 tests in `TestExtractPlanSummary` (8 original unchanged + 1 new) all pass.

## Implementation

Strip-on-parse keeps the verbose `-v/--verbose` full-diff path untouched: terraform's native coloring is still preserved in the verbatim print path, while the summary parser sees clean text. `parse_plan_for_drift` already delegates to `extract_plan_summary` for its summary string (per #772), so the drift-detection path inherits the same robustness without a second strip.

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Added new test for the regression (`test_strips_ansi_escape_codes_before_parsing`)
- [x] Manually verified against the OPNsense prod cutover capture

## Out of Scope

- Stripping ANSI from the verbose `-v` full-diff display path. Terraform's native coloring is desirable for human reading; ANSI-strip is parser-only.
- Passing `-no-color` to the `terraform plan` invocation. Cleaner at the surface but loses native coloring in the verbose display path. The strip-on-parse approach preserves both behaviors.
- Wider terraform-output normalization (whitespace, line-endings, etc.). Address only the ANSI codes that block the regex.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
