### PR TITLE
fix: nested loader flattens entry config to match resource-centric

### DIFF
--- a/src/infrafoundry/core/config/package_loader.py
+++ b/src/infrafoundry/core/config/package_loader.py
@@ -711,12 +711,23 @@ class PackageLoader:
                             f"'{NESTED_PROVIDER_NAMESPACE}.{dotted}' is missing "
                             "the required 'name:' field"
                         )
+                    # Mirror ResourceCentricLoader: extract the inner
+                    # ``config:`` dict and expose entry ``name`` inside it for
+                    # template/component convenience. Components downstream
+                    # read fields directly off ``ResourceConfig.config``
+                    # (e.g. ``config["device"]`` for VLANs); the nested loader
+                    # used to pass ``item`` through unchanged, leaving fields
+                    # buried under ``config.config.<field>`` and silently
+                    # breaking every direct-API component validator.
+                    entry_config = item.get("config", {})
+                    if "name" not in entry_config:
+                        entry_config["name"] = item["name"]
                     results.append(
                         ResourceConfig(
                             name=item["name"],
                             type=dotted,
                             provider=item.get("provider", provider),
-                            config=item,
+                            config=entry_config,
                             events=item.get("events"),
                             import_id=item.get("import_id"),
                         )

--- a/tests/unit/providers/opnsense/migrate/test_migrate_emits_nested.py
+++ b/tests/unit/providers/opnsense/migrate/test_migrate_emits_nested.py
@@ -860,7 +860,7 @@ class TestMigrateKeaDHCPEmitsNested:
         v4_subnets = [r for r in parsed if r.type == "kea.dhcp4.subnets"]
         assert len(v4_subnets) == 1
         assert v4_subnets[0].name == "lan"
-        assert v4_subnets[0].config["config"]["subnet"] == "10.0.0.0/24"
+        assert v4_subnets[0].config["subnet"] == "10.0.0.0/24"
 
     def test_kea_dhcp4_reservations_round_trip(
         self, manager_with_service: tuple[Any, MagicMock]


### PR DESCRIPTION
## Description

The nested-format loader in `PackageLoader._parse_nested_provider_format` (added
in #793 Phase 2) sets `ResourceConfig.config = item` for list-shape entries,
where `item` is the whole entry mapping `{name, config: {<fields>}, [import_id]}`.
Direct-API component code reads fields directly off `resource.config` (e.g.
`resource.config["device"]` for VLANs, `resource.config["subnet"]` for kea
subnets), so every field-level access fails with "missing required field"
because the actual fields are buried one level deeper.

`ResourceCentricLoader` already does the right thing — it extracts
`item.get("config", {})`, adds `name` for template convenience, and assigns
the flattened dict to `ResourceConfig.config`. This PR mirrors that contract
in `_parse_nested_provider_format` so both loaders produce the same shape.

Phase 4's migrate golden test had a round-trip assertion reading
`v4_subnets[0].config["config"]["subnet"]` — that was asserting the buggy
shape. Updated to `v4_subnets[0].config["subnet"]`.

## Related Issue

Addresses #800.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `_parse_nested_provider_format`: extract `entry_config = item.get("config", {})`,
  inject `name` if not already present, and pass `entry_config` as `ResourceConfig.config`.
- Update `tests/unit/providers/opnsense/migrate/test_migrate_emits_nested.py`
  round-trip assertion to match the corrected shape.

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes

Targeted scope verified locally:

- `tests/unit/providers/opnsense/migrate/` — 17 passed
- `tests/unit/core/config/test_package_loader_nested.py` — 43 passed
- `tests/unit/providers/opnsense/` — 2107 passed (full provider suite)
- `doit lint` — clean
- `doit type_check` — clean
- `foundry infra plan --env prod --provider opnsense` against converted
  `endavis-infra/` no longer errors at VLAN validation (proceeds to apply path).

## Notes

Discovered during #793 Phase 6 verification — the converted nested YAML in
`endavis-infra/` was failing the VLAN validator on the first entry. Without
this fix, every direct-API component breaks on nested-format input, even though
Phase 4's golden tests "passed" (they only round-tripped the YAML, never
exercised the component code that consumes the loader output).
