### PR TITLE
refactor: emit nested-format YAML from direct-OPNsense migrate paths

### DIFF
--- a/src/infrafoundry/providers/opnsense/services/_nested_emit.py
+++ b/src/infrafoundry/providers/opnsense/services/_nested_emit.py
@@ -1,0 +1,237 @@
+"""Helper for emitting nested-format YAML from direct-OPNsense ``migrate`` calls.
+
+Centralises the structural wrapping that turns a flat list of resources for
+a single dotted resource type (or a dict-shape singleton) into the nested
+``opnsense:`` namespace document defined by ADR-0016 (#793 Phase 4).
+
+The flat resource-centric output that each service's ``export_to_yaml``
+historically emitted::
+
+    resources:
+      - provider: opnsense
+        type: aliases
+        name: web-servers
+        config: {...}
+
+is replaced (per ADR-0016) by an API-aligned nested layout::
+
+    opnsense:
+      firewall:
+        aliases:
+          - name: web-servers
+            config: {...}
+
+For singletons (e.g. ``firewall.log``)::
+
+    opnsense:
+      firewall:
+        log:
+          enabled: false
+
+The helper is intentionally simple and only handles **single-type** documents
+— each component manager's ``migrate()`` method emits one resource type at a
+time. Multi-type emission is left to a future caller (e.g. a hypothetical
+``migrate --all`` command); the same helper composes via dict-merge.
+
+Per ADR-0016, the leaf shape (list vs dict) is declared by
+``DOTTED_RESOURCE_SHAPES`` in ``infrafoundry.core.config.package_loader`` and
+this helper validates the call against that table so an authoring mistake in
+a service's ``export_to_yaml`` surfaces immediately rather than producing
+YAML the loader will later reject.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+# ``NESTED_PROVIDER_NAMESPACE`` and the shape table live in the loader so the
+# parse and emit sides agree on a single source of truth.
+from infrafoundry.core.config.package_loader import (
+    DOTTED_RESOURCE_SHAPES,
+    NESTED_PROVIDER_NAMESPACE,
+)
+
+
+def emit_nested_list_yaml(dotted_type: str, entries: list[dict[str, Any]]) -> str:
+    """Wrap a list of resources at *dotted_type* into nested-format YAML.
+
+    Each entry must already carry a ``name:`` field (and typically a
+    ``config:`` block); the helper does not synthesise either. The dotted
+    path is split on ``.`` and each component becomes a nested mapping key
+    under the top-level ``opnsense:`` namespace.
+
+    Args:
+        dotted_type: API-aligned dotted path (e.g. ``firewall.aliases``,
+            ``kea.dhcp4.subnets``). Must be registered as a list-shape
+            type in ``DOTTED_RESOURCE_SHAPES``.
+        entries: List of resource dicts to emit under the leaf list.
+            Empty list is allowed (renders as ``[]`` at the leaf).
+
+    Returns:
+        YAML string starting with ``opnsense:`` and the nested structure.
+
+    Raises:
+        ValueError: If *dotted_type* is unknown or not a list-shape type.
+    """
+    _check_shape(dotted_type, expected="list")
+    nested = _build_nested_branch(dotted_type, entries)
+    return yaml.safe_dump({NESTED_PROVIDER_NAMESPACE: nested}, sort_keys=False)
+
+
+def emit_nested_singleton_yaml(dotted_type: str, config: dict[str, Any]) -> str:
+    """Wrap a singleton config mapping at *dotted_type* into nested YAML.
+
+    Args:
+        dotted_type: API-aligned dotted path (e.g. ``firewall.log``,
+            ``tailscale.settings``). Must be registered as a dict-shape
+            type in ``DOTTED_RESOURCE_SHAPES``.
+        config: Mapping of singleton fields. Becomes the leaf mapping
+            verbatim.
+
+    Returns:
+        YAML string starting with ``opnsense:`` and the nested structure.
+
+    Raises:
+        ValueError: If *dotted_type* is unknown or not a dict-shape type.
+    """
+    _check_shape(dotted_type, expected="dict")
+    nested = _build_nested_branch(dotted_type, config)
+    return yaml.safe_dump({NESTED_PROVIDER_NAMESPACE: nested}, sort_keys=False)
+
+
+def emit_nested_multi_yaml(branches: dict[str, Any]) -> str:
+    """Wrap multiple dotted-type branches into a single nested YAML document.
+
+    Used by component managers that legitimately emit more than one resource
+    type in one call (e.g. :class:`KeaDHCPManager.migrate` exports DHCPv4
+    subnets, DHCPv4 reservations, DHCPv6 subnets and DHCPv6 reservations
+    together so the operator gets one document with the full Kea picture).
+
+    Args:
+        branches: Mapping of ``dotted_type`` → ``list[dict] | dict`` payload.
+            Each key is validated against ``DOTTED_RESOURCE_SHAPES`` and the
+            payload shape must match the declared leaf shape.
+
+    Returns:
+        YAML string with all branches merged under a single
+        ``opnsense:`` top-level key.
+
+    Raises:
+        ValueError: If any dotted_type is unknown or its payload shape
+            doesn't match the declared leaf shape.
+    """
+    nested: dict[str, Any] = {}
+    for dotted_type, payload in branches.items():
+        if isinstance(payload, list):
+            _check_shape(dotted_type, expected="list")
+        elif isinstance(payload, dict):
+            _check_shape(dotted_type, expected="dict")
+        else:
+            raise ValueError(
+                f"emit_nested_multi_yaml: payload for '{dotted_type}' must be "
+                f"a list or dict, got {type(payload).__name__}"
+            )
+        _merge_nested_branch(nested, dotted_type, payload)
+    return yaml.safe_dump({NESTED_PROVIDER_NAMESPACE: nested}, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_shape(dotted_type: str, *, expected: str) -> None:
+    """Validate that *dotted_type* is registered with the *expected* shape.
+
+    Args:
+        dotted_type: The dotted resource type to validate.
+        expected: ``"list"`` or ``"dict"`` — the shape the caller is about
+            to emit.
+
+    Raises:
+        ValueError: If *dotted_type* is not in ``DOTTED_RESOURCE_SHAPES``
+            or if its declared shape is not *expected*.
+    """
+    if dotted_type not in DOTTED_RESOURCE_SHAPES:
+        raise ValueError(
+            f"Unknown direct-OPNsense resource type {dotted_type!r}. "
+            f"Known dotted paths: {sorted(DOTTED_RESOURCE_SHAPES)!r}"
+        )
+    declared = DOTTED_RESOURCE_SHAPES[dotted_type]
+    if declared != expected:
+        raise ValueError(
+            f"Resource type {dotted_type!r} is declared as {declared!r} "
+            f"shape but caller is emitting {expected!r}-shape data."
+        )
+
+
+def _build_nested_branch(dotted_type: str, leaf: Any) -> dict[str, Any]:
+    """Build a nested dict tree from a dotted path and its leaf value.
+
+    Example:
+        ``_build_nested_branch("kea.dhcp4.subnets", [...])`` returns
+        ``{"kea": {"dhcp4": {"subnets": [...]}}}``.
+
+    Args:
+        dotted_type: Dotted resource type (e.g. ``"firewall.aliases"``).
+        leaf: Value to place at the leaf — a list of entry dicts for
+            list-shape types, or a config mapping for dict-shape types.
+
+    Returns:
+        Nested mapping with *leaf* placed at the path indicated by
+        *dotted_type*.
+    """
+    parts = dotted_type.split(".")
+    nested: dict[str, Any] = {}
+    cursor: dict[str, Any] = nested
+    for key in parts[:-1]:
+        next_level: dict[str, Any] = {}
+        cursor[key] = next_level
+        cursor = next_level
+    cursor[parts[-1]] = leaf
+    return nested
+
+
+def _merge_nested_branch(target: dict[str, Any], dotted_type: str, leaf: Any) -> None:
+    """Place *leaf* into *target* at the dotted path, creating intermediates.
+
+    Used by :func:`emit_nested_multi_yaml` to merge multiple branches into
+    a single nested document. If two branches share a parent (e.g.
+    ``firewall.aliases`` and ``firewall.rules``) the parent dict is
+    extended rather than overwritten. A direct collision (the leaf key
+    already set) raises ``ValueError`` — emitting the same dotted type
+    twice is a programming error.
+
+    Args:
+        target: Pre-existing nested mapping; mutated in place.
+        dotted_type: Dotted path under which to place *leaf*.
+        leaf: List or dict to set at the leaf position.
+
+    Raises:
+        ValueError: If an intermediate key in *target* is already set to
+            a non-dict value or if the leaf key is already present.
+    """
+    parts = dotted_type.split(".")
+    cursor = target
+    for key in parts[:-1]:
+        next_value = cursor.get(key)
+        if next_value is None:
+            new_level: dict[str, Any] = {}
+            cursor[key] = new_level
+            cursor = new_level
+        elif isinstance(next_value, dict):
+            cursor = next_value
+        else:
+            raise ValueError(
+                f"Cannot merge '{dotted_type}': intermediate key {key!r} "
+                f"in target already holds a non-dict ({type(next_value).__name__})."
+            )
+    leaf_key = parts[-1]
+    if leaf_key in cursor:
+        raise ValueError(
+            f"Cannot merge '{dotted_type}': leaf key {leaf_key!r} already "
+            "present in target. Each dotted type may only be emitted once."
+        )
+    cursor[leaf_key] = leaf

--- a/src/infrafoundry/providers/opnsense/services/alias.py
+++ b/src/infrafoundry/providers/opnsense/services/alias.py
@@ -120,10 +120,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Controller base for all alias CRUD + reconfigure endpoints.
@@ -653,21 +652,24 @@ class AliasService(BaseService):
         (the diff engine keys on ``config.name``, not the top-level
         ``name``).
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); aliases land at ``opnsense.firewall.aliases`` as
+        a YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and a
+            ``firewall.aliases`` list leaf.
         """
         live = self.search()
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "aliases",
                 "name": alias.name,
                 "config": _live_to_export_config(alias),
             }
             for alias in live
             if alias.type not in _SYSTEM_ALIAS_TYPES
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("firewall.aliases", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/firewall_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/firewall_rule.py
@@ -50,13 +50,12 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-import yaml
-
 from infrafoundry.core.exceptions import APIError, InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
 
 from ._category_marker import INFRAFOUNDRY_CATEGORY_NAME as _SHARED_CATEGORY_NAME
 from ._category_marker import ensure_infrafoundry_category
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 logger = logging.getLogger(__name__)
@@ -1037,22 +1036,25 @@ class FirewallRuleService(BaseService):
         controller (HTTP 404) does not abort the entire migrate — the
         export degrades to an empty resource list with a WARNING log.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); firewall rules land at ``opnsense.firewall.rules``
+        as a YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and a
+            ``firewall.rules`` list leaf.
         """
         rules: list[LiveFirewallRule] = self.search_tolerant()
         managed = [r for r in rules if r.managed_name is not None]
         marker_uuid = self._category_uuid  # may be None if cache cold
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "firewall_rules",
                 "name": r.managed_name,
                 "config": _live_to_export_config(r, marker_uuid),
             }
             for r in managed
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("firewall.rules", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/gateway.py
+++ b/src/infrafoundry/providers/opnsense/services/gateway.py
@@ -56,10 +56,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Allowed values for the ``ipprotocol`` discriminator.
@@ -609,21 +608,24 @@ class GatewayService(BaseService):
         we issue a ``getGateway/<uuid>`` to capture the option-dict-only
         fields (``interface``, ``ipprotocol``) at full fidelity.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); gateways land at ``opnsense.routing.gateways`` as
+        a YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and a
+            ``routing.gateways`` list leaf.
         """
         live = self.search()
         managed = [g for g in live if g.is_managed]
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "gateways",
                 "name": g.name,
                 "config": _live_to_export_config(self.get(g.uuid)),
             }
             for g in managed
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("routing.gateways", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/interface_assignment.py
+++ b/src/infrafoundry/providers/opnsense/services/interface_assignment.py
@@ -35,10 +35,9 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # ---------------------------------------------------------------------------
@@ -940,21 +939,22 @@ class InterfaceAssignmentService(BaseService):
     def export_to_yaml(self) -> str:
         """Export the current interface assignments to InfraFoundry YAML.
 
-        Produces a resource-centric YAML document where each row's
-        ``identifier`` becomes both ``name`` (operator-facing) and
-        the future-state binding key. ``ipv4``/``ipv6`` are emitted
+        Each row's ``identifier`` becomes both ``name`` (operator-facing)
+        and the future-state binding key. ``ipv4``/``ipv6`` are emitted
         verbatim from the live raw dicts for forward-compat.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); assignments land at
+        ``opnsense.interfaces.assignments`` as a YAML sequence.
+
         Returns:
-            YAML string suitable for placement under
-            ``envs/<env>/resources/`` or
-            ``envs/<env>/opnsense/interface_assignments.yaml``.
+            YAML string with the nested ``opnsense:`` namespace and an
+            ``interfaces.assignments`` list leaf, suitable for placement
+            under ``envs/<env>/resources/``.
         """
         live = self.list()
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "interface_assignments",
                 "name": entry.identifier,
                 "config": {
                     "device": entry.device,
@@ -966,7 +966,7 @@ class InterfaceAssignmentService(BaseService):
             }
             for entry in live
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("interfaces.assignments", entries)
 
     # ------------------------------------------------------------------
     # Read paths (``list`` is defined LAST so it doesn't shadow the

--- a/src/infrafoundry/providers/opnsense/services/kea_dhcp.py
+++ b/src/infrafoundry/providers/opnsense/services/kea_dhcp.py
@@ -23,9 +23,8 @@ accept.
 import logging
 from typing import Any, Final
 
-import yaml
-
 from ..api_client import KeaClient, OPNsenseClient
+from ._nested_emit import emit_nested_multi_yaml
 from .base import BaseService
 
 logger = logging.getLogger(__name__)
@@ -769,108 +768,120 @@ class KeaDHCPService(BaseService):
     def export_to_yaml(self) -> str:
         """Export current Kea DHCP configuration to YAML.
 
-        Exports both DHCPv4 and DHCPv6 configurations in InfraFoundry
-        resource-centric format.
+        Emits all four Kea resource types (DHCPv4 subnets, DHCPv4
+        reservations, DHCPv6 subnets, DHCPv6 reservations) in a single
+        nested document under the ``opnsense:`` namespace per ADR-0016
+        (#793 Phase 4):
+
+        .. code-block:: yaml
+
+            opnsense:
+              kea:
+                dhcp4:
+                  subnets: [...]
+                  reservations: [...]
+                dhcp6:
+                  subnets: [...]
+                  reservations: [...]
+
+        Empty branches are still emitted (as ``[]``) so the operator can
+        see at a glance which Kea surfaces are unconfigured.
 
         Returns:
-            YAML string containing all Kea DHCP resources
+            YAML string with the nested ``opnsense:`` namespace and four
+            list leaves under ``kea.dhcp4`` / ``kea.dhcp6``.
         """
-        resources = []
-
-        # Export DHCPv4 subnets
-        dhcpv4_subnets = self.search_dhcpv4_subnets()
-        for subnet in dhcpv4_subnets:
-            resource = {
-                "provider": "opnsense",
-                "type": "kea_subnet",
-                "name": subnet.get("description", "").lower().replace(" ", "_"),
-                "config": {
-                    "subnet": subnet.get("subnet", ""),
-                    "pools": subnet.get("pools", []),
-                    "description": subnet.get("description", ""),
-                },
+        # DHCPv4 subnets
+        dhcp4_subnet_entries: list[dict[str, Any]] = []
+        for subnet in self.search_dhcpv4_subnets():
+            entry_config: dict[str, Any] = {
+                "subnet": subnet.get("subnet", ""),
+                "pools": subnet.get("pools", []),
+                "description": subnet.get("description", ""),
             }
-            # Add optional fields if present
             if subnet.get("option_data_autocollect") == "1":
-                resource["config"]["auto_collect"] = True
+                entry_config["auto_collect"] = True
             if dns_servers := subnet.get("option_data_dns_servers"):
-                resource["config"]["dns_servers"] = [s.strip() for s in dns_servers.split(",")]
+                entry_config["dns_servers"] = [s.strip() for s in dns_servers.split(",")]
             if routers := subnet.get("option_data_routers"):
-                resource["config"]["routers"] = [r.strip() for r in routers.split(",")]
+                entry_config["routers"] = [r.strip() for r in routers.split(",")]
             if domain_name := subnet.get("option_data_domain_name"):
-                resource["config"]["domain_name"] = domain_name
+                entry_config["domain_name"] = domain_name
             if ntp_servers := subnet.get("option_data_ntp_servers"):
-                resource["config"]["ntp_servers"] = [n.strip() for n in ntp_servers.split(",")]
+                entry_config["ntp_servers"] = [n.strip() for n in ntp_servers.split(",")]
+            dhcp4_subnet_entries.append(
+                {
+                    "name": subnet.get("description", "").lower().replace(" ", "_"),
+                    "config": entry_config,
+                }
+            )
 
-            resources.append(resource)
-
-        # Export DHCPv4 reservations
-        dhcpv4_reservations = self.search_dhcpv4_reservations()
-        for reservation in dhcpv4_reservations:
+        # DHCPv4 reservations
+        dhcp4_reservation_entries: list[dict[str, Any]] = []
+        for reservation in self.search_dhcpv4_reservations():
             hostname = reservation.get("hostname", "")
-            name = hostname.lower().replace(" ", "_").replace("-", "_")
-            resource = {
-                "provider": "opnsense",
-                "type": "kea_reservation",
-                "name": name,
-                "config": {
-                    "subnet": reservation.get("subnet", ""),
-                    "hw_address": reservation.get("hw_address", ""),
-                    "ip_address": reservation.get("ip_address", ""),
-                },
+            res_config: dict[str, Any] = {
+                "subnet": reservation.get("subnet", ""),
+                "hw_address": reservation.get("hw_address", ""),
+                "ip_address": reservation.get("ip_address", ""),
             }
             if hostname:
-                resource["config"]["hostname"] = hostname
+                res_config["hostname"] = hostname
             if description := reservation.get("description"):
-                resource["config"]["description"] = description
+                res_config["description"] = description
+            dhcp4_reservation_entries.append(
+                {
+                    "name": hostname.lower().replace(" ", "_").replace("-", "_"),
+                    "config": res_config,
+                }
+            )
 
-            resources.append(resource)
-
-        # Export DHCPv6 subnets
-        dhcpv6_subnets = self.search_dhcpv6_subnets()
-        for subnet in dhcpv6_subnets:
-            resource = {
-                "provider": "opnsense",
-                "type": "kea_dhcp6_subnet",
-                "name": f"{subnet.get('description', '').lower().replace(' ', '_')}_v6",
-                "config": {
-                    "subnet": subnet.get("subnet", ""),
-                    "description": subnet.get("description", ""),
-                },
+        # DHCPv6 subnets
+        dhcp6_subnet_entries: list[dict[str, Any]] = []
+        for subnet in self.search_dhcpv6_subnets():
+            entry_config = {
+                "subnet": subnet.get("subnet", ""),
+                "description": subnet.get("description", ""),
             }
-            # Add optional fields if present
             if subnet.get("option_data_autocollect") == "1":
-                resource["config"]["auto_collect"] = True
+                entry_config["auto_collect"] = True
             if dns_servers := subnet.get("option_data_dns_servers"):
-                resource["config"]["dns_servers"] = [s.strip() for s in dns_servers.split(",")]
+                entry_config["dns_servers"] = [s.strip() for s in dns_servers.split(",")]
             if domain_search := subnet.get("option_data_domain_search"):
-                resource["config"]["domain_search"] = [d.strip() for d in domain_search.split(",")]
+                entry_config["domain_search"] = [d.strip() for d in domain_search.split(",")]
+            dhcp6_subnet_entries.append(
+                {
+                    "name": f"{subnet.get('description', '').lower().replace(' ', '_')}_v6",
+                    "config": entry_config,
+                }
+            )
 
-            resources.append(resource)
-
-        # Export DHCPv6 reservations
-        dhcpv6_reservations = self.search_dhcpv6_reservations()
-        for reservation in dhcpv6_reservations:
+        # DHCPv6 reservations
+        dhcp6_reservation_entries: list[dict[str, Any]] = []
+        for reservation in self.search_dhcpv6_reservations():
             hostname = reservation.get("hostname", "")
-            name = f"{hostname.lower().replace(' ', '_').replace('-', '_')}_v6"
-            resource = {
-                "provider": "opnsense",
-                "type": "kea_dhcp6_reservation",
-                "name": name,
-                "config": {
-                    "subnet": reservation.get("subnet", ""),
-                    "ip_address": reservation.get("ip_address", ""),
-                },
+            res_config = {
+                "subnet": reservation.get("subnet", ""),
+                "ip_address": reservation.get("ip_address", ""),
             }
             if duid := reservation.get("duid"):
-                resource["config"]["duid"] = duid
+                res_config["duid"] = duid
             if hostname:
-                resource["config"]["hostname"] = hostname
+                res_config["hostname"] = hostname
             if description := reservation.get("description"):
-                resource["config"]["description"] = description
+                res_config["description"] = description
+            dhcp6_reservation_entries.append(
+                {
+                    "name": f"{hostname.lower().replace(' ', '_').replace('-', '_')}_v6",
+                    "config": res_config,
+                }
+            )
 
-            resources.append(resource)
-
-        # Generate YAML
-        config = {"resources": resources}
-        return yaml.dump(config, default_flow_style=False, sort_keys=False)
+        return emit_nested_multi_yaml(
+            {
+                "kea.dhcp4.subnets": dhcp4_subnet_entries,
+                "kea.dhcp4.reservations": dhcp4_reservation_entries,
+                "kea.dhcp6.subnets": dhcp6_subnet_entries,
+                "kea.dhcp6.reservations": dhcp6_reservation_entries,
+            }
+        )

--- a/src/infrafoundry/providers/opnsense/services/nat_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/nat_rule.py
@@ -51,13 +51,12 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-import yaml
-
 from infrafoundry.core.exceptions import APIError, InfraFoundryError
 from infrafoundry.core.provider import ResourceConfig
 
 from ._category_marker import INFRAFOUNDRY_CATEGORY_NAME as _SHARED_CATEGORY_NAME
 from ._category_marker import ensure_infrafoundry_category
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 logger = logging.getLogger(__name__)
@@ -1156,21 +1155,24 @@ class NATRuleService(BaseService):
         respond cleanly are still extracted, with a WARNING log naming
         any kind that was skipped.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); NAT rules land at ``opnsense.firewall.nat`` as a
+        YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and a
+            ``firewall.nat`` list leaf.
         """
         rules: list[LiveNATRule] = self.search_all_tolerant()
         managed = [r for r in rules if r.managed_name is not None]
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "nat_rules",
                 "name": r.managed_name,
                 "config": _live_to_export_config(r),
             }
             for r in managed
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("firewall.nat", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/static_route.py
+++ b/src/infrafoundry/providers/opnsense/services/static_route.py
@@ -72,10 +72,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Controller base for all static-route CRUD + reconfigure endpoints.
@@ -523,20 +522,23 @@ class StaticRouteService(BaseService):
         OPNsense has no name field — the operator can rename freely after
         import; identity is the tuple, not the name.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); routes land at ``opnsense.routing.static`` as a
+        YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and a
+            ``routing.static`` list leaf.
         """
         live = self.search()
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "static_routes",
                 "name": _synthesize_name(route),
                 "config": _live_to_export_config(self.get(route.uuid)),
             }
             for route in live
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("routing.static", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/unbound_forward.py
+++ b/src/infrafoundry/providers/opnsense/services/unbound_forward.py
@@ -68,10 +68,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Allowed values for the ``type`` discriminator.
@@ -589,20 +588,23 @@ class UnboundForwardService(BaseService):
         — the operator can rename freely after import; identity is the
         tuple, not the name.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); forwards land at ``opnsense.unbound.forwards`` as
+        a YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and an
+            ``unbound.forwards`` list leaf.
         """
         live = self.search()
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "unbound_forward",
                 "name": _synthesize_name(forward),
                 "config": _live_to_export_config(self.get(forward.uuid)),
             }
             for forward in live
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("unbound.forwards", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/unbound_host_alias.py
+++ b/src/infrafoundry/providers/opnsense/services/unbound_host_alias.py
@@ -65,10 +65,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Controller base for all host-alias CRUD endpoints.
@@ -587,8 +586,13 @@ class UnboundHostAliasService(BaseService):
         has no name field — the operator can rename freely after import;
         identity is the tuple, not the name.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); host aliases land at
+        ``opnsense.unbound.host_aliases`` as a YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and an
+            ``unbound.host_aliases`` list leaf.
         """
         live = self.search()
         # Build a UUID → "hostname.domain" map from the live host-override
@@ -605,16 +609,14 @@ class UnboundHostAliasService(BaseService):
             if uuid:
                 uuid_to_label[uuid] = label or uuid
 
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "unbound_host_alias",
                 "name": _synthesize_name(alias),
                 "config": _live_to_export_config(self.get(alias.uuid), uuid_to_label),
             }
             for alias in live
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("unbound.host_aliases", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/unbound_host_override.py
+++ b/src/infrafoundry/providers/opnsense/services/unbound_host_override.py
@@ -75,10 +75,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Controller base for all host-override endpoints (shared with host-alias
@@ -604,20 +603,23 @@ class UnboundHostOverrideService(BaseService):
         for stable, human-readable resource keys. The operator can rename
         after import — identity is the natural-key tuple, not the name.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); host overrides land at
+        ``opnsense.unbound.host_overrides`` as a YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and an
+            ``unbound.host_overrides`` list leaf.
         """
         live = self.search()
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "unbound_host_override",
                 "name": _synthesize_name(override),
                 "config": _live_to_export_config(override),
             }
             for override in live
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("unbound.host_overrides", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/virtual_ip.py
+++ b/src/infrafoundry/providers/opnsense/services/virtual_ip.py
@@ -70,10 +70,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Allowed values for the ``mode`` discriminator. ``ipalias`` (NOT
@@ -693,20 +692,23 @@ class VirtualIPService(BaseService):
         URI for CARP entries; the operator must populate the secret
         manually before re-applying.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); virtual IPs land at
+        ``opnsense.interfaces.virtual_ips`` as a YAML sequence.
+
         Returns:
-            YAML string with ``provider/type/name/config`` entries.
+            YAML string with the nested ``opnsense:`` namespace and an
+            ``interfaces.virtual_ips`` list leaf.
         """
         live = self.search()
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "virtual_ips",
                 "name": _synthesize_name(vip),
                 "config": _live_to_export_config(self.get(vip.uuid)),
             }
             for vip in live
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("interfaces.virtual_ips", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/src/infrafoundry/providers/opnsense/services/vlan.py
+++ b/src/infrafoundry/providers/opnsense/services/vlan.py
@@ -22,10 +22,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import yaml
-
 from infrafoundry.core.provider import ResourceConfig
 
+from ._nested_emit import emit_nested_list_yaml
 from .base import BaseService
 
 # Required fields on every VLAN config. Matches the OPNsense schema:
@@ -381,15 +380,17 @@ class VlanService(BaseService):
     def export_to_yaml(self) -> str:
         """Export the current VLAN configuration to InfraFoundry YAML.
 
+        Output is the nested ``opnsense:`` schema defined by ADR-0016
+        (#793 Phase 4); VLANs land at ``opnsense.interfaces.vlans`` as a
+        YAML sequence.
+
         Returns:
-            YAML string containing ``provider/type/name/config`` entries
-            suitable for inclusion in a resource-centric config file.
+            YAML string with the nested ``opnsense:`` namespace and an
+            ``interfaces.vlans`` list leaf.
         """
         live = self.search()
-        resources = [
+        entries = [
             {
-                "provider": "opnsense",
-                "type": "vlans",
                 "name": f"vlan-{v.device}-{v.tag}",
                 "config": {
                     "device": v.device,
@@ -400,7 +401,7 @@ class VlanService(BaseService):
             }
             for v in live
         ]
-        return yaml.safe_dump({"resources": resources}, sort_keys=False)
+        return emit_nested_list_yaml("interfaces.vlans", entries)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/opnsense/migrate/test_migrate_emits_nested.py
+++ b/tests/unit/providers/opnsense/migrate/test_migrate_emits_nested.py
@@ -1,0 +1,943 @@
+"""End-to-end golden tests: ``Manager.migrate(...)`` emits nested-format YAML.
+
+Per ADR-0016 (#793 Phase 4), every direct-OPNsense component manager's
+``migrate()`` method must emit the new nested ``opnsense:`` schema rather
+than the legacy flat resource-centric format. The CLI (``foundry config
+migrate --provider opnsense --component <type>``) writes whatever each
+manager returns verbatim, so the ``migrate()`` output must round-trip
+through :class:`PackageLoader` cleanly to land at the documented dotted
+``ResourceConfig.type``.
+
+Each test below:
+
+1. Mocks the live OPNsense API (each manager's ``Service.from_environment``
+   factory) to return a small set of records.
+2. Calls ``Manager.migrate(env_name, provider_name=...)``.
+3. Asserts the YAML output has the nested ``opnsense:`` namespace at the
+   expected dotted path (e.g. ``opnsense.firewall.aliases``).
+4. Loads the YAML back through :func:`_parse_nested_provider_format` and
+   verifies the resulting ``ResourceConfig`` list matches the mocked-live
+   records by name and dotted type — this is the operator-facing contract:
+   ``migrate`` output must be re-readable by the loader.
+
+The 14 nominal direct-OPNsense resource types (per the ADR-0016 mapping
+table) are covered across 12 manager classes — :class:`KeaDHCPManager`
+emits all four Kea types in one document, so a single test exercises the
+full Kea quartet with assertions per type.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from infrafoundry.core.config.package_loader import (
+    DOTTED_RESOURCE_SHAPES,
+    NESTED_PROVIDER_NAMESPACE,
+    PackageLoader,
+)
+from infrafoundry.core.provider import ResourceConfig
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _round_trip(yaml_text: str, source_filename: str) -> list[ResourceConfig]:
+    """Parse a nested YAML document the way the loader does at runtime.
+
+    Equivalent to a single env-load step for the opnsense provider.
+    Returns the list of ``ResourceConfig`` items the loader would emit
+    if this were a real ``envs/<env>/<...>.yaml`` file.
+    """
+    data = yaml.safe_load(yaml_text)
+    assert isinstance(data, dict), f"top-level YAML must be a mapping, got {type(data).__name__}"
+    nested = data.get(NESTED_PROVIDER_NAMESPACE)
+    assert isinstance(nested, dict), (
+        f"top-level '{NESTED_PROVIDER_NAMESPACE}:' must be a mapping; got {type(nested).__name__}"
+    )
+    loader = PackageLoader(base_dir=Path("/tmp/unused"))
+    return loader._parse_nested_provider_format(nested, NESTED_PROVIDER_NAMESPACE, source_filename)
+
+
+def _assert_nested_path_present(yaml_text: str, dotted_type: str, *, expected_shape: str) -> Any:
+    """Assert the YAML has the expected dotted path under ``opnsense:``.
+
+    Returns the leaf value at the path so per-type tests can make
+    further assertions on its shape and contents.
+    """
+    data = yaml.safe_load(yaml_text)
+    assert NESTED_PROVIDER_NAMESPACE in data, (
+        f"expected top-level '{NESTED_PROVIDER_NAMESPACE}:' in YAML; got "
+        f"{sorted(data) if isinstance(data, dict) else type(data).__name__}"
+    )
+    cursor: Any = data[NESTED_PROVIDER_NAMESPACE]
+    parts = dotted_type.split(".")
+    for key in parts[:-1]:
+        assert isinstance(cursor, dict) and key in cursor, (
+            f"missing intermediate key '{key}' on path "
+            f"'{NESTED_PROVIDER_NAMESPACE}.{dotted_type}': cursor={cursor!r}"
+        )
+        cursor = cursor[key]
+    leaf_key = parts[-1]
+    assert isinstance(cursor, dict) and leaf_key in cursor, (
+        f"missing leaf key '{leaf_key}' under "
+        f"'{NESTED_PROVIDER_NAMESPACE}.{dotted_type}': cursor={cursor!r}"
+    )
+    leaf = cursor[leaf_key]
+    if expected_shape == "list":
+        assert isinstance(leaf, list), (
+            f"'{NESTED_PROVIDER_NAMESPACE}.{dotted_type}' must be a list "
+            f"(got {type(leaf).__name__})"
+        )
+    elif expected_shape == "dict":
+        assert isinstance(leaf, dict), (
+            f"'{NESTED_PROVIDER_NAMESPACE}.{dotted_type}' must be a dict "
+            f"(got {type(leaf).__name__})"
+        )
+    return leaf
+
+
+def _assert_no_flat_resources_key(yaml_text: str) -> None:
+    """Sanity check: no flat-format ``resources:`` top-level survivor."""
+    data = yaml.safe_load(yaml_text)
+    assert isinstance(data, dict)
+    assert "resources" not in data, (
+        "Nested-format output should not contain the flat 'resources:' key. "
+        f"Got top-level keys: {sorted(data)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. interfaces.vlans -- VlanManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateVlansEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.vlan.VlanService"
+
+    def test_vlans_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.vlan import VlanManager
+
+        # Build a mock that has a real ``export_to_yaml`` (which is what
+        # we're testing) — patch only ``from_environment``.
+        from infrafoundry.providers.opnsense.services.vlan import VlanService
+
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {"uuid": "u1", "if": "igb0", "tag": "10", "descr": "vlan10", "pcp": "0"},
+                {"uuid": "u2", "if": "igb1", "tag": "20", "descr": "vlan20", "pcp": "0"},
+            ]
+        }
+        real_service = VlanService(client)
+
+        manager = VlanManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = real_service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "interfaces.vlans", expected_shape="list")
+        assert len(leaf) == 2
+        assert leaf[0]["name"] == "vlan-igb0-10"
+        assert leaf[0]["config"]["device"] == "igb0"
+        assert leaf[0]["config"]["tag"] == 10
+        assert leaf[1]["name"] == "vlan-igb1-20"
+        _assert_no_flat_resources_key(yaml_text)
+
+        # Round-trip through the loader.
+        parsed = _round_trip(yaml_text, "vlans.yaml")
+        assert [(r.name, r.type) for r in parsed] == [
+            ("vlan-igb0-10", "interfaces.vlans"),
+            ("vlan-igb1-20", "interfaces.vlans"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# 2. interfaces.assignments -- InterfaceAssignmentManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateInterfaceAssignmentsEmitsNested:
+    SERVICE_PATH = (
+        "infrafoundry.providers.opnsense.components.interface_assignment.InterfaceAssignmentService"
+    )
+
+    def test_interface_assignments_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.interface_assignment import (
+            InterfaceAssignmentManager,
+        )
+        from infrafoundry.providers.opnsense.services.interface_assignment import (
+            InterfaceAssignmentService,
+        )
+
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {
+                    "identifier": "lan",
+                    "device": "igb1",
+                    "description": "LAN",
+                    "ipv4": [{"ipaddr": "10.0.0.1", "subnet": "24"}],
+                    "ipv6": [],
+                    "is_physical": True,
+                },
+                {
+                    "identifier": "wan",
+                    "device": "igb0",
+                    "description": "WAN",
+                    "ipv4": [{"ipaddr": "dhcp"}],
+                    "ipv6": [],
+                    "is_physical": True,
+                },
+            ]
+        }
+        real_service = InterfaceAssignmentService(client)
+
+        manager = InterfaceAssignmentManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = real_service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(
+            yaml_text, "interfaces.assignments", expected_shape="list"
+        )
+        names = sorted(entry["name"] for entry in leaf)
+        assert names == ["lan", "wan"]
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "interface_assignments.yaml")
+        assert {(r.name, r.type) for r in parsed} == {
+            ("lan", "interfaces.assignments"),
+            ("wan", "interfaces.assignments"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# 3. firewall.aliases -- AliasManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateAliasesEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.alias.AliasService"
+
+    def test_aliases_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.alias import AliasManager
+        from infrafoundry.providers.opnsense.services.alias import AliasService
+
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {
+                    "uuid": "u1",
+                    "name": "web_servers",
+                    "type": {"host": {"value": "Host(s)", "selected": 1}},
+                    "description": "Web tier",
+                    "content": "10.0.0.1\n10.0.0.2",
+                    "enabled": "1",
+                },
+                {
+                    "uuid": "u2",
+                    "name": "trusted_nets",
+                    "type": {"network": {"value": "Network(s)", "selected": 1}},
+                    "description": "Trusted",
+                    "content": "10.0.0.0/24",
+                    "enabled": "1",
+                },
+            ]
+        }
+        real_service = AliasService(client)
+
+        manager = AliasManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = real_service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "firewall.aliases", expected_shape="list")
+        assert len(leaf) == 2
+        names = [entry["name"] for entry in leaf]
+        assert "web_servers" in names
+        assert "trusted_nets" in names
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "aliases.yaml")
+        assert {(r.name, r.type) for r in parsed} == {
+            ("web_servers", "firewall.aliases"),
+            ("trusted_nets", "firewall.aliases"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# 4. firewall.nat -- NATRuleManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateNATRulesEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.nat_rule.NATRuleService"
+
+    def test_nat_rules_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.nat_rule import NATRuleManager
+
+        # NATRuleService.search_all_tolerant() returns ``list[LiveNATRule]``.
+        # We mock that directly to keep the test focused on the migrate
+        # path's nested wrapping (rather than re-validating the search
+        # parser, which has its own dedicated tests).
+        from infrafoundry.providers.opnsense.services.nat_rule import (
+            LiveNATRule,
+            NATRuleService,
+        )
+
+        live_rules = [
+            LiveNATRule(
+                uuid="u1",
+                kind="outbound",
+                description="WAN nat [infrafoundry:wan-nat]",
+                managed_name="wan-nat",
+                raw={
+                    "uuid": "u1",
+                    "description": "WAN nat [infrafoundry:wan-nat]",
+                    "interface": "wan",
+                    "enabled": "1",
+                },
+            ),
+            LiveNATRule(
+                uuid="u2",
+                kind="port_forward",
+                description="ssh fwd [infrafoundry:ssh-fwd]",
+                managed_name="ssh-fwd",
+                raw={
+                    "uuid": "u2",
+                    "description": "ssh fwd [infrafoundry:ssh-fwd]",
+                    "interface": "wan",
+                    "enabled": "1",
+                },
+            ),
+        ]
+        service = NATRuleService(MagicMock())
+        with patch.object(service, "search_all_tolerant", return_value=live_rules):
+            manager = NATRuleManager(tmp_path)
+            with patch(self.SERVICE_PATH) as svc_cls:
+                svc_cls.from_environment.return_value = service
+                yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "firewall.nat", expected_shape="list")
+        names = sorted(entry["name"] for entry in leaf)
+        assert names == ["ssh-fwd", "wan-nat"]
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "nat_rules.yaml")
+        assert {(r.name, r.type) for r in parsed} == {
+            ("wan-nat", "firewall.nat"),
+            ("ssh-fwd", "firewall.nat"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# 5. firewall.rules -- FirewallRuleManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateFirewallRulesEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.firewall_rule.FirewallRuleService"
+
+    def test_firewall_rules_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.firewall_rule import (
+            FirewallRuleManager,
+        )
+        from infrafoundry.providers.opnsense.services.firewall_rule import (
+            FirewallRuleService,
+        )
+
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {
+                    "uuid": "u1",
+                    "description": "lan-allow [infrafoundry:lan-allow]",
+                    "interface": "lan",
+                    "action": "pass",
+                    "enabled": "1",
+                },
+            ]
+        }
+        service = FirewallRuleService(client)
+        # Prime the marker so unmanaged rules with no infrafoundry tag
+        # are filtered correctly.
+        service._category_uuid = "marker-uuid"
+
+        manager = FirewallRuleManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "firewall.rules", expected_shape="list")
+        names = [entry["name"] for entry in leaf]
+        assert "lan-allow" in names
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "firewall_rules.yaml")
+        assert {(r.name, r.type) for r in parsed} == {("lan-allow", "firewall.rules")}
+
+
+# ---------------------------------------------------------------------------
+# 6. routing.gateways -- GatewayManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateGatewaysEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.gateway.GatewayService"
+
+    def test_gateways_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.gateway import GatewayManager
+        from infrafoundry.providers.opnsense.services.gateway import GatewayService
+
+        # The service issues a search + per-gateway get; mock both.
+        client = MagicMock()
+        # ``search`` response is a {"rows": [...]} dict.
+        # ``get`` response is a {"gateway_item": {...}} envelope.
+        client.request.side_effect = [
+            {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "name": "WAN_GW",
+                        "interface": "wan",
+                        "ipprotocol": "inet",
+                        "gateway": "10.0.0.1",
+                        "priority": "200",
+                        "is_dynamic": "0",
+                        "is_disabled": "0",
+                        "default_gw": "1",
+                    },
+                ]
+            },
+            # getGateway/u1
+            {
+                "gateway_item": {
+                    "name": "WAN_GW",
+                    "interface": {"wan": {"value": "WAN", "selected": 1}},
+                    "ipprotocol": {"inet": {"value": "IPv4", "selected": 1}},
+                    "gateway": "10.0.0.1",
+                    "priority": "200",
+                    "disabled": "0",
+                    "monitor_disable": "0",
+                    "fargw": "0",
+                    "force_down": "0",
+                    "nonlocalgateway": "0",
+                    "monitor": "",
+                    "monitor_noroute": "0",
+                    "weight": "1",
+                    "data_payload": "1",
+                    "descr": "",
+                }
+            },
+        ]
+        service = GatewayService(client)
+
+        manager = GatewayManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "routing.gateways", expected_shape="list")
+        assert leaf
+        assert leaf[0]["name"] == "WAN_GW"
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "gateways.yaml")
+        assert [(r.name, r.type) for r in parsed] == [("WAN_GW", "routing.gateways")]
+
+
+# ---------------------------------------------------------------------------
+# 7. routing.static -- StaticRouteManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateStaticRoutesEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.static_route.StaticRouteService"
+
+    def test_static_routes_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.static_route import (
+            StaticRouteManager,
+        )
+        from infrafoundry.providers.opnsense.services.static_route import StaticRouteService
+
+        client = MagicMock()
+        client.request.side_effect = [
+            # searchroute
+            {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "network": "10.0.10.0/24",
+                        "gateway": "WAN_GW",
+                        "descr": "internal",
+                        "disabled": "0",
+                    },
+                ]
+            },
+            # getroute/u1
+            {
+                "route": {
+                    "network": "10.0.10.0/24",
+                    "gateway": {
+                        "WAN_GW": {"value": "WAN_GW - 10.0.0.1", "selected": 1},
+                    },
+                    "descr": "internal",
+                    "disabled": "0",
+                }
+            },
+        ]
+        service = StaticRouteService(client)
+
+        manager = StaticRouteManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "routing.static", expected_shape="list")
+        assert leaf
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "static_routes.yaml")
+        assert len(parsed) == 1
+        assert parsed[0].type == "routing.static"
+
+
+# ---------------------------------------------------------------------------
+# 8. interfaces.virtual_ips -- VirtualIPManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateVirtualIPsEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.virtual_ip.VirtualIPService"
+
+    def test_virtual_ips_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.virtual_ip import VirtualIPManager
+        from infrafoundry.providers.opnsense.services.virtual_ip import VirtualIPService
+
+        client = MagicMock()
+        client.request.side_effect = [
+            # searchItem
+            {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "interface": "lan",
+                        "mode": "ipalias",
+                        "address": "10.0.0.10",
+                        "vhid": "",
+                        "subnet_bits": "24",
+                        "subnet": "10.0.0.10/24",
+                        "descr": "alias",
+                    },
+                ]
+            },
+            # getItem/u1
+            {
+                "vip": {
+                    "interface": {"lan": {"value": "LAN", "selected": 1}},
+                    "mode": {"ipalias": {"value": "IP Alias", "selected": 1}},
+                    "address": "10.0.0.10",
+                    "subnet_bits": "24",
+                    "vhid": "",
+                    "advbase": "1",
+                    "advskew": "0",
+                    "descr": "alias",
+                    "password": "",
+                    "nobind": "0",
+                    "peer": "",
+                    "peer6": "",
+                }
+            },
+        ]
+        service = VirtualIPService(client)
+
+        manager = VirtualIPManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(
+            yaml_text, "interfaces.virtual_ips", expected_shape="list"
+        )
+        assert leaf
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "virtual_ips.yaml")
+        assert len(parsed) == 1
+        assert parsed[0].type == "interfaces.virtual_ips"
+
+
+# ---------------------------------------------------------------------------
+# 9. unbound.host_overrides -- UnboundHostOverrideManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateUnboundHostOverridesEmitsNested:
+    SERVICE_PATH = (
+        "infrafoundry.providers.opnsense.components.unbound_host_override"
+        ".UnboundHostOverrideService"
+    )
+
+    def test_unbound_host_overrides_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.unbound_host_override import (
+            UnboundHostOverrideManager,
+        )
+        from infrafoundry.providers.opnsense.services.unbound_host_override import (
+            UnboundHostOverrideService,
+        )
+
+        client = MagicMock()
+        client.request.return_value = {
+            "rows": [
+                {
+                    "uuid": "u1",
+                    "hostname": "web",
+                    "domain": "example.com",
+                    "rr": "A",
+                    "server": "10.0.0.1",
+                    "description": "",
+                    "enabled": "1",
+                },
+                {
+                    "uuid": "u2",
+                    "hostname": "mail",
+                    "domain": "example.com",
+                    "rr": "A",
+                    "server": "10.0.0.2",
+                    "description": "",
+                    "enabled": "1",
+                },
+            ]
+        }
+        service = UnboundHostOverrideService(client)
+
+        manager = UnboundHostOverrideManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(
+            yaml_text, "unbound.host_overrides", expected_shape="list"
+        )
+        names = sorted(entry["name"] for entry in leaf)
+        assert names == ["mail-example-com", "web-example-com"]
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "unbound_host_overrides.yaml")
+        assert {(r.name, r.type) for r in parsed} == {
+            ("web-example-com", "unbound.host_overrides"),
+            ("mail-example-com", "unbound.host_overrides"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# 10. unbound.host_aliases -- UnboundHostAliasManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateUnboundHostAliasesEmitsNested:
+    SERVICE_PATH = (
+        "infrafoundry.providers.opnsense.components.unbound_host_alias.UnboundHostAliasService"
+    )
+
+    def test_unbound_host_aliases_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.unbound_host_alias import (
+            UnboundHostAliasManager,
+        )
+        from infrafoundry.providers.opnsense.services.unbound_host_alias import (
+            UnboundHostAliasService,
+        )
+
+        client = MagicMock()
+        # Sequence: searchHostAlias, then per-uuid getHostAlias, then
+        # searchHostOverride for the parent label map.
+        client.request.side_effect = [
+            # searchHostAlias
+            {
+                "rows": [
+                    {
+                        "uuid": "a1",
+                        "host": {"u_parent": {"value": "web", "selected": 1}},
+                        "hostname": "www",
+                        "domain": "example.com",
+                        "description": "",
+                    },
+                ]
+            },
+            # searchHostOverride
+            {
+                "rows": [
+                    {
+                        "uuid": "u_parent",
+                        "hostname": "web",
+                        "domain": "example.com",
+                    },
+                ]
+            },
+            # getHostAlias/a1
+            {
+                "alias": {
+                    "host": {"u_parent": {"value": "web", "selected": 1}},
+                    "hostname": "www",
+                    "domain": "example.com",
+                    "description": "",
+                    "enabled": "1",
+                }
+            },
+        ]
+        service = UnboundHostAliasService(client)
+
+        manager = UnboundHostAliasManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "unbound.host_aliases", expected_shape="list")
+        assert leaf
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "unbound_host_aliases.yaml")
+        assert len(parsed) == 1
+        assert parsed[0].type == "unbound.host_aliases"
+
+
+# ---------------------------------------------------------------------------
+# 11. unbound.forwards -- UnboundForwardManager
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateUnboundForwardsEmitsNested:
+    SERVICE_PATH = (
+        "infrafoundry.providers.opnsense.components.unbound_forward.UnboundForwardService"
+    )
+
+    def test_unbound_forwards_emit_nested(self, tmp_path: Path) -> None:
+        from infrafoundry.providers.opnsense.components.unbound_forward import (
+            UnboundForwardManager,
+        )
+        from infrafoundry.providers.opnsense.services.unbound_forward import (
+            UnboundForwardService,
+        )
+
+        client = MagicMock()
+        client.request.side_effect = [
+            # searchForward
+            {
+                "rows": [
+                    {
+                        "uuid": "u1",
+                        "type": "forward",
+                        "domain": "example.com",
+                        "server": "1.1.1.1",
+                        "port": "53",
+                        "verify": "",
+                        "description": "",
+                        "enabled": "1",
+                    },
+                ]
+            },
+            # getForward/u1
+            {
+                "dot": {
+                    "type": {"forward": {"value": "Forward", "selected": 1}},
+                    "domain": "example.com",
+                    "server": "1.1.1.1",
+                    "port": "53",
+                    "verify": "",
+                    "description": "",
+                    "enabled": "1",
+                }
+            },
+        ]
+        service = UnboundForwardService(client)
+
+        manager = UnboundForwardManager(tmp_path)
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        leaf = _assert_nested_path_present(yaml_text, "unbound.forwards", expected_shape="list")
+        assert leaf
+        _assert_no_flat_resources_key(yaml_text)
+
+        parsed = _round_trip(yaml_text, "unbound_forwards.yaml")
+        assert len(parsed) == 1
+        assert parsed[0].type == "unbound.forwards"
+
+
+# ---------------------------------------------------------------------------
+# 12-15. KeaDHCPManager emits all four kea types in one call:
+#   kea.dhcp4.subnets, kea.dhcp4.reservations,
+#   kea.dhcp6.subnets, kea.dhcp6.reservations.
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateKeaDHCPEmitsNested:
+    SERVICE_PATH = "infrafoundry.providers.opnsense.components.kea_dhcp.KeaDHCPService"
+
+    @pytest.fixture
+    def manager_with_service(self, tmp_path: Path) -> tuple[Any, Any]:
+        from infrafoundry.providers.opnsense.components.kea_dhcp import KeaDHCPManager
+        from infrafoundry.providers.opnsense.services.kea_dhcp import KeaDHCPService
+
+        # Build a *real* KeaDHCPService so ``export_to_yaml`` runs the
+        # nested-emit code path. Replace only the four search methods.
+        # Using ``MagicMock()`` for the whole service auto-mocks
+        # ``export_to_yaml`` to return a MagicMock, which downstream
+        # ``yaml.safe_load`` then reads from indefinitely (allocates
+        # tens of GB and hangs).
+        service = KeaDHCPService(MagicMock())
+        service.search_dhcpv4_subnets = MagicMock(  # type: ignore[method-assign]
+            return_value=[
+                {"description": "lan", "subnet": "10.0.0.0/24", "pools": "10.0.0.10-10.0.0.99"},
+            ]
+        )
+        service.search_dhcpv4_reservations = MagicMock(  # type: ignore[method-assign]
+            return_value=[
+                {
+                    "subnet": "10.0.0.0/24",
+                    "hw_address": "aa:bb:cc:dd:ee:ff",
+                    "ip_address": "10.0.0.50",
+                    "hostname": "fileserver",
+                    "description": "FS",
+                },
+            ]
+        )
+        service.search_dhcpv6_subnets = MagicMock(  # type: ignore[method-assign]
+            return_value=[
+                {"description": "lan", "subnet": "2001:db8::/64"},
+            ]
+        )
+        service.search_dhcpv6_reservations = MagicMock(  # type: ignore[method-assign]
+            return_value=[
+                {
+                    "subnet": "2001:db8::/64",
+                    "duid": "00:01:00:01:aa:bb",
+                    "ip_address": "2001:db8::50",
+                    "hostname": "fileserver",
+                    "description": "FS6",
+                },
+            ]
+        )
+
+        manager = KeaDHCPManager(tmp_path)
+        return manager, service
+
+    def test_kea_emits_all_four_types_under_nested_namespace(
+        self, manager_with_service: tuple[Any, MagicMock]
+    ) -> None:
+        manager, service = manager_with_service
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        # All four leaves must be present even if some are empty.
+        for dotted in (
+            "kea.dhcp4.subnets",
+            "kea.dhcp4.reservations",
+            "kea.dhcp6.subnets",
+            "kea.dhcp6.reservations",
+        ):
+            leaf = _assert_nested_path_present(yaml_text, dotted, expected_shape="list")
+            assert isinstance(leaf, list)
+        _assert_no_flat_resources_key(yaml_text)
+
+    def test_kea_dhcp4_subnets_round_trip(
+        self, manager_with_service: tuple[Any, MagicMock]
+    ) -> None:
+        manager, service = manager_with_service
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        parsed = _round_trip(yaml_text, "kea_dhcp.yaml")
+        v4_subnets = [r for r in parsed if r.type == "kea.dhcp4.subnets"]
+        assert len(v4_subnets) == 1
+        assert v4_subnets[0].name == "lan"
+        assert v4_subnets[0].config["config"]["subnet"] == "10.0.0.0/24"
+
+    def test_kea_dhcp4_reservations_round_trip(
+        self, manager_with_service: tuple[Any, MagicMock]
+    ) -> None:
+        manager, service = manager_with_service
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        parsed = _round_trip(yaml_text, "kea_dhcp.yaml")
+        v4_res = [r for r in parsed if r.type == "kea.dhcp4.reservations"]
+        assert len(v4_res) == 1
+        assert v4_res[0].name == "fileserver"
+
+    def test_kea_dhcp6_subnets_round_trip(
+        self, manager_with_service: tuple[Any, MagicMock]
+    ) -> None:
+        manager, service = manager_with_service
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        parsed = _round_trip(yaml_text, "kea_dhcp.yaml")
+        v6_subnets = [r for r in parsed if r.type == "kea.dhcp6.subnets"]
+        assert len(v6_subnets) == 1
+        assert v6_subnets[0].name == "lan_v6"
+
+    def test_kea_dhcp6_reservations_round_trip(
+        self, manager_with_service: tuple[Any, MagicMock]
+    ) -> None:
+        manager, service = manager_with_service
+        with patch(self.SERVICE_PATH) as svc_cls:
+            svc_cls.from_environment.return_value = service
+            yaml_text = manager.migrate("test-env")
+
+        parsed = _round_trip(yaml_text, "kea_dhcp.yaml")
+        v6_res = [r for r in parsed if r.type == "kea.dhcp6.reservations"]
+        assert len(v6_res) == 1
+        assert v6_res[0].name == "fileserver_v6"
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: all 14 dotted paths declared by the loader's shape table
+# match what the `migrate` paths currently emit. If a manager forgot to
+# wire its new dotted type into either ``DOTTED_RESOURCE_SHAPES`` or its
+# own ``export_to_yaml``, the round-trip tests above would fail per-type;
+# this guard catches a stale registration in one place.
+# ---------------------------------------------------------------------------
+
+
+class TestDottedTypeRegistrySanity:
+    """The 14 phase-1 list-shape resource types are all accounted for."""
+
+    EXPECTED_LIST_TYPES: tuple[str, ...] = (
+        "interfaces.vlans",
+        "interfaces.assignments",
+        "firewall.aliases",
+        "firewall.nat",
+        "firewall.rules",
+        "routing.gateways",
+        "routing.static",
+        "interfaces.virtual_ips",
+        "unbound.host_overrides",
+        "unbound.host_aliases",
+        "unbound.forwards",
+        "kea.dhcp4.subnets",
+        "kea.dhcp4.reservations",
+        "kea.dhcp6.subnets",
+        "kea.dhcp6.reservations",
+    )
+
+    def test_each_phase_1_dotted_type_registered_as_list(self) -> None:
+        for dotted in self.EXPECTED_LIST_TYPES:
+            assert dotted in DOTTED_RESOURCE_SHAPES, (
+                f"{dotted!r} is not in DOTTED_RESOURCE_SHAPES — the loader "
+                "won't accept its nested-format YAML."
+            )
+            assert DOTTED_RESOURCE_SHAPES[dotted] == "list", (
+                f"{dotted!r} declared as {DOTTED_RESOURCE_SHAPES[dotted]!r}, expected 'list'."
+            )

--- a/tests/unit/providers/opnsense/test_alias_service.py
+++ b/tests/unit/providers/opnsense/test_alias_service.py
@@ -1032,7 +1032,10 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         svc = AliasService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty list at the leaf, not flat ``resources: []``.
+        assert "aliases: []" in text
+        loaded = yaml.safe_load(text)
+        assert loaded == {"opnsense": {"firewall": {"aliases": []}}}
 
     def test_export_round_trip_loads_back_to_dict(self) -> None:
         client = MagicMock()
@@ -1057,19 +1060,19 @@ class TestExportToYaml:
         svc = AliasService(client)
         text = svc.export_to_yaml()
         loaded = yaml.safe_load(text)
-        assert "resources" in loaded
-        assert len(loaded["resources"]) == 2
+        # Nested format per ADR-0016 (#793 Phase 4).
+        assert loaded["opnsense"]["firewall"]["aliases"]
+        aliases = loaded["opnsense"]["firewall"]["aliases"]
+        assert len(aliases) == 2
 
-        web = loaded["resources"][0]
-        assert web["provider"] == "opnsense"
-        assert web["type"] == "aliases"
+        web = aliases[0]
         assert web["name"] == "web_servers"
         assert web["config"]["name"] == "web_servers"
         assert web["config"]["type"] == "host"
         assert web["config"]["content"] == ["10.0.0.1"]
         assert "proto" not in web["config"]
 
-        geo = loaded["resources"][1]
+        geo = aliases[1]
         assert geo["name"] == "geo_eu"
         assert geo["config"]["type"] == "geoip"
         assert geo["config"]["proto"] == "IPv4"
@@ -1086,7 +1089,8 @@ class TestExportToYaml:
         }
         svc = AliasService(client)
         loaded = yaml.safe_load(svc.export_to_yaml())
-        names = [r["name"] for r in loaded["resources"]]
+        aliases = loaded["opnsense"]["firewall"]["aliases"]
+        names = [r["name"] for r in aliases]
         assert names == ["web_servers"]
 
 

--- a/tests/unit/providers/opnsense/test_firewall_rule_service.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_service.py
@@ -873,7 +873,8 @@ class TestSearchTolerant:
         with caplog.at_level(logging.WARNING):
             text = svc.export_to_yaml()
 
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.firewall.rules.
+        assert "rules: []" in text
         warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
         assert len(warnings) == 1
 
@@ -1170,15 +1171,18 @@ class TestExportToYaml:
         text = svc.export_to_yaml()
         assert "lan-allow" in text
         assert "manual" not in text  # unmanaged excluded
-        assert "type: firewall_rules" in text
-        assert "provider: opnsense" in text
+        # Nested format per ADR-0016 (#793 Phase 4).
+        assert "opnsense:" in text
+        assert "firewall:" in text
+        assert "rules:" in text
 
     def test_export_with_no_managed_rules_yields_empty_resources(self) -> None:
         client = MagicMock()
         client.request.return_value = {"rows": []}
         svc = FirewallRuleService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.firewall.rules.
+        assert "rules: []" in text
 
     def test_export_strips_marker_from_categories(self) -> None:
         client = MagicMock()

--- a/tests/unit/providers/opnsense/test_gateway_service.py
+++ b/tests/unit/providers/opnsense/test_gateway_service.py
@@ -649,7 +649,8 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         svc = GatewayService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.routing.gateways.
+        assert "gateways: []" in text
 
 
 class TestLiveToExportConfig:

--- a/tests/unit/providers/opnsense/test_interface_assignment_service.py
+++ b/tests/unit/providers/opnsense/test_interface_assignment_service.py
@@ -1067,6 +1067,8 @@ class TestApplyDiffResult:
 
 
 class TestExportToYaml:
+    """Nested ``opnsense:`` schema per ADR-0016 (#793 Phase 4)."""
+
     def test_round_trip_structure(self) -> None:
         client = MagicMock()
         client.request.return_value = {
@@ -1088,8 +1090,9 @@ class TestExportToYaml:
         service = InterfaceAssignmentService(client)
         rendered = service.export_to_yaml()
         parsed = yaml.safe_load(rendered)
-        assert "resources" in parsed
-        names = {r["name"] for r in parsed["resources"]}
+        # Nested format: assignments at opnsense.interfaces.assignments.
+        assignments = parsed["opnsense"]["interfaces"]["assignments"]
+        names = {r["name"] for r in assignments}
         assert names == {"lan", "wan"}
 
     def test_export_with_no_assignments(self) -> None:
@@ -1097,7 +1100,7 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         service = InterfaceAssignmentService(client)
         parsed = yaml.safe_load(service.export_to_yaml())
-        assert parsed == {"resources": []}
+        assert parsed == {"opnsense": {"interfaces": {"assignments": []}}}
 
     def test_export_skips_unassigned_interfaces(self) -> None:
         client = MagicMock()
@@ -1106,4 +1109,5 @@ class TestExportToYaml:
         }
         service = InterfaceAssignmentService(client)
         parsed = yaml.safe_load(service.export_to_yaml())
-        assert len(parsed["resources"]) == 1
+        assignments = parsed["opnsense"]["interfaces"]["assignments"]
+        assert len(assignments) == 1

--- a/tests/unit/providers/opnsense/test_nat_rule_service.py
+++ b/tests/unit/providers/opnsense/test_nat_rule_service.py
@@ -1654,7 +1654,8 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         svc = NATRuleService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.firewall.nat.
+        assert "nat: []" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/opnsense/test_static_route_service.py
+++ b/tests/unit/providers/opnsense/test_static_route_service.py
@@ -752,7 +752,8 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         svc = StaticRouteService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.routing.static.
+        assert "static: []" in text
 
 
 class TestLiveToExportConfig:

--- a/tests/unit/providers/opnsense/test_unbound_forward_service.py
+++ b/tests/unit/providers/opnsense/test_unbound_forward_service.py
@@ -844,7 +844,8 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         svc = UnboundForwardService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.unbound.forwards.
+        assert "forwards: []" in text
 
 
 class TestLiveToExportConfig:

--- a/tests/unit/providers/opnsense/test_unbound_host_alias_service.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_alias_service.py
@@ -868,7 +868,8 @@ class TestExportToYaml:
         client.request.side_effect = [{"rows": []}, {"rows": []}]
         svc = UnboundHostAliasService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.unbound.host_aliases.
+        assert "host_aliases: []" in text
 
 
 class TestLiveToExportConfig:

--- a/tests/unit/providers/opnsense/test_unbound_host_override_service.py
+++ b/tests/unit/providers/opnsense/test_unbound_host_override_service.py
@@ -413,7 +413,8 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         svc = UnboundHostOverrideService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.unbound.host_overrides.
+        assert "host_overrides: []" in text
 
     def test_export_round_trip_loads_back_to_dict(self) -> None:
         client = MagicMock()
@@ -440,24 +441,23 @@ class TestExportToYaml:
         svc = UnboundHostOverrideService(client)
         text = svc.export_to_yaml()
         loaded = yaml.safe_load(text)
-        assert "resources" in loaded
-        assert len(loaded["resources"]) == 3
+        # Nested format per ADR-0016 (#793 Phase 4).
+        overrides = loaded["opnsense"]["unbound"]["host_overrides"]
+        assert len(overrides) == 3
 
-        web = loaded["resources"][0]
-        assert web["provider"] == "opnsense"
-        assert web["type"] == "unbound_host_override"
+        web = overrides[0]
         assert web["name"] == "web-example-com"
         assert web["config"]["hostname"] == "web"
         assert web["config"]["domain"] == "example.com"
         assert web["config"]["server"] == "10.0.0.1"
         assert "rr" not in web["config"]
 
-        web6 = loaded["resources"][1]
+        web6 = overrides[1]
         assert web6["name"] == "web6-example-com-aaaa"
         assert web6["config"]["rr"] == "AAAA"
         assert web6["config"]["server"] == "2001:db8::1"
 
-        mx = loaded["resources"][2]
+        mx = overrides[2]
         assert mx["name"] == "@-example-com-mx"
         assert mx["config"]["rr"] == "MX"
         assert mx["config"]["mxprio"] == "10"
@@ -466,18 +466,16 @@ class TestExportToYaml:
 
     def test_export_field_order_stable(self) -> None:
         # ``yaml.safe_dump(..., sort_keys=False)`` preserves insertion
-        # order on the resource dict, so ``provider`` precedes ``type``
-        # precedes ``name`` precedes ``config`` in the output. Operator
-        # diffs are noisy if this churns.
+        # order on the entry dict, so under nested format each entry's
+        # ``name`` precedes ``config``. Operator diffs are noisy if this
+        # churns.
         client = MagicMock()
         client.request.return_value = {"rows": [_row("web", "example.com", server="10.0.0.1")]}
         svc = UnboundHostOverrideService(client)
         text = svc.export_to_yaml()
-        provider_idx = text.index("provider:")
-        type_idx = text.index("type:")
         name_idx = text.index("name:")
         config_idx = text.index("config:")
-        assert provider_idx < type_idx < name_idx < config_idx
+        assert name_idx < config_idx
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/opnsense/test_virtual_ip_service.py
+++ b/tests/unit/providers/opnsense/test_virtual_ip_service.py
@@ -883,7 +883,8 @@ class TestExportToYaml:
         client.request.return_value = {"rows": []}
         svc = VirtualIPService(client)
         text = svc.export_to_yaml()
-        assert "resources: []" in text
+        # Nested format: empty leaf list at opnsense.interfaces.virtual_ips.
+        assert "virtual_ips: []" in text
 
 
 class TestLiveToExportConfig:

--- a/tests/unit/providers/opnsense/test_vlan_service.py
+++ b/tests/unit/providers/opnsense/test_vlan_service.py
@@ -575,7 +575,7 @@ class TestComputeDiffViaServiceMethod:
 
 
 class TestExportToYaml:
-    """Live VLANs render as resource-centric YAML."""
+    """Live VLANs render as nested ``opnsense:`` YAML (ADR-0016, #793 Phase 4)."""
 
     def test_export_renders_yaml(self) -> None:
         client = MagicMock()
@@ -589,11 +589,15 @@ class TestExportToYaml:
         assert "vlan-igb0-10" in text
         assert "device: igb0" in text
         assert "tag: 10" in text
-        assert "type: vlans" in text
+        # Nested format: VLANs land at opnsense.interfaces.vlans (per ADR-0016).
+        assert "opnsense:" in text
+        assert "interfaces:" in text
+        assert "vlans:" in text
 
     def test_export_with_no_vlans_yields_empty_resources(self) -> None:
         client = MagicMock()
         client.request.return_value = {"rows": []}
         service = VlanService(client)
         text = service.export_to_yaml()
-        assert "resources: []" in text
+        # Empty leaf list at opnsense.interfaces.vlans.
+        assert "vlans: []" in text


### PR DESCRIPTION
## Description

Phase 4 of #793. Each direct-OPNsense component manager's `migrate()` delegates
to its service's `export_to_yaml()`; this PR updates those service methods to
emit the API-aligned nested `opnsense:` schema (ADR-0016) instead of the legacy
flat resource-centric format.

A new helper module `services/_nested_emit.py` centralises the wrapping
(list/singleton/multi-branch shapes), validates the dotted path against
`DOTTED_RESOURCE_SHAPES` (the loader's source of truth), and lets services emit
by composition rather than hand-rolling YAML. The Kea service uses the
multi-branch helper to keep its all-four-types output in a single document.

End-to-end golden tests cover all 15 dotted resource types; each test mocks the
live API, calls `Manager.migrate()`, and round-trips the output through the
loader's nested-format parser.

This PR is **stacked on top of [#797 (Phase 3)](../pull/797)**. After merge it
will retarget to `main` automatically.

## Related Issue

Addresses #793.

## Type of Change

- [x] Code refactoring

## Changes Made

- Add `services/_nested_emit.py` helper with three emit functions (list, singleton, multi-branch)
- Update 12 service files to emit nested `opnsense:` YAML via the helper
- Update 11 service test files to assert nested format
- Add `tests/unit/providers/opnsense/migrate/test_migrate_emits_nested.py` (17 golden tests for all 15 dotted types)

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Targeted scope verified locally:

- `tests/unit/providers/opnsense/migrate/` — all 17 golden round-trip tests pass
- Modified service tests (11 files) — all pass
- Manager tests (15 files) — all pass
- CLI migrate test — passes
- `doit lint` — clean
- `doit type_check` — clean

## Notes

The kea fixture in the new golden test file uses a real `KeaDHCPService(MagicMock())`
with patched search methods rather than `service = MagicMock()` directly. The
latter pattern caused `service.export_to_yaml()` to return a `MagicMock`; downstream
`yaml.safe_load(MagicMock())` then read from `.read()` indefinitely and allocated
~30 GB before OOM. Worth flagging because it matches at least one of the
unexplained pytest OOMs hit twice this week.
