### PR TITLE
feat: enable bash-ban-raw-tools hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/bash-ban-raw-tools.py"
           }
         ]
       }

--- a/tests/test_bash_ban_raw_tools.py
+++ b/tests/test_bash_ban_raw_tools.py
@@ -1,0 +1,261 @@
+"""Tests for the ``bash-ban-raw-tools`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/bash-ban-raw-tools.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import time
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "bash-ban-raw-tools.py"
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("bash_ban_raw_tools", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["bash_ban_raw_tools"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("bash_ban_raw_tools", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _bash_payload(command: str) -> str:
+    """Build a Bash tool payload for the given command."""
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+def _non_bash_payload(tool_name: str) -> str:
+    """Build a non-Bash tool payload."""
+    return json.dumps({"tool_name": tool_name, "tool_input": {"file_path": "README.md"}})
+
+
+# ---------------------------------------------------------------------------
+# Allow cases
+# ---------------------------------------------------------------------------
+
+
+def test_non_bash_tool_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-Bash tools (e.g. Read) are always allowed."""
+    _set_stdin(monkeypatch, _non_bash_payload("Read"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_benign_bash_command_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Safe Bash commands like ``ls -la`` are allowed."""
+    _set_stdin(monkeypatch, _bash_payload("ls -la"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_malformed_json_exits_1(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON input exits with code 1 (parity with block-dangerous-commands)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 1
+
+
+def test_banned_word_as_non_leading_non_pipe_token_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``echo cat`` — banned word is not the leading token and not after a pipe."""
+    _set_stdin(monkeypatch, _bash_payload("echo cat"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Block: banned leading commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat README.md",
+        "head foo.txt",
+        "tail -f log.txt",
+        "find . -name '*.py'",
+        "grep pattern file.py",
+        "rg pattern",
+        "wc -l file.txt",
+    ],
+)
+def test_banned_leading_command_exits_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Each banned leading command is blocked with exit code 2."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Block: piped truncators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls | head",
+        "ls | tail -100",
+        "cmd | head -n 5",
+    ],
+)
+def test_piped_truncator_exits_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Piped truncators (``... | head``, ``... | tail``) are blocked with exit code 2."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch: unlock file
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_unlock_file_allows_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file exists and mtime is within window, banned commands are allowed."""
+    unlock = tmp_path / "unlock"
+    unlock.touch()
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_stale_unlock_file_blocks_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file mtime is older than UNLOCK_WINDOW_SECONDS, command is blocked."""
+    unlock = tmp_path / "unlock"
+    unlock.touch()
+    # Set mtime to well past the window
+    stale_mtime = time.time() - (hook.UNLOCK_WINDOW_SECONDS + 60)
+    import os
+
+    os.utime(str(unlock), (stale_mtime, stale_mtime))
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_missing_unlock_file_blocks_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file does not exist, banned commands are blocked."""
+    unlock = tmp_path / "unlock"
+    # Do NOT create the file
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+
+    _set_stdin(monkeypatch, _bash_payload("grep pattern file.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Stderr reason content checks
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_reason_mentions_offending_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason mentions the offending command."""
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(tmp_path / "unlock"))
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    assert "cat" in captured.err
+
+
+def test_stderr_reason_mentions_unlock_file(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason mentions the escape hatch (UNLOCK_FILE path)."""
+    unlock_path = str(tmp_path / "unlock")
+    monkeypatch.setattr(hook, "UNLOCK_FILE", unlock_path)
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    assert unlock_path in captured.err

--- a/tools/hooks/ai/bash-ban-raw-tools.py
+++ b/tools/hooks/ai/bash-ban-raw-tools.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse hook to block raw shell commands when native tools are available.
+
+This hook intercepts Bash commands before execution and blocks those that AI agents
+should be using native file tools for instead (Read, Grep, Glob, Edit, Write).
+
+Blocks:
+  - Leading banned commands: cat, head, tail, find, grep, rg, wc
+  - Piped truncators: ... | head, ... | tail (regardless of args)
+
+Escape hatch:
+  Touch /tmp/bash-raw-unlock (or the configured UNLOCK_FILE) to allow banned
+  commands for 10 minutes. The file auto-expires — no cleanup needed.
+
+Exit codes:
+  0 - Allow command
+  1 - Malformed JSON input
+  2 - Block command (shows stderr to Claude)
+
+This hook is Claude-only (reads {"tool_name": "Bash", "tool_input": {"command": "..."}}).
+For always-on dangerous-command blocking, see: tools/hooks/ai/block-dangerous-commands.py
+For documentation, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+import json
+import shlex
+import sys
+import time
+from pathlib import Path
+
+# Commands that AI agents should never use via Bash when native tools are available
+BANNED_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "find", "grep", "rg", "wc"})
+
+# Commands that are banned when they appear after a pipe (regardless of arguments)
+PIPE_TRUNCATORS: frozenset[str] = frozenset({"head", "tail"})
+
+# Escape hatch: touch this file to allow banned commands for UNLOCK_WINDOW_SECONDS
+UNLOCK_FILE: str = "/tmp/bash-raw-unlock"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
+
+# How long the escape hatch stays valid after the file is touched (seconds)
+UNLOCK_WINDOW_SECONDS: int = 600
+
+# Native tool suggestions for each banned command
+_SUGGESTIONS: dict[str, str] = {
+    "cat": "Read",
+    "head": "Read",
+    "tail": "Read",
+    "find": "Glob",
+    "grep": "Grep",
+    "rg": "Grep",
+    "wc": "Read (then count lines/words in the result)",
+}
+
+
+def tokenize(command: str) -> list[str]:
+    """
+    Tokenize command using shlex for proper shell quote handling.
+
+    Returns list of tokens with quotes stripped from values.
+    Falls back to non-POSIX mode, then simple whitespace split on malformed input.
+    """
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        try:
+            return shlex.split(command, posix=False)
+        except ValueError:
+            return command.split()
+
+
+def is_unlocked() -> bool:
+    """Return True iff UNLOCK_FILE exists and was modified within UNLOCK_WINDOW_SECONDS."""
+    path = Path(UNLOCK_FILE)
+    try:
+        mtime = path.stat().st_mtime
+        return (time.time() - mtime) <= UNLOCK_WINDOW_SECONDS
+    except OSError:
+        return False
+
+
+def find_banned_leading(tokens: list[str]) -> str | None:
+    """Return the first token if it is in BANNED_COMMANDS, else None."""
+    if tokens and tokens[0] in BANNED_COMMANDS:
+        return tokens[0]
+    return None
+
+
+def find_banned_pipe(tokens: list[str]) -> str | None:
+    """
+    Scan for a pipe token immediately followed by a PIPE_TRUNCATOR.
+
+    Returns the truncator name if found, else None.
+    """
+    for i, token in enumerate(tokens):
+        if token == "|" and i + 1 < len(tokens) and tokens[i + 1] in PIPE_TRUNCATORS:  # nosec B105 - "|" is the shell pipe character, not a credential.
+            return tokens[i + 1]
+    return None
+
+
+def _build_reason(offending: str) -> str:
+    """Build a human-readable block reason for the given offending command."""
+    suggestion = _SUGGESTIONS.get(offending, "a native tool")
+    return (
+        f"Blocked: `{offending}` is a raw shell command.\n"
+        f"Use the native `{suggestion}` tool instead — it produces a better result "
+        f"with fewer tokens.\n"
+        f"Escape hatch: `touch {UNLOCK_FILE}` to allow raw commands for "
+        f"{UNLOCK_WINDOW_SECONDS // 60} minutes."
+    )
+
+
+def main() -> int:
+    """Main entry point."""
+    try:
+        input_data: dict[str, object] = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"Invalid JSON input: {e}", file=sys.stderr)
+        return 1
+
+    # This hook is Claude-only: expects {"tool_name": ..., "tool_input": {...}}
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        return 0
+
+    tool_input = input_data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command", "")
+    if not isinstance(command, str) or not command:
+        return 0
+
+    # Escape hatch: allow if unlock file is fresh
+    if is_unlocked():
+        return 0
+
+    tokens = tokenize(command)
+
+    # Check for banned leading command
+    offending = find_banned_leading(tokens)
+    if offending is not None:
+        print(_build_reason(offending), file=sys.stderr)
+        return 2
+
+    # Check for banned pipe-truncator
+    offending = find_banned_pipe(tokens)
+    if offending is not None:
+        print(_build_reason(offending), file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Ports the `bash-ban-raw-tools` hook from upstream [pyproject-template PR #534](https://github.com/endavis/pyproject-template/pull/534) and enables it in committed settings.

### What it does

A `PreToolUse` hook on the Bash tool that blocks AI agents from invoking raw shell tools when a native Claude Code / Gemini CLI tool exists:

| Blocked | Use instead |
| :--- | :--- |
| `cat`, `head`, `tail` (and `... \| head`, `... \| tail`) | `Read` |
| `find` | `Glob` |
| `grep`, `rg` | `Grep` |
| `wc` | `Read` then count in code, or `Grep -c` |

When triggered, exits with code 2 and stderr-reports the appropriate native-tool replacement. mtime-based `/tmp/bash-raw-unlock` escape hatch grants a 10-minute window for cases where shell pipelines are genuinely the right call.

### Why we enable it

`AGENTS.md` already mandates "prefer native file tools over raw shell" — this hook is the enforcement mechanism for that rule. Upstream ships it disabled-by-default (because humans collaborating in the same repo run legitimate shell commands), but for InfraFoundry the rule applies project-wide to all AI agents and we want it enforced at the tool level rather than relying on agents to self-comply.

Human collaborators are not affected — humans don't invoke the Bash tool through Claude Code; they run shell commands in their own terminal directly.

### Changes

- `tools/hooks/ai/bash-ban-raw-tools.py` (new, 156 lines) — the hook script.
- `tests/test_bash_ban_raw_tools.py` (new, 261 lines) — 19 cases covering allow lists, all seven banned lead commands, piped truncators, fresh/stale/missing unlock file, stderr-reason content.
- `.claude/settings.json` (+4/-0) — wire the hook as a second entry under the existing `PreToolUse` Bash matcher, alongside `block-dangerous-commands.py`. Both hooks now run before any Bash invocation by AI agents.

### Not adopted from upstream

- **`docs/development/ai/command-blocking.md` cross-reference** (one-line addition pointing to `token-efficiency-add-ons.md#bash-raw-tool-ban-opt-in`) — that target file doesn't exist locally yet; it lands with upstream #520 in Phase E along with this cross-reference. Keeping them together avoids a stale link.

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

| File | Type | Lines |
| :--- | :--- | :--- |
| `tools/hooks/ai/bash-ban-raw-tools.py` | new | 156 |
| `tests/test_bash_ban_raw_tools.py` | new | 261 |
| `.claude/settings.json` | modified | +4/-0 |

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally; 19/19 hook tests pass; `.claude/settings.json` validated as JSON.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (cross-reference deferred to Phase E with #520)
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase B.2 of the pyproject-template sync (#823). Phase B.3 (Claude Max usage helper, upstream #562) is next and closes Phase B.
