### PR TITLE
refactor: rename direct-OPNsense ResourceConfig.type strings to dotted paths (#793 Phase 1)

### DIFF
--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -35,6 +35,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Transient flat→dotted resource-type translation for the direct-OPNsense
+# provider's filename-derived stem path (#793 Phase 1). Old flat YAML files
+# (e.g., ``vlans.yaml`` with a top-level ``vlans:`` key) keep parsing
+# correctly while internal ``ResourceConfig.type`` strings are already
+# dotted everywhere else (dispatch tables, validators, manager guards).
+# Per ADR-0016, the cutover is hard at Phase 5 in lockstep with the
+# operator-side ``endavis-infra/`` conversion script (#793 Phase 6).
+#
+# TODO: remove in #793 Phase 5 hard cutover.
+STEM_TO_DOTTED: dict[str, str] = {
+    "vlans": "interfaces.vlans",
+    "interface_assignments": "interfaces.assignments",
+    "aliases": "firewall.aliases",
+    "nat_rules": "firewall.nat",
+    "firewall_rules": "firewall.rules",
+    "gateways": "routing.gateways",
+    "static_routes": "routing.static",
+    "virtual_ips": "interfaces.virtual_ips",
+    "unbound_host_override": "unbound.host_overrides",
+    "unbound_host_alias": "unbound.host_aliases",
+    "unbound_forward": "unbound.forwards",
+    "kea_subnet": "kea.dhcp4.subnets",
+    "kea_reservation": "kea.dhcp4.reservations",
+    "kea_dhcp6_subnet": "kea.dhcp6.subnets",
+    "kea_dhcp6_reservation": "kea.dhcp6.reservations",
+}
+
 
 class PackageLoader:
     """Loads infrastructure packages from provider subdirectories.
@@ -476,10 +503,16 @@ class PackageLoader:
                 f"got {type(resource_list).__name__}"
             )
 
+        # Translate flat type names to dotted paths for direct-OPNsense
+        # components per ADR-0016 (#793 Phase 1). Non-OPNsense filename stems
+        # (and any new top-level keys) pass through unchanged.
+        # TODO: remove in #793 Phase 5 hard cutover.
+        emitted_type = STEM_TO_DOTTED.get(resource_type, resource_type)
+
         return [
             ResourceConfig(
                 name=item["name"],
-                type=resource_type,
+                type=emitted_type,
                 provider=item.get("provider", provider),
                 config=item,
                 events=item.get("events"),
@@ -514,10 +547,17 @@ class PackageLoader:
             config = item.get("config", item)
             if "config" in item and "name" not in config:
                 config["name"] = item["name"]
+            # Translate flat type names to dotted paths for direct-OPNsense
+            # components per ADR-0016 (#793 Phase 1). Existing blueprints and
+            # user resource-centric YAML files (e.g. ``type: kea_reservation``)
+            # continue parsing while internal dispatch keys are already dotted.
+            # TODO: remove in #793 Phase 5 hard cutover.
+            raw_type = str(item["type"])
+            emitted_type = STEM_TO_DOTTED.get(raw_type, raw_type)
             result.append(
                 ResourceConfig(
                     name=item["name"],
-                    type=item["type"],
+                    type=emitted_type,
                     provider=item.get("provider", default_provider),
                     config=config,
                     events=item.get("events"),

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from infrafoundry.core.config.package_loader import PackageLoader
+from infrafoundry.core.config.package_loader import STEM_TO_DOTTED, PackageLoader
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.secrets.provider import SecretProvider
 
@@ -87,10 +87,16 @@ class ProviderCentricLoader:
                 f"got {type(resource_list).__name__}"
             )
 
+        # Translate flat type names to dotted paths for direct-OPNsense
+        # components per ADR-0016 (#793 Phase 1). Old flat YAML files
+        # (e.g. ``vlans.yaml`` with ``vlans:`` top-level key) keep parsing.
+        # TODO: remove in #793 Phase 5 hard cutover.
+        emitted_type = STEM_TO_DOTTED.get(resource_type, resource_type)
+
         resources = [
             ResourceConfig(
                 name=item["name"],
-                type=resource_type,
+                type=emitted_type,
                 provider=provider,
                 config=item,
                 import_id=item.get("import_id"),

--- a/src/infrafoundry/core/config/resource_centric_loader.py
+++ b/src/infrafoundry/core/config/resource_centric_loader.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import yaml
 
+from infrafoundry.core.config.package_loader import STEM_TO_DOTTED
 from infrafoundry.core.provider import ResourceConfig
 
 
@@ -88,10 +89,18 @@ class ResourceCentricLoader:
             # Include name in config for template convenience
             config["name"] = item["name"]
 
+            # Translate flat type names to dotted paths for direct-OPNsense
+            # components per ADR-0016 (#793 Phase 1). Existing user
+            # resource-centric YAML files keep parsing while internal
+            # dispatch keys are dotted.
+            # TODO: remove in #793 Phase 5 hard cutover.
+            raw_type = str(item["type"])
+            emitted_type = STEM_TO_DOTTED.get(raw_type, raw_type)
+
             resources.append(
                 ResourceConfig(
                     name=item["name"],
-                    type=item["type"],
+                    type=emitted_type,
                     provider=item["provider"],
                     config=config,
                     import_id=item.get("import_id"),

--- a/src/infrafoundry/core/extractors.py
+++ b/src/infrafoundry/core/extractors.py
@@ -59,7 +59,7 @@ class ExtractorRegistry:
         Args:
             provider_name: Provider name (e.g., ``"opnsense"``).
             resource_type: Resource type / component name
-                (e.g., ``"vlans"``, ``"kea_dhcp"``).
+                (e.g., ``"interfaces.vlans"``, ``"kea_dhcp"``).
             extractor: An object satisfying the :class:`Extractor`
                 Protocol.
         """

--- a/src/infrafoundry/core/runners/opnsense_direct_runner.py
+++ b/src/infrafoundry/core/runners/opnsense_direct_runner.py
@@ -168,7 +168,8 @@ class OPNsenseDirectRunner(BaseRunner):
 
         Args:
             resources: All provider resources for the current environment.
-            type_name: ``ResourceConfig.type`` to keep (e.g., ``"vlans"``).
+            type_name: ``ResourceConfig.type`` to keep
+                (e.g., ``"interfaces.vlans"``).
             target_resources: Optional name filter (CLI ``--resource``).
 
         Returns:
@@ -198,7 +199,7 @@ class OPNsenseDirectRunner(BaseRunner):
         Returns:
             VLAN ResourceConfig entries the runner should act on.
         """
-        return OPNsenseDirectRunner._filter_by_type(resources, "vlans", target_resources)
+        return OPNsenseDirectRunner._filter_by_type(resources, "interfaces.vlans", target_resources)
 
     @staticmethod
     def _resolve_dispatch_table(provider: ProviderBase) -> dict[str, type[Any]]:
@@ -321,7 +322,7 @@ class OPNsenseDirectRunner(BaseRunner):
         """Render a one-line plan summary for a single component's diff.
 
         Args:
-            type_name: Resource type name (e.g., ``"vlans"``).
+            type_name: Resource type name (e.g., ``"interfaces.vlans"``).
             diff: A ``Diff``-like object exposing ``adds``/``updates``/
                 ``deletes``/``locked`` lists. Read-only components may
                 supply additional attributes (e.g., ``read_only``,

--- a/src/infrafoundry/providers/opnsense/__init__.py
+++ b/src/infrafoundry/providers/opnsense/__init__.py
@@ -126,17 +126,17 @@ class OPNsenseProvider(
         from .components.vlan import VlanManager
 
         components: list[tuple[str, type]] = [
-            ("vlans", VlanManager),
-            ("interface_assignments", InterfaceAssignmentManager),
-            ("aliases", AliasManager),
-            ("nat_rules", NATRuleManager),
-            ("firewall_rules", FirewallRuleManager),
-            ("gateways", GatewayManager),
-            ("static_routes", StaticRouteManager),
-            ("virtual_ips", VirtualIPManager),
-            ("unbound_host_override", UnboundHostOverrideManager),
-            ("unbound_host_alias", UnboundHostAliasManager),
-            ("unbound_forward", UnboundForwardManager),
+            ("interfaces.vlans", VlanManager),
+            ("interfaces.assignments", InterfaceAssignmentManager),
+            ("firewall.aliases", AliasManager),
+            ("firewall.nat", NATRuleManager),
+            ("firewall.rules", FirewallRuleManager),
+            ("routing.gateways", GatewayManager),
+            ("routing.static", StaticRouteManager),
+            ("interfaces.virtual_ips", VirtualIPManager),
+            ("unbound.host_overrides", UnboundHostOverrideManager),
+            ("unbound.host_aliases", UnboundHostAliasManager),
+            ("unbound.forwards", UnboundForwardManager),
             ("kea_dhcp", KeaDHCPManager),
             ("isc_to_kea", ISCToKeaMigrationManager),
         ]
@@ -244,21 +244,21 @@ class OPNsenseProvider(
         # so a brand-new override exists on the box before any aliases
         # reference it (#776).
         return {
-            "vlans": VlanManager,
-            "interface_assignments": InterfaceAssignmentManager,
-            "aliases": AliasManager,
-            "nat_rules": NATRuleManager,
-            "firewall_rules": FirewallRuleManager,
-            "gateways": GatewayManager,
-            "static_routes": StaticRouteManager,
-            "virtual_ips": VirtualIPManager,
-            "unbound_host_override": UnboundHostOverrideManager,
-            "unbound_host_alias": UnboundHostAliasManager,
-            "unbound_forward": UnboundForwardManager,
-            "kea_subnet": KeaDHCPv4SubnetManager,
-            "kea_reservation": KeaDHCPv4ReservationManager,
-            "kea_dhcp6_subnet": KeaDHCPv6SubnetManager,
-            "kea_dhcp6_reservation": KeaDHCPv6ReservationManager,
+            "interfaces.vlans": VlanManager,
+            "interfaces.assignments": InterfaceAssignmentManager,
+            "firewall.aliases": AliasManager,
+            "firewall.nat": NATRuleManager,
+            "firewall.rules": FirewallRuleManager,
+            "routing.gateways": GatewayManager,
+            "routing.static": StaticRouteManager,
+            "interfaces.virtual_ips": VirtualIPManager,
+            "unbound.host_overrides": UnboundHostOverrideManager,
+            "unbound.host_aliases": UnboundHostAliasManager,
+            "unbound.forwards": UnboundForwardManager,
+            "kea.dhcp4.subnets": KeaDHCPv4SubnetManager,
+            "kea.dhcp4.reservations": KeaDHCPv4ReservationManager,
+            "kea.dhcp6.subnets": KeaDHCPv6SubnetManager,
+            "kea.dhcp6.reservations": KeaDHCPv6ReservationManager,
         }
 
     def get_finalization_hooks(self) -> dict[str, Callable[[str], None]]:
@@ -367,21 +367,21 @@ class OPNsenseProvider(
     def get_resource_types(self) -> list[str]:
         """Get supported resource types."""
         return [
-            "firewall_rules",
-            "vlans",
-            "interface_assignments",
-            "aliases",
-            "kea_subnet",
-            "kea_reservation",
-            "kea_dhcp6_subnet",
-            "kea_dhcp6_reservation",
-            "unbound_host_override",
-            "nat_rules",
-            "gateways",
-            "static_routes",
-            "virtual_ips",
-            "unbound_host_alias",
-            "unbound_forward",
+            "firewall.rules",
+            "interfaces.vlans",
+            "interfaces.assignments",
+            "firewall.aliases",
+            "kea.dhcp4.subnets",
+            "kea.dhcp4.reservations",
+            "kea.dhcp6.subnets",
+            "kea.dhcp6.reservations",
+            "unbound.host_overrides",
+            "firewall.nat",
+            "routing.gateways",
+            "routing.static",
+            "interfaces.virtual_ips",
+            "unbound.host_aliases",
+            "unbound.forwards",
         ]
 
     @override
@@ -401,21 +401,26 @@ class OPNsenseProvider(
     def get_dependencies(self) -> dict[str, list[str]]:
         """Get resource dependencies."""
         return {
-            "firewall_rules": ["aliases", "vlans", "interface_assignments", "gateways"],
-            "vlans": [],
-            "interface_assignments": ["vlans"],
-            "aliases": [],
-            "kea_subnet": ["vlans"],
-            "kea_reservation": ["kea_subnet"],
-            "kea_dhcp6_subnet": ["vlans"],
-            "kea_dhcp6_reservation": ["kea_dhcp6_subnet"],
-            "unbound_host_override": [],
-            "nat_rules": ["aliases", "interface_assignments"],
-            "gateways": ["interface_assignments"],
-            "static_routes": ["gateways"],
-            "virtual_ips": ["interface_assignments"],
-            "unbound_host_alias": ["unbound_host_override"],
-            "unbound_forward": [],
+            "firewall.rules": [
+                "firewall.aliases",
+                "interfaces.vlans",
+                "interfaces.assignments",
+                "routing.gateways",
+            ],
+            "interfaces.vlans": [],
+            "interfaces.assignments": ["interfaces.vlans"],
+            "firewall.aliases": [],
+            "kea.dhcp4.subnets": ["interfaces.vlans"],
+            "kea.dhcp4.reservations": ["kea.dhcp4.subnets"],
+            "kea.dhcp6.subnets": ["interfaces.vlans"],
+            "kea.dhcp6.reservations": ["kea.dhcp6.subnets"],
+            "unbound.host_overrides": [],
+            "firewall.nat": ["firewall.aliases", "interfaces.assignments"],
+            "routing.gateways": ["interfaces.assignments"],
+            "routing.static": ["routing.gateways"],
+            "interfaces.virtual_ips": ["interfaces.assignments"],
+            "unbound.host_aliases": ["unbound.host_overrides"],
+            "unbound.forwards": [],
         }
 
     @override
@@ -496,7 +501,7 @@ class OPNsenseProvider(
         """Migrate current VLAN configuration to InfraFoundry YAML.
 
         .. deprecated::
-            Use ``get_extractor("opnsense", "vlans").extract(env_name)``.
+            Use ``get_extractor("opnsense", "interfaces.vlans").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -509,18 +514,18 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_vlan is deprecated; "
-            'use get_extractor("opnsense", "vlans").extract(env_name).',
+            'use get_extractor("opnsense", "interfaces.vlans").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "vlans").extract(env_name)
+        return get_extractor("opnsense", "interfaces.vlans").extract(env_name)
 
     def migrate_interface_assignment(self, env_name: str) -> str:
         """Migrate current interface assignments to InfraFoundry YAML.
 
         .. deprecated::
             Use
-            ``get_extractor("opnsense", "interface_assignments").extract(env_name)``.
+            ``get_extractor("opnsense", "interfaces.assignments").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -533,17 +538,17 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_interface_assignment is deprecated; "
-            'use get_extractor("opnsense", "interface_assignments").extract(env_name).',
+            'use get_extractor("opnsense", "interfaces.assignments").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "interface_assignments").extract(env_name)
+        return get_extractor("opnsense", "interfaces.assignments").extract(env_name)
 
     def migrate_nat_rule(self, env_name: str) -> str:
         """Migrate current NAT rules (outbound + 1:1) to InfraFoundry YAML.
 
         .. deprecated::
-            Use ``get_extractor("opnsense", "nat_rules").extract(env_name)``.
+            Use ``get_extractor("opnsense", "firewall.nat").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -556,17 +561,17 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_nat_rule is deprecated; "
-            'use get_extractor("opnsense", "nat_rules").extract(env_name).',
+            'use get_extractor("opnsense", "firewall.nat").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "nat_rules").extract(env_name)
+        return get_extractor("opnsense", "firewall.nat").extract(env_name)
 
     def migrate_firewall_rule(self, env_name: str) -> str:
         """Migrate current firewall rules (MVC) to InfraFoundry YAML.
 
         .. deprecated::
-            Use ``get_extractor("opnsense", "firewall_rules").extract(env_name)``.
+            Use ``get_extractor("opnsense", "firewall.rules").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -579,17 +584,17 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_firewall_rule is deprecated; "
-            'use get_extractor("opnsense", "firewall_rules").extract(env_name).',
+            'use get_extractor("opnsense", "firewall.rules").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "firewall_rules").extract(env_name)
+        return get_extractor("opnsense", "firewall.rules").extract(env_name)
 
     def migrate_gateway(self, env_name: str) -> str:
         """Migrate current gateways to InfraFoundry YAML.
 
         .. deprecated::
-            Use ``get_extractor("opnsense", "gateways").extract(env_name)``.
+            Use ``get_extractor("opnsense", "routing.gateways").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -602,18 +607,18 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_gateway is deprecated; "
-            'use get_extractor("opnsense", "gateways").extract(env_name).',
+            'use get_extractor("opnsense", "routing.gateways").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "gateways").extract(env_name)
+        return get_extractor("opnsense", "routing.gateways").extract(env_name)
 
     def migrate_static_route(self, env_name: str) -> str:
         """Migrate current static routes to InfraFoundry YAML.
 
         .. deprecated::
             Use
-            ``get_extractor("opnsense", "static_routes").extract(env_name)``.
+            ``get_extractor("opnsense", "routing.static").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -626,18 +631,18 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_static_route is deprecated; "
-            'use get_extractor("opnsense", "static_routes").extract(env_name).',
+            'use get_extractor("opnsense", "routing.static").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "static_routes").extract(env_name)
+        return get_extractor("opnsense", "routing.static").extract(env_name)
 
     def migrate_virtual_ip(self, env_name: str) -> str:
         """Migrate current virtual IPs (CARP / ipalias / proxyarp) to InfraFoundry YAML.
 
         .. deprecated::
             Use
-            ``get_extractor("opnsense", "virtual_ips").extract(env_name)``.
+            ``get_extractor("opnsense", "interfaces.virtual_ips").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -650,18 +655,18 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_virtual_ip is deprecated; "
-            'use get_extractor("opnsense", "virtual_ips").extract(env_name).',
+            'use get_extractor("opnsense", "interfaces.virtual_ips").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "virtual_ips").extract(env_name)
+        return get_extractor("opnsense", "interfaces.virtual_ips").extract(env_name)
 
     def migrate_unbound_host_alias(self, env_name: str) -> str:
         """Migrate current Unbound host aliases to InfraFoundry YAML.
 
         .. deprecated::
             Use
-            ``get_extractor("opnsense", "unbound_host_alias").extract(env_name)``.
+            ``get_extractor("opnsense", "unbound.host_aliases").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -674,18 +679,18 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_unbound_host_alias is deprecated; "
-            'use get_extractor("opnsense", "unbound_host_alias").extract(env_name).',
+            'use get_extractor("opnsense", "unbound.host_aliases").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "unbound_host_alias").extract(env_name)
+        return get_extractor("opnsense", "unbound.host_aliases").extract(env_name)
 
     def migrate_unbound_forward(self, env_name: str) -> str:
         """Migrate current Unbound forwarders to InfraFoundry YAML.
 
         .. deprecated::
             Use
-            ``get_extractor("opnsense", "unbound_forward").extract(env_name)``.
+            ``get_extractor("opnsense", "unbound.forwards").extract(env_name)``.
             This shim will be removed after one minor version.
 
         Args:
@@ -698,11 +703,11 @@ class OPNsenseProvider(
 
         warnings.warn(
             "OPNsenseProvider.migrate_unbound_forward is deprecated; "
-            'use get_extractor("opnsense", "unbound_forward").extract(env_name).',
+            'use get_extractor("opnsense", "unbound.forwards").extract(env_name).',
             DeprecationWarning,
             stacklevel=2,
         )
-        return get_extractor("opnsense", "unbound_forward").extract(env_name)
+        return get_extractor("opnsense", "unbound.forwards").extract(env_name)
 
     def migrate_isc_to_kea(self, env_name: str, interfaces: list[str] | None = None) -> str:
         """Migrate ISC DHCP configuration to Kea DHCP format.

--- a/src/infrafoundry/providers/opnsense/components/alias.py
+++ b/src/infrafoundry/providers/opnsense/components/alias.py
@@ -267,7 +267,7 @@ def _desired_with_resource_names(
     parsed = alias_configs_from_resources(resources)
     parsed_iter = iter(parsed)
     for resource in resources:
-        if resource.type != "aliases":
+        if resource.type != "firewall.aliases":
             continue
         cfg = next(parsed_iter, None)
         if cfg is None:

--- a/src/infrafoundry/providers/opnsense/components/virtual_ip.py
+++ b/src/infrafoundry/providers/opnsense/components/virtual_ip.py
@@ -303,7 +303,7 @@ class VirtualIPManager(BaseComponentManager):
         try:
             resolved_resources: list[ResourceConfig] = []
             for resource in resources:
-                if resource.type != "virtual_ips":
+                if resource.type != "interfaces.virtual_ips":
                     # Forward non-virtual_ips resources unchanged so the
                     # parser sees them and skips them as expected.
                     resolved_resources.append(resource)

--- a/src/infrafoundry/providers/opnsense/services/alias.py
+++ b/src/infrafoundry/providers/opnsense/services/alias.py
@@ -389,7 +389,7 @@ def alias_configs_from_resources(
     """
     configs: list[AliasConfig] = []
     for resource in resources:
-        if resource.type != "aliases":
+        if resource.type != "firewall.aliases":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/firewall_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/firewall_rule.py
@@ -616,7 +616,7 @@ def firewall_rule_configs_from_resources(
     """
     configs: list[FirewallRuleConfig] = []
     for resource in resources:
-        if resource.type != "firewall_rules":
+        if resource.type != "firewall.rules":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/gateway.py
+++ b/src/infrafoundry/providers/opnsense/services/gateway.py
@@ -346,7 +346,7 @@ def gateway_configs_from_resources(
     """
     configs: list[GatewayConfig] = []
     for resource in resources:
-        if resource.type != "gateways":
+        if resource.type != "routing.gateways":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/interface_assignment.py
+++ b/src/infrafoundry/providers/opnsense/services/interface_assignment.py
@@ -241,7 +241,7 @@ def interface_assignment_configs_from_resources(
     """
     configs: list[InterfaceAssignmentConfig] = []
     for resource in resources:
-        if resource.type != "interface_assignments":
+        if resource.type != "interfaces.assignments":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/nat_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/nat_rule.py
@@ -586,7 +586,7 @@ def nat_rule_configs_from_resources(
     """
     configs: list[NATRuleConfig] = []
     for resource in resources:
-        if resource.type != "nat_rules":
+        if resource.type != "firewall.nat":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/static_route.py
+++ b/src/infrafoundry/providers/opnsense/services/static_route.py
@@ -313,7 +313,7 @@ def static_route_configs_from_resources(
     """
     configs: list[StaticRouteConfig] = []
     for resource in resources:
-        if resource.type != "static_routes":
+        if resource.type != "routing.static":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/unbound_forward.py
+++ b/src/infrafoundry/providers/opnsense/services/unbound_forward.py
@@ -341,7 +341,7 @@ def unbound_forward_configs_from_resources(
     """
     configs: list[UnboundForwardConfig] = []
     for resource in resources:
-        if resource.type != "unbound_forward":
+        if resource.type != "unbound.forwards":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/unbound_host_alias.py
+++ b/src/infrafoundry/providers/opnsense/services/unbound_host_alias.py
@@ -347,7 +347,7 @@ def unbound_host_alias_configs_from_resources(
     """
     configs: list[UnboundHostAliasConfig] = []
     for resource in resources:
-        if resource.type != "unbound_host_alias":
+        if resource.type != "unbound.host_aliases":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/unbound_host_override.py
+++ b/src/infrafoundry/providers/opnsense/services/unbound_host_override.py
@@ -351,7 +351,7 @@ def unbound_host_override_configs_from_resources(
     """
     configs: list[UnboundHostOverrideConfig] = []
     for resource in resources:
-        if resource.type != "unbound_host_override":
+        if resource.type != "unbound.host_overrides":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/virtual_ip.py
+++ b/src/infrafoundry/providers/opnsense/services/virtual_ip.py
@@ -383,7 +383,7 @@ def virtual_ip_configs_from_resources(
     """
     configs: list[VirtualIPConfig] = []
     for resource in resources:
-        if resource.type != "virtual_ips":
+        if resource.type != "interfaces.virtual_ips":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/services/vlan.py
+++ b/src/infrafoundry/providers/opnsense/services/vlan.py
@@ -192,7 +192,7 @@ def vlan_configs_from_resources(resources: list[ResourceConfig]) -> list[VlanCon
     """
     vlans: list[VlanConfig] = []
     for resource in resources:
-        if resource.type != "vlans":
+        if resource.type != "interfaces.vlans":
             continue
 
         config = resource.config

--- a/src/infrafoundry/providers/opnsense/templates/opnsense/outputs.tf.j2
+++ b/src/infrafoundry/providers/opnsense/templates/opnsense/outputs.tf.j2
@@ -1,21 +1,21 @@
 # Outputs for OPNsense resources
 
-{% if resources_by_type.get('aliases') %}
+{% if resources_by_type.get('firewall.aliases') %}
 output "aliases" {
   description = "Created aliases"
   value = [
-    {% for alias in resources_by_type['aliases'] %}
+    {% for alias in resources_by_type['firewall.aliases'] %}
     "{{ alias.config.name }}",
     {% endfor %}
   ]
 }
 {% endif %}
 
-{% if resources_by_type.get('unbound_host_override') %}
+{% if resources_by_type.get('unbound.host_overrides') %}
 output "unbound_host_overrides" {
   description = "Created Unbound DNS host overrides"
   value = [
-    {% for override in resources_by_type['unbound_host_override'] %}
+    {% for override in resources_by_type['unbound.host_overrides'] %}
     "{{ override.config.hostname }}.{{ override.config.domain }}",
     {% endfor %}
   ]

--- a/src/infrafoundry/providers/opnsense/validator.py
+++ b/src/infrafoundry/providers/opnsense/validator.py
@@ -270,17 +270,17 @@ class OPNsenseValidator:
         Returns:
             Dict with collected references organized by type
         """
-        aliases = [r for r in resources if r.type == "aliases"]
-        vlans = [r for r in resources if r.type == "vlans"]
-        firewall_rules = [r for r in resources if r.type == "firewall_rules"]
-        unbound_host_overrides = [r for r in resources if r.type == "unbound_host_override"]
-        unbound_host_aliases = [r for r in resources if r.type == "unbound_host_alias"]
-        unbound_forwards = [r for r in resources if r.type == "unbound_forward"]
-        interface_assignments = [r for r in resources if r.type == "interface_assignments"]
-        nat_rules = [r for r in resources if r.type == "nat_rules"]
-        gateways = [r for r in resources if r.type == "gateways"]
-        static_routes = [r for r in resources if r.type == "static_routes"]
-        virtual_ips = [r for r in resources if r.type == "virtual_ips"]
+        aliases = [r for r in resources if r.type == "firewall.aliases"]
+        vlans = [r for r in resources if r.type == "interfaces.vlans"]
+        firewall_rules = [r for r in resources if r.type == "firewall.rules"]
+        unbound_host_overrides = [r for r in resources if r.type == "unbound.host_overrides"]
+        unbound_host_aliases = [r for r in resources if r.type == "unbound.host_aliases"]
+        unbound_forwards = [r for r in resources if r.type == "unbound.forwards"]
+        interface_assignments = [r for r in resources if r.type == "interfaces.assignments"]
+        nat_rules = [r for r in resources if r.type == "firewall.nat"]
+        gateways = [r for r in resources if r.type == "routing.gateways"]
+        static_routes = [r for r in resources if r.type == "routing.static"]
+        virtual_ips = [r for r in resources if r.type == "interfaces.virtual_ips"]
 
         alias_names = {a.name for a in aliases}
         vlan_names = {v.name for v in vlans}

--- a/src/infrafoundry/providers/opnsense/validators/firewall_rule_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/firewall_rule_validator.py
@@ -618,7 +618,7 @@ def _index_managed_gateway_protocols(
     """Build ``{gateway_name: protocol}`` from managed gateway resources."""
     result: dict[str, str] = {}
     for gateway in managed_gateways:
-        if gateway.type != "gateways":
+        if gateway.type != "routing.gateways":
             continue
         protocol = gateway.config.get("protocol")
         if isinstance(protocol, str) and protocol in ("inet", "inet6"):

--- a/tests/integration/test_advanced_workflows.py
+++ b/tests/integration/test_advanced_workflows.py
@@ -212,7 +212,7 @@ class TestDriftDetection:
         opnsense_provider.pyinfra_dir = Path("/tmp/pyinfra/opnsense")
         opnsense_provider.ensure_directories = Mock()
         opnsense_provider.generate_terraform = Mock()
-        opnsense_provider.get_resource_types = Mock(return_value=["vlans"])
+        opnsense_provider.get_resource_types = Mock(return_value=["interfaces.vlans"])
         opnsense_provider.get_dependencies = Mock(return_value={})
         opnsense_provider.get_terraform_env_vars = Mock(return_value={})
 
@@ -368,8 +368,8 @@ vlans:
         opnsense_provider.generate_terraform = Mock()
         opnsense_provider.generate_ansible = Mock()
         opnsense_provider.validate_config = Mock()
-        opnsense_provider.get_resource_types = Mock(return_value=["vlans"])
-        opnsense_provider.get_dependencies = Mock(return_value={"vlans": []})
+        opnsense_provider.get_resource_types = Mock(return_value=["interfaces.vlans"])
+        opnsense_provider.get_dependencies = Mock(return_value={"interfaces.vlans": []})
         opnsense_provider.set_environment = Mock()
         opnsense_provider.get_terraform_env_vars = Mock(return_value={})
 

--- a/tests/unit/providers/opnsense/test_alias_manager.py
+++ b/tests/unit/providers/opnsense/test_alias_manager.py
@@ -49,7 +49,7 @@ def _resource(
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="aliases", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.aliases", provider="opnsense", config=config)
 
 
 def _live(

--- a/tests/unit/providers/opnsense/test_alias_service.py
+++ b/tests/unit/providers/opnsense/test_alias_service.py
@@ -122,7 +122,7 @@ def _live(
 
 
 def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
-    return ResourceConfig(name=name, type="aliases", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.aliases", provider="opnsense", config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -793,7 +793,7 @@ class TestConfigsFromResources:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "bad", "type": "host"},
         )
@@ -804,7 +804,7 @@ class TestConfigsFromResources:
 
     def test_non_aliases_resources_ignored(self) -> None:
         ok = _resource("ok", {"name": "ok", "type": "host"})
-        other = ResourceConfig(name="x", type="vlans", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="interfaces.vlans", provider="opnsense", config={})
         result = alias_configs_from_resources([ok, other])
         assert len(result) == 1
         assert result[0].name == "ok"

--- a/tests/unit/providers/opnsense/test_alias_validator.py
+++ b/tests/unit/providers/opnsense/test_alias_validator.py
@@ -43,7 +43,7 @@ def _alias(name: str, **overrides: Any) -> ResourceConfig:
         "content": ["192.0.2.1"],
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="aliases", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.aliases", provider="opnsense", config=config)
 
 
 @pytest.fixture
@@ -106,7 +106,7 @@ class TestName:
     def test_space_rejected(self, validator: AliasValidator, report: ValidationReport) -> None:
         r = ResourceConfig(
             name="bad space",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "bad space", "type": "host", "content": ["192.0.2.1"]},
         )
@@ -128,7 +128,7 @@ class TestName:
     def test_empty_name_rejected(self, validator: AliasValidator, report: ValidationReport) -> None:
         r = ResourceConfig(
             name="bad",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "", "type": "host", "content": ["192.0.2.1"]},
         )
@@ -140,7 +140,7 @@ class TestName:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": 12345, "type": "host", "content": ["192.0.2.1"]},
         )
@@ -154,7 +154,7 @@ class TestName:
         # resource name.
         r = ResourceConfig(
             name="ok_name",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"type": "host", "content": ["192.0.2.1"]},
         )
@@ -234,7 +234,7 @@ class TestType:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "bad", "content": ["192.0.2.1"]},
         )
@@ -244,7 +244,7 @@ class TestType:
     def test_empty_type_rejected(self, validator: AliasValidator, report: ValidationReport) -> None:
         r = ResourceConfig(
             name="bad",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "bad", "type": "", "content": []},
         )
@@ -256,7 +256,7 @@ class TestType:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "bad", "type": 12345, "content": []},
         )
@@ -393,7 +393,7 @@ class TestContentShape:
         # to OPNsense.
         r = ResourceConfig(
             name="ok",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "ok", "type": "host"},
         )
@@ -588,13 +588,13 @@ class TestUniqueness:
         # wire identity) independently from the top-level resource name.
         first = ResourceConfig(
             name="first",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "shared", "type": "host", "content": ["192.0.2.1"]},
         )
         dup = ResourceConfig(
             name="dup",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "shared", "type": "host", "content": ["192.0.2.2"]},
         )
@@ -607,13 +607,13 @@ class TestUniqueness:
         # Two entries with distinct wire names — no collision.
         a = ResourceConfig(
             name="entry_a",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "entry_a", "type": "host", "content": ["192.0.2.1"]},
         )
         b = ResourceConfig(
             name="entry_b",
-            type="aliases",
+            type="firewall.aliases",
             provider="opnsense",
             config={"name": "entry_b", "type": "host", "content": ["192.0.2.2"]},
         )

--- a/tests/unit/providers/opnsense/test_firewall_rule_manager.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_manager.py
@@ -38,7 +38,7 @@ def _resource(name: str, *, lock: bool = False, **overrides: Any) -> ResourceCon
     if lock:
         config["lock"] = True
     config.update(overrides)
-    return ResourceConfig(name=name, type="firewall_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.rules", provider="opnsense", config=config)
 
 
 def _live_managed(uuid: str, name: str) -> LiveFirewallRule:

--- a/tests/unit/providers/opnsense/test_firewall_rule_service.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_service.py
@@ -147,7 +147,7 @@ def _live(
 
 
 def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
-    return ResourceConfig(name=name, type="firewall_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.rules", provider="opnsense", config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -678,7 +678,7 @@ class TestConfigsFromResources:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="firewall_rules",
+            type="firewall.rules",
             provider="opnsense",
             config={"interface": "lan"},
         )
@@ -689,7 +689,7 @@ class TestConfigsFromResources:
 
     def test_non_firewall_resources_ignored(self) -> None:
         fw = _resource("ok", {"interface": "lan"})
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = firewall_rule_configs_from_resources([fw, other])
         assert len(result) == 1
 

--- a/tests/unit/providers/opnsense/test_firewall_rule_validator.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_validator.py
@@ -39,13 +39,13 @@ def _rule(name: str, **overrides: Any) -> ResourceConfig:
         "interface": "lan",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="firewall_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.rules", provider="opnsense", config=config)
 
 
 def _gw(name: str, *, protocol: str = "inet") -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="gateways",
+        type="routing.gateways",
         provider="opnsense",
         config={"interface": "wan", "protocol": protocol, "gateway": "192.0.2.1"},
     )

--- a/tests/unit/providers/opnsense/test_gateway_manager.py
+++ b/tests/unit/providers/opnsense/test_gateway_manager.py
@@ -38,7 +38,7 @@ def _resource(name: str, *, lock: bool = False) -> ResourceConfig:
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="gateways", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="routing.gateways", provider="opnsense", config=config)
 
 
 def _live_managed(uuid: str, name: str) -> LiveGateway:

--- a/tests/unit/providers/opnsense/test_gateway_service.py
+++ b/tests/unit/providers/opnsense/test_gateway_service.py
@@ -84,7 +84,7 @@ def _live(
 
 
 def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
-    return ResourceConfig(name=name, type="gateways", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="routing.gateways", provider="opnsense", config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -373,7 +373,7 @@ class TestConfigsFromResources:
             "ok",
             {"interface": "wan", "protocol": "inet", "gateway": "192.0.2.1"},
         )
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = gateway_configs_from_resources([gw, other])
         assert len(result) == 1
 
@@ -432,7 +432,7 @@ class TestConfigsFromResources:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="gateways",
+            type="routing.gateways",
             provider="opnsense",
             config={"interface": "wan", "protocol": "inet", "gateway": "192.0.2.1"},
         )

--- a/tests/unit/providers/opnsense/test_gateway_validator.py
+++ b/tests/unit/providers/opnsense/test_gateway_validator.py
@@ -43,7 +43,7 @@ def _gw(name: str, **overrides: Any) -> ResourceConfig:
         "gateway": "192.0.2.1",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="gateways", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="routing.gateways", provider="opnsense", config=config)
 
 
 @pytest.fixture
@@ -87,7 +87,7 @@ class TestProtocol:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="gateways",
+            type="routing.gateways",
             provider="opnsense",
             config={"interface": "wan", "gateway": "192.0.2.1"},
         )
@@ -160,7 +160,7 @@ class TestInterface:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="gateways",
+            type="routing.gateways",
             provider="opnsense",
             config={"protocol": "inet", "gateway": "192.0.2.1"},
         )

--- a/tests/unit/providers/opnsense/test_interface_assignment_manager.py
+++ b/tests/unit/providers/opnsense/test_interface_assignment_manager.py
@@ -48,7 +48,7 @@ def _resource(
     if extra:
         config.update(extra)
     return ResourceConfig(
-        name=name, type="interface_assignments", provider="opnsense", config=config
+        name=name, type="interfaces.assignments", provider="opnsense", config=config
     )
 
 

--- a/tests/unit/providers/opnsense/test_interface_assignment_service.py
+++ b/tests/unit/providers/opnsense/test_interface_assignment_service.py
@@ -90,7 +90,7 @@ def _resource(
     if ipv6 is not None:
         config["ipv6"] = ipv6
     return ResourceConfig(
-        name=name, type="interface_assignments", provider="opnsense", config=config
+        name=name, type="interfaces.assignments", provider="opnsense", config=config
     )
 
 
@@ -251,7 +251,7 @@ class TestConfigsFromResources:
 
     def test_non_matching_resources_ignored(self) -> None:
         ifa = _resource("lan")
-        alias = ResourceConfig(name="a", type="aliases", provider="opnsense", config={})
+        alias = ResourceConfig(name="a", type="firewall.aliases", provider="opnsense", config={})
         result = interface_assignment_configs_from_resources([ifa, alias])
         assert len(result) == 1
 
@@ -327,7 +327,7 @@ class TestConfigsFromResources:
     def test_missing_device_rejected(self) -> None:
         bad = ResourceConfig(
             name="lan",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"description": "lan"},
         )
@@ -342,7 +342,7 @@ class TestConfigsFromResources:
     def test_non_string_description_rejected(self) -> None:
         bad = ResourceConfig(
             name="lan",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "description": 123},
         )
@@ -352,7 +352,7 @@ class TestConfigsFromResources:
     def test_non_bool_enabled_rejected(self) -> None:
         bad = ResourceConfig(
             name="lan",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "enabled": "yes"},
         )
@@ -362,7 +362,7 @@ class TestConfigsFromResources:
     def test_non_bool_lock_rejected(self) -> None:
         bad = ResourceConfig(
             name="lan",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "lock": "yes"},
         )
@@ -372,7 +372,7 @@ class TestConfigsFromResources:
     def test_non_string_spoof_mac_rejected(self) -> None:
         bad = ResourceConfig(
             name="lan",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "spoof_mac": 12345},
         )
@@ -430,7 +430,7 @@ class TestConfigsFromResources:
     def test_ipv4_block_must_be_mapping(self) -> None:
         bad = ResourceConfig(
             name="opt5",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "ipv4": "static"},
         )
@@ -441,7 +441,7 @@ class TestConfigsFromResources:
         # YAML "ipv4:" with no value parses as None.
         bad = ResourceConfig(
             name="opt5",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "ipv4": None},
         )
@@ -451,7 +451,7 @@ class TestConfigsFromResources:
     def test_ipv6_block_must_be_mapping(self) -> None:
         bad = ResourceConfig(
             name="opt5",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "ipv6": "track6"},
         )
@@ -461,7 +461,7 @@ class TestConfigsFromResources:
     def test_ipv6_none_treated_as_empty(self) -> None:
         bad = ResourceConfig(
             name="opt5",
-            type="interface_assignments",
+            type="interfaces.assignments",
             provider="opnsense",
             config={"device": "ixl1", "ipv6": None},
         )

--- a/tests/unit/providers/opnsense/test_interface_assignment_validator.py
+++ b/tests/unit/providers/opnsense/test_interface_assignment_validator.py
@@ -46,7 +46,7 @@ def _resource(
     if ipv6 is not None:
         config["ipv6"] = ipv6
     return ResourceConfig(
-        name=name, type="interface_assignments", provider="opnsense", config=config
+        name=name, type="interfaces.assignments", provider="opnsense", config=config
     )
 
 

--- a/tests/unit/providers/opnsense/test_kea_dhcp4_reservation_manager.py
+++ b/tests/unit/providers/opnsense/test_kea_dhcp4_reservation_manager.py
@@ -47,7 +47,7 @@ def _reservation(
 ) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="kea_reservation",
+        type="kea.dhcp4.reservations",
         provider="opnsense",
         config={
             "subnet": subnet,

--- a/tests/unit/providers/opnsense/test_kea_dhcp4_subnet_manager.py
+++ b/tests/unit/providers/opnsense/test_kea_dhcp4_subnet_manager.py
@@ -39,7 +39,7 @@ def _subnet(name: str, *, subnet: str = "10.0.10.0/24", **overrides: Any) -> Res
         "description": overrides.pop("description", f"{name} desc"),
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="kea_subnet", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="kea.dhcp4.subnets", provider="opnsense", config=config)
 
 
 SERVICE_PATH = "infrafoundry.providers.opnsense.components.kea_dhcp4_subnet.KeaDHCPService"

--- a/tests/unit/providers/opnsense/test_kea_dhcp6_reservation_manager.py
+++ b/tests/unit/providers/opnsense/test_kea_dhcp6_reservation_manager.py
@@ -43,7 +43,7 @@ def _reservation(
 ) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="kea_dhcp6_reservation",
+        type="kea.dhcp6.reservations",
         provider="opnsense",
         config={
             "subnet": subnet,

--- a/tests/unit/providers/opnsense/test_kea_dhcp6_subnet_manager.py
+++ b/tests/unit/providers/opnsense/test_kea_dhcp6_subnet_manager.py
@@ -35,7 +35,7 @@ def _subnet(name: str, *, subnet: str = "fd00:1::/64", **overrides: Any) -> Reso
         "description": overrides.pop("description", f"{name} desc"),
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="kea_dhcp6_subnet", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="kea.dhcp6.subnets", provider="opnsense", config=config)
 
 
 SERVICE_PATH = "infrafoundry.providers.opnsense.components.kea_dhcp6_subnet.KeaDHCPService"

--- a/tests/unit/providers/opnsense/test_nat_rule_manager.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_manager.py
@@ -37,7 +37,7 @@ def _outbound_resource(name: str, *, lock: bool = False) -> ResourceConfig:
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.nat", provider="opnsense", config=config)
 
 
 def _one_to_one_resource(name: str, *, lock: bool = False) -> ResourceConfig:
@@ -49,7 +49,7 @@ def _one_to_one_resource(name: str, *, lock: bool = False) -> ResourceConfig:
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.nat", provider="opnsense", config=config)
 
 
 def _port_forward_resource(name: str, *, lock: bool = False) -> ResourceConfig:
@@ -62,7 +62,7 @@ def _port_forward_resource(name: str, *, lock: bool = False) -> ResourceConfig:
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.nat", provider="opnsense", config=config)
 
 
 def _live_managed(uuid: str, name: str, kind: str) -> LiveNATRule:

--- a/tests/unit/providers/opnsense/test_nat_rule_service.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_service.py
@@ -200,7 +200,7 @@ def _resource(
     name: str,
     config: dict[str, Any],
 ) -> ResourceConfig:
-    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.nat", provider="opnsense", config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -980,7 +980,7 @@ class TestConfigsFromResourcesGeneral:
 
     def test_non_nat_resources_ignored(self) -> None:
         nat = _resource("ok", {"kind": "outbound", "interface": "wan", "target": "wanip"})
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = nat_rule_configs_from_resources([nat, other])
         assert len(result) == 1
 
@@ -1034,7 +1034,7 @@ class TestConfigsFromResourcesGeneral:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="nat_rules",
+            type="firewall.nat",
             provider="opnsense",
             config={"kind": "outbound", "interface": "wan", "target": "wanip"},
         )

--- a/tests/unit/providers/opnsense/test_nat_rule_validator.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_validator.py
@@ -37,7 +37,7 @@ def _outbound(name: str, **overrides: Any) -> ResourceConfig:
         "target": "wanip",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.nat", provider="opnsense", config=config)
 
 
 def _one_to_one(name: str, **overrides: Any) -> ResourceConfig:
@@ -47,7 +47,7 @@ def _one_to_one(name: str, **overrides: Any) -> ResourceConfig:
         "external": "198.51.100.10",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.nat", provider="opnsense", config=config)
 
 
 def _port_forward(name: str, **overrides: Any) -> ResourceConfig:
@@ -57,7 +57,7 @@ def _port_forward(name: str, **overrides: Any) -> ResourceConfig:
         "target": "10.0.0.10",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="nat_rules", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="firewall.nat", provider="opnsense", config=config)
 
 
 @pytest.fixture
@@ -85,7 +85,7 @@ class TestKind:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="nat_rules",
+            type="firewall.nat",
             provider="opnsense",
             config={"interface": "wan", "target": "wanip"},
         )
@@ -106,7 +106,7 @@ class TestKind:
         # "bad kind" negative-test coverage now.
         r = ResourceConfig(
             name="pf",
-            type="nat_rules",
+            type="firewall.nat",
             provider="opnsense",
             config={"kind": "unknown", "interface": "wan"},
         )
@@ -240,7 +240,7 @@ class TestOutboundRequiredFields:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="nat_rules",
+            type="firewall.nat",
             provider="opnsense",
             config={"kind": "outbound", "interface": "wan"},
         )
@@ -260,7 +260,7 @@ class TestOneToOneRequiredFields:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="nat_rules",
+            type="firewall.nat",
             provider="opnsense",
             config={"kind": "one_to_one", "interface": "wan"},
         )
@@ -507,7 +507,7 @@ class TestPortForwardValidation:
         # Port_forward requires a non-empty target (redirect destination).
         r = ResourceConfig(
             name="bad",
-            type="nat_rules",
+            type="firewall.nat",
             provider="opnsense",
             config={"kind": "port_forward", "interface": "wan"},
         )
@@ -525,7 +525,7 @@ class TestPortForwardValidation:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="nat_rules",
+            type="firewall.nat",
             provider="opnsense",
             config={"kind": "port_forward", "target": "10.0.0.10"},
         )

--- a/tests/unit/providers/opnsense/test_opnsense_direct_runner.py
+++ b/tests/unit/providers/opnsense/test_opnsense_direct_runner.py
@@ -107,7 +107,7 @@ class TestInitialize:
 def _vlan_resource(name: str, device: str, tag: int) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="vlans",
+        type="interfaces.vlans",
         provider="opnsense",
         config={
             "device": device,
@@ -121,14 +121,14 @@ def _vlan_resource(name: str, device: str, tag: int) -> ResourceConfig:
 def _alias_resource(name: str) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="aliases",
+        type="firewall.aliases",
         provider="opnsense",
         config={"name": name},
     )
 
 
 class TestFilterVlans:
-    """``_filter_vlans`` picks out only ``type='vlans'`` resources."""
+    """``_filter_vlans`` picks out only ``type='interfaces.vlans'`` resources."""
 
     def test_picks_only_vlan_resources(self) -> None:
         resources = [
@@ -164,9 +164,13 @@ class TestFilterByType:
             _alias_resource("a1"),
             _vlan_resource("v2", "igb0", 20),
         ]
-        vlans = OPNsenseDirectRunner._filter_by_type(resources, "vlans", target_resources=None)
+        vlans = OPNsenseDirectRunner._filter_by_type(
+            resources, "interfaces.vlans", target_resources=None
+        )
         assert {r.name for r in vlans} == {"v1", "v2"}
-        aliases = OPNsenseDirectRunner._filter_by_type(resources, "aliases", target_resources=None)
+        aliases = OPNsenseDirectRunner._filter_by_type(
+            resources, "firewall.aliases", target_resources=None
+        )
         assert {r.name for r in aliases} == {"a1"}
 
     def test_unknown_type_returns_empty(self) -> None:
@@ -180,8 +184,8 @@ class TestFilterByType:
             _vlan_resource("v2", "igb0", 20),
             _alias_resource("v1"),  # same name, different type
         ]
-        result = OPNsenseDirectRunner._filter_by_type(resources, "vlans", ["v1"])
-        assert [r.type for r in result] == ["vlans"]
+        result = OPNsenseDirectRunner._filter_by_type(resources, "interfaces.vlans", ["v1"])
+        assert [r.type for r in result] == ["interfaces.vlans"]
         assert [r.name for r in result] == ["v1"]
 
 
@@ -190,9 +194,9 @@ class TestResolveDispatchTable:
 
     def test_returns_provider_table_when_callable(self) -> None:
         provider = MagicMock()
-        provider.get_direct_api_resource_types.return_value = {"vlans": object}
+        provider.get_direct_api_resource_types.return_value = {"interfaces.vlans": object}
         table = OPNsenseDirectRunner._resolve_dispatch_table(provider)
-        assert table == {"vlans": object}
+        assert table == {"interfaces.vlans": object}
 
     def test_returns_empty_when_attribute_missing(self) -> None:
         class _Bare:
@@ -257,7 +261,9 @@ class TestPlanDelegation:
         runner = OPNsenseDirectRunner()
         # Even with VLAN registered, an empty resource list means no dispatch.
         manager_cls = MagicMock()
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
             result = runner.plan(provider_with_env)
         assert result["success"] is True
@@ -285,7 +291,9 @@ class TestPlanDelegation:
         manager_mock.plan.return_value = diff
         manager_cls = MagicMock(return_value=manager_mock)
 
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.plan(provider_with_env, add_only=True)
@@ -305,7 +313,9 @@ class TestPlanDelegation:
         manager_mock.plan.side_effect = RuntimeError("boom")
         manager_cls = MagicMock(return_value=manager_mock)
 
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.plan(provider_with_env)
@@ -320,7 +330,9 @@ class TestApplyDelegation:
     def test_no_vlans_returns_zero_counts(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
         manager_cls = MagicMock()
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
             result = runner.apply(provider_with_env)
         assert result["success"] is True
@@ -343,7 +355,9 @@ class TestApplyDelegation:
             "resource_outcomes": [outcome],
         }
         manager_cls = MagicMock(return_value=manager_mock)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.apply(provider_with_env, auto_approve=True, add_only=False)
@@ -366,7 +380,9 @@ class TestApplyDelegation:
             "resource_outcomes": [],
         }
         manager_cls = MagicMock(return_value=manager_mock)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             runner.apply(provider_with_env, add_only=True)
         # add_only kwarg propagated.
@@ -378,7 +394,9 @@ class TestApplyDelegation:
         manager_mock = MagicMock()
         manager_mock.apply.side_effect = RuntimeError("api down")
         manager_cls = MagicMock(return_value=manager_mock)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.apply(provider_with_env)
         assert result["success"] is False
@@ -391,7 +409,9 @@ class TestDestroyDelegation:
     def test_no_vlans_returns_zero(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
         manager_cls = MagicMock()
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
             result = runner.destroy(provider_with_env)
         assert result["success"] is True
@@ -407,7 +427,9 @@ class TestDestroyDelegation:
             "locked_skipped": 0,
         }
         manager_cls = MagicMock(return_value=manager_mock)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.destroy(provider_with_env, auto_approve=True)
         assert result["resources_destroyed"] == 1  # type: ignore[typeddict-item]
@@ -423,7 +445,9 @@ class TestGetResourceIds:
         manager_mock = MagicMock()
         manager_mock.get_resource_ids.return_value = {"v1": "uuid-1"}
         manager_cls = MagicMock(return_value=manager_mock)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             ids = runner.get_resource_ids(provider_with_env)
         assert ids == {"v1": "uuid-1"}
@@ -431,7 +455,9 @@ class TestGetResourceIds:
     def test_empty_when_no_vlans(self, provider_with_env: MagicMock) -> None:
         runner = OPNsenseDirectRunner()
         manager_cls = MagicMock()
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=[]):
             ids = runner.get_resource_ids(provider_with_env)
         assert ids == {}
@@ -445,7 +471,9 @@ class TestGetResourceIds:
         manager_mock = MagicMock()
         manager_mock.get_resource_ids.side_effect = RuntimeError("transient")
         manager_cls = MagicMock(return_value=manager_mock)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             ids = runner.get_resource_ids(provider_with_env)
         assert ids == {}
@@ -459,7 +487,7 @@ class TestGetResourceIds:
 def _ifa_resource(name: str) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="interface_assignments",
+        type="interfaces.assignments",
         provider="opnsense",
         config={"device": "igb0", "description": name},
     )
@@ -485,8 +513,8 @@ class TestMultiComponentDispatch:
         ifa_manager.plan.return_value = readonly_diff
 
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": MagicMock(return_value=vlan_manager),
-            "interface_assignments": MagicMock(return_value=ifa_manager),
+            "interfaces.vlans": MagicMock(return_value=vlan_manager),
+            "interfaces.assignments": MagicMock(return_value=ifa_manager),
         }
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -496,8 +524,8 @@ class TestMultiComponentDispatch:
         # vlans diff has an add → has_changes is True overall.
         assert result["has_changes"] is True  # type: ignore[typeddict-item]
         summary = result["changes_summary"]  # type: ignore[typeddict-item]
-        assert "vlans:" in summary
-        assert "interface_assignments:" in summary
+        assert "interfaces.vlans:" in summary
+        assert "interfaces.assignments:" in summary
         assert "read-only" in summary
 
     def test_apply_aggregates_counts_and_outcomes(self, provider_with_env: MagicMock) -> None:
@@ -525,8 +553,8 @@ class TestMultiComponentDispatch:
         }
 
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": MagicMock(return_value=vlan_manager),
-            "interface_assignments": MagicMock(return_value=ifa_manager),
+            "interfaces.vlans": MagicMock(return_value=vlan_manager),
+            "interfaces.assignments": MagicMock(return_value=ifa_manager),
         }
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -556,8 +584,8 @@ class TestMultiComponentDispatch:
         }
 
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": MagicMock(return_value=vlan_manager),
-            "interface_assignments": MagicMock(return_value=ifa_manager),
+            "interfaces.vlans": MagicMock(return_value=vlan_manager),
+            "interfaces.assignments": MagicMock(return_value=ifa_manager),
         }
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -575,8 +603,8 @@ class TestMultiComponentDispatch:
         ifa_manager.get_resource_ids.return_value = {"lan": "lan"}
 
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": MagicMock(return_value=vlan_manager),
-            "interface_assignments": MagicMock(return_value=ifa_manager),
+            "interfaces.vlans": MagicMock(return_value=vlan_manager),
+            "interfaces.assignments": MagicMock(return_value=ifa_manager),
         }
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -591,13 +619,13 @@ class TestMultiComponentDispatch:
         resources = [
             _alias_resource(
                 "a1"
-            ),  # "aliases" is intentionally absent from THIS test's mock dispatch
+            ),  # "firewall.aliases" is intentionally absent from THIS test's mock dispatch
             _vlan_resource("v1", "igb0", 10),
         ]
         vlan_manager = MagicMock()
         vlan_manager.plan.return_value = Diff()
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": MagicMock(return_value=vlan_manager),
+            "interfaces.vlans": MagicMock(return_value=vlan_manager),
         }
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
             result = runner.plan(provider_with_env)
@@ -605,7 +633,7 @@ class TestMultiComponentDispatch:
         # vlan_manager.plan called with only the VLAN resource, never the alias.
         vlan_manager.plan.assert_called_once()
         passed_resources = vlan_manager.plan.call_args.args[1]
-        assert all(r.type == "vlans" for r in passed_resources)
+        assert all(r.type == "interfaces.vlans" for r in passed_resources)
 
 
 # ---------------------------------------------------------------------------
@@ -652,7 +680,9 @@ class TestFinalizationHookPlumbing:
         runner = OPNsenseDirectRunner()
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_cls, _ = _hook_manager(hook_key="my_hook", created=1)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"my_hook": hook}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -663,7 +693,9 @@ class TestFinalizationHookPlumbing:
         runner = OPNsenseDirectRunner()
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_cls, _ = _hook_manager(hook_key="my_hook", created=0)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"my_hook": hook}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -680,8 +712,8 @@ class TestFinalizationHookPlumbing:
         cls_b, _ = _hook_manager(hook_key="shared_hook", updated=1)
 
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": cls_a,
-            "interface_assignments": cls_b,
+            "interfaces.vlans": cls_a,
+            "interfaces.assignments": cls_b,
         }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"shared_hook": hook}
@@ -699,8 +731,8 @@ class TestFinalizationHookPlumbing:
         cls_b, _ = _hook_manager(hook_key="hook_b", deleted=1)
 
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": cls_a,
-            "interface_assignments": cls_b,
+            "interfaces.vlans": cls_a,
+            "interfaces.assignments": cls_b,
         }
         hook_a = MagicMock()
         hook_b = MagicMock()
@@ -721,7 +753,9 @@ class TestFinalizationHookPlumbing:
         runner = OPNsenseDirectRunner()
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_cls, _ = _hook_manager(hook_key=None, created=1)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         # Provider exposes a hooks dict — but the manager didn't trigger any key.
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"unrelated": hook}
@@ -745,7 +779,7 @@ class TestFinalizationHookPlumbing:
                 pass
 
             def get_direct_api_resource_types(self) -> dict[str, Any]:
-                return {"vlans": manager_cls}
+                return {"interfaces.vlans": manager_cls}
 
         provider = _BareProvider()
         resources = [_vlan_resource("v1", "igb0", 10)]
@@ -758,7 +792,9 @@ class TestFinalizationHookPlumbing:
         runner = OPNsenseDirectRunner()
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_cls, _ = _hook_manager(hook_key="my_hook", created=1)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
 
         def _boom(_env: str) -> None:
             raise RuntimeError("reconfigure failed")
@@ -777,7 +813,9 @@ class TestFinalizationHookPlumbing:
         runner = OPNsenseDirectRunner()
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_cls, _ = _hook_manager(hook_key="missing_hook", created=1)
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         provider_with_env.get_finalization_hooks.return_value = {}
 
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -795,7 +833,9 @@ class TestFinalizationHookPlumbing:
             "resources_destroyed": 1,
             "locked_skipped": 0,
         }
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"my_hook": hook}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -808,7 +848,9 @@ class TestFinalizationHookPlumbing:
         resources = [_vlan_resource("v1", "igb0", 10)]
         manager_cls, instance = _hook_manager(hook_key="my_hook", created=1)
         instance.plan.return_value = Diff(adds=[VlanConfig("v1", "igb0", 10, "x", 0)])
-        provider_with_env.get_direct_api_resource_types.return_value = {"vlans": manager_cls}
+        provider_with_env.get_direct_api_resource_types.return_value = {
+            "interfaces.vlans": manager_cls
+        }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"my_hook": hook}
         with patch.object(OPNsenseDirectRunner, "_load_provider_resources", return_value=resources):
@@ -824,7 +866,7 @@ class TestFinalizationHookPlumbing:
 def _uho_resource(name: str) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={"hostname": "web", "domain": "example.com", "server": "192.168.1.10"},
     )
@@ -833,7 +875,7 @@ def _uho_resource(name: str) -> ResourceConfig:
 def _uha_resource(name: str) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="unbound_host_alias",
+        type="unbound.host_aliases",
         provider="opnsense",
         config={"host": "web", "hostname": "alias", "domain": "example.com"},
     )
@@ -842,7 +884,7 @@ def _uha_resource(name: str) -> ResourceConfig:
 def _ufwd_resource(name: str) -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="unbound_forward",
+        type="unbound.forwards",
         provider="opnsense",
         config={"server": "10.0.0.53"},
     )
@@ -874,9 +916,9 @@ class TestUnboundReconfigureCoalescing:
         cls_ufwd, _ = _hook_manager(hook_key="unbound_reconfigure", deleted=1)
 
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "unbound_host_override": cls_uho,
-            "unbound_host_alias": cls_uha,
-            "unbound_forward": cls_ufwd,
+            "unbound.host_overrides": cls_uho,
+            "unbound.host_aliases": cls_uha,
+            "unbound.forwards": cls_ufwd,
         }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"unbound_reconfigure": hook}
@@ -893,7 +935,7 @@ class TestUnboundReconfigureCoalescing:
         resources = [_uho_resource("override-1")]
         cls_uho, _ = _hook_manager(hook_key="unbound_reconfigure", created=1)
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "unbound_host_override": cls_uho,
+            "unbound.host_overrides": cls_uho,
         }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"unbound_reconfigure": hook}
@@ -913,8 +955,8 @@ class TestUnboundReconfigureCoalescing:
         # the dispatch table but no unbound manager fires.
         cls_vlan, _ = _hook_manager(hook_key=None, created=0)
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "vlans": cls_vlan,
-            "unbound_host_override": cls_uho,
+            "interfaces.vlans": cls_vlan,
+            "unbound.host_overrides": cls_uho,
         }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"unbound_reconfigure": hook}
@@ -934,7 +976,7 @@ class TestUnboundReconfigureCoalescing:
         resources = [_uho_resource("override-1")]
         cls_uho, _ = _hook_manager(hook_key="unbound_reconfigure", created=0)
         provider_with_env.get_direct_api_resource_types.return_value = {
-            "unbound_host_override": cls_uho,
+            "unbound.host_overrides": cls_uho,
         }
         hook = MagicMock()
         provider_with_env.get_finalization_hooks.return_value = {"unbound_reconfigure": hook}

--- a/tests/unit/providers/opnsense/test_opnsense_validator.py
+++ b/tests/unit/providers/opnsense/test_opnsense_validator.py
@@ -192,7 +192,7 @@ class TestValidateReferences:
         validator.interface_assignment_validator = MagicMock()
 
         resources = [
-            ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
+            ResourceConfig(name="alias1", type="firewall.aliases", provider="opnsense", config={}),
         ]
 
         validator.validate_references(resources)
@@ -217,7 +217,9 @@ class TestValidateReferences:
 
         validator.validate_references(
             [
-                ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
+                ResourceConfig(
+                    name="alias1", type="firewall.aliases", provider="opnsense", config={}
+                ),
             ]
         )
 
@@ -230,7 +232,9 @@ class TestCollectResourceReferences:
     def test_collects_aliases(self, validator):
         """Collects alias resources."""
         resources = [
-            ResourceConfig(name="my-alias", type="aliases", provider="opnsense", config={}),
+            ResourceConfig(
+                name="my-alias", type="firewall.aliases", provider="opnsense", config={}
+            ),
         ]
 
         refs = validator._collect_resource_references(resources)
@@ -241,7 +245,7 @@ class TestCollectResourceReferences:
     def test_collects_vlans(self, validator):
         """Collects VLAN resources."""
         resources = [
-            ResourceConfig(name="vlan10", type="vlans", provider="opnsense", config={}),
+            ResourceConfig(name="vlan10", type="interfaces.vlans", provider="opnsense", config={}),
         ]
 
         refs = validator._collect_resource_references(resources)
@@ -252,7 +256,7 @@ class TestCollectResourceReferences:
     def test_collects_firewall_rules(self, validator):
         """Collects firewall rule resources."""
         resources = [
-            ResourceConfig(name="rule1", type="firewall_rules", provider="opnsense", config={}),
+            ResourceConfig(name="rule1", type="firewall.rules", provider="opnsense", config={}),
         ]
 
         refs = validator._collect_resource_references(resources)
@@ -263,7 +267,7 @@ class TestCollectResourceReferences:
         """Collects unbound host override resources."""
         resources = [
             ResourceConfig(
-                name="host1", type="unbound_host_override", provider="opnsense", config={}
+                name="host1", type="unbound.host_overrides", provider="opnsense", config={}
             ),
         ]
 
@@ -276,7 +280,7 @@ class TestCollectResourceReferences:
         resources = [
             ResourceConfig(
                 name="lan",
-                type="interface_assignments",
+                type="interfaces.assignments",
                 provider="opnsense",
                 config={"device": "ixl1"},
             ),

--- a/tests/unit/providers/opnsense/test_provider_extractors.py
+++ b/tests/unit/providers/opnsense/test_provider_extractors.py
@@ -16,19 +16,19 @@ from infrafoundry.core.extractors import (
 from infrafoundry.providers.opnsense import OPNsenseProvider, _ExtractorAdapter
 
 EXPECTED_RESOURCE_TYPES = [
-    "aliases",
-    "firewall_rules",
-    "gateways",
-    "interface_assignments",
+    "firewall.aliases",
+    "firewall.rules",
+    "routing.gateways",
+    "interfaces.assignments",
     "isc_to_kea",
     "kea_dhcp",
-    "nat_rules",
-    "static_routes",
-    "unbound_forward",
-    "unbound_host_alias",
-    "unbound_host_override",
-    "virtual_ips",
-    "vlans",
+    "firewall.nat",
+    "routing.static",
+    "unbound.forwards",
+    "unbound.host_aliases",
+    "unbound.host_overrides",
+    "interfaces.virtual_ips",
+    "interfaces.vlans",
 ]
 
 
@@ -129,8 +129,8 @@ def test_extractor_adapter_extract_no_kwargs(tmp_path: Path) -> None:
 
 @pytest.mark.usefixtures("provider")
 def test_vlans_extractor_delegates_to_vlan_manager() -> None:
-    """The registered ``opnsense:vlans`` extractor delegates to ``VlanManager.migrate``."""
-    extractor = get_extractor("opnsense", "vlans")
+    """``opnsense:interfaces.vlans`` extractor delegates to ``VlanManager.migrate``."""
+    extractor = get_extractor("opnsense", "interfaces.vlans")
 
     # The adapter holds a class reference; replacing the class's
     # ``__init__`` and ``migrate`` exercises the full extract path.
@@ -151,10 +151,10 @@ def test_vlans_extractor_delegates_to_vlan_manager() -> None:
 
 @pytest.mark.usefixtures("provider")
 def test_aliases_extractor_delegates_to_alias_manager() -> None:
-    """The registered ``opnsense:aliases`` extractor delegates to ``AliasManager.migrate``."""
+    """``opnsense:firewall.aliases`` extractor delegates to ``AliasManager.migrate``."""
     from infrafoundry.providers.opnsense.components.alias import AliasManager
 
-    extractor = get_extractor("opnsense", "aliases")
+    extractor = get_extractor("opnsense", "firewall.aliases")
 
     assert isinstance(extractor, _ExtractorAdapter)
     assert extractor.manager_class is AliasManager
@@ -174,12 +174,12 @@ def test_aliases_extractor_delegates_to_alias_manager() -> None:
 
 @pytest.mark.usefixtures("provider")
 def test_unbound_host_override_extractor_delegates_to_manager() -> None:
-    """``opnsense:unbound_host_override`` delegates to ``UnboundHostOverrideManager.migrate``."""
+    """``opnsense:unbound.host_overrides`` delegates to ``UnboundHostOverrideManager.migrate``."""
     from infrafoundry.providers.opnsense.components.unbound_host_override import (
         UnboundHostOverrideManager,
     )
 
-    extractor = get_extractor("opnsense", "unbound_host_override")
+    extractor = get_extractor("opnsense", "unbound.host_overrides")
 
     assert isinstance(extractor, _ExtractorAdapter)
     assert extractor.manager_class is UnboundHostOverrideManager

--- a/tests/unit/providers/opnsense/test_resource_name_validator.py
+++ b/tests/unit/providers/opnsense/test_resource_name_validator.py
@@ -26,9 +26,9 @@ def validator(report):
 def test_validate_unique_names(validator, report):
     """Test validation with all unique names."""
     resources = [
-        ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="alias2", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="vlan1", type="vlans", provider="opnsense", config={}),
+        ResourceConfig(name="alias1", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="alias2", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="vlan1", type="interfaces.vlans", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)
@@ -39,9 +39,9 @@ def test_validate_unique_names(validator, report):
 def test_validate_duplicate_names_same_type(validator, report):
     """Test validation with duplicate names in same type."""
     resources = [
-        ResourceConfig(name="web_servers", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="db_servers", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="web_servers", type="aliases", provider="opnsense", config={}),
+        ResourceConfig(name="web_servers", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="db_servers", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="web_servers", type="firewall.aliases", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)
@@ -57,9 +57,9 @@ def test_validate_duplicate_names_same_type(validator, report):
 def test_validate_same_name_different_types(validator, report):
     """Test validation with same name across different types (allowed)."""
     resources = [
-        ResourceConfig(name="web", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="web", type="vlans", provider="opnsense", config={}),
-        ResourceConfig(name="web", type="firewall_rules", provider="opnsense", config={}),
+        ResourceConfig(name="web", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="web", type="interfaces.vlans", provider="opnsense", config={}),
+        ResourceConfig(name="web", type="firewall.rules", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)
@@ -71,9 +71,9 @@ def test_validate_same_name_different_types(validator, report):
 def test_validate_multiple_duplicates_same_type(validator, report):
     """Test validation with multiple duplicate names in same type."""
     resources = [
-        ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
+        ResourceConfig(name="alias1", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="alias1", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="alias1", type="firewall.aliases", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)
@@ -85,10 +85,10 @@ def test_validate_multiple_duplicates_same_type(validator, report):
 def test_validate_duplicates_in_multiple_types(validator, report):
     """Test validation with duplicates in multiple types."""
     resources = [
-        ResourceConfig(name="dup1", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="dup1", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="dup2", type="vlans", provider="opnsense", config={}),
-        ResourceConfig(name="dup2", type="vlans", provider="opnsense", config={}),
+        ResourceConfig(name="dup1", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="dup1", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="dup2", type="interfaces.vlans", provider="opnsense", config={}),
+        ResourceConfig(name="dup2", type="interfaces.vlans", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)
@@ -106,7 +106,7 @@ def test_validate_empty_resources(validator, report):
 def test_validate_single_resource(validator, report):
     """Test validation with single resource."""
     resources = [
-        ResourceConfig(name="alias1", type="aliases", provider="opnsense", config={}),
+        ResourceConfig(name="alias1", type="firewall.aliases", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)
@@ -117,7 +117,7 @@ def test_validate_single_resource(validator, report):
 def test_validate_many_unique_resources(validator, report):
     """Test validation with many unique resources."""
     resources = [
-        ResourceConfig(name=f"alias{i}", type="aliases", provider="opnsense", config={})
+        ResourceConfig(name=f"alias{i}", type="firewall.aliases", provider="opnsense", config={})
         for i in range(100)
     ]
 
@@ -129,23 +129,23 @@ def test_validate_many_unique_resources(validator, report):
 def test_validate_check_name_format(validator, report):
     """Test that check name includes resource type and name."""
     resources = [
-        ResourceConfig(name="duplicate", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="duplicate", type="aliases", provider="opnsense", config={}),
+        ResourceConfig(name="duplicate", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="duplicate", type="firewall.aliases", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)
 
     call_args = report.add_check.call_args[1]
-    assert "aliases" in call_args["check_name"]
+    assert "firewall.aliases" in call_args["check_name"]
     assert "duplicate" in call_args["check_name"]
 
 
 def test_validate_case_sensitive_names(validator, report):
     """Test that name comparison is case-sensitive."""
     resources = [
-        ResourceConfig(name="WebServers", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="webservers", type="aliases", provider="opnsense", config={}),
-        ResourceConfig(name="WEBSERVERS", type="aliases", provider="opnsense", config={}),
+        ResourceConfig(name="WebServers", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="webservers", type="firewall.aliases", provider="opnsense", config={}),
+        ResourceConfig(name="WEBSERVERS", type="firewall.aliases", provider="opnsense", config={}),
     ]
 
     validator.validate(resources)

--- a/tests/unit/providers/opnsense/test_static_route_manager.py
+++ b/tests/unit/providers/opnsense/test_static_route_manager.py
@@ -43,7 +43,7 @@ def _resource(
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="static_routes", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="routing.static", provider="opnsense", config=config)
 
 
 def _live(

--- a/tests/unit/providers/opnsense/test_static_route_service.py
+++ b/tests/unit/providers/opnsense/test_static_route_service.py
@@ -78,7 +78,7 @@ def _live(
 
 
 def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
-    return ResourceConfig(name=name, type="static_routes", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="routing.static", provider="opnsense", config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -465,7 +465,7 @@ class TestConfigsFromResources:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="static_routes",
+            type="routing.static",
             provider="opnsense",
             config={"network": "10.0.0.0/24", "gateway": "WAN_DHCP"},
         )
@@ -476,7 +476,7 @@ class TestConfigsFromResources:
 
     def test_non_static_routes_resources_ignored(self) -> None:
         sr = _resource("ok", {"network": "10.0.0.0/24", "gateway": "WAN_DHCP"})
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = static_route_configs_from_resources([sr, other])
         assert len(result) == 1
         assert result[0].name == "ok"

--- a/tests/unit/providers/opnsense/test_static_route_validator.py
+++ b/tests/unit/providers/opnsense/test_static_route_validator.py
@@ -36,13 +36,13 @@ def _route(name: str, **overrides: Any) -> ResourceConfig:
         "gateway": "WAN_DHCP",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="static_routes", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="routing.static", provider="opnsense", config=config)
 
 
 def _gw(name: str, *, protocol: str = "inet") -> ResourceConfig:
     return ResourceConfig(
         name=name,
-        type="gateways",
+        type="routing.gateways",
         provider="opnsense",
         config={"interface": "wan", "protocol": protocol, "gateway": "192.0.2.1"},
     )
@@ -95,7 +95,7 @@ class TestNetwork:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="static_routes",
+            type="routing.static",
             provider="opnsense",
             config={"gateway": "WAN_DHCP"},
         )
@@ -209,7 +209,7 @@ class TestGateway:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="static_routes",
+            type="routing.static",
             provider="opnsense",
             config={"network": "10.0.0.0/24"},
         )
@@ -451,7 +451,7 @@ class TestEdgeCases:
         # from ``GatewayValidator`` and is skipped here.
         bad_gw = ResourceConfig(
             name="bad-gw",
-            type="gateways",
+            type="routing.gateways",
             provider="opnsense",
             config={"interface": "wan", "protocol": "ipv7", "gateway": "192.0.2.1"},
         )

--- a/tests/unit/providers/opnsense/test_unbound_forward_manager.py
+++ b/tests/unit/providers/opnsense/test_unbound_forward_manager.py
@@ -47,7 +47,7 @@ def _resource(
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="unbound_forward", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="unbound.forwards", provider="opnsense", config=config)
 
 
 def _live(

--- a/tests/unit/providers/opnsense/test_unbound_forward_service.py
+++ b/tests/unit/providers/opnsense/test_unbound_forward_service.py
@@ -106,7 +106,7 @@ def _live(
 
 
 def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
-    return ResourceConfig(name=name, type="unbound_forward", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="unbound.forwards", provider="opnsense", config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -526,7 +526,7 @@ class TestConfigsFromResources:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_forward",
+            type="unbound.forwards",
             provider="opnsense",
             config={"server": "1.1.1.1"},
         )
@@ -536,7 +536,7 @@ class TestConfigsFromResources:
 
     def test_non_unbound_forward_resources_ignored(self) -> None:
         ok = _resource("ok", {"server": "1.1.1.1"})
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = unbound_forward_configs_from_resources([ok, other])
         assert len(result) == 1
         assert result[0].name == "ok"

--- a/tests/unit/providers/opnsense/test_unbound_forward_validator.py
+++ b/tests/unit/providers/opnsense/test_unbound_forward_validator.py
@@ -37,7 +37,7 @@ def _forward(name: str, **overrides: Any) -> ResourceConfig:
         "server": "10.0.0.53",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="unbound_forward", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="unbound.forwards", provider="opnsense", config=config)
 
 
 @pytest.fixture
@@ -109,7 +109,7 @@ class TestDomain:
         # ``domain`` is optional — missing is fine (defaults to empty).
         r = ResourceConfig(
             name="ok",
-            type="unbound_forward",
+            type="unbound.forwards",
             provider="opnsense",
             config={"server": "10.0.0.53"},
         )
@@ -148,7 +148,7 @@ class TestServer:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_forward",
+            type="unbound.forwards",
             provider="opnsense",
             config={"domain": "x"},
         )

--- a/tests/unit/providers/opnsense/test_unbound_host_alias_manager.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_alias_manager.py
@@ -52,7 +52,9 @@ def _resource(
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="unbound_host_alias", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="unbound.host_aliases", provider="opnsense", config=config
+    )
 
 
 def _live(

--- a/tests/unit/providers/opnsense/test_unbound_host_alias_service.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_alias_service.py
@@ -89,7 +89,9 @@ def _live(
 
 
 def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
-    return ResourceConfig(name=name, type="unbound_host_alias", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="unbound.host_aliases", provider="opnsense", config=config
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -532,7 +534,7 @@ class TestConfigsFromResources:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_host_alias",
+            type="unbound.host_aliases",
             provider="opnsense",
             config={"host": "p", "hostname": "h", "domain": "d"},
         )
@@ -543,7 +545,7 @@ class TestConfigsFromResources:
 
     def test_non_unbound_host_alias_resources_ignored(self) -> None:
         ok = _resource("ok", {"host": "p", "hostname": "h", "domain": "d"})
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = unbound_host_alias_configs_from_resources([ok, other])
         assert len(result) == 1
         assert result[0].name == "ok"

--- a/tests/unit/providers/opnsense/test_unbound_host_alias_validator.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_alias_validator.py
@@ -35,7 +35,9 @@ def _alias(name: str, **overrides: Any) -> ResourceConfig:
         "domain": "internal",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="unbound_host_alias", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="unbound.host_aliases", provider="opnsense", config=config
+    )
 
 
 @pytest.fixture
@@ -103,7 +105,7 @@ class TestHostCrossRef:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_host_alias",
+            type="unbound.host_aliases",
             provider="opnsense",
             config={"hostname": "db", "domain": "internal"},
         )
@@ -156,7 +158,7 @@ class TestHostname:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_host_alias",
+            type="unbound.host_aliases",
             provider="opnsense",
             config={"host": "db-primary", "domain": "internal"},
         )
@@ -209,7 +211,7 @@ class TestDomain:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_host_alias",
+            type="unbound.host_aliases",
             provider="opnsense",
             config={"host": "db-primary", "hostname": "db"},
         )

--- a/tests/unit/providers/opnsense/test_unbound_host_override_manager.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_override_manager.py
@@ -64,7 +64,7 @@ def _resource(
     if lock:
         config["lock"] = True
     return ResourceConfig(
-        name=name, type="unbound_host_override", provider="opnsense", config=config
+        name=name, type="unbound.host_overrides", provider="opnsense", config=config
     )
 
 

--- a/tests/unit/providers/opnsense/test_unbound_host_override_service.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_override_service.py
@@ -565,7 +565,7 @@ def _live_for_diff(
 
 def _resource_config(name: str, config: dict[str, Any]) -> ResourceConfig:
     return ResourceConfig(
-        name=name, type="unbound_host_override", provider="opnsense", config=config
+        name=name, type="unbound.host_overrides", provider="opnsense", config=config
     )
 
 
@@ -962,7 +962,7 @@ class TestConfigsFromResources:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_host_override",
+            type="unbound.host_overrides",
             provider="opnsense",
             config={"hostname": "h", "domain": "d"},
         )
@@ -973,7 +973,7 @@ class TestConfigsFromResources:
 
     def test_non_unbound_host_override_resources_ignored(self) -> None:
         ok = _resource_config("ok", {"hostname": "h", "domain": "d"})
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = unbound_host_override_configs_from_resources([ok, other])
         assert len(result) == 1
         assert result[0].name == "ok"

--- a/tests/unit/providers/opnsense/test_unbound_host_override_validator.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_override_validator.py
@@ -43,7 +43,7 @@ def _override(name: str, **overrides: Any) -> ResourceConfig:
     }
     config.update(overrides)
     return ResourceConfig(
-        name=name, type="unbound_host_override", provider="opnsense", config=config
+        name=name, type="unbound.host_overrides", provider="opnsense", config=config
     )
 
 
@@ -79,7 +79,7 @@ class TestHostnameDomain:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_host_override",
+            type="unbound.host_overrides",
             provider="opnsense",
             config={"domain": "example.com"},
         )
@@ -103,7 +103,7 @@ class TestHostnameDomain:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="unbound_host_override",
+            type="unbound.host_overrides",
             provider="opnsense",
             config={"hostname": "web"},
         )

--- a/tests/unit/providers/opnsense/test_unbound_validator.py
+++ b/tests/unit/providers/opnsense/test_unbound_validator.py
@@ -25,7 +25,7 @@ def test_validate_valid_override(validator, report):
     """Test validation of a valid host override with all fields."""
     override = ResourceConfig(
         name="web-server",
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={
             "hostname": "web",
@@ -46,7 +46,7 @@ def test_validate_missing_hostname(validator, report):
     """Test validation fails when hostname is missing."""
     override = ResourceConfig(
         name="bad-override",
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={
             "domain": "example.com",
@@ -72,7 +72,7 @@ def test_validate_missing_domain(validator, report):
     """Test validation fails when domain is missing."""
     override = ResourceConfig(
         name="bad-override",
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={
             "hostname": "web",
@@ -98,7 +98,7 @@ def test_validate_empty_hostname(validator, report):
     """Test validation fails when hostname is empty string."""
     override = ResourceConfig(
         name="bad-override",
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={
             "hostname": "",
@@ -122,7 +122,7 @@ def test_validate_invalid_server_ip(validator, report):
     """Test validation fails when server is not a valid IP address."""
     override = ResourceConfig(
         name="bad-ip",
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={
             "hostname": "web",
@@ -149,7 +149,7 @@ def test_validate_valid_ipv6_server(validator, report):
     """Test validation passes with valid IPv6 server address."""
     override = ResourceConfig(
         name="ipv6-override",
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={
             "hostname": "web",
@@ -174,7 +174,7 @@ def test_validate_no_server_field(validator, report):
     """Test validation passes when server field is not provided (optional)."""
     override = ResourceConfig(
         name="no-server",
-        type="unbound_host_override",
+        type="unbound.host_overrides",
         provider="opnsense",
         config={
             "hostname": "web",
@@ -202,7 +202,7 @@ def test_validate_multiple_resources(validator, report):
     overrides = [
         ResourceConfig(
             name="web",
-            type="unbound_host_override",
+            type="unbound.host_overrides",
             provider="opnsense",
             config={
                 "hostname": "web",
@@ -212,7 +212,7 @@ def test_validate_multiple_resources(validator, report):
         ),
         ResourceConfig(
             name="mail",
-            type="unbound_host_override",
+            type="unbound.host_overrides",
             provider="opnsense",
             config={
                 "hostname": "mail",
@@ -233,7 +233,7 @@ def test_validate_mixed_valid_and_invalid(validator, report):
     overrides = [
         ResourceConfig(
             name="good",
-            type="unbound_host_override",
+            type="unbound.host_overrides",
             provider="opnsense",
             config={
                 "hostname": "web",
@@ -243,7 +243,7 @@ def test_validate_mixed_valid_and_invalid(validator, report):
         ),
         ResourceConfig(
             name="bad",
-            type="unbound_host_override",
+            type="unbound.host_overrides",
             provider="opnsense",
             config={
                 "hostname": "",

--- a/tests/unit/providers/opnsense/test_virtual_ip_manager.py
+++ b/tests/unit/providers/opnsense/test_virtual_ip_manager.py
@@ -59,7 +59,9 @@ def _resource(
         config["lock"] = True
     if extras:
         config.update(extras)
-    return ResourceConfig(name=name, type="virtual_ips", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="interfaces.virtual_ips", provider="opnsense", config=config
+    )
 
 
 def _live(

--- a/tests/unit/providers/opnsense/test_virtual_ip_service.py
+++ b/tests/unit/providers/opnsense/test_virtual_ip_service.py
@@ -118,7 +118,9 @@ def _live(
 
 
 def _resource(name: str, config: dict[str, Any]) -> ResourceConfig:
-    return ResourceConfig(name=name, type="virtual_ips", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="interfaces.virtual_ips", provider="opnsense", config=config
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -534,7 +536,7 @@ class TestParserRejection:
     def test_non_dict_config_rejected(self) -> None:
         r = ResourceConfig(
             name="bad",
-            type="virtual_ips",
+            type="interfaces.virtual_ips",
             provider="opnsense",
             config={"mode": "ipalias", "interface": "lan", "address": "10.0.0.10", "network": "24"},
         )
@@ -562,7 +564,7 @@ class TestParserRejection:
             "ok",
             {"mode": "ipalias", "interface": "lan", "address": "10.0.0.10", "network": "24"},
         )
-        other = ResourceConfig(name="x", type="aliases", provider="opnsense", config={})
+        other = ResourceConfig(name="x", type="firewall.aliases", provider="opnsense", config={})
         result = virtual_ip_configs_from_resources([v, other])
         assert len(result) == 1
         assert result[0].name == "ok"

--- a/tests/unit/providers/opnsense/test_virtual_ip_validator.py
+++ b/tests/unit/providers/opnsense/test_virtual_ip_validator.py
@@ -47,7 +47,9 @@ def _ipalias(name: str, **overrides: Any) -> ResourceConfig:
         "network": "24",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="virtual_ips", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="interfaces.virtual_ips", provider="opnsense", config=config
+    )
 
 
 def _carp(name: str, **overrides: Any) -> ResourceConfig:
@@ -60,7 +62,9 @@ def _carp(name: str, **overrides: Any) -> ResourceConfig:
         "password": "secret://env_secrets/opnsense/carp_passwords/lan_carp_1",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="virtual_ips", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="interfaces.virtual_ips", provider="opnsense", config=config
+    )
 
 
 def _proxyarp(name: str, **overrides: Any) -> ResourceConfig:
@@ -71,7 +75,9 @@ def _proxyarp(name: str, **overrides: Any) -> ResourceConfig:
         "network": "32",
     }
     config.update(overrides)
-    return ResourceConfig(name=name, type="virtual_ips", provider="opnsense", config=config)
+    return ResourceConfig(
+        name=name, type="interfaces.virtual_ips", provider="opnsense", config=config
+    )
 
 
 @pytest.fixture
@@ -140,7 +146,7 @@ class TestMode:
         # Missing mode coerces to default (ipalias) — should not fail.
         r = ResourceConfig(
             name="ok",
-            type="virtual_ips",
+            type="interfaces.virtual_ips",
             provider="opnsense",
             config={
                 "interface": "lan",
@@ -229,7 +235,7 @@ class TestInterface:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="virtual_ips",
+            type="interfaces.virtual_ips",
             provider="opnsense",
             config={
                 "mode": "ipalias",
@@ -292,7 +298,7 @@ class TestAddress:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="virtual_ips",
+            type="interfaces.virtual_ips",
             provider="opnsense",
             config={
                 "mode": "ipalias",
@@ -381,7 +387,7 @@ class TestNetwork:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="virtual_ips",
+            type="interfaces.virtual_ips",
             provider="opnsense",
             config={
                 "mode": "ipalias",
@@ -485,7 +491,7 @@ class TestCarpVhid:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="virtual_ips",
+            type="interfaces.virtual_ips",
             provider="opnsense",
             config={
                 "mode": "carp",
@@ -580,7 +586,7 @@ class TestCarpPassword:
     ) -> None:
         r = ResourceConfig(
             name="bad",
-            type="virtual_ips",
+            type="interfaces.virtual_ips",
             provider="opnsense",
             config={
                 "mode": "carp",

--- a/tests/unit/providers/opnsense/test_vlan_manager.py
+++ b/tests/unit/providers/opnsense/test_vlan_manager.py
@@ -37,7 +37,7 @@ def _resource(name: str, device: str, tag: int, *, lock: bool = False) -> Resour
     }
     if lock:
         config["lock"] = True
-    return ResourceConfig(name=name, type="vlans", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="interfaces.vlans", provider="opnsense", config=config)
 
 
 SERVICE_PATH = "infrafoundry.providers.opnsense.components.vlan.VlanService"

--- a/tests/unit/providers/opnsense/test_vlan_service.py
+++ b/tests/unit/providers/opnsense/test_vlan_service.py
@@ -66,7 +66,7 @@ def _resource(
     }
     if lock is not None:
         config["lock"] = lock
-    return ResourceConfig(name=name, type="vlans", provider="opnsense", config=config)
+    return ResourceConfig(name=name, type="interfaces.vlans", provider="opnsense", config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -292,7 +292,7 @@ class TestVlanConfigsFromResources:
 
     def test_non_vlan_resources_ignored(self) -> None:
         vlan = _resource("v1", "igb0", 100)
-        alias = ResourceConfig(name="a", type="aliases", provider="opnsense", config={})
+        alias = ResourceConfig(name="a", type="firewall.aliases", provider="opnsense", config={})
         result = vlan_configs_from_resources([vlan, alias])
         assert len(result) == 1
         assert result[0].name == "v1"
@@ -300,7 +300,7 @@ class TestVlanConfigsFromResources:
     def test_missing_required_field(self) -> None:
         bad = ResourceConfig(
             name="v1",
-            type="vlans",
+            type="interfaces.vlans",
             provider="opnsense",
             config={"device": "igb0", "tag": 10, "description": "x"},  # priority missing
         )
@@ -325,7 +325,7 @@ class TestVlanConfigsFromResources:
     def test_non_integer_tag(self) -> None:
         bad = ResourceConfig(
             name="v1",
-            type="vlans",
+            type="interfaces.vlans",
             provider="opnsense",
             config={
                 "device": "igb0",
@@ -340,7 +340,7 @@ class TestVlanConfigsFromResources:
     def test_empty_device_rejected(self) -> None:
         bad = ResourceConfig(
             name="v1",
-            type="vlans",
+            type="interfaces.vlans",
             provider="opnsense",
             config={
                 "device": "",
@@ -365,7 +365,7 @@ class TestVlanConfigsFromResources:
     def test_lock_must_be_boolean(self) -> None:
         bad = ResourceConfig(
             name="v1",
-            type="vlans",
+            type="interfaces.vlans",
             provider="opnsense",
             config={
                 "device": "igb0",
@@ -381,7 +381,7 @@ class TestVlanConfigsFromResources:
     def test_description_must_be_string(self) -> None:
         bad = ResourceConfig(
             name="v1",
-            type="vlans",
+            type="interfaces.vlans",
             provider="opnsense",
             config={
                 "device": "igb0",

--- a/tests/unit/providers/opnsense/test_vlan_validator.py
+++ b/tests/unit/providers/opnsense/test_vlan_validator.py
@@ -38,7 +38,7 @@ def _vlan(name: str, **config_overrides) -> ResourceConfig:
         "priority": 0,
     }
     base.update(config_overrides)
-    return ResourceConfig(name=name, type="vlans", provider="opnsense", config=base)
+    return ResourceConfig(name=name, type="interfaces.vlans", provider="opnsense", config=base)
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +81,7 @@ def test_validate_no_device_skipped(validator, report):
     """Absence of ``device`` is not a validator concern (caught by config loader)."""
     vlan = ResourceConfig(
         name="v",
-        type="vlans",
+        type="interfaces.vlans",
         provider="opnsense",
         config={},
     )

--- a/tests/unit/test_aiqum_blueprint.py
+++ b/tests/unit/test_aiqum_blueprint.py
@@ -77,7 +77,7 @@ def test_aiqum_example_renders_vm_and_dhcp_resources(loader: PackageLoader) -> N
     assert vm.name == "aiqum"
 
     dhcp = by_provider["opnsense"]
-    assert dhcp.type == "kea_reservation"
+    assert dhcp.type == "kea.dhcp4.reservations"
     assert dhcp.name == "aiqum"
 
 
@@ -127,7 +127,9 @@ def test_aiqum_example_dhcp_config_uses_merged_values(loader: PackageLoader) -> 
         PACKAGE_DIR, provider="proxmox", env_name="dev"
     )
 
-    dhcp = next(r for r in resources if r.provider == "opnsense" and r.type == "kea_reservation")
+    dhcp = next(
+        r for r in resources if r.provider == "opnsense" and r.type == "kea.dhcp4.reservations"
+    )
     config = dhcp.config
 
     assert config["subnet_ref"] == "my-subnet"
@@ -241,8 +243,8 @@ def test_aiqum_blueprint_supports_multiple_instances(tmp_path: Path) -> None:
     assert vm_b.config["target_node"] == "pve2"
 
     # DHCP reservations also distinct
-    dhcp_a = next(r for r in resources_a if r.type == "kea_reservation")
-    dhcp_b = next(r for r in resources_b if r.type == "kea_reservation")
+    dhcp_a = next(r for r in resources_a if r.type == "kea.dhcp4.reservations")
+    dhcp_b = next(r for r in resources_b if r.type == "kea.dhcp4.reservations")
     assert dhcp_a.name == "aiqum-a"
     assert dhcp_b.name == "aiqum-b"
     assert dhcp_a.config["ip_address"] == "192.168.1.51"

--- a/tests/unit/test_cli_list.py
+++ b/tests/unit/test_cli_list.py
@@ -39,7 +39,7 @@ def sample_resources():
     firewall = Mock()
     firewall.name = "firewall-01"
     firewall.provider = "opnsense"
-    firewall.type = "firewall_rules"
+    firewall.type = "firewall.rules"
 
     return [vm1, vm2, firewall]
 

--- a/tests/unit/test_cli_migrate.py
+++ b/tests/unit/test_cli_migrate.py
@@ -206,7 +206,7 @@ def test_migrate_vlans_via_registry(
                 "--provider",
                 "opnsense",
                 "--component",
-                "vlans",
+                "interfaces.vlans",
                 "--output",
                 str(output_file),
             ],
@@ -407,7 +407,7 @@ def test_migrate_unsupported_component_lists_registered(
         # the error rather than every name to keep the test robust to
         # additional registrations.
         assert "Unsupported component" in result.output
-        assert "vlans" in result.output
+        assert "interfaces.vlans" in result.output
         assert not output_file.exists()
 
 

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -554,7 +554,7 @@ resources:
         assert resources[0].type == "ova_vm"
         assert resources[0].name == "ontap-node-01"
         assert resources[1].provider == "opnsense"
-        assert resources[1].type == "kea_reservation"
+        assert resources[1].type == "kea.dhcp4.reservations"
 
     def test_resource_centric_default_provider(self, temp_dir):
         """Resource-centric items without provider use parent provider."""

--- a/tests/unit/test_provider_templates.py
+++ b/tests/unit/test_provider_templates.py
@@ -395,7 +395,7 @@ class TestOPNsenseTemplates:
         """Create VLAN resource."""
         return ResourceConfig(
             provider="opnsense",
-            type="vlans",
+            type="interfaces.vlans",
             name="vlan-100",
             config={"name": "vlan-100", "tag": 100, "parent": "igb0", "description": "Web VLAN"},
         )
@@ -405,7 +405,7 @@ class TestOPNsenseTemplates:
         """Create alias resource."""
         return ResourceConfig(
             provider="opnsense",
-            type="aliases",
+            type="firewall.aliases",
             name="web-servers",
             config={
                 "name": "web-servers",
@@ -437,7 +437,7 @@ class TestOPNsenseTemplates:
         """
         rule = ResourceConfig(
             provider="opnsense",
-            type="firewall_rules",
+            type="firewall.rules",
             name="allow-web-traffic",
             config={"name": "allow-web-traffic", "action": "pass", "interface": "lan"},
         )
@@ -849,19 +849,19 @@ class TestProviderResourceGrouping:
         resources = [
             ResourceConfig(
                 provider="opnsense",
-                type="firewall_rules",
+                type="firewall.rules",
                 name="rule1",
                 config={"name": "rule1", "action": "pass"},
             ),
             ResourceConfig(
                 provider="opnsense",
-                type="vlans",
+                type="interfaces.vlans",
                 name="vlan1",
                 config={"name": "vlan1", "tag": 100},
             ),
             ResourceConfig(
                 provider="opnsense",
-                type="aliases",
+                type="firewall.aliases",
                 name="alias1",
                 config={"name": "alias1", "type": "host"},
             ),
@@ -982,11 +982,11 @@ class TestProviderDependencies:
         # Firewall rules (direct-API per ADR-0015) depend on aliases, vlans,
         # interface_assignments (for ``interface``), and gateways (for the
         # ``gateway`` policy-routing field).
-        assert "firewall_rules" in deps
-        assert "aliases" in deps["firewall_rules"]
-        assert "vlans" in deps["firewall_rules"]
-        assert "interface_assignments" in deps["firewall_rules"]
-        assert "gateways" in deps["firewall_rules"]
+        assert "firewall.rules" in deps
+        assert "firewall.aliases" in deps["firewall.rules"]
+        assert "interfaces.vlans" in deps["firewall.rules"]
+        assert "interfaces.assignments" in deps["firewall.rules"]
+        assert "routing.gateways" in deps["firewall.rules"]
 
     def test_kubernetes_get_dependencies(self, tmp_path: Path):
         """Test Kubernetes resource dependencies."""

--- a/tests/unit/test_proxmox_k3s_cluster_blueprint.py
+++ b/tests/unit/test_proxmox_k3s_cluster_blueprint.py
@@ -81,7 +81,7 @@ def test_proxmox_k3s_cluster_example_renders_correct_resource_count(
     assert len(resources) == 6
 
     vms = [r for r in resources if r.type == "vm"]
-    dhcps = [r for r in resources if r.type == "kea_reservation"]
+    dhcps = [r for r in resources if r.type == "kea.dhcp4.reservations"]
     assert len(vms) == 3
     assert len(dhcps) == 3
     assert all(r.provider == "proxmox" for r in vms)
@@ -166,7 +166,7 @@ def test_proxmox_k3s_cluster_example_dhcp_configs(loader: PackageLoader) -> None
         PACKAGE_DIR, provider="proxmox", env_name="dev"
     )
 
-    dhcps_by_name = {r.name: r for r in resources if r.type == "kea_reservation"}
+    dhcps_by_name = {r.name: r for r in resources if r.type == "kea.dhcp4.reservations"}
     assert set(dhcps_by_name) == {
         "k3s-dev-server-dhcp",
         "k3s-dev-agent-1-dhcp",
@@ -305,12 +305,12 @@ def test_proxmox_k3s_cluster_blueprint_supports_multiple_instances(tmp_path: Pat
     # A: 1 server + 2 agents = 3 VMs + 3 DHCP reservations = 6
     assert len(resources_a) == 6
     assert sum(1 for r in resources_a if r.type == "vm") == 3
-    assert sum(1 for r in resources_a if r.type == "kea_reservation") == 3
+    assert sum(1 for r in resources_a if r.type == "kea.dhcp4.reservations") == 3
 
     # B: 1 server + 4 agents = 5 VMs + 5 DHCP reservations = 10
     assert len(resources_b) == 10
     assert sum(1 for r in resources_b if r.type == "vm") == 5
-    assert sum(1 for r in resources_b if r.type == "kea_reservation") == 5
+    assert sum(1 for r in resources_b if r.type == "kea.dhcp4.reservations") == 5
 
     # VM names are distinct between instances
     vm_names_a = {r.name for r in resources_a if r.type == "vm"}
@@ -332,7 +332,7 @@ def test_proxmox_k3s_cluster_blueprint_supports_multiple_instances(tmp_path: Pat
     assert vm_b_agent4.config["network"][0]["macaddr"] == "BC:24:11:00:0B:04"
 
     # DHCP reservation names follow the "<vm>-dhcp" template
-    dhcp_names_a = {r.name for r in resources_a if r.type == "kea_reservation"}
+    dhcp_names_a = {r.name for r in resources_a if r.type == "kea.dhcp4.reservations"}
     assert dhcp_names_a == {"k3s-a-server-dhcp", "k3s-a-agent-1-dhcp", "k3s-a-agent-2-dhcp"}
 
     # Events are per-instance: requires field references the correct server_name
@@ -377,7 +377,7 @@ def test_proxmox_k3s_cluster_blueprint_with_zero_agents(tmp_path: Path) -> None:
 
     assert len(resources) == 2
     vms = [r for r in resources if r.type == "vm"]
-    dhcps = [r for r in resources if r.type == "kea_reservation"]
+    dhcps = [r for r in resources if r.type == "kea.dhcp4.reservations"]
     assert len(vms) == 1
     assert len(dhcps) == 1
     assert vms[0].name == "k3s-solo-server"

--- a/tests/unit/test_service_vm_blueprint.py
+++ b/tests/unit/test_service_vm_blueprint.py
@@ -81,7 +81,7 @@ def test_service_vm_renders_vm_and_dhcp_resources(loader: PackageLoader) -> None
     assert vm.name == "infra-web"
 
     dhcp = by_provider["opnsense"]
-    assert dhcp.type == "kea_reservation"
+    assert dhcp.type == "kea.dhcp4.reservations"
     assert dhcp.name == "infra-web"
 
 
@@ -133,7 +133,9 @@ def test_service_vm_dhcp_config_uses_merged_values(loader: PackageLoader) -> Non
         PACKAGE_DIR, provider="proxmox", env_name="dev"
     )
 
-    dhcp = next(r for r in resources if r.provider == "opnsense" and r.type == "kea_reservation")
+    dhcp = next(
+        r for r in resources if r.provider == "opnsense" and r.type == "kea.dhcp4.reservations"
+    )
     config = dhcp.config
 
     assert config["subnet_ref"] == "opt1-infrastructure"
@@ -224,8 +226,8 @@ def test_service_vm_blueprint_supports_multiple_instances(tmp_path: Path) -> Non
     assert vm_b.config["target_node"] == "pve2"
 
     # DHCP reservations also distinct
-    dhcp_a = next(r for r in resources_a if r.type == "kea_reservation")
-    dhcp_b = next(r for r in resources_b if r.type == "kea_reservation")
+    dhcp_a = next(r for r in resources_a if r.type == "kea.dhcp4.reservations")
+    dhcp_b = next(r for r in resources_b if r.type == "kea.dhcp4.reservations")
     assert dhcp_a.name == "svc-a"
     assert dhcp_b.name == "svc-b"
     assert dhcp_a.config["ip_address"] == "192.168.10.71"


### PR DESCRIPTION
## Description

Renames the 15 internal `ResourceConfig.type` strings for direct-OPNsense
resource types from flat underscored names (`firewall_log`, `kea_subnet`,
`tailscale_settings`, etc.) to dotted paths matching the API endpoint
hierarchy (`firewall.log`, `kea.dhcp4.subnets`, `tailscale.settings`, etc.)
per ADR-0016.

Adds a transient `STEM_TO_DOTTED` translation shim in the loader (and the
`provider_centric_loader.py` / `resource_centric_loader.py` modules) so
existing flat-keyed YAML files continue to parse correctly during the
multi-phase rollout. The shim is marked with `TODO: remove in #793 Phase 5
hard cutover` comments.

This is **Phase 1 of 6** in the #793 implementation plan. YAML schema is
**unchanged** in this phase — only internal type strings rename. User's
existing flat YAML files (`aliases.yaml` with `aliases:` top-level key,
etc.) continue to work via the shim.

### Files changed (72 total)

- **Provider dispatch + extractors**:
  `src/infrafoundry/providers/opnsense/__init__.py`
- **Loader shim** (3 files):
  `src/infrafoundry/core/config/{package_loader,provider_centric_loader,resource_centric_loader}.py`
- **Validators + services + components** (15 files): all `r.type == "..."`
  guards updated to dotted strings.
- **Runner**:
  `src/infrafoundry/core/runners/opnsense_direct_runner.py` — filter default
  updated; dispatch logic was already data-driven.
- **Templates**:
  `src/infrafoundry/providers/opnsense/templates/opnsense/outputs.tf.j2` —
  `resources_by_type.get('aliases')` → `resources_by_type.get('firewall.aliases')`.
- **Tests** (52 files): bulk update of `type="..."` literals across manager,
  service, validator tests + blueprint tests.

### Plan deviation

The plan called out `_parse_resources_from_data` (provider-centric stem
path) as the shim site. Implementation extended the shim to ALSO apply in
`_parse_resource_centric` and the separate `provider_centric_loader.py` /
`resource_centric_loader.py` modules — because blueprint YAML files use
resource-centric format with flat `type:` strings, and without applying the
shim there, blueprint-driven configurations would break in this phase.

This deviation is consistent with the plan's spirit ("existing flat YAML
files still parse correctly"). All four shim sites carry identical
`TODO: remove in #793 Phase 5 hard cutover` comments for cleanup tracking.

## Related Issue

Addresses #793.

## Test Plan

- [x] `doit check` green (format, lint, type-check, security, spell-check, test).
- [x] 5362 tests passed, 19 skipped, 0 failed.
- [x] Coverage 85.73% (above 69% gate).
- [x] Sanity grep confirms no stale flat type strings in dispatch/filter/guard logic.
- [x] Blueprint tests still pass (the shim correctly translates flat `type:` in resource-centric YAML).

## Out of Scope (deferred to later phases)

- Loader nested-format support (Phase 2).
- Cross-reference resolver and validator updates (Phase 3).
- `migrate()` method changes to emit nested YAML (Phase 4).
- Removal of the `STEM_TO_DOTTED` shim (Phase 5 hard cutover).
- `endavis-infra/` conversion script (Phase 6, separate repo).

## Stacked PR base

This PR is stacked on top of `refactor/793-adr-nested-schema-convention`
(Phase 0 ADR PR #794). After creation, the base will be retargeted to that
branch via `gh pr edit --base` so the diff shows only Phase 1's changes.
After Phase 0 merges to `main`, GitHub will retarget this PR to `main` and
a rebase may be required.
