### PR TITLE
feat: adopt session-lifecycle support (/checkpoint, /restore, auto-hooks)

### DIFF
--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -1,0 +1,60 @@
+# Checkpoint
+
+Capture a resumption prompt for picking up the current work later.
+
+When invoked, write a self-contained prompt to `tmp/checkpoints/` so the user (or a future agent session via `/restore`) can pick up where they left off without re-reading the current conversation. This is the **save** side of the checkpoint/restore pair — `/restore` is the load side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug describing the topic. If empty, infer a 3-5 word descriptive slug from the conversation context.
+
+## Instructions
+
+### Step 1: Compute the filename
+
+Filename format: `{inv_epoch}-{slug}.md` in `tmp/checkpoints/`.
+
+`inv_epoch` is a 10-digit integer that *decreases* as time advances, so default `ls` (no flags) lists newest entries first. Compute:
+
+```bash
+INV_EPOCH=$(printf '%010d' $((9999999999 - $(date +%s))))
+```
+
+(The prefix is for sort order only; users read the slug and file contents, not the number.)
+
+Run `mkdir -p tmp/checkpoints` before writing. Don't overwrite existing files; if a same-named file exists, append a 1-letter discriminator (`-a`, `-b`, …) to the slug.
+
+> Note: this directory deviates from the `tmp/agents/<agent-type>/` convention in `AGENTS.md`. `tmp/checkpoints/` is intentionally shared (not per-agent) so checkpoints are portable across agents — Claude can write a checkpoint and Gemini or Codex can restore from it.
+
+### Step 2: Draft the prompt
+
+The prompt must be **paste-ready** — readable cold by a future agent session that has zero context from this conversation. Use absolute references throughout: issue/PR numbers, file paths, ISO dates (no "yesterday"/"this morning").
+
+Structure:
+
+- **Title** — short description of what's deferred.
+- **Paste-block intro** — one line telling the future user what to do (paste into a fresh agent session at the repo's working directory).
+- **Status as of {today's ISO date}** — what landed recently (merged PRs and closed issues with brief descriptions), current branch state, anything in-flight.
+- **Open issues** (if any are filed but not started) — number, title, one-line scope.
+- **Goal** — the bigger-picture objective this work serves.
+- **Pick: option N (the recommendation)** — list 2-3 numbered next-step options. Mark the recommendation. Brief tradeoff notes.
+- **User direction recorded** — decisions, preferences, or constraints surfaced in the current conversation that future sessions need to honor (e.g., "no cross-provider X", "always prefer Y pattern").
+- **Pre-action reads** — files/docs the future session should read before starting, scoped per option.
+- **Workflow** — short reminder of project conventions (Issue → Branch → PR per `AGENTS.md`, etc.).
+- **Start by:** — concrete first command (e.g., `/<currentai>:plan 714`, or `git checkout main && git pull`).
+
+Add anything else load-bearing — open blockers, runtime gotchas, manual prerequisite steps. Keep tight; this is a paste-block, not a doc.
+
+Don't dump conversation history. Don't include `.claude/scheduled_tasks.lock` or other local-environment ephemera. Don't restate `MEMORY.md` content (it's auto-loaded in future sessions).
+
+### Step 3: Confirm to the user
+
+Report:
+- The full path to the created file.
+- A one-line summary of what's captured.
+- The quick-use reminder: "paste the file contents into a fresh agent session at this repo's root."
+
+## Notes
+
+- Files persist; no auto-cleanup. The user can `rm` old prompts manually when they're stale.
+- If invoked multiple times in one session, write a new file each time. The user may want separate resumption-points for separate work threads.
+- The prefix uses 10 digits because epoch will exceed 10 digits in the year 2286; that's fine for foreseeable use. If you ever need to extend, bump to 11+ digits.
+- The companion `/restore` command loads a captured checkpoint in a future session — point users to it.

--- a/.claude/commands/restore.md
+++ b/.claude/commands/restore.md
@@ -1,0 +1,54 @@
+# Restore
+
+Load a previously captured checkpoint prompt from `tmp/checkpoints/` and continue the work it describes.
+
+When invoked, find the right checkpoint file, read it, and **treat its contents as the user's initial instructions for this session.** This is the **load** side of the checkpoint/restore pair — `/checkpoint` is the save side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug to filter by. If empty, picks the most recent checkpoint regardless of slug.
+
+## Instructions
+
+### Step 1: Find the checkpoint file
+
+Files live in `tmp/checkpoints/` with names like `{inv_epoch}-{slug}.md`. The `inv_epoch` prefix is monotonically *decreasing* in time, so the lexically smallest filename is the most recent.
+
+```bash
+mkdir -p tmp/checkpoints  # idempotent
+```
+
+**If `$ARGUMENTS` is empty:** pick the lexically first file in the directory (newest).
+
+```bash
+ls tmp/checkpoints/*.md 2>/dev/null | head -1
+```
+
+**If `$ARGUMENTS` is provided:** treat it as a slug fragment. Pick the lexically first file whose name matches `*-${ARGUMENTS}*.md`.
+
+```bash
+ls tmp/checkpoints/*-${ARGUMENTS}*.md 2>/dev/null | head -1
+```
+
+(Lexically-first = newest, because of the inv_epoch convention.)
+
+### Step 2: Handle edge cases
+
+- **Directory empty or missing:** tell the user `tmp/checkpoints/` has no checkpoints; suggest `/checkpoint <slug>` to capture one. Stop.
+- **No match for the slug:** list available checkpoint filenames so the user can pick one. Stop and wait.
+- **Multiple matches:** silently pick the newest, but mention how many were considered and offer to load a different one if asked.
+
+### Step 3: Load and act on the checkpoint
+
+1. Read the chosen file (use the Read tool).
+2. Print a one-line confirmation: `Restoring from {filename} ({slug}, captured {date if discoverable})`.
+3. **Treat the file's contents as if the user had pasted them as their first message.** Follow the instructions inside — most checkpoints end with a "Start by:" line that names a concrete first action; do that. If the checkpoint has multiple "Pick" options, default to the recommended one unless the user said otherwise.
+4. Don't summarize the checkpoint back to the user before acting — they already wrote it. Just proceed. (Exception: if the checkpoint is ambiguous about the next step, ask once before acting.)
+
+### Step 4: Honor any "User direction recorded" or constraints in the checkpoint
+
+Checkpoints typically capture decisions and preferences from the prior session. Treat them as binding for this session unless explicitly overridden in the user's current message.
+
+## Notes
+
+- Checkpoints are immutable once written. If the situation has changed since capture (a referenced PR landed, an issue closed, etc.), verify before acting on stale references — `gh issue view <n>`, `git log`, etc.
+- The companion `/checkpoint` command writes new checkpoints — point users to it if they want to capture something for later in this session.
+- The `inv_epoch` prefix is a sort-only artifact; the user reads the slug, not the number. Always show the slug (or full filename) in confirmation messages, not just the prefix.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,28 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 90,
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/precompact-checkpoint.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/session-resume-restore.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gemini/commands/checkpoint.md
+++ b/.gemini/commands/checkpoint.md
@@ -1,0 +1,60 @@
+# Checkpoint
+
+Capture a resumption prompt for picking up the current work later.
+
+When invoked, write a self-contained prompt to `tmp/checkpoints/` so the user (or a future agent session via `/restore`) can pick up where they left off without re-reading the current conversation. This is the **save** side of the checkpoint/restore pair — `/restore` is the load side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug describing the topic. If empty, infer a 3-5 word descriptive slug from the conversation context.
+
+## Instructions
+
+### Step 1: Compute the filename
+
+Filename format: `{inv_epoch}-{slug}.md` in `tmp/checkpoints/`.
+
+`inv_epoch` is a 10-digit integer that *decreases* as time advances, so default `ls` (no flags) lists newest entries first. Compute:
+
+```bash
+INV_EPOCH=$(printf '%010d' $((9999999999 - $(date +%s))))
+```
+
+(The prefix is for sort order only; users read the slug and file contents, not the number.)
+
+Run `mkdir -p tmp/checkpoints` before writing. Don't overwrite existing files; if a same-named file exists, append a 1-letter discriminator (`-a`, `-b`, …) to the slug.
+
+> Note: this directory deviates from the `tmp/agents/<agent-type>/` convention in `AGENTS.md`. `tmp/checkpoints/` is intentionally shared (not per-agent) so checkpoints are portable across agents — Claude can write a checkpoint and Gemini or Codex can restore from it.
+
+### Step 2: Draft the prompt
+
+The prompt must be **paste-ready** — readable cold by a future agent session that has zero context from this conversation. Use absolute references throughout: issue/PR numbers, file paths, ISO dates (no "yesterday"/"this morning").
+
+Structure:
+
+- **Title** — short description of what's deferred.
+- **Paste-block intro** — one line telling the future user what to do (paste into a fresh agent session at the repo's working directory).
+- **Status as of {today's ISO date}** — what landed recently (merged PRs and closed issues with brief descriptions), current branch state, anything in-flight.
+- **Open issues** (if any are filed but not started) — number, title, one-line scope.
+- **Goal** — the bigger-picture objective this work serves.
+- **Pick: option N (the recommendation)** — list 2-3 numbered next-step options. Mark the recommendation. Brief tradeoff notes.
+- **User direction recorded** — decisions, preferences, or constraints surfaced in the current conversation that future sessions need to honor (e.g., "no cross-provider X", "always prefer Y pattern").
+- **Pre-action reads** — files/docs the future session should read before starting, scoped per option.
+- **Workflow** — short reminder of project conventions (Issue → Branch → PR per `AGENTS.md`, etc.).
+- **Start by:** — concrete first command (e.g., `/<currentai>:plan 714`, or `git checkout main && git pull`).
+
+Add anything else load-bearing — open blockers, runtime gotchas, manual prerequisite steps. Keep tight; this is a paste-block, not a doc.
+
+Don't dump conversation history. Don't include `.claude/scheduled_tasks.lock` or other local-environment ephemera. Don't restate `MEMORY.md` content (it's auto-loaded in future sessions).
+
+### Step 3: Confirm to the user
+
+Report:
+- The full path to the created file.
+- A one-line summary of what's captured.
+- The quick-use reminder: "paste the file contents into a fresh agent session at this repo's root."
+
+## Notes
+
+- Files persist; no auto-cleanup. The user can `rm` old prompts manually when they're stale.
+- If invoked multiple times in one session, write a new file each time. The user may want separate resumption-points for separate work threads.
+- The prefix uses 10 digits because epoch will exceed 10 digits in the year 2286; that's fine for foreseeable use. If you ever need to extend, bump to 11+ digits.
+- The companion `/restore` command loads a captured checkpoint in a future session — point users to it.

--- a/.gemini/commands/restore.md
+++ b/.gemini/commands/restore.md
@@ -1,0 +1,54 @@
+# Restore
+
+Load a previously captured checkpoint prompt from `tmp/checkpoints/` and continue the work it describes.
+
+When invoked, find the right checkpoint file, read it, and **treat its contents as the user's initial instructions for this session.** This is the **load** side of the checkpoint/restore pair — `/checkpoint` is the save side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug to filter by. If empty, picks the most recent checkpoint regardless of slug.
+
+## Instructions
+
+### Step 1: Find the checkpoint file
+
+Files live in `tmp/checkpoints/` with names like `{inv_epoch}-{slug}.md`. The `inv_epoch` prefix is monotonically *decreasing* in time, so the lexically smallest filename is the most recent.
+
+```bash
+mkdir -p tmp/checkpoints  # idempotent
+```
+
+**If `$ARGUMENTS` is empty:** pick the lexically first file in the directory (newest).
+
+```bash
+ls tmp/checkpoints/*.md 2>/dev/null | head -1
+```
+
+**If `$ARGUMENTS` is provided:** treat it as a slug fragment. Pick the lexically first file whose name matches `*-${ARGUMENTS}*.md`.
+
+```bash
+ls tmp/checkpoints/*-${ARGUMENTS}*.md 2>/dev/null | head -1
+```
+
+(Lexically-first = newest, because of the inv_epoch convention.)
+
+### Step 2: Handle edge cases
+
+- **Directory empty or missing:** tell the user `tmp/checkpoints/` has no checkpoints; suggest `/checkpoint <slug>` to capture one. Stop.
+- **No match for the slug:** list available checkpoint filenames so the user can pick one. Stop and wait.
+- **Multiple matches:** silently pick the newest, but mention how many were considered and offer to load a different one if asked.
+
+### Step 3: Load and act on the checkpoint
+
+1. Read the chosen file (use the Read tool).
+2. Print a one-line confirmation: `Restoring from {filename} ({slug}, captured {date if discoverable})`.
+3. **Treat the file's contents as if the user had pasted them as their first message.** Follow the instructions inside — most checkpoints end with a "Start by:" line that names a concrete first action; do that. If the checkpoint has multiple "Pick" options, default to the recommended one unless the user said otherwise.
+4. Don't summarize the checkpoint back to the user before acting — they already wrote it. Just proceed. (Exception: if the checkpoint is ambiguous about the next step, ask once before acting.)
+
+### Step 4: Honor any "User direction recorded" or constraints in the checkpoint
+
+Checkpoints typically capture decisions and preferences from the prior session. Treat them as binding for this session unless explicitly overridden in the user's current message.
+
+## Notes
+
+- Checkpoints are immutable once written. If the situation has changed since capture (a referenced PR landed, an issue closed, etc.), verify before acting on stale references — `gh issue view <n>`, `git log`, etc.
+- The companion `/checkpoint` command writes new checkpoints — point users to it if they want to capture something for later in this session.
+- The `inv_epoch` prefix is a sort-only artifact; the user reads the slug, not the number. Always show the slug (or full filename) in confirmation messages, not just the prefix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,6 +458,8 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 
 **Cleanup rule:** Agents must delete their temporary files when the task is complete. Do not leave stale files in `tmp/agents/`.
 
+**Exception:** `tmp/checkpoints/` is the one location outside `tmp/agents/<agent-type>/`. Checkpoints written by `/checkpoint` are portable project-state captures meant to be readable by any agent — Claude can write a checkpoint and Gemini or Codex can restore from it.
+
 ## Token Efficiency
 - **Be Concise:** Minimal text output.
 - **Use Local Tools:** Prefer native file tools over sub-agents (see [AI Agent File Operations](#ai-agent-file-operations)).

--- a/docs/development/ai/auto-checkpoint-hook.md
+++ b/docs/development/ai/auto-checkpoint-hook.md
@@ -1,0 +1,173 @@
+---
+title: Auto-Checkpoint and Session-Restore Hooks
+description: PreCompact and SessionStart hooks that preserve context across autocompact events
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - hooks
+  - checkpoint
+---
+
+# Auto-Checkpoint and Session-Restore Hooks
+
+Two Claude Code hooks that wire the existing `/checkpoint` and `/restore` primitives into the
+`PreCompact` and `SessionStart` lifecycle events, so context is preserved automatically when
+autocompact fires mid-task — no human in the loop required.
+
+## What They Do
+
+### PreCompact hook (`precompact-checkpoint.py`)
+
+Before Claude Code compacts the conversation context, the hook:
+
+1. Reads the `transcript_path` from the hook payload.
+2. Takes up to 200 KB from the tail of the JSONL transcript.
+3. Spawns `claude -p --bare --model claude-sonnet-4-6` with a strict-JSON prompt asking for:
+   `{title, status, in_flight_work, constraints, files_touched, next_steps, resume_prompt}`.
+4. Parses the JSON response and renders it into a markdown checkpoint file matching the
+   `/checkpoint` section structure (Title, Status, In-flight work, Constraints, Files touched,
+   Next steps, Resume prompt).
+5. Writes the file to `tmp/checkpoints/{inv_epoch}-auto-precompact.md` where `inv_epoch` is a
+   10-digit decreasing integer (newest sorts first under default `ls`).
+6. On any failure (timeout, missing CLI, non-zero exit, JSON parse error, missing transcript),
+   falls back to a banner + raw transcript tail tagged `AUTO_PARTIAL`.
+7. Always exits 0 — the hook never blocks the compaction event.
+
+### SessionStart hook (`session-resume-restore.py`)
+
+When Claude Code starts a session whose trigger contains "compact" or "resume":
+
+1. Globs `tmp/checkpoints/*-auto-precompact*.md` and picks the lexically smallest file
+   (newest by `inv_epoch` convention).
+2. Reads the file and emits it as `hookSpecificOutput.additionalContext` so the model sees
+   the checkpoint body as injected context at session start.
+3. If no matching file exists, no-ops silently.
+4. Always exits 0.
+
+## Filename Convention
+
+Auto-checkpoint filenames follow the same `{inv_epoch}-{slug}.md` convention as manual
+`/checkpoint` files:
+
+```
+tmp/checkpoints/9999999999-auto-precompact.md
+```
+
+The `inv_epoch` is computed as `9999999999 - int(time.time())`, matching Step 1 of
+`.claude/commands/checkpoint.md` exactly. On same-second collision (rare), a single letter
+suffix is appended: `…-auto-precompact-a.md`, `…-auto-precompact-b.md`, etc.
+
+Because the convention is shared, manual `/restore` can also load auto-precompact files
+by slug: `/restore auto-precompact`.
+
+## Opt-Out and Widening
+
+| Env var | Effect |
+|---|---|
+| `CLAUDE_NO_AUTO_RESTORE=1` | SessionStart hook no-ops even when checkpoints exist |
+| `CLAUDE_RESTORE_ANY=1` | SessionStart hook widens glob to `*.md`, restoring any checkpoint (not just auto-precompact ones) |
+
+Set these in `.claude/settings.local.json` (gitignored) or in your shell profile:
+
+```json
+{
+  "env": {
+    "CLAUDE_NO_AUTO_RESTORE": "1"
+  }
+}
+```
+
+## Synthesis Prompt Shape
+
+The PreCompact hook sends a structured prompt requesting strict JSON output:
+
+```
+{title, status, in_flight_work, constraints, files_touched (array),
+ next_steps, resume_prompt}
+```
+
+If the model wraps the JSON in markdown fences, the hook strips them before parsing.
+On any parse failure, the hook falls back to `AUTO_PARTIAL` mode (raw transcript tail).
+
+## Fallback Behavior
+
+| Condition | Result |
+|---|---|
+| Synthesis succeeds, JSON valid | Full structured checkpoint written |
+| Synthesis returns non-zero exit | `AUTO_PARTIAL` fallback written |
+| `claude` CLI not found (`FileNotFoundError`) | `AUTO_PARTIAL` fallback written |
+| Synthesis times out (90 s) | `AUTO_PARTIAL` fallback written |
+| JSON parse fails | `AUTO_PARTIAL` fallback written |
+| Transcript file missing | `AUTO_PARTIAL` fallback written (empty tail) |
+| Malformed stdin JSON | Exits 0, no file written |
+
+`AUTO_PARTIAL` files are tagged in their title so you can identify them and know the
+structured fields are absent.
+
+## Settings Wiring
+
+`.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 90,
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/precompact-checkpoint.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/session-resume-restore.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `timeout: 90` on `PreCompact` matches the synthesis subprocess timeout so the hook
+does not hang indefinitely if the CLI is slow to respond.
+
+## Manual Verification
+
+These steps cannot be run by a subagent but are provided for contributor verification:
+
+1. Start a long session; run `/compact` to force a `PreCompact` event. Confirm a new file
+   appears in `tmp/checkpoints/` with the `-auto-precompact.md` suffix.
+2. Read the file. Confirm it has the expected sections — not just an `AUTO_PARTIAL` dump.
+3. Start a fresh session via `claude --resume`. Confirm the checkpoint body appears inlined
+   in the new session's initial context.
+4. Set `CLAUDE_NO_AUTO_RESTORE=1`, repeat step 3; confirm no inlining.
+5. Force a synthesis failure (temporarily rename `claude` on PATH); repeat step 1; confirm
+   the `AUTO_PARTIAL` fallback file is produced.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`tools/hooks/ai/precompact-checkpoint.py`](../../../tools/hooks/ai/precompact-checkpoint.py) | PreCompact hook script |
+| [`tools/hooks/ai/session-resume-restore.py`](../../../tools/hooks/ai/session-resume-restore.py) | SessionStart hook script |
+| [`tests/test_hook_precompact_checkpoint.py`](../../../tests/test_hook_precompact_checkpoint.py) | Pytest coverage for PreCompact hook |
+| [`tests/test_hook_session_resume_restore.py`](../../../tests/test_hook_session_resume_restore.py) | Pytest coverage for SessionStart hook |
+| [`.claude/settings.json`](../../../.claude/settings.json) | Wires both hooks into the lifecycle |
+
+## Related
+
+- [AI Command Blocking](command-blocking.md) — sibling `PreToolUse` hook for dangerous commands
+- [Ruff Auto-Fix on Edit](ruff-fix-hook.md) — sibling `PostToolUse` hook for Python formatting
+- [Slash Commands and Workflows](slash-commands.md) — the `/checkpoint` and `/restore` manual commands
+- [AGENTS.md](../../../AGENTS.md) — `tmp/checkpoints/` convention and cross-agent portability

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -49,6 +49,12 @@ Gemini commands under `.gemini/commands/` are **output-only**: Gemini does not p
 
 Entries are alphabetical. Each one names the command, its arguments, what it does, its position in the workflow, and any design note worth knowing.
 
+### `/checkpoint [slug]`
+
+**Args:** optional kebab-case slug describing the topic. **Source:** `.claude/commands/checkpoint.md` (and `.gemini/commands/checkpoint.md`).
+
+Captures a paste-ready resumption prompt to `tmp/checkpoints/{inv_epoch}-{slug}.md` so the user (or a future agent session via `/restore`) can pick up where they left off without re-reading the current conversation. Filename prefix is monotonically decreasing in time so `ls` shows newest first. **Cross-agent portability:** `tmp/checkpoints/` is intentionally shared (not per-agent) so a checkpoint written by Claude can be restored in Gemini or Codex and vice versa — the documented exception to the `tmp/agents/<agent-type>/` rule in `AGENTS.md`. **Workflow position:** any time, independent of the issue lifecycle. **Design note:** checkpoints are immutable once written; verify referenced issues/PRs are still current before acting on stale references.
+
 ### `/close-issue <n>`
 
 **Args:** issue number. **Source:** `.claude/commands/close-issue.md`.
@@ -85,6 +91,16 @@ Dual-agent replacement for `/plan-issue`. Validates the issue, warns if plan com
 **Args:** issue number. **Source:** `.claude/commands/plan-issue.md`.
 
 Runs in the main conversation context (not a subagent) so the user can ask questions and refine the plan interactively. Enters plan mode, validates the issue, warns if a plan comment already exists, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches issue details, explores the codebase, and drafts a plan with the standard sections (Overview, Files to Create/Modify, Test Plan, Documentation, Validation). It iterates inside plan mode with `AskUserQuestion` until the user approves, then exits plan mode and posts the approved plan as an issue comment. **Workflow position:** first step of the single-agent workflow. **Design note:** plan mode is preserved throughout iteration; exiting plan mode means "post the approved plan", nothing more.
+
+### `/restore [slug]`
+
+**Args:** optional kebab-case slug to filter by. **Source:** `.claude/commands/restore.md` (and `.gemini/commands/restore.md`).
+
+Loads a previously captured checkpoint prompt from `tmp/checkpoints/` and continues the work it describes. If no slug is given, picks the lexically first file (newest). The file's contents are treated as the initial user instruction for the new session. **Workflow position:** at the start of a session resuming earlier work. **Design note:** the companion `/checkpoint` writes the file — together they form the save/load pair.
+
+### Auto-checkpoint (PreCompact / SessionStart hooks)
+
+Two lifecycle hooks complement `/checkpoint` and `/restore` to automate the pause/resume pattern for the most common context-loss event: autocompact firing mid-task. The `PreCompact` hook synthesizes a checkpoint to `tmp/checkpoints/{inv_epoch}-auto-precompact.md` before compaction; the `SessionStart` hook (matcher `compact|resume`) injects the newest auto-precompact file into the new session automatically. Auto-precompact files share the same convention and directory as manual `/checkpoint` files, so `/restore auto-precompact` also works. Set `CLAUDE_NO_AUTO_RESTORE=1` to opt out of the auto-restore; set `CLAUDE_RESTORE_ANY=1` to widen the restore glob to any `*.md` checkpoint. See [Auto-Checkpoint and Session-Restore Hooks](auto-checkpoint-hook.md).
 
 ### `/review-both`
 
@@ -141,4 +157,5 @@ GitHub Copilot CLI automatically discovers project skills from `.claude/commands
 - [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
 - [AI Enforcement Principles](enforcement-principles.md) — how this template enforces rules in code, not just instructions.
 - [AI Command Blocking](command-blocking.md) — tool-level hooks that block dangerous commands.
+- [Auto-Checkpoint and Session-Restore Hooks](auto-checkpoint-hook.md) — PreCompact and SessionStart hooks that automate the `/checkpoint` ↔ `/restore` pair around autocompact.
 - [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.

--- a/tests/test_hook_precompact_checkpoint.py
+++ b/tests/test_hook_precompact_checkpoint.py
@@ -1,0 +1,272 @@
+"""Tests for the ``precompact-checkpoint`` PreCompact hook.
+
+The hook script lives at ``tools/hooks/ai/precompact-checkpoint.py``. Its filename
+contains hyphens, so it isn't directly importable — we load it via ``importlib`` and
+invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "precompact-checkpoint.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("precompact_checkpoint", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["precompact_checkpoint"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("precompact_checkpoint", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _payload(cwd: str, transcript_path: str = "") -> str:
+    """Build a minimal PreCompact payload."""
+    return json.dumps({"cwd": cwd, "transcript_path": transcript_path})
+
+
+def _good_synthesis() -> dict[str, object]:
+    """Return a valid synthesis dict."""
+    return {
+        "title": "Add caching layer",
+        "status": "In progress — cache module drafted",
+        "in_flight_work": "Implementing LRU cache in src/cache.py",
+        "constraints": "Must be thread-safe",
+        "files_touched": ["src/cache.py", "tests/test_cache.py"],
+        "next_steps": "1. Write tests\n2. Run doit check",
+        "resume_prompt": "Continue implementing the cache module.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_writes_checkpoint(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Stub synthesizer returns valid JSON → markdown file written with correct sections."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: _good_synthesis())
+    _set_stdin(monkeypatch, _payload(str(tmp_path), "transcript.jsonl"))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    text = checkpoints[0].read_text(encoding="utf-8")
+    assert "Add caching layer" in text
+    assert "In progress" in text
+    assert "src/cache.py" in text
+    assert "Continue implementing" in text
+
+
+def test_happy_path_filename_convention(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Written file must match ``{inv_epoch}-auto-precompact.md`` pattern."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: _good_synthesis())
+    _set_stdin(monkeypatch, _payload(str(tmp_path), "t.jsonl"))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    name = checkpoints[0].name
+    # Name must be "{10-digit-prefix}-auto-precompact.md"
+    parts = name.split("-", 1)
+    assert len(parts) == 2
+    assert parts[0].isdigit() and len(parts[0]) == 10
+
+
+# ---------------------------------------------------------------------------
+# Fallback: synthesis returns None
+# ---------------------------------------------------------------------------
+
+
+def test_synthesis_none_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Synthesizer returns None → fallback file written with AUTO_PARTIAL banner."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    transcript_file = tmp_path / "t.jsonl"
+    transcript_file.write_text("some transcript content", encoding="utf-8")
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: None)
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(transcript_file)))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    text = checkpoints[0].read_text(encoding="utf-8")
+    assert "AUTO_PARTIAL" in text
+
+
+# ---------------------------------------------------------------------------
+# Fallback: invalid JSON from synthesizer
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_synthesis_json_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Real synthesize_checkpoint with JSON parse failure → fallback (mocked at subprocess)."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    transcript_file = tmp_path / "t.jsonl"
+    transcript_file.write_text("transcript", encoding="utf-8")
+
+    # Simulate synthesize_checkpoint returning None (as it would on JSONDecodeError).
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: None)
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(transcript_file)))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    assert "AUTO_PARTIAL" in checkpoints[0].read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Missing transcript path
+# ---------------------------------------------------------------------------
+
+
+def test_missing_transcript_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing transcript file → fallback written; exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    # Provide a path that does not exist; synthesize_checkpoint not called.
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(tmp_path / "nonexistent.jsonl")))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    assert "AUTO_PARTIAL" in checkpoints[0].read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Malformed stdin JSON
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_stdin_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid JSON on stdin → exits 0, no file written."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    _set_stdin(monkeypatch, "not json at all")
+
+    assert hook.main() == 0
+
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    assert not checkpoints_dir.exists() or not list(checkpoints_dir.glob("*.md"))
+
+
+# ---------------------------------------------------------------------------
+# Subprocess raises TimeoutExpired
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_checkpoint_timeout_returns_none(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """synthesize_checkpoint swallows TimeoutExpired and returns None."""
+
+    def _raise_timeout(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=90)
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+
+    result = hook.synthesize_checkpoint("some transcript")
+    assert result is None
+
+
+def test_timeout_in_main_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If synthesize_checkpoint raises (or returns None after timeout), fallback is written."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    transcript_file = tmp_path / "t.jsonl"
+    transcript_file.write_text("session transcript", encoding="utf-8")
+
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: None)
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(transcript_file)))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    assert "AUTO_PARTIAL" in checkpoints[0].read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# inv_epoch helper
+# ---------------------------------------------------------------------------
+
+
+def test_inv_epoch_is_10_digit_decreasing(
+    hook: types.ModuleType,
+) -> None:
+    """_inv_epoch() produces a 10-digit string that decreases over time."""
+    import time
+
+    e1 = hook._inv_epoch()
+    time.sleep(0.01)
+    e2 = hook._inv_epoch()
+
+    assert len(e1) == 10
+    assert e1.isdigit()
+    # e1 was computed first (earlier time → larger inv_epoch).
+    assert int(e1) >= int(e2)

--- a/tests/test_hook_session_resume_restore.py
+++ b/tests/test_hook_session_resume_restore.py
@@ -1,0 +1,245 @@
+"""Tests for the ``session-resume-restore`` SessionStart hook.
+
+The hook script lives at ``tools/hooks/ai/session-resume-restore.py``. Its filename
+contains hyphens, so it isn't directly importable — we load it via ``importlib`` and
+invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "session-resume-restore.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("session_resume_restore", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["session_resume_restore"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("session_resume_restore", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _payload(cwd: str) -> str:
+    """Build a minimal SessionStart payload."""
+    return json.dumps({"cwd": cwd})
+
+
+def _make_checkpoint(checkpoints_dir: Path, name: str, body: str = "checkpoint body") -> Path:
+    """Create a checkpoint file under *checkpoints_dir* and return its path."""
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+    p = checkpoints_dir / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy path: single auto-precompact checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_single_checkpoint_returned(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Single *-auto-precompact*.md → stdout JSON with additionalContext = file body."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-auto-precompact.md", "resume here")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert out["hookSpecificOutput"]["additionalContext"] == "resume here"
+
+
+# ---------------------------------------------------------------------------
+# Multiple checkpoints → lexically smallest (newest) selected
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_checkpoints_newest_selected(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Lexically smallest name (smallest inv_epoch → newest) is selected.
+
+    inv_epoch = 9999999999 - int(time.time()): it *decreases* as time advances.
+    A smaller inv_epoch means more time has passed → the file was created later → it is newer.
+    sorted() ascending picks the smallest inv_epoch first, which is the newest file.
+    """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    # Larger inv_epoch = fewer seconds elapsed → created earlier → older.
+    _make_checkpoint(checkpoints_dir, "9999999000-auto-precompact.md", "older")
+    # Smaller inv_epoch = more seconds elapsed → created later → newer.
+    _make_checkpoint(checkpoints_dir, "9999998000-auto-precompact.md", "newer")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["hookSpecificOutput"]["additionalContext"] == "newer"
+
+
+# ---------------------------------------------------------------------------
+# No checkpoint files → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_no_checkpoints_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No matching files → no stdout, exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# tmp/checkpoints/ doesn't exist → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_missing_checkpoints_dir_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing tmp/checkpoints/ directory → no-op, exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    # Do NOT create the directory.
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE_NO_AUTO_RESTORE=1 → no-op even when checkpoints exist
+# ---------------------------------------------------------------------------
+
+
+def test_no_auto_restore_env_skips(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLAUDE_NO_AUTO_RESTORE=1 → no-op even when a checkpoint exists."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_NO_AUTO_RESTORE", "1")
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-auto-precompact.md", "should not restore")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# Manual /checkpoint files (no auto-precompact slug) ignored by default glob
+# ---------------------------------------------------------------------------
+
+
+def test_manual_checkpoint_ignored_by_default(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Manual checkpoint (no auto-precompact slug) is ignored by default glob."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_RESTORE_ANY", raising=False)
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-my-manual-checkpoint.md", "manual")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_restore_any_env_includes_manual_checkpoint(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLAUDE_RESTORE_ANY=1 widens the glob to include manual checkpoints."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_RESTORE_ANY", "1")
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-my-manual-checkpoint.md", "manual body")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["hookSpecificOutput"]["additionalContext"] == "manual body"
+
+
+# ---------------------------------------------------------------------------
+# Malformed stdin JSON → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_stdin_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Invalid JSON on stdin → no-op, exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    _set_stdin(monkeypatch, "not valid json {{")
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""

--- a/tools/hooks/ai/precompact-checkpoint.py
+++ b/tools/hooks/ai/precompact-checkpoint.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreCompact hook that synthesizes a checkpoint before context compaction.
+
+Triggered when Claude Code is about to compact the conversation context. Reads the
+transcript, spawns a headless ``claude -p`` to synthesize a structured checkpoint,
+and writes the result to ``tmp/checkpoints/{inv_epoch}-auto-precompact.md``.
+
+The hook is best-effort: any failure (timeout, missing CLI, non-zero exit, JSON parse
+failure, missing transcript) falls back to a banner + raw transcript tail tagged
+``AUTO_PARTIAL``. Always exits 0 so it never blocks the compaction event.
+
+For full documentation, see: docs/development/ai/auto-checkpoint-hook.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess  # nosec B404 - required to invoke claude CLI
+import sys
+import time
+from pathlib import Path
+
+# Maximum transcript bytes to include in the synthesis prompt.
+TRANSCRIPT_TAIL_BYTES = 200_000
+
+# Timeout for the synthesis subprocess (seconds). Set to 90 per issue #513 note.
+SYNTHESIS_TIMEOUT_SECONDS = 90
+
+# JSON schema the synthesis prompt asks for.
+SYNTHESIS_SCHEMA = (
+    "{title, status, in_flight_work, constraints, files_touched (array), next_steps, resume_prompt}"
+)
+
+# Prompt sent to the headless claude -p call.
+SYNTHESIS_PROMPT_TEMPLATE = """\
+You are summarizing a coding session for checkpoint/restore. \
+Read the transcript excerpt below and produce ONLY a JSON object with EXACTLY these keys \
+(no extra prose, no markdown fences, just the raw JSON):
+
+{schema}
+
+Field guidance:
+- title: short description of current work (e.g. "Add caching layer to user service")
+- status: one-line summary of what has landed recently and what is in-flight
+- in_flight_work: detailed description of what is currently being worked on
+- constraints: key decisions, preferences, or constraints from this session to preserve
+- files_touched: array of file paths that have been created or modified
+- next_steps: ordered list of next actions the future session should take
+- resume_prompt: a self-contained paste-ready prompt for a future agent session
+
+TRANSCRIPT (last {byte_count} bytes):
+{transcript}
+""".strip()
+
+# Markdown template for the rendered checkpoint.
+CHECKPOINT_TEMPLATE = """\
+# Auto-Checkpoint: {title}
+
+> **AUTO-PRECOMPACT** checkpoint written by the PreCompact hook before context compaction.
+> Restore with `/restore auto-precompact` in a fresh session.
+
+## Status
+
+{status}
+
+## In-Flight Work
+
+{in_flight_work}
+
+## Constraints to Preserve
+
+{constraints}
+
+## Files Touched
+
+{files_touched}
+
+## Next Steps
+
+{next_steps}
+
+## Resume Prompt
+
+{resume_prompt}
+""".strip()
+
+
+def _inv_epoch() -> str:
+    """Return a 10-digit decreasing integer string (newest sorts first)."""
+    return f"{9_999_999_999 - int(time.time()):010d}"
+
+
+def _unique_path(checkpoints_dir: Path, slug: str) -> Path:
+    """Return a unique path under *checkpoints_dir* for *slug*.
+
+    On collision (same-second invocation), appends ``-a``, ``-b``, … to the
+    epoch prefix until a free name is found.
+    """
+    epoch = _inv_epoch()
+    candidate = checkpoints_dir / f"{epoch}-{slug}.md"
+    if not candidate.exists():
+        return candidate
+    for ch in "abcdefghijklmnopqrstuvwxyz":
+        candidate = checkpoints_dir / f"{epoch}-{slug}-{ch}.md"
+        if not candidate.exists():
+            return candidate
+    # Extremely unlikely: fall back to a microsecond suffix.
+    candidate = checkpoints_dir / f"{epoch}-{slug}-x{time.time_ns()}.md"
+    return candidate
+
+
+def synthesize_checkpoint(transcript_tail: str) -> dict[str, object] | None:
+    """Call headless ``claude -p`` with a synthesis prompt; return parsed JSON or None.
+
+    Returns None immediately when *transcript_tail* is empty (nothing to synthesize).
+    """
+    if not transcript_tail:
+        return None
+    prompt = SYNTHESIS_PROMPT_TEMPLATE.format(
+        schema=SYNTHESIS_SCHEMA,
+        byte_count=len(transcript_tail.encode("utf-8", errors="replace")),
+        transcript=transcript_tail,
+    )
+    try:
+        result = subprocess.run(  # nosec B603 B607 - spawns claude CLI for synthesis
+            [
+                "claude",
+                "-p",
+                "--bare",
+                "--model",
+                "claude-sonnet-4-6",
+                prompt,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=SYNTHESIS_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            return None
+        raw = result.stdout.strip()
+        # Strip markdown fences if the model wrapped the JSON anyway.
+        if raw.startswith("```"):
+            lines = raw.splitlines()
+            raw = "\n".join(line for line in lines if not line.startswith("```")).strip()
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            return None
+        return parsed
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    except json.JSONDecodeError:
+        return None
+    except Exception:  # nosec B110 - hook must never raise
+        return None
+
+
+def _render_checkpoint(data: dict[str, object]) -> str:
+    """Render *data* dict into the markdown checkpoint format."""
+    files_touched = data.get("files_touched", [])
+    if isinstance(files_touched, list):
+        files_str = "\n".join(f"- {f}" for f in files_touched) or "_none recorded_"
+    else:
+        files_str = str(files_touched)
+
+    return CHECKPOINT_TEMPLATE.format(
+        title=data.get("title", "Unknown"),
+        status=data.get("status", "_not recorded_"),
+        in_flight_work=data.get("in_flight_work", "_not recorded_"),
+        constraints=data.get("constraints", "_none recorded_"),
+        files_touched=files_str,
+        next_steps=data.get("next_steps", "_not recorded_"),
+        resume_prompt=data.get("resume_prompt", "_not recorded_"),
+    )
+
+
+def _fallback_checkpoint(transcript_tail: str, reason: str) -> str:
+    """Return an AUTO_PARTIAL checkpoint with a raw transcript tail."""
+    return (
+        f"# Auto-Checkpoint (AUTO_PARTIAL)\n\n"
+        f"> **AUTO_PARTIAL**: synthesis failed ({reason}). "
+        f"Raw transcript tail follows.\n\n"
+        f"## Raw Transcript Tail\n\n"
+        f"```\n{transcript_tail}\n```"
+    )
+
+
+def _read_transcript_tail(transcript_path: str) -> str | None:
+    """Read and return the tail of the JSONL transcript file, or None on error."""
+    try:
+        path = Path(transcript_path)
+        if not path.is_file():
+            return None
+        size = path.stat().st_size
+        if size == 0:
+            return ""
+        with path.open("rb") as fh:
+            if size > TRANSCRIPT_TAIL_BYTES:
+                fh.seek(size - TRANSCRIPT_TAIL_BYTES)
+            raw_bytes = fh.read()
+        return raw_bytes.decode("utf-8", errors="replace")
+    except (OSError, PermissionError):
+        return None
+    except Exception:  # nosec B110 - defensive
+        return None
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+        if not isinstance(input_data, dict):
+            return 0
+
+        cwd = input_data.get("cwd", "")
+        transcript_path = input_data.get("transcript_path", "")
+
+        # Determine project root (cwd or CLAUDE_PROJECT_DIR).
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "") or cwd
+        if not project_dir:
+            return 0
+
+        checkpoints_dir = Path(project_dir) / "tmp" / "checkpoints"
+        try:
+            checkpoints_dir.mkdir(parents=True, exist_ok=True)
+        except (OSError, PermissionError):
+            return 0
+
+        # Read transcript tail.
+        transcript_tail: str = ""
+        if transcript_path:
+            tail = _read_transcript_tail(transcript_path)
+            if tail is not None:
+                transcript_tail = tail
+            # If tail is None (file missing/unreadable), proceed with empty tail → fallback.
+
+        # Synthesize checkpoint (always attempt; returns None on empty/failure).
+        synthesized: dict[str, object] | None = synthesize_checkpoint(transcript_tail)
+
+        # Render content.
+        if synthesized is not None:
+            try:
+                content = _render_checkpoint(synthesized)
+            except Exception:  # nosec B110 - defensive render failure
+                content = _fallback_checkpoint(transcript_tail, "render error")
+        else:
+            reason = "synthesis returned None" if transcript_tail else "no transcript"
+            content = _fallback_checkpoint(transcript_tail, reason)
+
+        # Write the checkpoint file.
+        out_path = _unique_path(checkpoints_dir, "auto-precompact")
+        with contextlib.suppress(OSError, PermissionError):
+            out_path.write_text(content, encoding="utf-8")
+
+    except Exception:  # hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/session-resume-restore.py
+++ b/tools/hooks/ai/session-resume-restore.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Claude Code SessionStart hook that restores the most recent auto-precompact checkpoint.
+
+Triggered when Claude Code starts a session whose trigger contains "compact" or "resume"
+(configured via the matcher in ``.claude/settings.json``). Reads the newest
+``*-auto-precompact*.md`` from ``tmp/checkpoints/`` and injects its contents into the
+new session via ``hookSpecificOutput.additionalContext``.
+
+Opt-out: set ``CLAUDE_NO_AUTO_RESTORE=1`` to disable restoration entirely.
+Widen: set ``CLAUDE_RESTORE_ANY=1`` to restore any ``*.md`` checkpoint, not just
+``*-auto-precompact*.md`` ones.
+
+The hook is best-effort: any failure (missing directory, no matching files, malformed
+stdin) is swallowed and the hook exits 0 so it never blocks session startup.
+
+For full documentation, see: docs/development/ai/auto-checkpoint-hook.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Default glob: only auto-precompact checkpoints.
+DEFAULT_GLOB = "*-auto-precompact*.md"
+
+# Widened glob: any checkpoint (enabled when CLAUDE_RESTORE_ANY=1).
+ANY_GLOB = "*.md"
+
+
+def _find_newest_checkpoint(checkpoints_dir: Path, glob: str) -> Path | None:
+    """Return the lexically smallest (newest by inv_epoch) matching file, or None."""
+    try:
+        matches = sorted(checkpoints_dir.glob(glob))
+        return matches[0] if matches else None
+    except (OSError, PermissionError):
+        return None
+    except Exception:  # nosec B110 - defensive
+        return None
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        # Opt-out check.
+        if os.environ.get("CLAUDE_NO_AUTO_RESTORE"):
+            return 0
+
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+        if not isinstance(input_data, dict):
+            return 0
+
+        cwd = input_data.get("cwd", "")
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "") or cwd
+        if not project_dir:
+            return 0
+
+        checkpoints_dir = Path(project_dir) / "tmp" / "checkpoints"
+        if not checkpoints_dir.is_dir():
+            return 0
+
+        # Choose glob based on env var.
+        glob = ANY_GLOB if os.environ.get("CLAUDE_RESTORE_ANY") else DEFAULT_GLOB
+
+        newest = _find_newest_checkpoint(checkpoints_dir, glob)
+        if newest is None:
+            return 0
+
+        try:
+            body = newest.read_text(encoding="utf-8")
+        except (OSError, PermissionError):
+            return 0
+        except Exception:  # nosec B110 - defensive
+            return 0
+
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": body,
+            }
+        }
+        sys.stdout.write(json.dumps(output))
+        sys.stdout.flush()
+
+    except Exception:  # hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adopts the session checkpoint/restore feature from upstream pyproject-template PRs [#509](https://github.com/endavis/pyproject-template/pull/509), [#511](https://github.com/endavis/pyproject-template/pull/511), and [#536](https://github.com/endavis/pyproject-template/pull/536). Ships:

1. **Manual `/checkpoint` and `/restore` slash commands** for Claude Code and Gemini CLI, sharing a portable `tmp/checkpoints/` directory.
2. **Automatic `PreCompact` and `SessionStart` hooks** that synthesize a checkpoint before autocompact fires and inject it into the new session — minimizing context loss from autocompact mid-task without requiring manual `/checkpoint`.

### Why

Autocompact firing mid-task is the single most common cause of context loss in long Claude Code sessions. Manual checkpoints work but require the user to remember. The auto-hooks make the save/restore path automatic for the autocompact event specifically, while leaving manual `/checkpoint`/`/restore` available for explicit pause-and-resume needs.

### Changes

**Hooks (new):**
- `tools/hooks/ai/precompact-checkpoint.py` — PreCompact hook that writes `tmp/checkpoints/{inv_epoch}-auto-precompact.md` before autocompact. 90-second timeout.
- `tools/hooks/ai/session-resume-restore.py` — SessionStart hook (matcher `compact|resume`) that picks the newest auto-precompact file and injects it via `hookSpecificOutput.additionalContext`. Honors `CLAUDE_NO_AUTO_RESTORE=1` opt-out and `CLAUDE_RESTORE_ANY=1` to widen the glob.

**Tests (new):** 17 tests across two files (`test_hook_precompact_checkpoint.py`, `test_hook_session_resume_restore.py`).

**Commands (new):**
- `.claude/commands/checkpoint.md`, `.claude/commands/restore.md`
- `.gemini/commands/checkpoint.md`, `.gemini/commands/restore.md` (in `.md` format matching our existing `.gemini/commands/`; Phase C will convert all gemini commands to TOML via upstream #539)

**Wiring:**
- `.claude/settings.json` — `PreCompact` and `SessionStart` hooks added alongside existing `PreToolUse` (block-dangerous-commands) and `PostToolUse` (ruff-fix-on-edit). **Enabled in committed settings** per project direction. JSON validated.

**Docs:**
- `docs/development/ai/auto-checkpoint-hook.md` (new, 173 lines) — full design + env-var reference.
- `AGENTS.md` — add `tmp/checkpoints/` exception to the Temporary Files cleanup rule (parallel to upstream #511's hand-merge).
- `docs/development/ai/slash-commands.md` — add `/checkpoint`, `/restore`, and auto-checkpoint-hooks sections in the Command reference, plus a See-also link.

### Not adopted from upstream

- **`.agents/skills/{checkpoint,restore}/SKILL.md`** (`.agents/skills/` is upstream's Codex CLI skill pattern; we don't have that directory yet — deferred until we adopt the broader Codex setup).
- **`docs/development/ai/token-efficiency-add-ons.md` update** from #536 — that doc doesn't exist locally yet (added by #520 in Phase E); will pick up the auto-hook reference when we sync that file.

### Cross-agent portability

`tmp/checkpoints/` is intentionally shared (not per-agent) so checkpoints are portable across Claude, Gemini, and Codex. This is the documented exception to the `tmp/agents/<agent-type>/` rule in `AGENTS.md`. The exception line is added in this PR.

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

| File | Type | Lines |
| :--- | :--- | :--- |
| `tools/hooks/ai/precompact-checkpoint.py` | new | 268 |
| `tools/hooks/ai/session-resume-restore.py` | new | 99 |
| `tests/test_hook_precompact_checkpoint.py` | new | 272 |
| `tests/test_hook_session_resume_restore.py` | new | 245 |
| `.claude/commands/checkpoint.md` | new | 60 |
| `.claude/commands/restore.md` | new | 54 |
| `.gemini/commands/checkpoint.md` | new | 60 |
| `.gemini/commands/restore.md` | new | 54 |
| `docs/development/ai/auto-checkpoint-hook.md` | new | 173 |
| `.claude/settings.json` | modified | +23/-0 |
| `AGENTS.md` | modified | +2/-0 |
| `docs/development/ai/slash-commands.md` | modified | +15/-0 |

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type-check, security, spell-check, full test suite). The 17 new hook tests all pass; `.claude/settings.json` validated as JSON.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase B.1 of the pyproject-template sync (#823). Phase B.2 (bash-ban-raw-tools, upstream #534) and Phase B.3 (Claude Max usage helper, upstream #562) follow.
