### PR TITLE
refactor: drop direct-OPNsense flat→dotted shim (hard cutover)

### DIFF
--- a/blueprints/aiqum/dhcp.yaml
+++ b/blueprints/aiqum/dhcp.yaml
@@ -3,7 +3,7 @@
 # package directory provider. Outer name is templated for multi-instance safety.
 resources:
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ vm_name }}"
     config:
       subnet_ref: "{{ dhcp_subnet }}"

--- a/blueprints/k3s-cluster/providers/proxmox/dhcp.yaml
+++ b/blueprints/k3s-cluster/providers/proxmox/dhcp.yaml
@@ -6,7 +6,7 @@
 resources:
   # --- Server node ---
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ server_name }}-dhcp"
     config:
       subnet_ref: "{{ dhcp_subnet }}"
@@ -17,7 +17,7 @@ resources:
 
 {% for agent in agents %}
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ agent.name }}-dhcp"
     config:
       subnet_ref: "{{ dhcp_subnet }}"

--- a/blueprints/ontap-cluster/dhcp.yaml
+++ b/blueprints/ontap-cluster/dhcp.yaml
@@ -7,7 +7,7 @@
 # Node mgmt MACs are real NIC MACs from the VM config.
 resources:
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ node01_name }}"
     config:
       subnet_ref: "{{ dhcp_subnet }}"
@@ -17,7 +17,7 @@ resources:
       description: "ONTAP Simulator Node 1 (e0c mgmt)"
 
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ node02_name }}"
     config:
       subnet_ref: "{{ dhcp_subnet }}"
@@ -27,7 +27,7 @@ resources:
       description: "ONTAP Simulator Node 2 (e0c mgmt)"
 
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ cluster_name }}"
     config:
       subnet_ref: "{{ dhcp_subnet }}"
@@ -37,7 +37,7 @@ resources:
       description: "ONTAP Cluster Management LIF"
 
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ cluster_name }}-data1"
     config:
       subnet_ref: "{{ dhcp_subnet }}"
@@ -47,7 +47,7 @@ resources:
       description: "ONTAP Cluster Data LIF 1 ({{ svm_name }})"
 
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ cluster_name }}-data2"
     config:
       subnet_ref: "{{ dhcp_subnet }}"

--- a/blueprints/service-vm/dhcp.yaml
+++ b/blueprints/service-vm/dhcp.yaml
@@ -4,7 +4,7 @@
    multi-instance safety. -#}
 resources:
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: "{{ vm_name }}"
     config:
       subnet_ref: "{{ dhcp_subnet }}"

--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -35,35 +35,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Transient flat→dotted resource-type translation for the direct-OPNsense
-# provider's filename-derived stem path (#793 Phase 1). Old flat YAML files
-# (e.g., ``vlans.yaml`` with a top-level ``vlans:`` key) keep parsing
-# correctly while internal ``ResourceConfig.type`` strings are already
-# dotted everywhere else (dispatch tables, validators, manager guards).
-# Per ADR-0016, the cutover is hard at Phase 5 in lockstep with the
-# operator-side ``endavis-infra/`` conversion script (#793 Phase 6).
-#
-# TODO: remove in #793 Phase 5 hard cutover.
-STEM_TO_DOTTED: dict[str, str] = {
-    "vlans": "interfaces.vlans",
-    "interface_assignments": "interfaces.assignments",
-    "aliases": "firewall.aliases",
-    "nat_rules": "firewall.nat",
-    "firewall_rules": "firewall.rules",
-    "gateways": "routing.gateways",
-    "static_routes": "routing.static",
-    "virtual_ips": "interfaces.virtual_ips",
-    "unbound_host_override": "unbound.host_overrides",
-    "unbound_host_alias": "unbound.host_aliases",
-    "unbound_forward": "unbound.forwards",
-    "kea_subnet": "kea.dhcp4.subnets",
-    "kea_reservation": "kea.dhcp4.reservations",
-    "kea_dhcp6_subnet": "kea.dhcp6.subnets",
-    "kea_dhcp6_reservation": "kea.dhcp6.reservations",
-}
-
 # Map of dotted resource-type paths → declared YAML leaf shape under the
-# nested ``opnsense:`` namespace (#793 Phase 2, per ADR-0016).
+# nested ``opnsense:`` namespace (#793 per ADR-0016).
 #
 # - ``"list"`` paths must appear as YAML sequences (each entry a dict with a
 #   ``name:`` field). Each entry emits one ``ResourceConfig``.
@@ -74,13 +47,27 @@ STEM_TO_DOTTED: dict[str, str] = {
 # of ``firewall: {rules: [...]}``) raises a clear error rather than
 # silently round-tripping as a singleton.
 #
-# Currently-implemented list-shape types come from ``STEM_TO_DOTTED.values()``.
-# The remaining entries are documented in ADR-0016 from in-flight issues
-# #786 to #792; they are accepted by the loader now so operator YAML and tests
-# can land alongside each component as it ships, without requiring a loader
-# change for every new component.
+# Path entries below the divider come from in-flight feature issues
+# (#786 to #792); they are accepted by the loader now so operator YAML and
+# tests can land alongside each component as it ships, without requiring a
+# loader change for every new component.
 DOTTED_RESOURCE_SHAPES: dict[str, str] = {
-    **dict.fromkeys(STEM_TO_DOTTED.values(), "list"),
+    # Direct-OPNsense components currently shipped (#793).
+    "interfaces.vlans": "list",
+    "interfaces.assignments": "list",
+    "interfaces.virtual_ips": "list",
+    "firewall.aliases": "list",
+    "firewall.nat": "list",
+    "firewall.rules": "list",
+    "routing.gateways": "list",
+    "routing.static": "list",
+    "unbound.host_overrides": "list",
+    "unbound.host_aliases": "list",
+    "unbound.forwards": "list",
+    "kea.dhcp4.subnets": "list",
+    "kea.dhcp4.reservations": "list",
+    "kea.dhcp6.subnets": "list",
+    "kea.dhcp6.reservations": "list",
     # Singletons / surfaces from in-flight feature issues (ADR-0016).
     # #786 firewall_log
     "firewall.log": "dict",
@@ -591,16 +578,10 @@ class PackageLoader:
                 f"got {type(resource_list).__name__}"
             )
 
-        # Translate flat type names to dotted paths for direct-OPNsense
-        # components per ADR-0016 (#793 Phase 1). Non-OPNsense filename stems
-        # (and any new top-level keys) pass through unchanged.
-        # TODO: remove in #793 Phase 5 hard cutover.
-        emitted_type = STEM_TO_DOTTED.get(resource_type, resource_type)
-
         return [
             ResourceConfig(
                 name=item["name"],
-                type=emitted_type,
+                type=resource_type,
                 provider=item.get("provider", provider),
                 config=item,
                 events=item.get("events"),
@@ -777,17 +758,10 @@ class PackageLoader:
             config = item.get("config", item)
             if "config" in item and "name" not in config:
                 config["name"] = item["name"]
-            # Translate flat type names to dotted paths for direct-OPNsense
-            # components per ADR-0016 (#793 Phase 1). Existing blueprints and
-            # user resource-centric YAML files (e.g. ``type: kea_reservation``)
-            # continue parsing while internal dispatch keys are already dotted.
-            # TODO: remove in #793 Phase 5 hard cutover.
-            raw_type = str(item["type"])
-            emitted_type = STEM_TO_DOTTED.get(raw_type, raw_type)
             result.append(
                 ResourceConfig(
                     name=item["name"],
-                    type=emitted_type,
+                    type=str(item["type"]),
                     provider=item.get("provider", default_provider),
                     config=config,
                     events=item.get("events"),

--- a/src/infrafoundry/core/config/provider_centric_loader.py
+++ b/src/infrafoundry/core/config/provider_centric_loader.py
@@ -12,7 +12,6 @@ import yaml
 
 from infrafoundry.core.config.package_loader import (
     NESTED_PROVIDER_NAMESPACE,
-    STEM_TO_DOTTED,
     PackageLoader,
 )
 from infrafoundry.core.exceptions import InvalidConfigurationError
@@ -119,16 +118,10 @@ class ProviderCentricLoader:
                 f"got {type(resource_list).__name__}"
             )
 
-        # Translate flat type names to dotted paths for direct-OPNsense
-        # components per ADR-0016 (#793 Phase 1). Old flat YAML files
-        # (e.g. ``vlans.yaml`` with ``vlans:`` top-level key) keep parsing.
-        # TODO: remove in #793 Phase 5 hard cutover.
-        emitted_type = STEM_TO_DOTTED.get(resource_type, resource_type)
-
         resources = [
             ResourceConfig(
                 name=item["name"],
-                type=emitted_type,
+                type=resource_type,
                 provider=provider,
                 config=item,
                 import_id=item.get("import_id"),

--- a/src/infrafoundry/core/config/resource_centric_loader.py
+++ b/src/infrafoundry/core/config/resource_centric_loader.py
@@ -10,7 +10,6 @@ import yaml
 
 from infrafoundry.core.config.package_loader import (
     NESTED_PROVIDER_NAMESPACE,
-    STEM_TO_DOTTED,
     PackageLoader,
 )
 from infrafoundry.core.exceptions import InvalidConfigurationError
@@ -125,18 +124,10 @@ class ResourceCentricLoader:
             # Include name in config for template convenience
             config["name"] = item["name"]
 
-            # Translate flat type names to dotted paths for direct-OPNsense
-            # components per ADR-0016 (#793 Phase 1). Existing user
-            # resource-centric YAML files keep parsing while internal
-            # dispatch keys are dotted.
-            # TODO: remove in #793 Phase 5 hard cutover.
-            raw_type = str(item["type"])
-            emitted_type = STEM_TO_DOTTED.get(raw_type, raw_type)
-
             resources.append(
                 ResourceConfig(
                     name=item["name"],
-                    type=emitted_type,
+                    type=str(item["type"]),
                     provider=item["provider"],
                     config=config,
                     import_id=item.get("import_id"),

--- a/tests/integration/test_advanced_workflows.py
+++ b/tests/integration/test_advanced_workflows.py
@@ -347,14 +347,20 @@ class TestMultiProviderCoordination:
         # and the Mock provider sidesteps the actual runner dispatch.
         # The test asserts proxmox_provider.generate_terraform was
         # called — that remains the load-bearing assertion.
+        # Nested ``opnsense:`` schema per ADR-0016 (#793). After Phase 5
+        # the legacy flat ``vlans:`` top-level key is no longer translated
+        # to the ``interfaces.vlans`` dotted type.
         vlans_file = config_dir / "vlans.yaml"
         vlans_file.write_text(
             """
-vlans:
-  - name: lan-vlan
-    interface: igb1
-    tag: 100
-    description: LAN VLAN
+opnsense:
+  interfaces:
+    vlans:
+      - name: lan-vlan
+        config:
+          interface: igb1
+          tag: 100
+          description: LAN VLAN
 """
         )
 

--- a/tests/unit/core/config/test_package_loader_nested.py
+++ b/tests/unit/core/config/test_package_loader_nested.py
@@ -33,7 +33,7 @@ class TestNestedFormatConstants:
         assert NESTED_PROVIDER_NAMESPACE == "opnsense"
 
     def test_dotted_shapes_includes_existing_list_types(self):
-        """All current STEM_TO_DOTTED targets are list-shape paths."""
+        """The 15 currently-shipped direct-OPNsense paths are list-shape."""
         assert DOTTED_RESOURCE_SHAPES["firewall.aliases"] == "list"
         assert DOTTED_RESOURCE_SHAPES["firewall.rules"] == "list"
         assert DOTTED_RESOURCE_SHAPES["routing.gateways"] == "list"
@@ -469,20 +469,30 @@ class TestNestedFlatAmbiguity:
 
 
 @pytest.mark.unit
-class TestNestedFormatBackwardsCompat:
-    """Flat-format paths still work after Phase 2 (additive only)."""
+class TestFlatFormatNoLongerTranslated:
+    """After Phase 5 hard cutover (#793), legacy flat OPNsense type names
+    no longer auto-translate to dotted paths. Operators must use the nested
+    ``opnsense:`` schema (or already-dotted types in resource-centric files);
+    the conversion script in #793 Phase 6 does the one-shot migration.
+    """
 
-    def test_flat_provider_centric_still_works(self, temp_dir):
-        """``aliases.yaml`` with top-level ``aliases:`` still translates."""
+    def test_flat_provider_centric_keeps_stem_type(self, temp_dir):
+        """``aliases.yaml`` with top-level ``aliases:`` no longer translates.
+
+        The loader still parses the document but emits ``ResourceConfig.type
+        == 'aliases'`` (the filename stem). Dispatch will not match any
+        OPNsense direct-API component — the operator sees a clear "unknown
+        type" error downstream rather than silent acceptance.
+        """
         loader = PackageLoader(temp_dir)
         data = {"aliases": [{"name": "trusted", "config": {"type": "host"}}]}
         resources = loader._parse_resources_from_data(data, "aliases.yaml", "opnsense")
         assert len(resources) == 1
-        assert resources[0].type == "firewall.aliases"  # via STEM_TO_DOTTED
+        assert resources[0].type == "aliases"
         assert resources[0].name == "trusted"
 
-    def test_flat_resource_centric_still_works(self, temp_dir):
-        """``resources:`` list format still works (with STEM_TO_DOTTED)."""
+    def test_flat_resource_centric_keeps_raw_type(self, temp_dir):
+        """``resources:`` with legacy ``type: kea_subnet`` no longer translates."""
         loader = PackageLoader(temp_dir)
         data = {
             "resources": [
@@ -496,8 +506,25 @@ class TestNestedFormatBackwardsCompat:
         }
         resources = loader._parse_resources_from_data(data, "rc.yaml", "opnsense")
         assert len(resources) == 1
-        assert resources[0].type == "kea.dhcp4.subnets"  # via STEM_TO_DOTTED
+        assert resources[0].type == "kea_subnet"
         assert resources[0].name == "lan"
+
+    def test_resource_centric_dotted_type_passes_through(self, temp_dir):
+        """``resources:`` with already-dotted ``type:`` is unchanged."""
+        loader = PackageLoader(temp_dir)
+        data = {
+            "resources": [
+                {
+                    "provider": "opnsense",
+                    "type": "kea.dhcp4.subnets",
+                    "name": "lan",
+                    "config": {"subnet": "10.0.0.0/24"},
+                }
+            ]
+        }
+        resources = loader._parse_resources_from_data(data, "rc.yaml", "opnsense")
+        assert len(resources) == 1
+        assert resources[0].type == "kea.dhcp4.subnets"
 
     def test_unknown_nested_key_with_dict_value_recurses(self, temp_dir):
         """Unknown interior dict key recurses without error if no leaves."""
@@ -570,8 +597,15 @@ class TestNestedFormatProviderCentricLoader:
             loader.load_resources("dev", "opnsense", "fw")
         assert "cannot mix" in str(excinfo.value)
 
-    def test_provider_centric_loader_flat_still_works(self, temp_dir):
-        """Existing flat YAML still parses through the loader."""
+    def test_provider_centric_loader_flat_keeps_stem_type(self, temp_dir):
+        """After #793 Phase 5, flat OPNsense YAML no longer auto-translates.
+
+        The file parses (so existing test/blueprint fixtures don't break
+        outright), but the emitted ``ResourceConfig.type`` is the filename
+        stem (``aliases``) rather than the dotted path (``firewall.aliases``).
+        Dispatch will reject it downstream — operators must convert to the
+        nested ``opnsense:`` schema (see #793 Phase 6 conversion script).
+        """
         loader = ProviderCentricLoader(temp_dir)
         self._write_yaml(
             temp_dir / "dev" / "opnsense" / "aliases.yaml",
@@ -579,7 +613,7 @@ class TestNestedFormatProviderCentricLoader:
         )
         resources = loader.load_resources("dev", "opnsense", "aliases")
         assert len(resources) == 1
-        assert resources[0].type == "firewall.aliases"
+        assert resources[0].type == "aliases"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_package_loader.py
+++ b/tests/unit/test_package_loader.py
@@ -533,7 +533,7 @@ resources:
       vmid: 220
       target_node: pve1
   - provider: opnsense
-    type: kea_reservation
+    type: kea.dhcp4.reservations
     name: ontap-node-01
     config:
       subnet_ref: opt1-infrastructure


### PR DESCRIPTION
## Description

Phase 5 of #793 — hard cutover. Removes the transient `STEM_TO_DOTTED`
translation table and its three call sites that auto-translated legacy flat
direct-OPNsense type names (e.g. filename stem `vlans` → dotted
`interfaces.vlans`, resource-centric `type: kea_subnet` → `kea.dhcp4.reservations`)
to the API-aligned dotted paths introduced in Phase 1.

After this PR operators must use either:

- the nested `opnsense:` schema (per ADR-0016), or
- already-dotted `type:` strings in resource-centric files.

Flat OPNsense YAML still parses but emits `ResourceConfig.type` matching the
filename stem / raw type, which no longer matches any registered direct-OPNsense
component — dispatch fails with a clear "unknown type" error. The conversion
script in Phase 6 handles the one-shot operator-side migration.

Test fixtures using the legacy flat OPNsense format are converted to the
nested schema or dotted-type form in this same PR so the test suite stays green.

This PR is **stacked on top of [#798 (Phase 4)](../pull/798)**. After merge it
will retarget to `main` automatically.

## Related Issue

Addresses #793.

## Type of Change

- [x] Code refactoring
- [x] Breaking change (operator-facing legacy YAML format no longer auto-translated)

## Changes Made

- Remove `STEM_TO_DOTTED` constant from `package_loader.py`
- Inline the 15 direct-OPNsense list-shape entries explicitly in `DOTTED_RESOURCE_SHAPES`
- Drop the `STEM_TO_DOTTED.get(...)` call at three sites (`package_loader._parse_provider_centric`, `package_loader._parse_resource_centric`, and the equivalents in `provider_centric_loader.py` / `resource_centric_loader.py`)
- Convert `tests/integration/test_advanced_workflows.py` flat `vlans:` fixture to nested `opnsense.interfaces.vlans:`
- Update `tests/unit/test_package_loader.py` resource-centric fixture from `type: kea_reservation` → `type: kea.dhcp4.reservations`
- Update `tests/unit/core/config/test_package_loader_nested.py::TestNestedFormatBackwardsCompat` (renamed `TestFlatFormatNoLongerTranslated`) to assert the new pass-through behaviour

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality

Targeted scope verified locally:

- `tests/unit/core/config/test_package_loader_nested.py` — 43 passed
- `tests/unit/providers/opnsense/` — 2107 passed, 1 skipped (full provider suite, 2.30s)
- `tests/unit/test_package_loader.py` — passed
- `tests/unit/test_import_blocks.py` — passed
- `tests/integration/test_advanced_workflows.py` — passed
- `tests/unit/providers/opnsense/migrate/` (Phase 4 goldens) — 17 passed
- `doit lint` — clean
- `doit type_check` — clean
