### PR TITLE
docs: update divergences doc for sync-exclude mechanism

### DIFF
--- a/docs/development/pyproject-template-divergences.md
+++ b/docs/development/pyproject-template-divergences.md
@@ -19,9 +19,14 @@ Edit it in a **separate PR** with a `docs:` commit. Do not silently expand the
 skip-list inside a sync PR — that hides the decision. The divergence list is a
 deliberate policy artifact; additions deserve review on their own merits.
 
-A programmatic skip-list in `.config/pyproject_template/settings.toml` is a
-future improvement that would let tooling enforce these decisions. Until that
-lands, this doc is the MVP — a human reference consulted during sync-PR review.
+The programmatic skip-list lives at
+`.config/pyproject_template/sync-exclude.toml` and is consumed by
+`manage.py check` to silence Category 1 entries from the actionable drift
+list. **Category 1 changes must land in both that toml file and this doc in
+the same PR**, so the human-readable rationale stays in lockstep with the
+machine-readable rules. (The mechanism uses a separate file from
+`settings.toml` because `SettingsManager.save()` rewrites that one on every
+sync and would clobber user-managed entries.)
 
 > **Scope note:** by omission, every file not mentioned in one of the three
 > categories below is adopted verbatim from upstream. There is no explicit
@@ -33,6 +38,11 @@ These files exist upstream as part of the generic skeleton a new project would
 start from. InfraFoundry is a real project with its own package structure,
 tests, and documentation; upstream changes to these files should always be
 skipped.
+
+The entries below are encoded as glob patterns in
+`.config/pyproject_template/sync-exclude.toml` so `manage.py check` reports
+them on a separate "Skipped per project policy" summary line and does not
+include them in actionable drift.
 
 ### Skeleton source code
 - `src/package_name/` — skeleton package. InfraFoundry's package lives at
@@ -48,8 +58,15 @@ skipped.
 - `tests/benchmarks/test_bench_core.py`,
   `tests/benchmarks/test_bench_logging.py` — benchmarks for the skeleton
   package.
-- `tests/template/` — tests upstream runs against the template itself (bootstrap,
-  cleanup, doit helpers). Not relevant once bootstrapped.
+
+> **Note on `tests/template/`:** this directory is **not** blanket-skipped.
+> Upstream uses it for tests that exercise the `tools/pyproject_template/*`
+> and `tools/doit/*` modules — modules we keep and use. Tests in this
+> directory are evaluated per-file: skeleton-package tests (listed above)
+> stay out of the tree; tests that cover modules we ship are adopted.
+> Upstream additions to this directory surface as actionable drift in
+> `manage.py check` and require an explicit per-file adopt-or-exclude
+> decision.
 
 ### Skeleton documentation
 - `docs/examples/api.md`, `docs/examples/add-a-feature.md` — skeleton example


### PR DESCRIPTION
## Description

Brings `docs/development/pyproject-template-divergences.md` into line with the sync-exclude mechanism merged in #826 and fixes one inaccurate skip-list entry.

### What changed

1. **"How to update" section** — replaced the "future improvement" paragraph (which described a hypothetical programmatic skip-list) with a current-state pointer to `.config/pyproject_template/sync-exclude.toml`. Added the enforcement rule: **Category 1 changes must land in both the toml file and this doc in the same PR**, so the human-readable rationale and the machine-readable rules stay in lockstep.

2. **Top of Section 1 (Template-skeleton files)** — added a one-paragraph note explaining that the entries below are encoded as glob patterns in the toml and that `manage.py check` reports matches on a separate "Skipped per project policy" summary line.

3. **"Skeleton tests" subsection** — removed the inaccurate `tests/template/` blanket-skip line. We actively keep multiple files from that directory (`test_bootstrap.py`, `test_cleanup.py`, `test_setup_repo.py`, `test_utils.py`, `test_repo_settings.py`, `test_pyproject_template_main.py`, and as of #825 `test_doit_github.py`, as of #826 `test_check_template_updates.py`). Replaced the line with a callout note explaining the per-file policy: skeleton-package tests stay out, tests for modules we ship are adopted, upstream additions surface as actionable drift requiring an explicit decision.

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `docs/development/pyproject-template-divergences.md`: +22/-5 across three hunks (How-to-update paragraph, Section 1 intro, Skeleton-tests subsection).

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality (N/A — docs-only)
- [x] Manually tested the changes (`doit check` passes)

`doit check` passes locally (codespell included).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — docs-only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release; docs-only change)
- [x] My changes generate no new warnings

## Scope

Phase A.3 of the pyproject-template sync — closes out Phase A. Per the divergences doc's own update rule, this is filed as a separate `docs:` PR rather than folded into the sync mechanism PR (#826).
