### PR TITLE
refactor: add dotted-path cross-reference resolver for OPNsense validators (#793 Phase 3)

### DIFF
--- a/src/infrafoundry/providers/opnsense/validator.py
+++ b/src/infrafoundry/providers/opnsense/validator.py
@@ -27,6 +27,7 @@ from infrafoundry.providers.opnsense.validators import (
     UnboundValidator,
     VirtualIPValidator,
     VLANValidator,
+    build_xref_index,
 )
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -183,6 +184,13 @@ class OPNsenseValidator:
         # Collect resources by type
         resource_refs = self._collect_resource_references(resources)
 
+        # Build the dotted-type cross-reference index once (#793). The
+        # nested-dict shape gives O(1) lookup per resolver call inside
+        # each per-resource validator. Validators that haven't adopted
+        # the resolver yet ignore this argument; that's fine — the
+        # parameter is optional and additive.
+        xref_index = build_xref_index(resources)
+
         # Validate against live API
         try:
             # Get existing aliases from OPNsense
@@ -209,6 +217,7 @@ class OPNsenseValidator:
                 existing_aliases,
                 existing_gateways,
                 managed_gateways=resource_refs["gateways"],
+                index=xref_index,
             )
             self.vlan_validator.validate(
                 resource_refs["vlans"],
@@ -225,6 +234,7 @@ class OPNsenseValidator:
                 resource_refs["interface_assignment_names"],
                 existing_interfaces,
                 existing_aliases,
+                index=xref_index,
             )
             self.gateway_validator.validate(
                 resource_refs["gateways"],
@@ -236,17 +246,20 @@ class OPNsenseValidator:
                 resource_refs["gateways"],
                 resource_refs["gateway_names"],
                 existing_gateways,
+                index=xref_index,
             )
             self.virtual_ip_validator.validate(
                 resource_refs["virtual_ips"],
                 resource_refs["interface_assignment_names"],
                 existing_interfaces,
+                index=xref_index,
             )
             self.unbound_validator.validate(resource_refs["unbound_host_overrides"])
             self.unbound_host_alias_validator.validate(
                 resource_refs["unbound_host_aliases"],
                 resource_refs["unbound_host_override_names"],
                 existing_unbound_host_overrides,
+                index=xref_index,
             )
             self.unbound_forward_validator.validate(resource_refs["unbound_forwards"])
             self.resource_name_validator.validate(resources)

--- a/src/infrafoundry/providers/opnsense/validators/__init__.py
+++ b/src/infrafoundry/providers/opnsense/validators/__init__.py
@@ -1,5 +1,10 @@
 """Specialized validators for OPNsense resources."""
 
+from infrafoundry.providers.opnsense.validators._xref import (
+    XRefIndex,
+    build_xref_index,
+    resolve_xref,
+)
 from infrafoundry.providers.opnsense.validators.alias_validator import AliasValidator
 from infrafoundry.providers.opnsense.validators.firewall_rule_validator import (
     FirewallRuleValidator,
@@ -42,4 +47,7 @@ __all__ = [
     "UnboundValidator",
     "VLANValidator",
     "VirtualIPValidator",
+    "XRefIndex",
+    "build_xref_index",
+    "resolve_xref",
 ]

--- a/src/infrafoundry/providers/opnsense/validators/_xref.py
+++ b/src/infrafoundry/providers/opnsense/validators/_xref.py
@@ -1,0 +1,153 @@
+"""Shared dotted-path cross-reference resolver for OPNsense validators (#793).
+
+Provides a single resolver used by every validator that has cross-resource
+fields (gateway lookups, alias targets, host-override targets, future
+acmeclient cert→account refs, etc.). Centralising the logic here keeps
+the per-validator code focused on field-shape checks and avoids
+duplicating the dotted-path parsing across each validator.
+
+Cross-reference syntax (per ADR-0016):
+
+- ``<name>`` — bare name, relative within the validator's expected type.
+  Today's flat schema uses this form exclusively (e.g. ``gateway:
+  WAN_GW`` references ``routing.gateways`` by bare name); behaviour is
+  unchanged.
+- ``<sub>.<name>`` — in-plugin relative. Resolves within the current
+  plugin context (e.g. ``account: accounts.letsencrypt-prod`` from a
+  resource declared under ``acmeclient`` resolves to type
+  ``acmeclient.accounts``, name ``letsencrypt-prod``).
+- ``<plugin>.<sub>.<name>`` (or deeper) — cross-plugin absolute.
+  Fully qualified path including the target plugin (e.g.
+  ``update_cron: cron.jobs.acmeclient-auto-renew``). Used when the
+  reference crosses plugin boundaries.
+
+The resolver is intentionally non-strict on the target's existence —
+it returns ``None`` on a miss and lets the caller decide error
+severity (``ERROR`` for managed-only refs, ``WARNING`` plus a
+managed-or-live fallback for the OPNsense pattern of accepting either
+a YAML resource name or a live API row).
+
+Malformed values (empty string, leading/trailing dots, multiple
+consecutive dots) raise ``ValueError`` because they indicate a
+programming error or grossly malformed YAML — those are surfaced by
+the loader / per-field type checks, not by the cross-reference layer.
+"""
+
+from __future__ import annotations
+
+from infrafoundry.core.provider import ResourceConfig
+
+# Public alias for the index shape used throughout this module. The
+# nested-dict shape (``{dotted_type: {resource_name: ResourceConfig}}``)
+# gives O(1) lookup per resolver call; building it once at the start of
+# validation keeps the per-resource validators cheap.
+XRefIndex = dict[str, dict[str, ResourceConfig]]
+
+
+def build_xref_index(resources: list[ResourceConfig]) -> XRefIndex:
+    """Build a dotted-type index of resources for cross-reference lookup.
+
+    Walks the resource list once, grouping by ``resource.type`` and
+    keying the inner dict by ``resource.name``. Used by
+    ``OPNsenseValidator.validate()`` (called once at validation start)
+    to feed each per-resource validator.
+
+    Args:
+        resources: All resources in the current environment (already
+            loaded from YAML by ``package_loader``).
+
+    Returns:
+        Nested dict: ``{dotted_type: {resource_name: ResourceConfig}}``.
+        Empty if ``resources`` is empty. Resources sharing the same
+        ``(type, name)`` collide silently — uniqueness is enforced by
+        ``ResourceNameValidator``, not here.
+    """
+    index: XRefIndex = {}
+    for resource in resources:
+        index.setdefault(resource.type, {})[resource.name] = resource
+    return index
+
+
+def resolve_xref(
+    value: str,
+    expected_type: str,
+    index: XRefIndex,
+    current_plugin: str | None = None,
+) -> ResourceConfig | None:
+    """Resolve a cross-reference value against the dotted-type index.
+
+    Accepts the three forms described in this module's docstring (bare
+    name, in-plugin relative, cross-plugin absolute) and returns the
+    matched ``ResourceConfig`` or ``None`` if no resource matches the
+    parsed ``(type, name)`` tuple.
+
+    Args:
+        value: The cross-reference value as written in YAML
+            (e.g. ``"WAN_GW"``, ``"accounts.letsencrypt-prod"``,
+            ``"cron.jobs.acmeclient-auto-renew"``).
+        expected_type: The dotted type the validator expects when the
+            value is a bare name (e.g. ``"routing.gateways"``,
+            ``"firewall.aliases"``). Ignored when ``value`` carries a
+            dot-qualified path.
+        index: The dotted-type index built by ``build_xref_index``.
+        current_plugin: The plugin name to use when resolving the
+            in-plugin relative form (e.g. ``"acmeclient"``). Required
+            for the single-dot form; ignored for bare names and fully
+            qualified paths. ``None`` means in-plugin relative refs are
+            unresolvable (the caller is responsible for surfacing that
+            as an error if the value contains a dot).
+
+    Returns:
+        The matched ``ResourceConfig`` or ``None`` on miss.
+
+    Raises:
+        ValueError: If ``value`` is empty, has leading/trailing dots,
+            or contains consecutive dots — those indicate either a
+            programming error or grossly malformed YAML the loader
+            should have rejected. Single-dot values without a
+            ``current_plugin`` are *not* rejected here (they parse
+            cleanly but resolve to ``None``); the caller can surface a
+            clearer error in that case.
+    """
+    if not value:
+        raise ValueError("cross-reference value must be non-empty")
+    if value.startswith(".") or value.endswith("."):
+        raise ValueError(f"cross-reference value {value!r} must not start or end with a '.'")
+    if ".." in value:
+        raise ValueError(f"cross-reference value {value!r} must not contain consecutive dots")
+
+    parts = value.split(".")
+
+    if len(parts) == 1:
+        # Bare name — look up in the validator's expected type.
+        return _lookup(index, expected_type, parts[0])
+
+    if len(parts) == 2:
+        # In-plugin relative form: ``<sub>.<name>``. Without a current
+        # plugin we can't resolve — return None and let the caller fall
+        # back to bare-name lookup or surface an error.
+        if current_plugin is None:
+            return None
+        sub, name = parts
+        full_type = f"{current_plugin}.{sub}"
+        return _lookup(index, full_type, name)
+
+    # Cross-plugin absolute form: ``<plugin>.<sub>...<name>``. The last
+    # segment is the resource name; everything before it composes the
+    # dotted type. This naturally supports deeper nesting like
+    # ``kea.dhcp4.subnets.<name>`` (type ``kea.dhcp4.subnets``).
+    name = parts[-1]
+    full_type = ".".join(parts[:-1])
+    return _lookup(index, full_type, name)
+
+
+def _lookup(index: XRefIndex, dotted_type: str, name: str) -> ResourceConfig | None:
+    """Return ``index[dotted_type][name]`` or ``None`` on miss.
+
+    Pulled out so the three resolution branches share one lookup path
+    and the per-branch logic stays focused on parsing.
+    """
+    type_bucket = index.get(dotted_type)
+    if type_bucket is None:
+        return None
+    return type_bucket.get(name)

--- a/src/infrafoundry/providers/opnsense/validators/firewall_rule_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/firewall_rule_validator.py
@@ -42,6 +42,7 @@ from typing import Any
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.opnsense.validators._xref import XRefIndex, resolve_xref
 
 from ..services.firewall_rule import (
     ACTION_CHOICES,
@@ -51,6 +52,13 @@ from ..services.firewall_rule import (
     STATETYPE_CHOICES,
     encode_identity,
 )
+
+# Dotted types referenced by the firewall-rule cross-reference fields.
+# Pulled out as constants so the bare-name fallback and the resolver
+# call agree on the target type.
+_MANAGED_ALIAS_TYPE = "firewall.aliases"
+_MANAGED_GATEWAY_TYPE = "routing.gateways"
+_MANAGED_INTERFACE_TYPE = "interfaces.assignments"
 
 # OPNsense built-in net keywords commonly accepted in firewall rules.
 # Conservative — unknown values surface as warnings (not errors) so a
@@ -97,6 +105,7 @@ class FirewallRuleValidator:
         existing_aliases: dict[str, Any],
         existing_gateways: set[str],
         managed_gateways: list[ResourceConfig] | None = None,
+        index: XRefIndex | None = None,
     ) -> None:
         """Validate firewall-rule resources.
 
@@ -113,6 +122,11 @@ class FirewallRuleValidator:
             managed_gateways: ``gateways`` ``ResourceConfig`` entries —
                 used to resolve the gateway's IP protocol for the
                 protocol-match check.
+            index: Optional dotted-type cross-reference index (#793).
+                When provided, alias / interface / gateway fields
+                accept dotted-path forms in addition to bare names.
+                ``None`` falls back to bare-name lookup only,
+                preserving the pre-#793 behaviour.
         """
         gateway_protocols = _index_managed_gateway_protocols(managed_gateways or [])
         for rule in firewall_rules:
@@ -125,6 +139,7 @@ class FirewallRuleValidator:
                 existing_aliases=existing_aliases,
                 existing_gateways=existing_gateways,
                 gateway_protocols=gateway_protocols,
+                index=index,
             )
 
     def _validate_one(
@@ -138,6 +153,7 @@ class FirewallRuleValidator:
         existing_aliases: dict[str, Any],
         existing_gateways: set[str],
         gateway_protocols: dict[str, str],
+        index: XRefIndex | None,
     ) -> None:
         """Run all checks for a single firewall-rule entry."""
         self._validate_description(rule)
@@ -163,6 +179,7 @@ class FirewallRuleValidator:
             rule,
             interface_assignment_names=interface_assignment_names,
             existing_interfaces=existing_interfaces,
+            index=index,
         )
         self._validate_gateway(
             rule,
@@ -170,18 +187,21 @@ class FirewallRuleValidator:
             existing_gateways=existing_gateways,
             gateway_protocols=gateway_protocols,
             ipprotocol=ipprotocol,
+            index=index,
         )
         self._validate_net_field(
             rule,
             "source_net",
             alias_names=alias_names,
             existing_aliases=existing_aliases,
+            index=index,
         )
         self._validate_net_field(
             rule,
             "destination_net",
             alias_names=alias_names,
             existing_aliases=existing_aliases,
+            index=index,
         )
         self._validate_tcpflags_mutex(rule)
         self._validate_int_field(rule, "max")
@@ -412,6 +432,7 @@ class FirewallRuleValidator:
         *,
         interface_assignment_names: set[str],
         existing_interfaces: dict[str, Any],
+        index: XRefIndex | None,
     ) -> None:
         interface = rule.config.get("interface", "")
         state_policy = rule.config.get("state_policy", "")
@@ -440,11 +461,29 @@ class FirewallRuleValidator:
                 level=ValidationLevel.ERROR,
             )
             return
-        if interface in interface_assignment_names or interface in existing_interfaces:
+
+        # Dotted-form resolution (#793). On a hit, fall through to the
+        # bare-name check using the resolved name so live-interface
+        # lookups still work. ``current_plugin`` is the first segment
+        # of the referencing rule's type (e.g. ``firewall`` for
+        # ``firewall.rules``).
+        bare_name = interface
+        if index is not None and "." in interface:
+            current_plugin = rule.type.split(".", 1)[0] if "." in rule.type else None
+            resolved = resolve_xref(
+                interface,
+                expected_type=_MANAGED_INTERFACE_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                bare_name = resolved.name
+
+        if bare_name in interface_assignment_names or bare_name in existing_interfaces:
             self.report.add_check(
                 check_name=f"firewall_rule_{rule.name}_interface",
                 passed=True,
-                message=(f"Interface '{interface}' resolved for firewall_rule '{rule.name}'"),
+                message=(f"Interface '{bare_name}' resolved for firewall_rule '{rule.name}'"),
                 level=ValidationLevel.INFO,
             )
             return
@@ -471,6 +510,7 @@ class FirewallRuleValidator:
         existing_gateways: set[str],
         gateway_protocols: dict[str, str],
         ipprotocol: str | None,
+        index: XRefIndex | None,
     ) -> None:
         gateway = rule.config.get("gateway", "")
         if not gateway:
@@ -486,7 +526,25 @@ class FirewallRuleValidator:
                 level=ValidationLevel.ERROR,
             )
             return
-        if gateway not in gateway_names and gateway not in existing_gateways:
+
+        # Dotted-form resolution (#793). On a hit fall through to the
+        # bare-name flow with the resolved canonical name so the
+        # protocol-match heuristic keys off the bare gateway name.
+        # ``current_plugin`` is the first segment of the referencing
+        # rule's type.
+        bare_name = gateway
+        if index is not None and "." in gateway:
+            current_plugin = rule.type.split(".", 1)[0] if "." in rule.type else None
+            resolved = resolve_xref(
+                gateway,
+                expected_type=_MANAGED_GATEWAY_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                bare_name = resolved.name
+
+        if bare_name not in gateway_names and bare_name not in existing_gateways:
             self.report.add_check(
                 check_name=f"firewall_rule_{rule.name}_gateway",
                 passed=False,
@@ -502,15 +560,15 @@ class FirewallRuleValidator:
         # — the live-gateway heuristic (trailing-6) is best-effort.
         if ipprotocol in (None, "inet46"):
             return
-        gateway_protocol = gateway_protocols.get(gateway)
+        gateway_protocol = gateway_protocols.get(bare_name)
         if gateway_protocol is None:
-            gateway_protocol = "inet6" if gateway.endswith("6") else "inet"
+            gateway_protocol = "inet6" if bare_name.endswith("6") else "inet"
         if gateway_protocol != ipprotocol:
             self.report.add_check(
                 check_name=f"firewall_rule_{rule.name}_gateway_protocol",
                 passed=False,
                 message=(
-                    f"firewall_rule '{rule.name}' gateway '{gateway}' protocol "
+                    f"firewall_rule '{rule.name}' gateway '{bare_name}' protocol "
                     f"({gateway_protocol!r}) does not match rule ipprotocol "
                     f"({ipprotocol!r})"
                 ),
@@ -528,6 +586,7 @@ class FirewallRuleValidator:
         *,
         alias_names: set[str],
         existing_aliases: dict[str, Any],
+        index: XRefIndex | None,
     ) -> None:
         if field_name not in rule.config:
             return
@@ -546,11 +605,33 @@ class FirewallRuleValidator:
         if value == "":
             # Empty defaults to ``"any"`` in the parser; not a problem.
             return
-        if value in _NET_KEYWORDS or value in alias_names or value in existing_aliases:
+
+        # Dotted-form alias resolution (#793). On a hit, treat as alias
+        # match. The resolved canonical name is checked against
+        # ``alias_names`` for parity with the bare-name flow.
+        # ``current_plugin`` is the first segment of the referencing
+        # rule's type.
+        bare_value = value
+        if index is not None and "." in value:
+            current_plugin = rule.type.split(".", 1)[0] if "." in rule.type else None
+            resolved = resolve_xref(
+                value,
+                expected_type=_MANAGED_ALIAS_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                bare_value = resolved.name
+
+        if (
+            bare_value in _NET_KEYWORDS
+            or bare_value in alias_names
+            or bare_value in existing_aliases
+        ):
             return
-        if _looks_like_iface_sentinel(value):
+        if _looks_like_iface_sentinel(bare_value):
             return
-        if _looks_like_ip_or_cidr(value):
+        if _looks_like_ip_or_cidr(bare_value):
             return
         self.report.add_check(
             check_name=f"firewall_rule_{rule.name}_{field_name}",

--- a/src/infrafoundry/providers/opnsense/validators/nat_rule_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/nat_rule_validator.py
@@ -39,6 +39,13 @@ from typing import Any
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.opnsense.validators._xref import XRefIndex, resolve_xref
+
+# Dotted types referenced by NAT-rule cross-reference fields. Pulled
+# out as constants so the bare-name fallback and the resolver call
+# agree on the target type.
+_MANAGED_ALIAS_TYPE = "firewall.aliases"
+_MANAGED_INTERFACE_TYPE = "interfaces.assignments"
 
 # OPNsense built-in net/target keywords commonly accepted in NAT rules. The
 # set is intentionally conservative — unknown values surface as warnings
@@ -78,6 +85,7 @@ class NATRuleValidator:
         interface_assignment_names: set[str],
         existing_interfaces: dict[str, Any],
         existing_aliases: dict[str, Any],
+        index: XRefIndex | None = None,
     ) -> None:
         """Validate NAT-rule resources.
 
@@ -90,6 +98,10 @@ class NATRuleValidator:
                 ``OPNsenseValidator._get_existing_interfaces``.
             existing_aliases: Live alias map from
                 ``OPNsenseValidator._get_existing_aliases``.
+            index: Optional dotted-type cross-reference index (#793).
+                When provided, alias / interface fields accept dotted-
+                path forms in addition to bare names. ``None`` falls
+                back to bare-name lookup only.
         """
         for rule in nat_rules:
             self._validate_one(
@@ -98,6 +110,7 @@ class NATRuleValidator:
                 interface_assignment_names=interface_assignment_names,
                 existing_interfaces=existing_interfaces,
                 existing_aliases=existing_aliases,
+                index=index,
             )
 
     def _validate_one(
@@ -108,6 +121,7 @@ class NATRuleValidator:
         interface_assignment_names: set[str],
         existing_interfaces: dict[str, Any],
         existing_aliases: dict[str, Any],
+        index: XRefIndex | None,
     ) -> None:
         """Run all checks for a single NAT-rule entry."""
         kind = self._validate_kind(rule)
@@ -120,6 +134,7 @@ class NATRuleValidator:
             rule,
             interface_assignment_names=interface_assignment_names,
             existing_interfaces=existing_interfaces,
+            index=index,
         )
         if kind == "outbound":
             self._validate_outbound_required(rule)
@@ -128,18 +143,21 @@ class NATRuleValidator:
                 "source_net",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
             self._validate_net_field(
                 rule,
                 "destination_net",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
             self._validate_net_field(
                 rule,
                 "target",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
         elif kind == "one_to_one":
             self._validate_one_to_one_required(rule)
@@ -148,12 +166,14 @@ class NATRuleValidator:
                 "source_net",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
             self._validate_net_field(
                 rule,
                 "destination_net",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
             self._validate_one_to_one_type(rule)
             self._validate_natreflection(rule, kind="one_to_one")
@@ -164,18 +184,21 @@ class NATRuleValidator:
                 "source_net",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
             self._validate_net_field(
                 rule,
                 "destination_net",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
             self._validate_net_field(
                 rule,
                 "target",
                 alias_names=alias_names,
                 existing_aliases=existing_aliases,
+                index=index,
             )
             self._validate_pass_action(rule)
             self._validate_poolopts(rule)
@@ -300,6 +323,7 @@ class NATRuleValidator:
         *,
         interface_assignment_names: set[str],
         existing_interfaces: dict[str, Any],
+        index: XRefIndex | None,
     ) -> None:
         interface = rule.config.get("interface")
         if interface is None:
@@ -313,11 +337,28 @@ class NATRuleValidator:
                 level=ValidationLevel.ERROR,
             )
             return
-        if interface in interface_assignment_names or interface in existing_interfaces:
+
+        # Dotted-form resolution (#793). On a hit, fall through to the
+        # bare-name flow with the resolved canonical name so live-
+        # interface lookups still work consistently. ``current_plugin``
+        # is the first segment of the referencing rule's type.
+        bare_name = interface
+        if index is not None and "." in interface:
+            current_plugin = rule.type.split(".", 1)[0] if "." in rule.type else None
+            resolved = resolve_xref(
+                interface,
+                expected_type=_MANAGED_INTERFACE_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                bare_name = resolved.name
+
+        if bare_name in interface_assignment_names or bare_name in existing_interfaces:
             self.report.add_check(
                 check_name=f"nat_rule_{rule.name}_interface",
                 passed=True,
-                message=(f"Interface '{interface}' resolved for nat_rule '{rule.name}'"),
+                message=(f"Interface '{bare_name}' resolved for nat_rule '{rule.name}'"),
                 level=ValidationLevel.INFO,
             )
             return
@@ -342,6 +383,7 @@ class NATRuleValidator:
         *,
         alias_names: set[str],
         existing_aliases: dict[str, Any],
+        index: XRefIndex | None,
     ) -> None:
         if field_name not in rule.config:
             return
@@ -361,9 +403,31 @@ class NATRuleValidator:
             # Empty is allowed for optional fields; the per-kind required
             # check elsewhere catches mandatory fields with no value.
             return
-        if value in _NET_KEYWORDS or value in alias_names or value in existing_aliases:
+
+        # Dotted-form alias resolution (#793). On a hit, treat as alias
+        # match. The resolved canonical name is checked against
+        # ``alias_names`` for parity with the bare-name flow.
+        # ``current_plugin`` is the first segment of the referencing
+        # rule's type.
+        bare_value = value
+        if index is not None and "." in value:
+            current_plugin = rule.type.split(".", 1)[0] if "." in rule.type else None
+            resolved = resolve_xref(
+                value,
+                expected_type=_MANAGED_ALIAS_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                bare_value = resolved.name
+
+        if (
+            bare_value in _NET_KEYWORDS
+            or bare_value in alias_names
+            or bare_value in existing_aliases
+        ):
             return
-        if _looks_like_ip_or_cidr(value):
+        if _looks_like_ip_or_cidr(bare_value):
             return
         # Soft warning — new OPNsense versions may add keywords; don't
         # block a plan on an unknown one.

--- a/src/infrafoundry/providers/opnsense/validators/static_route_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/static_route_validator.py
@@ -29,6 +29,12 @@ import ipaddress
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.opnsense.validators._xref import XRefIndex, resolve_xref
+
+# All xref lookups for the opnsense provider use this dotted type for
+# managed gateways. Pulled out as a constant so the bare-name fallback
+# and the resolver call agree on the target type.
+_MANAGED_GATEWAY_TYPE = "routing.gateways"
 
 
 class StaticRouteValidator:
@@ -48,6 +54,7 @@ class StaticRouteValidator:
         managed_gateways: list[ResourceConfig],
         gateway_names: set[str],
         existing_gateways: set[str],
+        index: XRefIndex | None = None,
     ) -> None:
         """Validate static-route resources.
 
@@ -59,6 +66,12 @@ class StaticRouteValidator:
             gateway_names: Set of managed gateway names declared in YAML.
             existing_gateways: Set of live gateway names returned by
                 OPNsense's ``searchGateway`` (managed + dynamic).
+            index: Optional dotted-type cross-reference index (#793).
+                When provided, the gateway field accepts dotted-path
+                forms like ``routing.gateways.WAN_GW`` in addition to
+                bare names. ``None`` falls back to bare-name lookup
+                only — preserving the pre-#793 behaviour for callers
+                that haven't adopted the new resolver yet.
         """
         gateway_protocols = _index_managed_gateway_protocols(managed_gateways)
         for route in static_routes:
@@ -67,6 +80,7 @@ class StaticRouteValidator:
                 gateway_names=gateway_names,
                 existing_gateways=existing_gateways,
                 gateway_protocols=gateway_protocols,
+                index=index,
             )
 
     def _validate_one(
@@ -76,6 +90,7 @@ class StaticRouteValidator:
         gateway_names: set[str],
         existing_gateways: set[str],
         gateway_protocols: dict[str, str],
+        index: XRefIndex | None,
     ) -> None:
         """Run all checks for a single static-route entry."""
         network = self._validate_network(route)
@@ -83,6 +98,7 @@ class StaticRouteValidator:
             route,
             gateway_names=gateway_names,
             existing_gateways=existing_gateways,
+            index=index,
         )
         if network is not None and gateway is not None:
             self._validate_protocol_match(route, network, gateway, gateway_protocols)
@@ -140,8 +156,27 @@ class StaticRouteValidator:
         *,
         gateway_names: set[str],
         existing_gateways: set[str],
+        index: XRefIndex | None,
     ) -> str | None:
-        """Validate the ``gateway`` cross-reference. Returns the value or None."""
+        """Validate the ``gateway`` cross-reference. Returns the value or None.
+
+        The ``gateway`` field accepts three forms (#793):
+
+        - bare name (e.g. ``WAN_GW``) — looked up first via the dotted
+          resolver against ``routing.gateways`` (when ``index`` is
+          provided), then via the pre-loaded ``gateway_names`` set,
+          then against the live ``existing_gateways`` set.
+        - in-plugin relative (e.g. ``gateways.WAN_GW``) — resolved by
+          ``resolve_xref`` with ``current_plugin`` defaulted to
+          ``opnsense``.
+        - cross-plugin absolute (e.g. ``routing.gateways.WAN_GW``) —
+          resolved directly by ``resolve_xref``.
+
+        On a dotted miss we still fall back to bare-name lookup so a
+        flat-format YAML (no dots) keeps validating identically. The
+        resolved value (the bare name) is returned because downstream
+        protocol-match logic keys off the bare gateway name.
+        """
         gateway = route.config.get("gateway")
         if gateway is None:
             self.report.add_check(
@@ -159,14 +194,44 @@ class StaticRouteValidator:
                 level=ValidationLevel.ERROR,
             )
             return None
-        if gateway in gateway_names or gateway in existing_gateways:
+
+        # Dotted-form resolution (#793). On a hit we still return the
+        # *bare* gateway name so the protocol-match check keys off the
+        # canonical name in ``gateway_names`` / ``existing_gateways``.
+        # ``current_plugin`` is the first dotted segment of the
+        # referencing resource's type (e.g. ``routing`` for
+        # ``routing.static``) so an in-plugin relative ``gateways.<name>``
+        # resolves to ``routing.gateways.<name>``.
+        bare_name = gateway
+        if index is not None and "." in gateway:
+            current_plugin = route.type.split(".", 1)[0] if "." in route.type else None
+            resolved = resolve_xref(
+                gateway,
+                expected_type=_MANAGED_GATEWAY_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                bare_name = resolved.name
+                self.report.add_check(
+                    check_name=f"static_route_{route.name}_gateway",
+                    passed=True,
+                    message=(
+                        f"Gateway '{gateway}' resolved (via dotted-path) to "
+                        f"'{bare_name}' for static_route '{route.name}'"
+                    ),
+                    level=ValidationLevel.INFO,
+                )
+                return bare_name
+
+        if bare_name in gateway_names or bare_name in existing_gateways:
             self.report.add_check(
                 check_name=f"static_route_{route.name}_gateway",
                 passed=True,
-                message=f"Gateway '{gateway}' resolved for static_route '{route.name}'",
+                message=f"Gateway '{bare_name}' resolved for static_route '{route.name}'",
                 level=ValidationLevel.INFO,
             )
-            return gateway
+            return bare_name
         self.report.add_check(
             check_name=f"static_route_{route.name}_gateway",
             passed=False,

--- a/src/infrafoundry/providers/opnsense/validators/unbound_host_alias_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/unbound_host_alias_validator.py
@@ -23,6 +23,10 @@ from __future__ import annotations
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.opnsense.validators._xref import XRefIndex, resolve_xref
+
+# Cross-reference target type for the host-alias `host` field.
+_MANAGED_HOST_OVERRIDE_TYPE = "unbound.host_overrides"
 
 
 class UnboundHostAliasValidator:
@@ -41,6 +45,7 @@ class UnboundHostAliasValidator:
         host_aliases: list[ResourceConfig],
         managed_host_override_names: set[str],
         existing_host_override_names: set[str],
+        index: XRefIndex | None = None,
     ) -> None:
         """Validate Unbound host-alias resources.
 
@@ -52,6 +57,11 @@ class UnboundHostAliasValidator:
                 returned by OPNsense's ``searchHostOverride`` (the
                 ``hostname.domain`` form, plus the bare hostname for
                 short-name references).
+            index: Optional dotted-type cross-reference index (#793).
+                When provided, the ``host`` field accepts dotted-path
+                forms like ``unbound.host_overrides.<name>`` in
+                addition to bare names. ``None`` falls back to bare-
+                name lookup only.
         """
         seen_keys: dict[tuple[str, str], str] = {}
         for alias in host_aliases:
@@ -60,6 +70,7 @@ class UnboundHostAliasValidator:
                 managed_host_override_names=managed_host_override_names,
                 existing_host_override_names=existing_host_override_names,
                 seen_keys=seen_keys,
+                index=index,
             )
 
     def _validate_one(
@@ -69,12 +80,14 @@ class UnboundHostAliasValidator:
         managed_host_override_names: set[str],
         existing_host_override_names: set[str],
         seen_keys: dict[tuple[str, str], str],
+        index: XRefIndex | None,
     ) -> None:
         """Run all checks for a single host-alias entry."""
         host = self._validate_host(
             alias,
             managed_host_override_names=managed_host_override_names,
             existing_host_override_names=existing_host_override_names,
+            index=index,
         )
         hostname = self._validate_hostname(alias)
         self._validate_domain(alias)
@@ -95,8 +108,19 @@ class UnboundHostAliasValidator:
         *,
         managed_host_override_names: set[str],
         existing_host_override_names: set[str],
+        index: XRefIndex | None,
     ) -> str | None:
-        """Validate the ``host`` cross-reference. Returns the value or None."""
+        """Validate the ``host`` cross-reference. Returns the value or None.
+
+        The ``host`` field accepts the three forms in #793 (bare name,
+        in-plugin relative ``host_overrides.<name>``, cross-plugin
+        absolute ``unbound.host_overrides.<name>``). On a dotted miss
+        we fall back to bare-name lookup so the live ``hostname.domain``
+        form (which itself contains a dot) keeps validating against
+        the existing host-override set without confusion — that string
+        always passes the ``"." in host`` check but the resolver miss
+        is non-fatal.
+        """
         host = alias.config.get("host")
         if host is None:
             self.report.add_check(
@@ -114,6 +138,33 @@ class UnboundHostAliasValidator:
                 level=ValidationLevel.ERROR,
             )
             return None
+
+        # Dotted-form resolution (#793). The xref index always wins
+        # when its lookup matches; otherwise we fall back to bare-name
+        # checks so the live ``hostname.domain`` form (which has a dot)
+        # still resolves against ``existing_host_override_names``.
+        # ``current_plugin`` is the first segment of the referencing
+        # alias's type (e.g. ``unbound`` for ``unbound.host_aliases``).
+        if index is not None and "." in host:
+            current_plugin = alias.type.split(".", 1)[0] if "." in alias.type else None
+            resolved = resolve_xref(
+                host,
+                expected_type=_MANAGED_HOST_OVERRIDE_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                self.report.add_check(
+                    check_name=f"unbound_host_alias_{alias.name}_host",
+                    passed=True,
+                    message=(
+                        f"Host '{host}' resolved (via dotted-path) to "
+                        f"'{resolved.name}' for unbound_host_alias '{alias.name}'"
+                    ),
+                    level=ValidationLevel.INFO,
+                )
+                return resolved.name
+
         if host in managed_host_override_names or host in existing_host_override_names:
             self.report.add_check(
                 check_name=f"unbound_host_alias_{alias.name}_host",

--- a/src/infrafoundry/providers/opnsense/validators/virtual_ip_validator.py
+++ b/src/infrafoundry/providers/opnsense/validators/virtual_ip_validator.py
@@ -38,6 +38,10 @@ from typing import Any
 
 from infrafoundry.core.provider import ResourceConfig
 from infrafoundry.core.validation import ValidationLevel, ValidationReport
+from infrafoundry.providers.opnsense.validators._xref import XRefIndex, resolve_xref
+
+# Cross-reference target type for the virtual-IP `interface` field.
+_MANAGED_INTERFACE_TYPE = "interfaces.assignments"
 
 # Allowed values for the ``mode`` discriminator. The issue body's draft
 # was wrong; the live probe is authoritative.
@@ -69,6 +73,7 @@ class VirtualIPValidator:
         virtual_ips: list[ResourceConfig],
         managed_interface_names: set[str],
         existing_interfaces: dict[str, Any],
+        index: XRefIndex | None = None,
     ) -> None:
         """Validate virtual-IP resources.
 
@@ -79,6 +84,10 @@ class VirtualIPValidator:
                 YAML.
             existing_interfaces: Live interface map from
                 ``OPNsenseValidator._get_existing_interfaces``.
+            index: Optional dotted-type cross-reference index (#793).
+                When provided, the ``interface`` field accepts dotted-
+                path forms in addition to bare names. ``None`` falls
+                back to bare-name lookup only.
         """
         seen_keys: dict[tuple[str, str, str, str], str] = {}
         for vip in virtual_ips:
@@ -87,6 +96,7 @@ class VirtualIPValidator:
                 managed_interface_names=managed_interface_names,
                 existing_interfaces=existing_interfaces,
                 seen_keys=seen_keys,
+                index=index,
             )
 
     def _validate_one(
@@ -96,6 +106,7 @@ class VirtualIPValidator:
         managed_interface_names: set[str],
         existing_interfaces: dict[str, Any],
         seen_keys: dict[tuple[str, str, str, str], str],
+        index: XRefIndex | None,
     ) -> None:
         """Run all checks for a single virtual-IP entry."""
         mode = self._validate_mode(vip)
@@ -103,6 +114,7 @@ class VirtualIPValidator:
             vip,
             managed_interface_names=managed_interface_names,
             existing_interfaces=existing_interfaces,
+            index=index,
         )
         address = self._validate_address(vip)
         self._validate_network(vip, address)
@@ -159,6 +171,7 @@ class VirtualIPValidator:
         *,
         managed_interface_names: set[str],
         existing_interfaces: dict[str, Any],
+        index: XRefIndex | None,
     ) -> str | None:
         """Validate the ``interface`` cross-reference. Returns the value or None."""
         interface = vip.config.get("interface")
@@ -178,6 +191,32 @@ class VirtualIPValidator:
                 level=ValidationLevel.ERROR,
             )
             return None
+
+        # Dotted-form resolution (#793). The xref index always wins
+        # when its lookup matches; otherwise fall through to bare-name
+        # checks for backward compatibility with the flat schema.
+        # ``current_plugin`` is the first segment of the referencing
+        # vip's type (e.g. ``interfaces`` for ``interfaces.virtual_ips``).
+        if index is not None and "." in interface:
+            current_plugin = vip.type.split(".", 1)[0] if "." in vip.type else None
+            resolved = resolve_xref(
+                interface,
+                expected_type=_MANAGED_INTERFACE_TYPE,
+                index=index,
+                current_plugin=current_plugin,
+            )
+            if resolved is not None:
+                self.report.add_check(
+                    check_name=f"virtual_ip_{vip.name}_interface",
+                    passed=True,
+                    message=(
+                        f"Interface '{interface}' resolved (via dotted-path) to "
+                        f"'{resolved.name}' for virtual_ip '{vip.name}'"
+                    ),
+                    level=ValidationLevel.INFO,
+                )
+                return resolved.name
+
         if interface in managed_interface_names or interface in existing_interfaces:
             self.report.add_check(
                 check_name=f"virtual_ip_{vip.name}_interface",

--- a/tests/unit/providers/opnsense/test_firewall_rule_validator.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_validator.py
@@ -944,3 +944,125 @@ class TestEdgeCases:
             existing_gateways={"WAN_DHCP"},
         )
         assert not _failures(report, "firewall_rule_ok_gateway")
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path cross-references (#793) — forward-compat
+# ---------------------------------------------------------------------------
+
+
+class TestDottedPathXRefs:
+    """Forward-compat tests for the dotted-path resolver. Bare-name
+    behaviour (``index=None``) is unchanged — covered by the test
+    classes above. These tests confirm the new dotted forms are
+    accepted when an ``index`` is supplied."""
+
+    def test_cross_plugin_absolute_alias_in_source_net_resolves(
+        self, validator: FirewallRuleValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        admins = ResourceConfig(
+            name="admins",
+            type="firewall.aliases",
+            provider="opnsense",
+            config={"type": "host"},
+        )
+        index = build_xref_index([admins])
+        validator.validate(
+            [_rule("ok", source_net="firewall.aliases.admins")],
+            alias_names={"admins"},
+            interface_assignment_names=set(),
+            gateway_names=set(),
+            existing_interfaces={"lan": {}},
+            existing_aliases={},
+            existing_gateways=set(),
+            index=index,
+        )
+        # No warning surfaced for the dotted alias.
+        assert not [c for c in report.results if c.check_name == "firewall_rule_ok_source_net"]
+
+    def test_in_plugin_relative_alias_in_destination_net_resolves(
+        self, validator: FirewallRuleValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        admins = ResourceConfig(
+            name="admins",
+            type="firewall.aliases",
+            provider="opnsense",
+            config={"type": "host"},
+        )
+        index = build_xref_index([admins])
+        # Rule type ``firewall.rules`` → current_plugin="firewall" →
+        # ``aliases.admins`` resolves to ``firewall.aliases.admins``.
+        validator.validate(
+            [_rule("ok", destination_net="aliases.admins")],
+            alias_names={"admins"},
+            interface_assignment_names=set(),
+            gateway_names=set(),
+            existing_interfaces={"lan": {}},
+            existing_aliases={},
+            existing_gateways=set(),
+            index=index,
+        )
+        assert not [c for c in report.results if c.check_name == "firewall_rule_ok_destination_net"]
+
+    def test_cross_plugin_absolute_gateway_resolves(
+        self, validator: FirewallRuleValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        gw = _gw("WAN_GW", protocol="inet")
+        index = build_xref_index([gw])
+        validator.validate(
+            [_rule("ok", gateway="routing.gateways.WAN_GW")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            gateway_names={"WAN_GW"},
+            existing_interfaces={"lan": {}},
+            existing_aliases={},
+            existing_gateways=set(),
+            managed_gateways=[gw],
+            index=index,
+        )
+        assert not _failures(report, "firewall_rule_ok_gateway")
+
+    def test_cross_plugin_absolute_interface_resolves(
+        self, validator: FirewallRuleValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        iface = ResourceConfig(
+            name="lan",
+            type="interfaces.assignments",
+            provider="opnsense",
+            config={"name": "lan"},
+        )
+        index = build_xref_index([iface])
+        validator.validate(
+            [_rule("ok", interface="interfaces.assignments.lan")],
+            alias_names=set(),
+            interface_assignment_names={"lan"},
+            gateway_names=set(),
+            existing_interfaces={},
+            existing_aliases={},
+            existing_gateways=set(),
+            index=index,
+        )
+        assert not _failures(report, "firewall_rule_ok_interface")
+
+    def test_index_none_preserves_legacy_behaviour(
+        self, validator: FirewallRuleValidator, report: ValidationReport
+    ) -> None:
+        # Bare-name lookup still works without ``index``.
+        validator.validate(
+            [_rule("ok", gateway="WAN_DHCP")],
+            alias_names=set(),
+            interface_assignment_names=set(),
+            gateway_names=set(),
+            existing_interfaces={"lan": {}},
+            existing_aliases={},
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "firewall_rule_ok_gateway")

--- a/tests/unit/providers/opnsense/test_nat_rule_validator.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_validator.py
@@ -717,3 +717,96 @@ class TestEdgeCases:
         assert "nat_rule_b_interface" in names
         assert "nat_rule_d_interface" in names
         assert "nat_rule_c_interface" in names
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path cross-references (#793) — forward-compat
+# ---------------------------------------------------------------------------
+
+
+class TestDottedPathXRefs:
+    """Forward-compat tests for the dotted-path resolver. Bare-name
+    behaviour (``index=None``) is unchanged — covered by the test
+    classes above. These tests confirm the new dotted forms are
+    accepted when an ``index`` is supplied."""
+
+    def test_cross_plugin_absolute_alias_in_target_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        admins = ResourceConfig(
+            name="vip_pool",
+            type="firewall.aliases",
+            provider="opnsense",
+            config={"type": "host"},
+        )
+        index = build_xref_index([admins])
+        validator.validate(
+            [_outbound("ok", target="firewall.aliases.vip_pool")],
+            alias_names={"vip_pool"},
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+            index=index,
+        )
+        # No warning should appear on target.
+        assert not [c for c in report.results if c.check_name == "nat_rule_ok_target"]
+
+    def test_in_plugin_relative_alias_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        alias = ResourceConfig(
+            name="admins",
+            type="firewall.aliases",
+            provider="opnsense",
+            config={"type": "host"},
+        )
+        index = build_xref_index([alias])
+        # NAT rule type is ``firewall.nat`` → current_plugin="firewall"
+        # → ``aliases.admins`` resolves to ``firewall.aliases.admins``.
+        validator.validate(
+            [_outbound("ok", source_net="aliases.admins")],
+            alias_names={"admins"},
+            interface_assignment_names=set(),
+            existing_interfaces={"wan": {}},
+            existing_aliases={},
+            index=index,
+        )
+        assert not [c for c in report.results if c.check_name == "nat_rule_ok_source_net"]
+
+    def test_cross_plugin_absolute_interface_resolves(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        iface = ResourceConfig(
+            name="wan",
+            type="interfaces.assignments",
+            provider="opnsense",
+            config={"name": "wan"},
+        )
+        index = build_xref_index([iface])
+        validator.validate(
+            [_outbound("ok", interface="interfaces.assignments.wan")],
+            alias_names=set(),
+            interface_assignment_names={"wan"},
+            existing_interfaces={},
+            existing_aliases={},
+            index=index,
+        )
+        assert not _failures(report, "nat_rule_ok_interface")
+
+    def test_index_none_preserves_legacy_behaviour(
+        self, validator: NATRuleValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_outbound("ok", interface="wan")],
+            alias_names=set(),
+            interface_assignment_names={"wan"},
+            existing_interfaces={},
+            existing_aliases={},
+        )
+        assert not _failures(report, "nat_rule_ok_interface")

--- a/tests/unit/providers/opnsense/test_static_route_validator.py
+++ b/tests/unit/providers/opnsense/test_static_route_validator.py
@@ -465,3 +465,96 @@ class TestEdgeCases:
         # through to the trailing-6 heuristic (no trailing 6 ⇒ v4),
         # and a v4 network + heuristic-v4 ⇒ pass.
         assert not _failures(report, "static_route_ok_protocol_match")
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path cross-references (#793) — forward-compat
+# ---------------------------------------------------------------------------
+
+
+class TestDottedPathXRefs:
+    """The static-route validator accepts dotted-path gateway refs when
+    an ``index`` is supplied (Phase 3 of #793). Bare-name behaviour
+    is unchanged when ``index`` is None — covered by the other test
+    classes above. These tests confirm forward-compat for the new
+    syntax."""
+
+    def test_cross_plugin_absolute_gateway_ref_resolves(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        gw = _gw("WAN_GW", protocol="inet")
+        index = build_xref_index([gw])
+        validator.validate(
+            [_route("ok", gateway="routing.gateways.WAN_GW")],
+            managed_gateways=[gw],
+            gateway_names={"WAN_GW"},
+            existing_gateways=set(),
+            index=index,
+        )
+        assert not _failures(report, "static_route_ok_gateway")
+
+    def test_in_plugin_relative_gateway_ref_resolves(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        gw = _gw("WAN_GW", protocol="inet")
+        index = build_xref_index([gw])
+        validator.validate(
+            [_route("ok", gateway="gateways.WAN_GW")],
+            managed_gateways=[gw],
+            gateway_names={"WAN_GW"},
+            existing_gateways=set(),
+            index=index,
+        )
+        assert not _failures(report, "static_route_ok_gateway")
+
+    def test_dotted_miss_falls_back_to_bare_name(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        # Empty index — the dotted lookup misses, but we don't dotted-
+        # form the gateway value, so the bare-name path should still
+        # validate against the live gateway set.
+        index = build_xref_index([])
+        validator.validate(
+            [_route("ok", gateway="WAN_DHCP")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+            index=index,
+        )
+        assert not _failures(report, "static_route_ok_gateway")
+
+    def test_index_none_preserves_legacy_behaviour(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        # Calling without ``index`` is the pre-#793 contract: bare
+        # names only, no dotted-form support.
+        validator.validate(
+            [_route("ok", gateway="WAN_DHCP")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways={"WAN_DHCP"},
+        )
+        assert not _failures(report, "static_route_ok_gateway")
+
+    def test_dotted_unknown_falls_back_then_fails(
+        self, validator: StaticRouteValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        # Dotted form misses index AND falls back to bare-name lookup
+        # which also misses → final ERROR.
+        index = build_xref_index([])
+        validator.validate(
+            [_route("ok", gateway="routing.gateways.GHOST")],
+            managed_gateways=[],
+            gateway_names=set(),
+            existing_gateways=set(),
+            index=index,
+        )
+        assert _failures(report, "static_route_ok_gateway")

--- a/tests/unit/providers/opnsense/test_unbound_host_alias_validator.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_alias_validator.py
@@ -397,3 +397,98 @@ class TestEdgeCases:
         assert "unbound_host_alias_a_host" in names
         assert "unbound_host_alias_b_host" in names
         assert "unbound_host_alias_c_host" in names
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path cross-references (#793) — forward-compat
+# ---------------------------------------------------------------------------
+
+
+class TestDottedPathXRefs:
+    """Forward-compat tests for the dotted-path resolver. Bare-name
+    behaviour (``index=None``) is unchanged. Validating dotted refs
+    requires an ``index``."""
+
+    def test_cross_plugin_absolute_host_resolves(
+        self, validator: UnboundHostAliasValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        host = ResourceConfig(
+            name="db-primary",
+            type="unbound.host_overrides",
+            provider="opnsense",
+            config={"hostname": "db", "domain": "internal", "ip": "10.0.0.1"},
+        )
+        index = build_xref_index([host])
+        # ``unbound.host_overrides.db-primary`` is a 3-part path → cross-
+        # plugin absolute. Resolver matches the (type, name) tuple.
+        validator.validate(
+            [_alias("ok", host="unbound.host_overrides.db-primary")],
+            managed_host_override_names={"db-primary"},
+            existing_host_override_names=set(),
+            index=index,
+        )
+        passed = [
+            c for c in report.results if c.check_name == "unbound_host_alias_ok_host" and c.passed
+        ]
+        assert passed
+
+    def test_in_plugin_relative_host_resolves(
+        self, validator: UnboundHostAliasValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        host = ResourceConfig(
+            name="db-primary",
+            type="unbound.host_overrides",
+            provider="opnsense",
+            config={"hostname": "db", "domain": "internal", "ip": "10.0.0.1"},
+        )
+        index = build_xref_index([host])
+        # Alias type ``unbound.host_aliases`` → current_plugin="unbound"
+        # → ``host_overrides.db-primary`` resolves to
+        # ``unbound.host_overrides.db-primary``.
+        validator.validate(
+            [_alias("ok", host="host_overrides.db-primary")],
+            managed_host_override_names={"db-primary"},
+            existing_host_override_names=set(),
+            index=index,
+        )
+        passed = [
+            c for c in report.results if c.check_name == "unbound_host_alias_ok_host" and c.passed
+        ]
+        assert passed
+
+    def test_live_hostname_with_dot_falls_back_to_existing(
+        self, validator: UnboundHostAliasValidator, report: ValidationReport
+    ) -> None:
+        # The live ``hostname.domain`` form contains a dot but is NOT a
+        # dotted xref — the resolver lookup misses, then the bare-name
+        # fallback finds it in ``existing_host_override_names``.
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        index = build_xref_index([])
+        validator.validate(
+            [_alias("ok", host="db.internal")],
+            managed_host_override_names=set(),
+            existing_host_override_names={"db.internal"},
+            index=index,
+        )
+        passed = [
+            c for c in report.results if c.check_name == "unbound_host_alias_ok_host" and c.passed
+        ]
+        assert passed
+
+    def test_index_none_preserves_legacy_behaviour(
+        self, validator: UnboundHostAliasValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_alias("ok")],
+            managed_host_override_names={"db-primary"},
+            existing_host_override_names=set(),
+        )
+        passed = [
+            c for c in report.results if c.check_name == "unbound_host_alias_ok_host" and c.passed
+        ]
+        assert passed

--- a/tests/unit/providers/opnsense/test_virtual_ip_validator.py
+++ b/tests/unit/providers/opnsense/test_virtual_ip_validator.py
@@ -1098,3 +1098,76 @@ class TestEdgeCases:
             existing_interfaces={},
         )
         assert _failures(report, "virtual_ip_bad_address")
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path cross-references (#793) — forward-compat
+# ---------------------------------------------------------------------------
+
+
+class TestDottedPathXRefs:
+    """Forward-compat tests for the dotted-path resolver. Bare-name
+    behaviour (``index=None``) is unchanged. Validating dotted refs
+    requires an ``index``."""
+
+    def test_cross_plugin_absolute_interface_resolves(
+        self, validator: VirtualIPValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        iface = ResourceConfig(
+            name="lan",
+            type="interfaces.assignments",
+            provider="opnsense",
+            config={"name": "lan"},
+        )
+        index = build_xref_index([iface])
+        validator.validate(
+            [_ipalias("ok", interface="interfaces.assignments.lan")],
+            managed_interface_names={"lan"},
+            existing_interfaces={},
+            index=index,
+        )
+        passed = [
+            c for c in report.results if c.check_name == "virtual_ip_ok_interface" and c.passed
+        ]
+        assert passed
+
+    def test_in_plugin_relative_interface_resolves(
+        self, validator: VirtualIPValidator, report: ValidationReport
+    ) -> None:
+        from infrafoundry.providers.opnsense.validators._xref import build_xref_index
+
+        iface = ResourceConfig(
+            name="lan",
+            type="interfaces.assignments",
+            provider="opnsense",
+            config={"name": "lan"},
+        )
+        index = build_xref_index([iface])
+        # Virtual IP type ``interfaces.virtual_ips`` → current_plugin=
+        # "interfaces" → ``assignments.lan`` resolves to
+        # ``interfaces.assignments.lan``.
+        validator.validate(
+            [_ipalias("ok", interface="assignments.lan")],
+            managed_interface_names={"lan"},
+            existing_interfaces={},
+            index=index,
+        )
+        passed = [
+            c for c in report.results if c.check_name == "virtual_ip_ok_interface" and c.passed
+        ]
+        assert passed
+
+    def test_index_none_preserves_legacy_behaviour(
+        self, validator: VirtualIPValidator, report: ValidationReport
+    ) -> None:
+        validator.validate(
+            [_ipalias("ok")],
+            managed_interface_names={"lan"},
+            existing_interfaces={},
+        )
+        passed = [
+            c for c in report.results if c.check_name == "virtual_ip_ok_interface" and c.passed
+        ]
+        assert passed

--- a/tests/unit/providers/opnsense/test_xref.py
+++ b/tests/unit/providers/opnsense/test_xref.py
@@ -1,0 +1,376 @@
+"""Unit tests for the shared dotted-path cross-reference resolver (#793).
+
+Coverage:
+    - ``build_xref_index``: empty input, single resource, multi-type,
+      multi-name, round-trip.
+    - ``resolve_xref`` bare-name form: hit, miss, miss with empty index.
+    - ``resolve_xref`` in-plugin relative form: hit (with current_plugin),
+      miss (with current_plugin), no current_plugin returns None.
+    - ``resolve_xref`` cross-plugin absolute form: hit, miss, deeply
+      nested type (e.g. ``kea.dhcp4.subnets``).
+    - ``resolve_xref`` malformed values: empty string, leading dot,
+      trailing dot, consecutive dots — all raise ``ValueError``.
+    - Interaction round-trip: build index from list, resolve each
+      resource by its (type, name) and verify identity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from infrafoundry.core.provider import ResourceConfig
+from infrafoundry.providers.opnsense.validators._xref import (
+    XRefIndex,
+    build_xref_index,
+    resolve_xref,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resource(
+    name: str,
+    type_: str,
+    *,
+    provider: str = "opnsense",
+) -> ResourceConfig:
+    """Return a minimal ResourceConfig — config is empty since the resolver
+    only inspects ``name`` and ``type``."""
+    return ResourceConfig(name=name, type=type_, provider=provider, config={})
+
+
+# ---------------------------------------------------------------------------
+# build_xref_index
+# ---------------------------------------------------------------------------
+
+
+class TestBuildXRefIndex:
+    def test_empty_input_returns_empty_dict(self) -> None:
+        assert build_xref_index([]) == {}
+
+    def test_single_resource_indexed(self) -> None:
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        assert index == {"routing.gateways": {"WAN_GW": gw}}
+
+    def test_multiple_types_grouped_separately(self) -> None:
+        gw = _resource("WAN_GW", "routing.gateways")
+        alias = _resource("admins", "firewall.aliases")
+        rule = _resource("allow_admin", "firewall.rules")
+        index = build_xref_index([gw, alias, rule])
+        assert set(index.keys()) == {
+            "routing.gateways",
+            "firewall.aliases",
+            "firewall.rules",
+        }
+        assert index["routing.gateways"]["WAN_GW"] is gw
+        assert index["firewall.aliases"]["admins"] is alias
+        assert index["firewall.rules"]["allow_admin"] is rule
+
+    def test_multiple_names_per_type_indexed(self) -> None:
+        a1 = _resource("admins", "firewall.aliases")
+        a2 = _resource("guests", "firewall.aliases")
+        a3 = _resource("trusted", "firewall.aliases")
+        index = build_xref_index([a1, a2, a3])
+        assert set(index["firewall.aliases"].keys()) == {"admins", "guests", "trusted"}
+        assert index["firewall.aliases"]["admins"] is a1
+        assert index["firewall.aliases"]["guests"] is a2
+        assert index["firewall.aliases"]["trusted"] is a3
+
+    def test_deeply_nested_type_preserved_verbatim(self) -> None:
+        subnet = _resource("vlan10", "kea.dhcp4.subnets")
+        index = build_xref_index([subnet])
+        assert "kea.dhcp4.subnets" in index
+        assert index["kea.dhcp4.subnets"]["vlan10"] is subnet
+
+    def test_collision_last_resource_wins(self) -> None:
+        # Uniqueness is enforced by ResourceNameValidator, not here —
+        # the index silently overwrites collisions.
+        first = _resource("admins", "firewall.aliases")
+        second = _resource("admins", "firewall.aliases")
+        index = build_xref_index([first, second])
+        assert index["firewall.aliases"]["admins"] is second
+
+
+# ---------------------------------------------------------------------------
+# resolve_xref — bare name form
+# ---------------------------------------------------------------------------
+
+
+class TestResolveXRefBareName:
+    def test_bare_name_hit(self) -> None:
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        result = resolve_xref("WAN_GW", "routing.gateways", index)
+        assert result is gw
+
+    def test_bare_name_miss(self) -> None:
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        result = resolve_xref("UNKNOWN", "routing.gateways", index)
+        assert result is None
+
+    def test_bare_name_miss_unknown_type(self) -> None:
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        # Bare name lookup uses ``expected_type``; if the type isn't
+        # in the index the result is None.
+        result = resolve_xref("WAN_GW", "firewall.aliases", index)
+        assert result is None
+
+    def test_bare_name_miss_with_empty_index(self) -> None:
+        result = resolve_xref("WAN_GW", "routing.gateways", {})
+        assert result is None
+
+    def test_bare_name_ignores_current_plugin(self) -> None:
+        # ``current_plugin`` is only consulted for the single-dot form.
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        result = resolve_xref("WAN_GW", "routing.gateways", index, current_plugin="opnsense")
+        assert result is gw
+
+
+# ---------------------------------------------------------------------------
+# resolve_xref — in-plugin relative form
+# ---------------------------------------------------------------------------
+
+
+class TestResolveXRefInPluginRelative:
+    def test_in_plugin_relative_hit(self) -> None:
+        # ``accounts.letsencrypt-prod`` with current_plugin=acmeclient
+        # resolves to type ``acmeclient.accounts``, name ``letsencrypt-prod``.
+        account = _resource("letsencrypt-prod", "acmeclient.accounts")
+        index = build_xref_index([account])
+        result = resolve_xref(
+            "accounts.letsencrypt-prod",
+            expected_type="acmeclient.accounts",
+            index=index,
+            current_plugin="acmeclient",
+        )
+        assert result is account
+
+    def test_in_plugin_relative_miss_unknown_name(self) -> None:
+        account = _resource("letsencrypt-prod", "acmeclient.accounts")
+        index = build_xref_index([account])
+        result = resolve_xref(
+            "accounts.unknown",
+            expected_type="acmeclient.accounts",
+            index=index,
+            current_plugin="acmeclient",
+        )
+        assert result is None
+
+    def test_in_plugin_relative_miss_unknown_sub(self) -> None:
+        # ``unknown.foo`` with current_plugin=acmeclient resolves to
+        # type ``acmeclient.unknown`` — not in the index.
+        account = _resource("letsencrypt-prod", "acmeclient.accounts")
+        index = build_xref_index([account])
+        result = resolve_xref(
+            "unknown.letsencrypt-prod",
+            expected_type="acmeclient.accounts",
+            index=index,
+            current_plugin="acmeclient",
+        )
+        assert result is None
+
+    def test_in_plugin_relative_without_current_plugin_returns_none(self) -> None:
+        # Without current_plugin, the single-dot form is unresolvable.
+        account = _resource("letsencrypt-prod", "acmeclient.accounts")
+        index = build_xref_index([account])
+        result = resolve_xref(
+            "accounts.letsencrypt-prod",
+            expected_type="acmeclient.accounts",
+            index=index,
+            current_plugin=None,
+        )
+        assert result is None
+
+    def test_in_plugin_relative_uses_current_plugin_not_expected_type(self) -> None:
+        # Even when expected_type and current_plugin disagree, the
+        # current_plugin wins for the single-dot form. Useful for
+        # explicit dotted refs that don't match the field's default.
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        result = resolve_xref(
+            "gateways.WAN_GW",
+            expected_type="firewall.aliases",  # ignored for dotted form
+            index=index,
+            current_plugin="routing",
+        )
+        assert result is gw
+
+
+# ---------------------------------------------------------------------------
+# resolve_xref — cross-plugin absolute form
+# ---------------------------------------------------------------------------
+
+
+class TestResolveXRefCrossPluginAbsolute:
+    def test_two_segment_dotted_type_hit(self) -> None:
+        # ``cron.jobs.acmeclient-auto-renew`` resolves to type
+        # ``cron.jobs``, name ``acmeclient-auto-renew``.
+        job = _resource("acmeclient-auto-renew", "cron.jobs")
+        index = build_xref_index([job])
+        result = resolve_xref(
+            "cron.jobs.acmeclient-auto-renew",
+            expected_type="cron.jobs",
+            index=index,
+        )
+        assert result is job
+
+    def test_three_segment_dotted_type_hit(self) -> None:
+        # ``kea.dhcp4.subnets.vlan10`` resolves to type
+        # ``kea.dhcp4.subnets``, name ``vlan10``.
+        subnet = _resource("vlan10", "kea.dhcp4.subnets")
+        index = build_xref_index([subnet])
+        result = resolve_xref(
+            "kea.dhcp4.subnets.vlan10",
+            expected_type="kea.dhcp4.subnets",
+            index=index,
+        )
+        assert result is subnet
+
+    def test_cross_plugin_absolute_miss_unknown_name(self) -> None:
+        job = _resource("acmeclient-auto-renew", "cron.jobs")
+        index = build_xref_index([job])
+        result = resolve_xref(
+            "cron.jobs.unknown",
+            expected_type="cron.jobs",
+            index=index,
+        )
+        assert result is None
+
+    def test_cross_plugin_absolute_miss_unknown_type(self) -> None:
+        # Type ``cron.unknown`` not in index.
+        job = _resource("acmeclient-auto-renew", "cron.jobs")
+        index = build_xref_index([job])
+        result = resolve_xref(
+            "cron.unknown.acmeclient-auto-renew",
+            expected_type="cron.jobs",
+            index=index,
+        )
+        assert result is None
+
+    def test_cross_plugin_absolute_ignores_current_plugin(self) -> None:
+        # Cross-plugin absolute does NOT prepend current_plugin.
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        result = resolve_xref(
+            "routing.gateways.WAN_GW",
+            expected_type="firewall.aliases",
+            index=index,
+            current_plugin="acmeclient",  # ignored
+        )
+        assert result is gw
+
+    def test_cross_plugin_absolute_ignores_expected_type(self) -> None:
+        # When the path is fully qualified, ``expected_type`` is ignored.
+        gw = _resource("WAN_GW", "routing.gateways")
+        index = build_xref_index([gw])
+        result = resolve_xref(
+            "routing.gateways.WAN_GW",
+            expected_type="firewall.aliases",  # ignored
+            index=index,
+        )
+        assert result is gw
+
+
+# ---------------------------------------------------------------------------
+# resolve_xref — malformed input
+# ---------------------------------------------------------------------------
+
+
+class TestResolveXRefMalformed:
+    def test_empty_value_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            resolve_xref("", "routing.gateways", {})
+
+    def test_leading_dot_raises(self) -> None:
+        with pytest.raises(ValueError, match="must not start or end with"):
+            resolve_xref(".foo", "routing.gateways", {})
+
+    def test_trailing_dot_raises(self) -> None:
+        with pytest.raises(ValueError, match="must not start or end with"):
+            resolve_xref("foo.", "routing.gateways", {})
+
+    def test_consecutive_dots_raises(self) -> None:
+        with pytest.raises(ValueError, match="consecutive dots"):
+            resolve_xref("foo..bar", "routing.gateways", {})
+
+    def test_lone_dot_raises(self) -> None:
+        # ``.`` is both leading-dot and trailing-dot — first check
+        # wins, but either error is acceptable.
+        with pytest.raises(ValueError):
+            resolve_xref(".", "routing.gateways", {})
+
+    def test_consecutive_dots_in_middle_raises(self) -> None:
+        with pytest.raises(ValueError, match="consecutive dots"):
+            resolve_xref("a.b..c", "routing.gateways", {})
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: build index, resolve each resource by its own type/name
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_resolve_each_resource_by_bare_name(self) -> None:
+        resources = [
+            _resource("WAN_GW", "routing.gateways"),
+            _resource("admins", "firewall.aliases"),
+            _resource("allow_admin", "firewall.rules"),
+            _resource("vlan10", "kea.dhcp4.subnets"),
+        ]
+        index = build_xref_index(resources)
+        for resource in resources:
+            result = resolve_xref(resource.name, resource.type, index)
+            assert result is resource
+
+    def test_resolve_each_resource_by_cross_plugin_absolute(self) -> None:
+        resources = [
+            _resource("WAN_GW", "routing.gateways"),
+            _resource("admins", "firewall.aliases"),
+            _resource("vlan10", "kea.dhcp4.subnets"),
+        ]
+        index = build_xref_index(resources)
+        for resource in resources:
+            full_path = f"{resource.type}.{resource.name}"
+            result = resolve_xref(full_path, resource.type, index)
+            assert result is resource
+
+    def test_resolve_each_resource_by_in_plugin_relative(self) -> None:
+        # For an in-plugin relative ref the current_plugin is the
+        # first dotted segment of the resource's type.
+        resources = [
+            _resource("WAN_GW", "routing.gateways"),
+            _resource("admins", "firewall.aliases"),
+        ]
+        index = build_xref_index(resources)
+        for resource in resources:
+            plugin, _, sub = resource.type.partition(".")
+            value = f"{sub}.{resource.name}"
+            result = resolve_xref(
+                value,
+                expected_type=resource.type,
+                index=index,
+                current_plugin=plugin,
+            )
+            assert result is resource
+
+
+# ---------------------------------------------------------------------------
+# Type alias smoke test (mypy strict catches mis-shapes; a runtime
+# assertion is included for parity with the runtime behaviour).
+# ---------------------------------------------------------------------------
+
+
+class TestTypeAlias:
+    def test_xref_index_alias_is_dict_of_dicts(self) -> None:
+        index: XRefIndex = build_xref_index([_resource("WAN_GW", "routing.gateways")])
+        assert isinstance(index, dict)
+        for type_bucket in index.values():
+            assert isinstance(type_bucket, dict)
+            for resource in type_bucket.values():
+                assert isinstance(resource, ResourceConfig)


### PR DESCRIPTION
## Description

Adds a shared dotted-path cross-reference resolver
(`src/infrafoundry/providers/opnsense/validators/_xref.py`) that handles
all three cross-reference forms from ADR-0016, and updates 5 validators
to use it. Existing flat-form YAML continues to validate identically;
operators can also write dotted-form values once nested-format YAML
is in use.

This is **Phase 3 of 6** in the #793 implementation plan.

### Cross-reference forms supported

```yaml
# 1. Bare name (today's flat form, unchanged):
static_route:
  gateway: WAN_GW

# 2. In-plugin relative (new — current_plugin context auto-derived
#    from the referencing resource's type):
routing.static:
  gateway: gateways.WAN_GW       # resolves to routing.gateways.WAN_GW

# 3. Cross-plugin absolute (new):
acmeclient.settings:
  update_cron: cron.jobs.acmeclient-auto-renew
```

### New module

`_xref.py` exports:

- `XRefIndex` — type alias for `dict[str, dict[str, ResourceConfig]]`
- `build_xref_index(resources)` — walks all resources, groups by
  `resource.type`, keys inner dict by `resource.name`. Called once at
  `OPNsenseValidator.validate_references()` start.
- `resolve_xref(value, expected_type, index, current_plugin=None)` —
  parses the value's dotted form (or bare name), looks up the target,
  returns the matched `ResourceConfig` or `None` on miss. Raises
  `ValueError` on malformed values (empty, leading/trailing dots, etc.).

### Adopted validators

Each adopted validator gets an optional `index: XRefIndex | None = None`
parameter. The dotted-path resolution runs FIRST; on a miss, the
existing bare-name lookup runs (preserving flat-form behavior).

- `static_route_validator.py` — `gateway` field.
- `firewall_rule_validator.py` — `interface`, `gateway`, `source_net`,
  `destination_net` fields.
- `nat_rule_validator.py` — `interface`, `source_net`, `destination_net`,
  `target` fields.
- `unbound_host_alias_validator.py` — `host` field (cross-ref to
  `unbound.host_overrides`).
- `virtual_ip_validator.py` — `interface` field.

### Plan deviation: `current_plugin` is auto-derived

The plan suggested passing `current_plugin="acmeclient"` (etc.) explicitly.
Implementation derives it inside each adopted validator as
`resource.type.split(".", 1)[0]` so a `routing.static` resource resolves
`gateways.WAN_GW` to `routing.gateways.WAN_GW` automatically — more
correct than hard-coding `"opnsense"` (which wouldn't match any of the
dotted types). The resolver itself takes `current_plugin` as an explicit
argument (unchanged from plan); only the call sites changed.

## Related Issue

Addresses #793.

## Test Plan

- [x] `doit check` green (format, lint, type-check, security, spell-check, test).
- [x] 32 new tests in `test_xref.py` (100% coverage of `_xref.py`).
- [x] 21 new dotted-path tests across 5 adopted validator test files.
- [x] All pre-existing OPNsense validator tests pass unchanged (backward compat).
- [x] Full suite: 5,457 passed, 19 skipped, 0 failed. Coverage 85.83%.

## Out of Scope (deferred to later phases)

- `migrate()` method changes to emit nested YAML (Phase 4).
- Removal of flat-format parsing and `STEM_TO_DOTTED` shim (Phase 5 hard cutover).
- `endavis-infra/` conversion script (Phase 6, separate repo).
- Adopting the resolver in remaining validators that don't currently have
  cross-ref fields — covered by component-specific PRs as those features land.

## Stacked PR base

This PR is stacked on `refactor/793-loader-nested-format` (Phase 2 PR
#796), which is stacked on Phase 1 (#795), which is stacked on Phase 0
(#794). After upstream PRs merge to `main`, GitHub will retarget this
PR; rebases will be required to drop squash-merged commits.
