### PR TITLE
feat: add opt-in Claude Max usage helper for statusline

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -191,6 +191,13 @@ output="📁 ${dir}"
 [[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
 output+="\n${C_ACCENT}${model}${C_GRAY} | ${ctx}${C_RESET}"
 
+# Opt-in: append Claude Max usage to the model/context line when CLAUDE_USAGE_STATUSLINE=1.
+# See docs/development/ai/statusline.md#opt-in-claude-max-usage-display
+if [[ -n "$CLAUDE_USAGE_STATUSLINE" ]]; then
+    usage=$(bash "$CLAUDE_PROJECT_DIR/tools/statusline/claude-usage.sh" 2>/dev/null)
+    [[ -n "$usage" && "$usage" != "?" ]] && output+="${C_GRAY} | ${usage}${C_RESET}"
+fi
+
 printf '%b\n' "$output"
 
 # Get user's last message (text only, not tool results, skip unhelpful messages)

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -85,6 +85,55 @@ output="📁 ${dir}"
 [[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
 ```
 
+## Opt-In: Claude Max Usage Display
+
+For Claude Max subscribers, an optional helper at `tools/statusline/claude-usage.sh` displays
+weekly + 5-hour utilization. The default statusline runs the helper only when the
+`CLAUDE_USAGE_STATUSLINE` env var is set, so the default behavior is unchanged.
+
+> **Beta API**: This helper hits an undocumented OAuth endpoint (`/api/oauth/usage`)
+> gated by the `anthropic-beta: oauth-2025-04-20` header. Anthropic may change or remove
+> this endpoint without notice. When the official `claude --usage` flag ships
+> ([anthropics/claude-code#20399](https://github.com/anthropics/claude-code/issues/20399)),
+> prefer it.
+
+### Enable
+
+Set `CLAUDE_USAGE_STATUSLINE=1` in your shell environment:
+
+```bash
+# In ~/.zshrc, ~/.bashrc, or .envrc.local
+export CLAUDE_USAGE_STATUSLINE=1
+```
+
+Restart Claude Code. The statusline appends `5h:N% 7d:N%` to the model/context line.
+To disable temporarily: `unset CLAUDE_USAGE_STATUSLINE` and restart Claude Code.
+
+Example output (helper segment is the trailing portion of the third line):
+
+```
+📁 project | 🐍 .venv | Python: 3.12.12
+@username | 🔀 main (0 files uncommitted, synced 5m ago)
+Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens | 5h:25% 7d:6%
+```
+
+### Cache behavior
+
+Responses are cached at `${XDG_CACHE_HOME:-~/.cache}/claude-usage.json` for 60 seconds.
+Adjust `MAX_AGE` at the top of the script. To force a refresh: `rm ~/.cache/claude-usage.json`.
+
+### Helper requirements
+
+- Active Claude Code OAuth login (`${CLAUDE_CONFIG_DIR:-~/.claude}/.credentials.json`)
+- `curl` for HTTPS
+- `jq` (already required by base statusline)
+
+### Helper troubleshooting
+
+- **Outputs `?`**: missing/expired credentials, no network, beta endpoint changed schema, or
+  curl timeout (5s). Debug with `bash -x tools/statusline/claude-usage.sh`.
+- **Stale value**: cache has not expired. Delete the cache file or wait 60s.
+
 ## Requirements
 
 - `jq` - JSON processor (used for parsing Claude's input)

--- a/tests/test_statusline_claude_usage.py
+++ b/tests/test_statusline_claude_usage.py
@@ -1,0 +1,184 @@
+"""Tests for tools/statusline/claude-usage.sh opt-in helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# The helper is a bash script targeting Linux/macOS; the Windows GitHub Actions
+# runner's `bash` resolves to wsl.exe (which has no installed distribution),
+# so subprocess invocations cannot exercise the real shell behavior.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash helper is Linux/macOS only; Windows runner has no usable bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "statusline" / "claude-usage.sh"
+STATUSLINE = REPO_ROOT / ".claude" / "statusline-command.sh"
+
+_STATUSLINE_INPUT = json.dumps(
+    {
+        "model": {"display_name": "Claude"},
+        "cwd": "/tmp",
+        "transcript_path": "",
+        "context_window": {"context_window_size": 200000},
+    }
+)
+
+
+def _make_env(tmp_path: Path) -> dict[str, str]:
+    """Build a minimal, network-safe environment for subprocess calls."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    creds_dir = tmp_path / "creds"
+    creds_dir.mkdir()
+    return {
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(cache_dir),
+        "CLAUDE_CONFIG_DIR": str(creds_dir),
+        "PATH": os.environ["PATH"],
+    }
+
+
+def test_script_exists_and_executable() -> None:
+    """Helper script must exist at the expected path and be executable."""
+    assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), f"Script not executable: {SCRIPT}"
+
+
+def test_script_syntax_valid() -> None:
+    """bash -n must report no syntax errors."""
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, f"Syntax error:\n{result.stderr}"
+
+
+def test_emits_fallback_when_credentials_missing(tmp_path: Path) -> None:
+    """No .credentials.json and no cache -> output is literal '?', exit 0."""
+    env = _make_env(tmp_path)
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_uses_fresh_cache_skips_network(tmp_path: Path) -> None:
+    """Pre-seeded fresh cache is parsed and returned without hitting the network."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {"five_hour": {"utilization": 42.7}, "seven_day": {"utilization": 7.3}}
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    # Ensure mtime is current (fresh cache)
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "5h:42% 7d:7%"
+
+
+def test_emits_fallback_on_malformed_cache(tmp_path: Path) -> None:
+    """Fresh cache that contains invalid JSON emits '?'."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    cache_file.write_text("not-json", encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+    # No credentials file either, so the script won't fall through to the network
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_emits_fallback_when_token_field_missing(tmp_path: Path) -> None:
+    """Credentials file present but missing claudeAiOauth.accessToken -> '?'."""
+    env = _make_env(tmp_path)
+    creds_file = Path(env["CLAUDE_CONFIG_DIR"]) / ".credentials.json"
+    creds_file.write_text(json.dumps({}), encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def _seed_fresh_cache(env: dict[str, str]) -> None:
+    """Pre-write a parseable, fresh cache so the helper short-circuits curl."""
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {"five_hour": {"utilization": 42.7}, "seven_day": {"utilization": 7.3}}
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+
+def test_statusline_invokes_helper_when_env_set(tmp_path: Path) -> None:
+    """With CLAUDE_USAGE_STATUSLINE=1 and a fresh cache, statusline shows usage."""
+    env = _make_env(tmp_path)
+    env["CLAUDE_USAGE_STATUSLINE"] = "1"
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+    _seed_fresh_cache(env)
+
+    result = subprocess.run(
+        ["bash", str(STATUSLINE)],
+        input=_STATUSLINE_INPUT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "5h:42% 7d:7%" in result.stdout
+
+
+def test_statusline_skips_helper_when_env_unset(tmp_path: Path) -> None:
+    """Without CLAUDE_USAGE_STATUSLINE, statusline never invokes the helper."""
+    env = _make_env(tmp_path)
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+    # Fresh cache exists, so a bug that skipped the env check would still surface usage.
+    _seed_fresh_cache(env)
+
+    result = subprocess.run(
+        ["bash", str(STATUSLINE)],
+        input=_STATUSLINE_INPUT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "5h:" not in result.stdout
+    assert "7d:" not in result.stdout

--- a/tools/statusline/claude-usage.sh
+++ b/tools/statusline/claude-usage.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Opt-in Claude Max usage helper for statusline display.
+# Outputs: 5h:N% 7d:N% on success, or literal ? on any failure.
+# Wire into .claude/statusline-command.sh manually — not called by default.
+#
+# Requirements: curl, jq, active Claude Code OAuth login
+# See: docs/development/ai/statusline.md#opt-in-claude-max-usage-display
+
+# Cache TTL in seconds
+MAX_AGE=60
+
+CREDS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CREDS_FILE="$CREDS_DIR/.credentials.json"
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/claude-usage.json"
+
+# Check cache freshness first — avoids a network call and a token read on every invocation
+if [[ -f "$CACHE" ]]; then
+    if stat -f %m "$CACHE" >/dev/null 2>&1; then
+        cache_mtime=$(stat -f %m "$CACHE" 2>/dev/null)
+    else
+        cache_mtime=$(stat -c %Y "$CACHE" 2>/dev/null)
+    fi
+    if [[ -n "$cache_mtime" ]] && [[ "$cache_mtime" =~ ^[0-9]+$ ]]; then
+        now=$(date +%s)
+        age=$((now - cache_mtime))
+        if [[ $age -lt $MAX_AGE ]]; then
+            # Try to parse the cached response
+            result=$(jq -r '"5h:\(.five_hour.utilization|floor)% 7d:\(.seven_day.utilization|floor)%"' "$CACHE" 2>/dev/null)
+            if [[ -n "$result" ]]; then
+                echo "$result"
+                exit 0
+            fi
+            # Cache parse failed — fall through to emit ? (no network attempt without a token)
+            echo "?"
+            exit 0
+        fi
+    fi
+fi
+
+# Read OAuth token from credentials
+token=$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDS_FILE" 2>/dev/null)
+if [[ -z "$token" ]]; then
+    echo "?"
+    exit 0
+fi
+
+# Fetch fresh data
+response=$(curl -sf --max-time 5 \
+    -H "Authorization: Bearer $token" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+if [[ -z "$response" ]]; then
+    echo "?"
+    exit 0
+fi
+
+# Save to cache and parse
+echo "$response" > "$CACHE" 2>/dev/null
+result=$(jq -r '"5h:\(.five_hour.utilization|floor)% 7d:\(.seven_day.utilization|floor)%"' "$CACHE" 2>/dev/null)
+if [[ -n "$result" ]]; then
+    echo "$result"
+else
+    echo "?"
+fi


### PR DESCRIPTION
## Description

Ports the Claude Max usage helper from upstream [pyproject-template PR #562](https://github.com/endavis/pyproject-template/pull/562). For Claude Max subscribers, the helper displays weekly + 5-hour utilization in the statusline as `5h:N% 7d:N%`.

### Why opt-in (not enable-by-default)

The original Phase B plan called for B.3 to be "adopt + enable." After looking at the implementation, opt-in is the right shape:

1. **Subscription-gated** — the helper has no value to anyone without an active Claude Max subscription.
2. **Beta API surface** — hits an undocumented OAuth endpoint (`/api/oauth/usage`) gated by `anthropic-beta: oauth-2025-04-20`. Anthropic may change or remove it without notice. Wiring it always-on would silently start emitting `?` placeholders the day the endpoint shifts.
3. **Operator-level decision** — Claude Max status is per-person. Committing an always-on segment would be wrong for collaborators on the free/Pro plan.

The helper is wired in `.claude/statusline-command.sh` behind a `CLAUDE_USAGE_STATUSLINE` env var. Operators who want it set the variable in their own shell rc (`~/.zshrc`, `~/.bashrc`, or `.envrc.local`). Default statusline output is unchanged.

### Changes

- `tools/statusline/claude-usage.sh` (new, 65 lines): queries `/api/oauth/usage`, parses with `jq`, caches the response at `$XDG_CACHE_HOME/claude-usage.json` for 60s. Returns `?` on missing credentials, no network, schema change, or curl timeout (5s).
- `tests/test_statusline_claude_usage.py` (new, 184 lines): 8 cases covering fetch + cache + parse + error paths.
- `.claude/statusline-command.sh` (+7 lines): opt-in append guarded by `CLAUDE_USAGE_STATUSLINE`.
- `docs/development/ai/statusline.md` (+49 lines): new "Opt-In: Claude Max Usage Display" section with enable instructions, cache behavior, helper requirements, troubleshooting, and the beta-API caveat.

### Future migration

When Claude Code's official `claude --usage` flag ships (tracking issue: [anthropics/claude-code#20399](https://github.com/anthropics/claude-code/issues/20399)), the helper can drop the beta endpoint and use the flag instead. The doc notes this so future readers know it's a known interim.

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

| File | Type | Lines |
| :--- | :--- | :--- |
| `tools/statusline/claude-usage.sh` | new | 65 |
| `tests/test_statusline_claude_usage.py` | new | 184 |
| `.claude/statusline-command.sh` | modified | +7/-0 |
| `docs/development/ai/statusline.md` | modified | +49/-0 |

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally; 8/8 helper tests pass.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase B.3 of the pyproject-template sync (#823). Closes out Phase B. Phase C (AI-agent workflow refactor) follows next.
