### PR TITLE
fix: anchor Addresses regex in pr_merge to start of line

### DIFF
--- a/tests/template/test_doit_github.py
+++ b/tests/template/test_doit_github.py
@@ -1,0 +1,87 @@
+"""Tests for github.py doit tasks.
+
+Focused on `_extract_linked_issues`, which `doit pr_merge` uses to parse
+``Addresses #N`` tokens from a PR body. The parser is intentionally strict:
+only ``Addresses`` (capitalized) at the start of a line is matched. This
+prevents mid-sentence references and prose mentions from polluting the
+merge-commit subject or auto-close list.
+"""
+
+from __future__ import annotations
+
+from tools.doit.github import _extract_linked_issues
+
+
+class TestExtractLinkedIssues:
+    """Tests for `_extract_linked_issues` strict line-start matching."""
+
+    def test_addresses_issue(self) -> None:
+        """A bare ``Addresses #N`` at line start is matched."""
+        body = "Addresses #123"
+        result = _extract_linked_issues(body)
+        assert result == ["123"]
+
+    def test_addresses_lowercase_ignored(self) -> None:
+        """Lowercase ``addresses #N`` is ignored (case-sensitive)."""
+        body = "addresses #456"
+        result = _extract_linked_issues(body)
+        assert result == []
+
+    def test_addresses_uppercase_ignored(self) -> None:
+        """All-caps ``ADDRESSES #N`` is ignored (case-sensitive)."""
+        body = "ADDRESSES #789"
+        result = _extract_linked_issues(body)
+        assert result == []
+
+    def test_mid_sentence_ignored(self) -> None:
+        """``Addresses #N`` mid-line is ignored (must be at line start)."""
+        body = "This PR Addresses #123"
+        result = _extract_linked_issues(body)
+        assert result == []
+
+    def test_multiple_addresses(self) -> None:
+        """Multiple line-start matches are all returned, in order."""
+        body = "Addresses #123\nAddresses #456"
+        result = _extract_linked_issues(body)
+        assert result == ["123", "456"]
+
+    def test_duplicate_issues(self) -> None:
+        """Duplicate issue numbers are de-duplicated, preserving first occurrence."""
+        body = "Addresses #123\nAddresses #123"
+        result = _extract_linked_issues(body)
+        assert result == ["123"]
+
+    def test_no_issues(self) -> None:
+        """A body with no ``Addresses`` references returns an empty list."""
+        body = "This PR adds a new feature"
+        result = _extract_linked_issues(body)
+        assert result == []
+
+    def test_issue_in_code_block_still_matched(self) -> None:
+        """A line-start match inside a fenced code block is still matched.
+
+        Distinguishing real references from code-block content would require
+        a full markdown parser; the cheap parser opts to match by line
+        position and rely on convention. Authors who want to mention
+        ``Addresses #N`` without linking should indent or prose-wrap it.
+        """
+        body = "```\nAddresses #123\n```"
+        result = _extract_linked_issues(body)
+        assert result == ["123"]
+
+    def test_old_closes_keyword_not_matched(self) -> None:
+        """``Closes #N`` is intentionally not matched.
+
+        The project standardized on ``Addresses #N`` to keep
+        github-auto-close OFF and force explicit closing via PR merge.
+        Other keywords (Closes/Fixes/Part of) must not trigger the parser.
+        """
+        body = "Closes #123"
+        result = _extract_linked_issues(body)
+        assert result == []
+
+    def test_old_fixes_keyword_not_matched(self) -> None:
+        """``Fixes #N`` is intentionally not matched (see ``Closes``)."""
+        body = "Fixes #456"
+        result = _extract_linked_issues(body)
+        assert result == []

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -532,20 +532,23 @@ def _get_pr_info(pr_number: str | None, console: "ConsoleType") -> dict[str, Any
 def _extract_linked_issues(body: str) -> list[str]:
     """Extract linked issue numbers from PR body.
 
-    Looks for patterns like:
-    - Addresses #123
+    Matches only ``Addresses #N`` tokens that appear at the start of a line
+    with the exact capitalization ``Addresses``. Mid-sentence references,
+    lowercase ``addresses``, and other capitalizations are intentionally
+    ignored so that scope-mentions inside prose do not get parsed as
+    real links.
 
     Args:
         body: PR body text
 
     Returns:
-        List of issue numbers referenced with "Addresses"
+        List of issue numbers referenced with "Addresses" at line start
     """
     seen: set[str] = set()
     result: list[str] = []
 
-    pattern = r"addresses\s+#(\d+)"
-    for match in re.finditer(pattern, body, re.IGNORECASE):
+    pattern = r"^Addresses\s+#(\d+)"
+    for match in re.finditer(pattern, body, re.MULTILINE):
         issue = match.group(1)
         if issue not in seen:
             seen.add(issue)


### PR DESCRIPTION
## Description

Anchors the `Addresses #N` parser in `tools/doit/github.py` so it only matches lines that start with the literal token `Addresses` (capitalized). Mid-sentence and lowercase references are now ignored, preventing them from leaking into merge-commit subjects or the `--auto-close` list.

The previous parser used `re.IGNORECASE` and matched anywhere in the body. A PR description that prose-mentioned a sibling issue (e.g., "this also relates to addresses #122 work") would silently get that issue parsed as if it were a real link. The existing convention in `AGENTS.md` already requires `Addresses #N` at the start of a line — this PR makes the parser enforce it.

Ports the regex + test cases from upstream [pyproject-template PR #544](https://github.com/endavis/pyproject-template/pull/544).

## Related Issue

Addresses #823

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- `tools/doit/github.py`: regex changed from `r"addresses\s+#(\d+)"` + `re.IGNORECASE` to `r"^Addresses\s+#(\d+)"` + `re.MULTILINE`; docstring expanded to describe the line-start + capitalization rules.
- `tests/template/test_doit_github.py` (new): `TestExtractLinkedIssues` with 10 cases — positive at line start; negative for lowercase, uppercase, mid-sentence; multiple/duplicate/none; code-block-match-by-design; old `Closes`/`Fixes` keywords ignored.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type-check, security, spell-check, full test suite).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (existing docs already match the strict format; no doc changes needed)
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase A.1 of the pyproject-template sync. Phase A.2 (sync-exclude mechanism, upstream PR #507) follows in a separate PR.
