### PR TITLE
refactor: add nested-format YAML support to direct-OPNsense loader (#793 Phase 2)

### DIFF
--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -62,6 +62,61 @@ STEM_TO_DOTTED: dict[str, str] = {
     "kea_dhcp6_reservation": "kea.dhcp6.reservations",
 }
 
+# Map of dotted resource-type paths → declared YAML leaf shape under the
+# nested ``opnsense:`` namespace (#793 Phase 2, per ADR-0016).
+#
+# - ``"list"`` paths must appear as YAML sequences (each entry a dict with a
+#   ``name:`` field). Each entry emits one ``ResourceConfig``.
+# - ``"dict"`` paths must appear as YAML mappings. The whole mapping becomes
+#   a single singleton ``ResourceConfig`` with ``name="settings"``.
+#
+# Mismatched shape (e.g. operator typo ``firewall: {rules: {...}}`` instead
+# of ``firewall: {rules: [...]}``) raises a clear error rather than
+# silently round-tripping as a singleton.
+#
+# Currently-implemented list-shape types come from ``STEM_TO_DOTTED.values()``.
+# The remaining entries are documented in ADR-0016 from in-flight issues
+# #786 to #792; they are accepted by the loader now so operator YAML and tests
+# can land alongside each component as it ships, without requiring a loader
+# change for every new component.
+DOTTED_RESOURCE_SHAPES: dict[str, str] = {
+    **dict.fromkeys(STEM_TO_DOTTED.values(), "list"),
+    # Singletons / surfaces from in-flight feature issues (ADR-0016).
+    # #786 firewall_log
+    "firewall.log": "dict",
+    # #787 tailscale (settings singleton + subnets/auth lists)
+    "tailscale.settings": "dict",
+    "tailscale.subnets": "list",
+    "tailscale.auth": "dict",
+    # #788 radvd (singleton; subshape verified at component-land time)
+    "radvd": "dict",
+    # #789 cron jobs (list)
+    "cron.jobs": "list",
+    # #790 acmeclient (settings singleton + lists)
+    "acmeclient.settings": "dict",
+    "acmeclient.accounts": "list",
+    "acmeclient.validations": "list",
+    "acmeclient.certs": "list",
+    "acmeclient.actions": "list",
+    # #791 monit (settings singleton + lists)
+    "monit.settings": "dict",
+    "monit.alerts": "list",
+    "monit.services": "list",
+    "monit.tests": "list",
+    # #792 hostwatch (singleton; subshape verified at component-land time)
+    "hostwatch": "dict",
+}
+
+# Set of dotted resource-type paths recognised under the nested ``opnsense:``
+# namespace. Provided as a separate constant for callers that only need to
+# check membership (e.g. cross-reference resolvers in #793 Phase 3).
+DOTTED_RESOURCE_TYPES: frozenset[str] = frozenset(DOTTED_RESOURCE_SHAPES)
+
+# YAML namespace key that triggers the nested-format parse branch (#793
+# Phase 2). The direct-OPNsense provider is the only consumer; nested format
+# under any other top-level key is not currently supported.
+NESTED_PROVIDER_NAMESPACE: str = "opnsense"
+
 
 class PackageLoader:
     """Loads infrastructure packages from provider subdirectories.
@@ -463,14 +518,26 @@ class PackageLoader:
     ) -> list[ResourceConfig]:
         """Extract ResourceConfig objects from parsed YAML data.
 
-        Supports two formats:
+        Supports three formats:
 
-        1. **Resource-centric** (``resources:`` key): Each item declares its own
+        1. **Nested provider-namespace** (``opnsense:`` top-level key with a
+           dict value): Walk the nested structure under ``opnsense:`` to
+           collect leaves; each leaf's dotted path (e.g. ``firewall.aliases``,
+           ``kea.dhcp4.subnets``) becomes the ``ResourceConfig.type``. Lists
+           emit one resource per entry; dicts emit a single ``settings``
+           singleton. Provider is forced to ``opnsense``. Per ADR-0016
+           (#793 Phase 2).
+
+        2. **Resource-centric** (``resources:`` key): Each item declares its own
            ``provider`` and ``type``. The parent provider is used as fallback.
 
-        2. **Provider-centric** (type-named key like ``ova_vms:``): Resource type
+        3. **Provider-centric** (type-named key like ``ova_vms:``): Resource type
            is derived from the filename stem. Individual items may override
            ``provider`` via an optional ``provider`` field.
+
+        Mixing formats in the same file is rejected — a top-level
+        ``opnsense:`` dict alongside a ``resources:`` list or any flat
+        provider-centric key raises ``InvalidConfigurationError``.
 
         Args:
             data: Parsed YAML data dictionary
@@ -479,11 +546,32 @@ class PackageLoader:
 
         Returns:
             List of ResourceConfig objects
+
+        Raises:
+            InvalidConfigurationError: If the file mixes nested and flat
+                formats, contains an unknown nested path, or has a malformed
+                leaf (neither list nor dict).
         """
         if not data:
             return []
 
-        # Check for resource-centric format first
+        # Nested provider-namespace format (#793 Phase 2). Detect and branch
+        # before either of the flat parse paths so a top-level ``opnsense:``
+        # key always wins. Mixing with other formats is rejected explicitly.
+        nested = data.get(NESTED_PROVIDER_NAMESPACE)
+        if isinstance(nested, dict):
+            extra_keys = [k for k in data if k != NESTED_PROVIDER_NAMESPACE]
+            if extra_keys:
+                raise InvalidConfigurationError(
+                    f"{resource_file}: cannot mix nested '{NESTED_PROVIDER_NAMESPACE}:' "
+                    f"format with other top-level keys (found: {sorted(extra_keys)!r}). "
+                    "Use one format per file."
+                )
+            return self._parse_nested_provider_format(
+                nested, NESTED_PROVIDER_NAMESPACE, resource_file
+            )
+
+        # Check for resource-centric format
         if "resources" in data and isinstance(data["resources"], list):
             return self._parse_resource_centric(data["resources"], resource_file, provider)
 
@@ -521,6 +609,148 @@ class PackageLoader:
             for item in resource_list
             if isinstance(item, dict) and "name" in item
         ]
+
+    def _parse_nested_provider_format(
+        self,
+        namespace_data: dict[str, Any],
+        provider: str,
+        resource_file: str,
+    ) -> list[ResourceConfig]:
+        """Walk a nested ``provider:`` block and emit ``ResourceConfig`` items.
+
+        The block mirrors the OPNsense API path tree
+        (``/api/<plugin>/<surface>/<action>``). Per ADR-0016, the dotted path
+        registered in ``DOTTED_RESOURCE_SHAPES`` declares the expected leaf
+        shape:
+
+        - **List-shape** path (e.g. ``firewall.aliases``) — leaf must be a
+          YAML sequence; each entry must be a dict with a ``name:`` field.
+          Each entry emits one ``ResourceConfig``.
+        - **Dict-shape** path (e.g. ``firewall.log``) — leaf must be a YAML
+          mapping. Emits a single ``ResourceConfig`` with ``name="settings"``
+          and the mapping as ``config``.
+
+        Unknown dotted paths and shape mismatches (operator typo
+        ``firewall: {rules: {...}}`` instead of ``firewall: {rules: [...]}``)
+        produce a clear error naming the path.
+
+        Args:
+            namespace_data: Value of the top-level provider key (e.g. the
+                dict under ``opnsense:`` in the YAML).
+            provider: Provider name that all emitted ``ResourceConfig`` items
+                should carry. For now only ``"opnsense"`` is used by callers.
+            resource_file: Source filename for error messages.
+
+        Returns:
+            List of ``ResourceConfig`` objects with dotted ``type`` paths.
+
+        Raises:
+            InvalidConfigurationError: If a leaf has an unknown dotted path,
+                a shape mismatch, a malformed key, or a list entry without a
+                ``name:`` field.
+        """
+        results: list[ResourceConfig] = []
+        if not namespace_data:
+            return results
+
+        # Walk the tree; ``stack`` holds (current-dotted-path-parts, value).
+        # Empty path-parts means we are at the namespace root and have not
+        # consumed any key yet.
+        stack: list[tuple[tuple[str, ...], Any]] = [((), namespace_data)]
+        while stack:
+            path_parts, value = stack.pop()
+            dotted = ".".join(path_parts)
+
+            if isinstance(value, dict):
+                # Discrimination: if the *current* path is a known resource
+                # type, the dict is its leaf — validate shape and emit.
+                # Otherwise it is an interior node and we recurse.
+                if dotted and dotted in DOTTED_RESOURCE_SHAPES:
+                    expected_shape = DOTTED_RESOURCE_SHAPES[dotted]
+                    if expected_shape != "dict":
+                        raise InvalidConfigurationError(
+                            f"{resource_file}: '{NESTED_PROVIDER_NAMESPACE}.{dotted}' "
+                            f"is declared as a {expected_shape} resource type, "
+                            "got a YAML mapping. Use a YAML sequence "
+                            "('- name: ...' entries) for collections."
+                        )
+                    # Singleton leaf — emit one ResourceConfig with
+                    # name="settings" and the dict as config.
+                    results.append(
+                        ResourceConfig(
+                            name="settings",
+                            type=dotted,
+                            provider=provider,
+                            config=dict(value),
+                        )
+                    )
+                    continue
+                # Interior node — recurse into children.
+                for key, child in value.items():
+                    if not isinstance(key, str):
+                        raise InvalidConfigurationError(
+                            f"{resource_file}: nested key under "
+                            f"'{NESTED_PROVIDER_NAMESPACE}.{dotted or '<root>'}' "
+                            f"must be a string, got {type(key).__name__}: {key!r}"
+                        )
+                    stack.append(((*path_parts, key), child))
+            elif isinstance(value, list):
+                # List leaf — collection of resources. Path must be a known
+                # dotted list-shape resource type.
+                if not dotted:
+                    raise InvalidConfigurationError(
+                        f"{resource_file}: top-level list directly under "
+                        f"'{NESTED_PROVIDER_NAMESPACE}:' is not allowed; "
+                        "lists must live at a known dotted resource path."
+                    )
+                if dotted not in DOTTED_RESOURCE_SHAPES:
+                    raise InvalidConfigurationError(
+                        f"{resource_file}: unknown nested resource path "
+                        f"'{NESTED_PROVIDER_NAMESPACE}.{dotted}'. "
+                        f"Known paths: {sorted(DOTTED_RESOURCE_SHAPES)!r}"
+                    )
+                expected_shape = DOTTED_RESOURCE_SHAPES[dotted]
+                if expected_shape != "list":
+                    raise InvalidConfigurationError(
+                        f"{resource_file}: '{NESTED_PROVIDER_NAMESPACE}.{dotted}' "
+                        f"is declared as a {expected_shape} resource type, "
+                        "got a YAML sequence. Use a YAML mapping "
+                        "(key: value pairs) for singletons."
+                    )
+                for index, item in enumerate(value):
+                    if not isinstance(item, dict):
+                        raise InvalidConfigurationError(
+                            f"{resource_file}: entry {index} under "
+                            f"'{NESTED_PROVIDER_NAMESPACE}.{dotted}' must be a "
+                            f"mapping, got {type(item).__name__}"
+                        )
+                    if "name" not in item:
+                        raise InvalidConfigurationError(
+                            f"{resource_file}: entry {index} under "
+                            f"'{NESTED_PROVIDER_NAMESPACE}.{dotted}' is missing "
+                            "the required 'name:' field"
+                        )
+                    results.append(
+                        ResourceConfig(
+                            name=item["name"],
+                            type=dotted,
+                            provider=item.get("provider", provider),
+                            config=item,
+                            events=item.get("events"),
+                            import_id=item.get("import_id"),
+                        )
+                    )
+            else:
+                # Scalar or other malformed leaf at a position that demands
+                # either a list (collection) or a dict (singleton/interior).
+                raise InvalidConfigurationError(
+                    f"{resource_file}: leaf at "
+                    f"'{NESTED_PROVIDER_NAMESPACE}.{dotted or '<root>'}' must be a "
+                    f"list (collection) or a dict (singleton/interior), got "
+                    f"{type(value).__name__}: {value!r}"
+                )
+
+        return results
 
     def _parse_resource_centric(
         self, resources: list[Any], resource_file: str, default_provider: str

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from infrafoundry.core.config.package_loader import STEM_TO_DOTTED, PackageLoader
+from infrafoundry.core.config.package_loader import (
+    NESTED_PROVIDER_NAMESPACE,
+    STEM_TO_DOTTED,
+    PackageLoader,
+)
+from infrafoundry.core.exceptions import InvalidConfigurationError
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.secrets.provider import SecretProvider
 
@@ -44,6 +49,12 @@ class ProviderCentricLoader:
     ) -> list[ResourceConfig]:
         """Load resource configurations for a provider from a specific file.
 
+        Supports the nested ``opnsense:`` namespace format (#793 Phase 2,
+        per ADR-0016) in addition to the existing flat provider-centric
+        layout. Detection is by top-level key: a dict-valued ``opnsense:``
+        key triggers nested parsing; otherwise the filename-stem path is
+        used.
+
         Args:
             env_name: Environment name
             provider: Provider name (e.g., 'proxmox')
@@ -51,6 +62,10 @@ class ProviderCentricLoader:
 
         Returns:
             List of ResourceConfig objects
+
+        Raises:
+            InvalidConfigurationError: If a nested file mixes formats or
+                contains an unknown nested resource path.
         """
         resource_path = self.base_dir / env_name / provider / f"{resource_file}.yaml"
         if not resource_path.exists():
@@ -61,6 +76,23 @@ class ProviderCentricLoader:
 
         if not data:
             return []
+
+        # Nested provider-namespace format (#793 Phase 2) — branch before
+        # the filename-stem path so a top-level ``opnsense:`` key always
+        # wins, regardless of filename.
+        if isinstance(data, dict):
+            nested = data.get(NESTED_PROVIDER_NAMESPACE)
+            if isinstance(nested, dict):
+                extra_keys = [k for k in data if k != NESTED_PROVIDER_NAMESPACE]
+                if extra_keys:
+                    raise InvalidConfigurationError(
+                        f"{resource_path}: cannot mix nested "
+                        f"'{NESTED_PROVIDER_NAMESPACE}:' format with other top-level "
+                        f"keys (found: {sorted(extra_keys)!r}). Use one format per file."
+                    )
+                return self._package_loader._parse_nested_provider_format(
+                    nested, NESTED_PROVIDER_NAMESPACE, str(resource_path)
+                )
 
         # Extract resource type from filename
         # Supports:

--- a/src/infrafoundry/core/config/resource_centric_loader.py
+++ b/src/infrafoundry/core/config/resource_centric_loader.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import yaml
 
-from infrafoundry.core.config.package_loader import STEM_TO_DOTTED
+from infrafoundry.core.config.package_loader import (
+    NESTED_PROVIDER_NAMESPACE,
+    STEM_TO_DOTTED,
+    PackageLoader,
+)
+from infrafoundry.core.exceptions import InvalidConfigurationError
 from infrafoundry.core.provider import ResourceConfig
 
 
@@ -22,6 +27,10 @@ class ResourceCentricLoader:
             base_dir: Base directory for environment configs (e.g., ./envs)
         """
         self.base_dir = base_dir
+        # Lazily-instantiated helper for the nested-format walk; the loader
+        # delegates to ``PackageLoader._parse_nested_provider_format`` so the
+        # nested-format logic lives in a single module (#793 Phase 2).
+        self._package_loader = PackageLoader(base_dir)
 
     def load_resources(self, env_name: str) -> list[ResourceConfig]:
         """Load resource-centric configuration files.
@@ -36,6 +45,9 @@ class ResourceCentricLoader:
               cores: 4
               memory: 8192
         ```
+
+        Files under the nested ``opnsense:`` namespace (#793 Phase 2, per
+        ADR-0016) are also accepted; detection is by top-level key.
 
         Args:
             env_name: Environment name
@@ -62,11 +74,35 @@ class ResourceCentricLoader:
 
         Returns:
             List of ResourceConfig objects from the file
+
+        Raises:
+            InvalidConfigurationError: If a nested-format file mixes
+                ``opnsense:`` with other top-level keys.
         """
         with open(config_file) as f:
             data = yaml.safe_load(f)
 
-        if not data or "resources" not in data:
+        if not data:
+            return []
+
+        # Nested provider-namespace format (#793 Phase 2) — branch before
+        # the existing ``resources:``-key path so a top-level ``opnsense:``
+        # key always wins.
+        if isinstance(data, dict):
+            nested = data.get(NESTED_PROVIDER_NAMESPACE)
+            if isinstance(nested, dict):
+                extra_keys = [k for k in data if k != NESTED_PROVIDER_NAMESPACE]
+                if extra_keys:
+                    raise InvalidConfigurationError(
+                        f"{config_file}: cannot mix nested "
+                        f"'{NESTED_PROVIDER_NAMESPACE}:' format with other top-level "
+                        f"keys (found: {sorted(extra_keys)!r}). Use one format per file."
+                    )
+                return self._package_loader._parse_nested_provider_format(
+                    nested, NESTED_PROVIDER_NAMESPACE, str(config_file)
+                )
+
+        if "resources" not in data:
             return []
 
         resource_list = data["resources"]

--- a/tests/unit/core/config/__init__.py
+++ b/tests/unit/core/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration loader unit tests."""

--- a/tests/unit/core/config/test_package_loader_nested.py
+++ b/tests/unit/core/config/test_package_loader_nested.py
@@ -1,0 +1,685 @@
+"""Unit tests for the nested ``opnsense:`` provider-namespace YAML format.
+
+Covers ``PackageLoader._parse_nested_provider_format`` and the
+``_parse_resources_from_data`` detection branch added in #793 Phase 2 per
+ADR-0016. The flat (resource-centric / provider-centric) parse paths are
+covered by ``tests/unit/test_package_loader.py`` and remain unchanged in
+this phase.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from infrafoundry.core.config.package_loader import (
+    DOTTED_RESOURCE_SHAPES,
+    DOTTED_RESOURCE_TYPES,
+    NESTED_PROVIDER_NAMESPACE,
+    PackageLoader,
+)
+from infrafoundry.core.config.provider_centric_loader import ProviderCentricLoader
+from infrafoundry.core.config.resource_centric_loader import ResourceCentricLoader
+from infrafoundry.core.exceptions import InvalidConfigurationError
+
+
+@pytest.mark.unit
+class TestNestedFormatConstants:
+    """Sanity checks for the ADR-0016 dotted-path tables."""
+
+    def test_namespace_is_opnsense(self):
+        """Top-level YAML key is ``opnsense:`` per ADR-0016."""
+        assert NESTED_PROVIDER_NAMESPACE == "opnsense"
+
+    def test_dotted_shapes_includes_existing_list_types(self):
+        """All current STEM_TO_DOTTED targets are list-shape paths."""
+        assert DOTTED_RESOURCE_SHAPES["firewall.aliases"] == "list"
+        assert DOTTED_RESOURCE_SHAPES["firewall.rules"] == "list"
+        assert DOTTED_RESOURCE_SHAPES["routing.gateways"] == "list"
+        assert DOTTED_RESOURCE_SHAPES["routing.static"] == "list"
+        assert DOTTED_RESOURCE_SHAPES["interfaces.vlans"] == "list"
+        assert DOTTED_RESOURCE_SHAPES["unbound.host_overrides"] == "list"
+        assert DOTTED_RESOURCE_SHAPES["kea.dhcp4.subnets"] == "list"
+        assert DOTTED_RESOURCE_SHAPES["kea.dhcp6.reservations"] == "list"
+
+    def test_dotted_shapes_includes_documented_singletons(self):
+        """ADR-0016 future singletons are registered as dict-shape."""
+        # #786 firewall_log
+        assert DOTTED_RESOURCE_SHAPES["firewall.log"] == "dict"
+        # #787 tailscale settings
+        assert DOTTED_RESOURCE_SHAPES["tailscale.settings"] == "dict"
+        # #788 radvd
+        assert DOTTED_RESOURCE_SHAPES["radvd"] == "dict"
+
+    def test_dotted_resource_types_matches_shapes(self):
+        """``DOTTED_RESOURCE_TYPES`` mirrors ``DOTTED_RESOURCE_SHAPES`` keys."""
+        assert frozenset(DOTTED_RESOURCE_SHAPES) == DOTTED_RESOURCE_TYPES
+
+
+@pytest.mark.unit
+class TestParseNestedSingleton:
+    """Singleton (dict-leaf) shape — emits one ResourceConfig with name='settings'."""
+
+    def test_firewall_log_singleton_emits_one_settings(self, temp_dir):
+        """``opnsense.firewall.log`` dict leaf becomes a ``settings`` resource."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {
+                    "log": {
+                        "log_default_block": False,
+                        "log_default_pass": False,
+                    }
+                }
+            }
+        }
+        resources = loader._parse_resources_from_data(data, "test.yaml", "opnsense")
+        assert len(resources) == 1
+        assert resources[0].name == "settings"
+        assert resources[0].type == "firewall.log"
+        assert resources[0].provider == "opnsense"
+        assert resources[0].config == {
+            "log_default_block": False,
+            "log_default_pass": False,
+        }
+
+    def test_tailscale_settings_singleton(self, temp_dir):
+        """``opnsense.tailscale.settings`` is a registered singleton."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "tailscale": {
+                    "settings": {"enabled": True, "exit_node": False},
+                }
+            }
+        }
+        resources = loader._parse_resources_from_data(data, "ts.yaml", "opnsense")
+        assert len(resources) == 1
+        assert resources[0].name == "settings"
+        assert resources[0].type == "tailscale.settings"
+        assert resources[0].config == {"enabled": True, "exit_node": False}
+
+    def test_radvd_singleton_at_first_level(self, temp_dir):
+        """``opnsense.radvd`` is a registered single-segment singleton."""
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": {"radvd": {"interfaces": ["lan"], "ra_lifetime": 1800}}}
+        resources = loader._parse_resources_from_data(data, "radvd.yaml", "opnsense")
+        assert len(resources) == 1
+        assert resources[0].name == "settings"
+        assert resources[0].type == "radvd"
+        assert resources[0].config == {"interfaces": ["lan"], "ra_lifetime": 1800}
+
+    def test_singleton_config_is_a_copy(self, temp_dir):
+        """Mutating the emitted ``config`` does not leak into source data."""
+        loader = PackageLoader(temp_dir)
+        original = {"log_default_block": False}
+        data = {"opnsense": {"firewall": {"log": original}}}
+        resources = loader._parse_resources_from_data(data, "test.yaml", "opnsense")
+        resources[0].config["log_default_block"] = True
+        assert original == {"log_default_block": False}
+
+
+@pytest.mark.unit
+class TestParseNestedList:
+    """List (sequence-leaf) shape — emits one ResourceConfig per entry."""
+
+    def test_firewall_aliases_list(self, temp_dir):
+        """``opnsense.firewall.aliases`` list leaf emits one config per entry."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {
+                    "aliases": [
+                        {
+                            "name": "web-servers",
+                            "config": {"type": "host", "content": "10.0.0.1"},
+                        },
+                        {
+                            "name": "db-servers",
+                            "config": {"type": "host", "content": "10.0.0.5"},
+                        },
+                    ]
+                }
+            }
+        }
+        resources = loader._parse_resources_from_data(data, "fw.yaml", "opnsense")
+        assert len(resources) == 2
+        names = {r.name for r in resources}
+        assert names == {"web-servers", "db-servers"}
+        for resource in resources:
+            assert resource.type == "firewall.aliases"
+            assert resource.provider == "opnsense"
+
+    def test_kea_dhcp4_subnets_three_levels_deep(self, temp_dir):
+        """Three-level dotted path (kea.dhcp4.subnets) walks correctly."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "kea": {
+                    "dhcp4": {
+                        "subnets": [
+                            {"name": "lan", "config": {"subnet": "10.0.0.0/24"}},
+                        ]
+                    }
+                }
+            }
+        }
+        resources = loader._parse_resources_from_data(data, "kea.yaml", "opnsense")
+        assert len(resources) == 1
+        assert resources[0].type == "kea.dhcp4.subnets"
+        assert resources[0].name == "lan"
+
+    def test_routing_gateways_list_carries_per_entry_metadata(self, temp_dir):
+        """List entries' ``provider`` / ``import_id`` / ``events`` propagate."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "routing": {
+                    "gateways": [
+                        {
+                            "name": "wan-gw",
+                            "import_id": "GWID_WAN",
+                            "config": {"gateway": "1.2.3.4"},
+                            "events": {
+                                "AFTER_APPLY": [{"type": "webhook", "url": "https://x"}],
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+        resources = loader._parse_resources_from_data(data, "gw.yaml", "opnsense")
+        assert len(resources) == 1
+        gw = resources[0]
+        assert gw.import_id == "GWID_WAN"
+        assert gw.events is not None
+        assert gw.events["AFTER_APPLY"][0]["url"] == "https://x"
+
+    def test_empty_list_emits_nothing(self, temp_dir):
+        """An empty list at a known list-shape path emits zero resources."""
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": {"firewall": {"aliases": []}}}
+        resources = loader._parse_resources_from_data(data, "fw.yaml", "opnsense")
+        assert resources == []
+
+
+@pytest.mark.unit
+class TestParseNestedMixed:
+    """Mixed dict + list shapes coexisting under the same plugin sub-tree."""
+
+    def test_dict_singleton_and_list_collection_under_firewall(self, temp_dir):
+        """``firewall: {log: {...}, aliases: [...], rules: [...]}`` works."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {
+                    "log": {"log_default_block": False},
+                    "aliases": [{"name": "trusted", "config": {"type": "host"}}],
+                    "rules": [{"name": "allow-web", "config": {"interface": "lan"}}],
+                }
+            }
+        }
+        resources = loader._parse_resources_from_data(data, "fw.yaml", "opnsense")
+        types = {r.type for r in resources}
+        assert types == {"firewall.log", "firewall.aliases", "firewall.rules"}
+        # Singleton has name="settings"; list entries keep their own names.
+        log_resource = next(r for r in resources if r.type == "firewall.log")
+        assert log_resource.name == "settings"
+        alias_resource = next(r for r in resources if r.type == "firewall.aliases")
+        assert alias_resource.name == "trusted"
+
+    def test_multi_plugin_under_opnsense(self, temp_dir):
+        """Multiple plugins (firewall, routing, kea, unbound) coexist."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {
+                    "aliases": [{"name": "a1", "config": {}}],
+                },
+                "routing": {
+                    "gateways": [{"name": "g1", "config": {}}],
+                    "static": [{"name": "s1", "config": {}}],
+                },
+                "unbound": {
+                    "host_overrides": [{"name": "h1", "config": {}}],
+                },
+                "kea": {
+                    "dhcp4": {
+                        "subnets": [{"name": "k1", "config": {}}],
+                    }
+                },
+            }
+        }
+        resources = loader._parse_resources_from_data(data, "all.yaml", "opnsense")
+        types = {r.type for r in resources}
+        assert types == {
+            "firewall.aliases",
+            "routing.gateways",
+            "routing.static",
+            "unbound.host_overrides",
+            "kea.dhcp4.subnets",
+        }
+        assert len(resources) == 5
+
+
+@pytest.mark.unit
+class TestParseNestedEmpty:
+    """Empty / missing nested structures."""
+
+    def test_empty_namespace_emits_nothing(self, temp_dir):
+        """``opnsense: {}`` returns an empty list."""
+        loader = PackageLoader(temp_dir)
+        data: dict = {"opnsense": {}}
+        resources = loader._parse_resources_from_data(data, "empty.yaml", "opnsense")
+        assert resources == []
+
+    def test_empty_data_returns_empty_list(self, temp_dir):
+        """Empty data dict returns an empty list (existing behaviour)."""
+        loader = PackageLoader(temp_dir)
+        resources = loader._parse_resources_from_data({}, "empty.yaml", "opnsense")
+        assert resources == []
+
+    def test_namespace_value_none_falls_through_to_flat(self, temp_dir):
+        """``opnsense: null`` does not trigger nested parsing.
+
+        ``null`` is not a dict, so the existing flat-format code path is
+        used. Filename stem ``opnsense`` is not a known type so nothing
+        is emitted (consistent with passing through to the flat branch).
+        """
+        loader = PackageLoader(temp_dir)
+        data: dict = {"opnsense": None}
+        resources = loader._parse_resources_from_data(data, "opnsense.yaml", "opnsense")
+        # Flat path treats opnsense: null as an empty resource list for the
+        # filename-derived stem.
+        assert resources == []
+
+
+@pytest.mark.unit
+class TestParseNestedUnknownPath:
+    """Unknown dotted paths under ``opnsense:`` are rejected."""
+
+    def test_unknown_top_level_plugin_with_list_leaf(self, temp_dir):
+        """``opnsense.bogus.thing: [...]`` raises with the bad path."""
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": {"bogus": {"thing": [{"name": "x"}]}}}
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "bogus.yaml", "opnsense")
+        assert "bogus.thing" in str(excinfo.value)
+        assert "unknown nested resource path" in str(excinfo.value)
+
+    def test_unknown_path_under_known_plugin(self, temp_dir):
+        """``opnsense.firewall.unknown: [...]`` is rejected."""
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": {"firewall": {"unknown": [{"name": "x"}]}}}
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "bad.yaml", "opnsense")
+        assert "firewall.unknown" in str(excinfo.value)
+
+
+@pytest.mark.unit
+class TestParseNestedShapeMismatch:
+    """Shape mismatches (list vs dict) are rejected with a clear error."""
+
+    def test_known_list_path_with_dict_leaf_rejected(self, temp_dir):
+        """``firewall.aliases: {...}`` (dict where list expected) errors."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {"aliases": {"name": "oops", "config": {}}},
+            }
+        }
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "bad.yaml", "opnsense")
+        msg = str(excinfo.value)
+        assert "firewall.aliases" in msg
+        assert "list" in msg
+
+    def test_known_dict_path_with_list_leaf_rejected(self, temp_dir):
+        """``firewall.log: [...]`` (list where dict expected) errors."""
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": {"firewall": {"log": [{"x": 1}]}}}
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "bad.yaml", "opnsense")
+        msg = str(excinfo.value)
+        assert "firewall.log" in msg
+        assert "dict" in msg
+
+
+@pytest.mark.unit
+class TestParseNestedMalformedLeaf:
+    """Scalar / malformed leaves at known paths are rejected."""
+
+    def test_string_leaf_rejected(self, temp_dir):
+        """A string at a leaf raises a clear error."""
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": {"firewall": {"aliases": "not-a-list"}}}
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "bad.yaml", "opnsense")
+        msg = str(excinfo.value)
+        assert "firewall.aliases" in msg
+        assert "str" in msg
+
+    def test_int_leaf_rejected(self, temp_dir):
+        """An int at a leaf raises a clear error."""
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": {"firewall": {"log": 42}}}
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "bad.yaml", "opnsense")
+        msg = str(excinfo.value)
+        assert "firewall.log" in msg
+
+    def test_top_level_list_under_namespace_rejected(self, temp_dir):
+        """A bare list directly under ``opnsense:`` is rejected.
+
+        ``opnsense:`` itself is not a dict in this case, so the nested
+        branch is not entered. The existing flat path treats ``opnsense:``
+        like a top-level list keyed off the filename stem.
+        """
+        loader = PackageLoader(temp_dir)
+        data = {"opnsense": ["a", "b"]}
+        # Not a dict — falls through to flat parsing. Filename stem
+        # 'opnsense' is not a known type, so we look up data['opnsense'],
+        # which is a list of non-dicts; result is an empty list (existing
+        # behaviour for non-dict items).
+        resources = loader._parse_resources_from_data(data, "opnsense.yaml", "opnsense")
+        assert resources == []
+
+
+@pytest.mark.unit
+class TestParseNestedListEntryValidation:
+    """Each list entry must be a dict with a ``name:`` field."""
+
+    def test_missing_name_in_list_entry_raises(self, temp_dir):
+        """List entry without ``name:`` raises a clear error."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {
+                    "aliases": [{"config": {"type": "host"}}],
+                }
+            }
+        }
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "fw.yaml", "opnsense")
+        msg = str(excinfo.value)
+        assert "firewall.aliases" in msg
+        assert "name" in msg
+
+    def test_non_dict_list_entry_raises(self, temp_dir):
+        """List entry that is a scalar raises a clear error."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {"aliases": ["bare-string-not-dict"]},
+            }
+        }
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "fw.yaml", "opnsense")
+        msg = str(excinfo.value)
+        assert "firewall.aliases" in msg
+        assert "str" in msg
+
+    def test_list_entry_index_in_error_message(self, temp_dir):
+        """Error message references the offending list entry index."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {
+                "firewall": {
+                    "aliases": [
+                        {"name": "ok", "config": {}},
+                        {"config": {}},  # missing name at index 1
+                    ]
+                }
+            }
+        }
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "fw.yaml", "opnsense")
+        # Either order of stack pop is fine as long as index 1 is named.
+        assert "1" in str(excinfo.value)
+
+
+@pytest.mark.unit
+class TestNestedFlatAmbiguity:
+    """Mixing nested ``opnsense:`` with other top-level keys is rejected."""
+
+    def test_nested_alongside_flat_aliases_rejected(self, temp_dir):
+        """``opnsense:`` plus a flat top-level key is ambiguous."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {"firewall": {"log": {"log_default_block": False}}},
+            "aliases": [{"name": "x", "config": {}}],
+        }
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "mixed.yaml", "opnsense")
+        msg = str(excinfo.value)
+        assert "cannot mix" in msg
+        assert "aliases" in msg
+
+    def test_nested_alongside_resource_centric_rejected(self, temp_dir):
+        """``opnsense:`` plus ``resources:`` is ambiguous."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "opnsense": {"firewall": {"log": {"log_default_block": False}}},
+            "resources": [{"provider": "opnsense", "type": "x", "name": "y", "config": {}}],
+        }
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_resources_from_data(data, "mixed.yaml", "opnsense")
+        assert "cannot mix" in str(excinfo.value)
+
+
+@pytest.mark.unit
+class TestNestedFormatBackwardsCompat:
+    """Flat-format paths still work after Phase 2 (additive only)."""
+
+    def test_flat_provider_centric_still_works(self, temp_dir):
+        """``aliases.yaml`` with top-level ``aliases:`` still translates."""
+        loader = PackageLoader(temp_dir)
+        data = {"aliases": [{"name": "trusted", "config": {"type": "host"}}]}
+        resources = loader._parse_resources_from_data(data, "aliases.yaml", "opnsense")
+        assert len(resources) == 1
+        assert resources[0].type == "firewall.aliases"  # via STEM_TO_DOTTED
+        assert resources[0].name == "trusted"
+
+    def test_flat_resource_centric_still_works(self, temp_dir):
+        """``resources:`` list format still works (with STEM_TO_DOTTED)."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "resources": [
+                {
+                    "provider": "opnsense",
+                    "type": "kea_subnet",
+                    "name": "lan",
+                    "config": {"subnet": "10.0.0.0/24"},
+                }
+            ]
+        }
+        resources = loader._parse_resources_from_data(data, "rc.yaml", "opnsense")
+        assert len(resources) == 1
+        assert resources[0].type == "kea.dhcp4.subnets"  # via STEM_TO_DOTTED
+        assert resources[0].name == "lan"
+
+    def test_unknown_nested_key_with_dict_value_recurses(self, temp_dir):
+        """Unknown interior dict key recurses without error if no leaves."""
+        loader = PackageLoader(temp_dir)
+        # ``opnsense.foo.bar`` has no list/dict leaf at a known path —
+        # walking finds nothing and returns empty.
+        data: dict = {"opnsense": {"foo": {"bar": {"baz": {}}}}}
+        resources = loader._parse_resources_from_data(data, "x.yaml", "opnsense")
+        assert resources == []
+
+
+@pytest.mark.unit
+class TestNestedFormatProviderCentricLoader:
+    """ProviderCentricLoader recognises the nested format too."""
+
+    def _write_yaml(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def test_provider_centric_loader_parses_nested_singleton(self, temp_dir):
+        """Top-level ``opnsense:`` in a flat-style provider file is parsed."""
+        loader = ProviderCentricLoader(temp_dir)
+        # Filename stem is 'log' but the file is nested-format. The
+        # nested branch should win regardless.
+        self._write_yaml(
+            temp_dir / "dev" / "opnsense" / "log.yaml",
+            "opnsense:\n  firewall:\n    log:\n      log_default_block: false\n",
+        )
+        resources = loader.load_resources("dev", "opnsense", "log")
+        assert len(resources) == 1
+        assert resources[0].type == "firewall.log"
+        assert resources[0].name == "settings"
+        assert resources[0].provider == "opnsense"
+
+    def test_provider_centric_loader_parses_nested_list(self, temp_dir):
+        """Top-level ``opnsense:`` with list leaves works."""
+        loader = ProviderCentricLoader(temp_dir)
+        self._write_yaml(
+            temp_dir / "dev" / "opnsense" / "fw.yaml",
+            (
+                "opnsense:\n"
+                "  firewall:\n"
+                "    aliases:\n"
+                "      - name: a1\n"
+                "        config:\n"
+                "          type: host\n"
+            ),
+        )
+        resources = loader.load_resources("dev", "opnsense", "fw")
+        assert len(resources) == 1
+        assert resources[0].type == "firewall.aliases"
+        assert resources[0].name == "a1"
+
+    def test_provider_centric_loader_rejects_mixed_format(self, temp_dir):
+        """Mixing ``opnsense:`` with other top-level keys raises."""
+        loader = ProviderCentricLoader(temp_dir)
+        self._write_yaml(
+            temp_dir / "dev" / "opnsense" / "fw.yaml",
+            (
+                "opnsense:\n"
+                "  firewall:\n"
+                "    log:\n"
+                "      log_default_block: false\n"
+                "aliases:\n"
+                "  - name: x\n"
+                "    config: {}\n"
+            ),
+        )
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader.load_resources("dev", "opnsense", "fw")
+        assert "cannot mix" in str(excinfo.value)
+
+    def test_provider_centric_loader_flat_still_works(self, temp_dir):
+        """Existing flat YAML still parses through the loader."""
+        loader = ProviderCentricLoader(temp_dir)
+        self._write_yaml(
+            temp_dir / "dev" / "opnsense" / "aliases.yaml",
+            ("aliases:\n  - name: trusted\n    type: host\n    content: 10.0.0.1\n"),
+        )
+        resources = loader.load_resources("dev", "opnsense", "aliases")
+        assert len(resources) == 1
+        assert resources[0].type == "firewall.aliases"
+
+
+@pytest.mark.unit
+class TestNestedFormatResourceCentricLoader:
+    """ResourceCentricLoader recognises the nested format too."""
+
+    def _write_yaml(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def test_resource_centric_loader_parses_nested(self, temp_dir):
+        """A resource-centric file with ``opnsense:`` at the top is nested."""
+        loader = ResourceCentricLoader(temp_dir)
+        self._write_yaml(
+            temp_dir / "dev" / "resources" / "opnsense.yaml",
+            (
+                "opnsense:\n"
+                "  firewall:\n"
+                "    log:\n"
+                "      log_default_block: false\n"
+                "      log_default_pass: true\n"
+            ),
+        )
+        resources = loader.load_resources("dev")
+        assert len(resources) == 1
+        assert resources[0].type == "firewall.log"
+        assert resources[0].name == "settings"
+        assert resources[0].provider == "opnsense"
+        assert resources[0].config == {
+            "log_default_block": False,
+            "log_default_pass": True,
+        }
+
+    def test_resource_centric_loader_rejects_mixed_format(self, temp_dir):
+        """Mixing ``opnsense:`` with ``resources:`` raises."""
+        loader = ResourceCentricLoader(temp_dir)
+        self._write_yaml(
+            temp_dir / "dev" / "resources" / "mixed.yaml",
+            (
+                "opnsense:\n"
+                "  firewall:\n"
+                "    log:\n"
+                "      log_default_block: false\n"
+                "resources:\n"
+                "  - provider: opnsense\n"
+                "    type: kea_subnet\n"
+                "    name: lan\n"
+                "    config:\n"
+                "      subnet: 10.0.0.0/24\n"
+            ),
+        )
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader.load_resources("dev")
+        assert "cannot mix" in str(excinfo.value)
+
+    def test_resource_centric_loader_flat_still_works(self, temp_dir):
+        """Existing resource-centric YAML still parses through the loader."""
+        loader = ResourceCentricLoader(temp_dir)
+        self._write_yaml(
+            temp_dir / "dev" / "resources" / "vms.yaml",
+            (
+                "resources:\n"
+                "  - provider: proxmox\n"
+                "    type: vm\n"
+                "    name: web-01\n"
+                "    config:\n"
+                "      cores: 4\n"
+            ),
+        )
+        resources = loader.load_resources("dev")
+        assert len(resources) == 1
+        assert resources[0].name == "web-01"
+        assert resources[0].provider == "proxmox"
+        assert resources[0].type == "vm"
+
+
+@pytest.mark.unit
+class TestParseNestedDirect:
+    """Direct calls to ``_parse_nested_provider_format`` for edge cases."""
+
+    def test_direct_call_with_empty_namespace(self, temp_dir):
+        """Calling with an empty dict returns an empty list."""
+        loader = PackageLoader(temp_dir)
+        result = loader._parse_nested_provider_format({}, "opnsense", "x.yaml")
+        assert result == []
+
+    def test_direct_call_carries_provider_argument(self, temp_dir):
+        """Provider passed in is reflected in emitted resources."""
+        loader = PackageLoader(temp_dir)
+        result = loader._parse_nested_provider_format(
+            {"firewall": {"log": {"x": 1}}}, "opnsense", "x.yaml"
+        )
+        assert result[0].provider == "opnsense"
+
+    def test_direct_call_non_string_key_rejected(self, temp_dir):
+        """Non-string interior key raises a clear error."""
+        loader = PackageLoader(temp_dir)
+        # Build a dict with an int key — Python allows it; YAML normally
+        # wouldn't, but the loader must defend against it.
+        data: dict = {123: {}}
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            loader._parse_nested_provider_format(data, "opnsense", "x.yaml")
+        assert "must be a string" in str(excinfo.value)


### PR DESCRIPTION
## Description

Adds nested-YAML format support to the direct-OPNsense loader (and the
`provider_centric_loader.py` / `resource_centric_loader.py` variants) so
YAML files using the new `opnsense.<plugin>.<surface>` hierarchy from
ADR-0016 are accepted **alongside** the existing flat formats.

This is **Phase 2 of 6** in the #793 implementation plan. Both formats
(flat AND nested) coexist after this PR. Flat-format parsing continues to
work via the `STEM_TO_DOTTED` shim from Phase 1. The flat path is not
removed until Phase 5.

### How nested detection works

A top-level `opnsense:` dict key triggers nested parsing. The loader walks
the tree, validates each leaf path against the new `DOTTED_RESOURCE_SHAPES`
table, and emits one or more `ResourceConfig` per leaf:

- **Dict leaf at a registered singleton path** (e.g., `opnsense.firewall.log`):
  emits one `ResourceConfig` with `name="settings"` and `type="firewall.log"`.
- **List leaf at a registered list path** (e.g., `opnsense.firewall.aliases`):
  emits one `ResourceConfig` per list entry, type=`firewall.aliases`.
- **Shape mismatch** (list-where-dict-expected, vice versa): clear error.
- **Unknown path**: clear error naming the path.
- **Malformed leaf** (scalar at a leaf, top-level list under namespace): clear error.
- **Mixed nested + flat in one file**: rejected (no silent precedence —
  matches AGENTS.md no-silent-failures stance).

### Pre-registered future singletons / lists

Per ADR-0016's documented future-singleton table, the new
`DOTTED_RESOURCE_SHAPES` table pre-registers the paths from in-flight
feature issues #786-#792:

- `firewall.log` (#786)
- `tailscale.{settings,subnets,auth}` (#787)
- `radvd` (#788)
- `cron.jobs` (#789)
- `acmeclient.{settings,accounts,validations,certs,actions}` (#790)
- `monit.{settings,alerts,services,tests}` (#791)
- `hostwatch` (#792)

This makes the loader forward-compatible — operator YAML and tests for those
component PRs can use nested format without each component PR needing to
update the loader.

### Files changed

- `src/infrafoundry/core/config/package_loader.py` (+225 lines)
- `src/infrafoundry/core/config/provider_centric_loader.py` (+34 lines)
- `src/infrafoundry/core/config/resource_centric_loader.py` (+40 lines)
- `tests/unit/core/config/__init__.py` (new package marker)
- `tests/unit/core/config/test_package_loader_nested.py` (new, 42 tests)

### New constants

- `DOTTED_RESOURCE_SHAPES: dict[str, str]` — source of truth for which
  paths are list-shaped vs. singleton-shaped.
- `DOTTED_RESOURCE_TYPES: frozenset[str]` — derived membership-only mirror
  for cross-reference resolvers (Phase 3 will use this).
- `NESTED_PROVIDER_NAMESPACE: str = "opnsense"` — the top-level key that
  triggers nested parsing.

### Plan deviation

Plan called for `DOTTED_RESOURCE_TYPES: frozenset[str]` for path
validation. Implementation used `DOTTED_RESOURCE_SHAPES: dict[str, str]`
as the primary source (carries shape info needed for ADR-0016 Risk Area #1
operator-typo detection: `firewall: {rules: {...}}` where a list is
expected). `DOTTED_RESOURCE_TYPES` is kept as a derived frozenset for
Phase 3 cross-reference resolvers that don't need shape info.

## Related Issue

Addresses #793.

## Test Plan

- [x] `doit check` green (format, lint, type-check, security, spell-check, test).
- [x] 42 new unit tests in `test_package_loader_nested.py` all pass.
- [x] Existing 5,362+ tests untouched and green; total now 5,423 (+42 new + others).
- [x] 122/122 existing config/loader tests pass (no regressions).
- [x] Coverage maintained ≥69%.

## Out of Scope (deferred to later phases)

- Cross-reference resolver and validator updates (Phase 3).
- `migrate()` method changes to emit nested YAML (Phase 4).
- Removal of flat-format parsing and `STEM_TO_DOTTED` shim (Phase 5 hard cutover).
- `endavis-infra/` conversion script (Phase 6, separate repo).
- Component implementations for #786-#792 features.

## Stacked PR base

This PR is stacked on top of `refactor/793-rename-types-dispatch` (Phase 1
PR #795), which is stacked on `refactor/793-adr-nested-schema-convention`
(Phase 0 PR #794). After the upstream PRs merge to `main`, GitHub will
retarget this PR; a rebase will be required to drop the squash-merged
commits.
