### PR TITLE
feat: establish rules-as-imports pattern across all four AI CLIs

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,151 @@
+# Per-Stack Rule-Shaped Skills (Codex CLI)
+
+## Purpose
+
+Rule-shaped skills in this directory capture **narrow, recurring footguns** that Codex CLI keeps
+getting wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md`
+carries broad workflow and architectural rules for the whole project. A rule-shaped skill carries
+three to ten numbered self-checks for one specific failure mode — small enough to survive a context
+window, sharp enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+> **Codex-native loading:** Codex auto-loads a skill when the task description matches the skill's
+> `description:` frontmatter. The `description:` field IS the skill-gate trigger — there is no
+> `@import` directive or glob-import mechanism. Write the `description:` so that it matches only the
+> tasks where the self-checks apply (e.g., "Use when generating typed Python from a YANG schema").
+>
+> This is the Codex equivalent of `.claude/rules/` (Claude Code) and `.gemini/rules/` (Gemini CLI).
+> For the Claude and Gemini variants, see those directories. For the GitHub Copilot variant, see
+> [`.github/instructions/README.md`](../../.github/instructions/README.md).
+
+## When to author a rule-shaped skill
+
+Write a rule-shaped skill when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to match a single, focused `description:` gate.
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File location and naming
+
+Each rule-shaped skill lives in its own subdirectory:
+
+```
+.agents/skills/<name>/SKILL.md
+```
+
+Use a short, lowercase, hyphenated name that reflects the domain (e.g., `codegen`, `db-migrations`,
+`api-contracts`). Keep rule-shaped skills in separate directories from the workflow skills that
+already exist here (`ghissue-plan`, `ghissue-implement`, etc.).
+
+## File structure
+
+Each rule-shaped skill's `SKILL.md` must have YAML frontmatter followed by three required sections:
+
+```
+---
+name: <name>
+description: <task-match trigger — the sentence Codex uses to decide when to load this skill>
+---
+
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+### `description:` frontmatter
+
+The `description:` field controls when Codex loads the skill. Write it as a sentence that matches
+only the tasks where the self-checks apply:
+
+- `description: Use when generating typed Python from a YANG schema` — task-specific
+- `description: Use when writing or modifying database migration files` — task-specific
+
+Avoid broad descriptions like `description: Use when writing Python` — that turns the skill into
+ambient context, not a gate.
+
+### Body sections
+
+- **`Skill: <name>`** — the first line after frontmatter, no heading. Names the capability gate so
+  the model can self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A skill with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per skill body (excluding frontmatter). If a body grows past 30 lines,
+split it into two skills.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule-shaped skills must be derived from documented
+failures, not from intuition or generic advice. A checklist written in advance of any failure will
+drift into noise — the model will pattern-match the checklist language and satisfy it superficially.
+A checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the
+rule-shaped skill is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen/SKILL.md` rule-shaped skill might look like for a
+downstream project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an ADR
+(ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual
+rule-shaped skills belong in downstream repos, not in this template.
+
+```
+---
+name: codegen
+description: Use when generating typed Python from a YANG schema in pynetappfoundry
+---
+
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## Shared discipline across CLIs
+
+The **discipline** (≤30 lines, numbered self-checks, observed-failures footer) is shared across all
+four CLIs even though the file format and load mechanism differ:
+
+| CLI | Directory | Load mechanism |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
+| Gemini CLI | `.gemini/rules/` | One `@./.gemini/rules/<name>.md` line per rule file in `GEMINI.md` (literal paths only) |
+| GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+| Codex CLI | `.agents/skills/<name>/` | `description:` frontmatter is the skill-gate trigger |
+
+See [`.claude/rules/README.md`](../../.claude/rules/README.md),
+[`.gemini/rules/README.md`](../../.gemini/rules/README.md), and
+[`.github/instructions/README.md`](../../.github/instructions/README.md) for the other CLI variants.
+
+## What NOT to put in a rule-shaped skill
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`" belong
+  in `AGENTS.md`, not here. Rule-shaped skills are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule was
+  violated, the rule-shaped skill is not ready to be written yet.
+- **Workflow logic** — do not mix rule-shaped skills (self-check checklists) with workflow skills
+  (multi-step instructions like `ghissue-plan`). Keep them in separate subdirectories.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,6 @@
 @../AGENTS.md
+<!-- Uncomment when you add rule files. See .claude/rules/README.md for the pattern. -->
+<!-- @./rules/*.md -->
 
 # BASIC CLAUDE INSTRUCTIONS
 

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,110 @@
+# Per-Stack Rule Files
+
+## Purpose
+
+Rule files in this directory capture **narrow, recurring footguns** that an AI agent keeps getting
+wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md` carries
+broad workflow and architectural rules for the whole project. A rule file carries three to ten
+numbered self-checks for one specific failure mode — small enough to survive a context window, sharp
+enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+## When to author a rule file
+
+Write a rule file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File structure
+
+Each rule file must have three parts:
+
+```
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+- **`Skill: <name>`** — the first line, no heading. Names the capability gate so the model can
+  self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, split it.
+
+## How to load
+
+Uncomment the `@./rules/*.md` line in `.claude/CLAUDE.md`:
+
+```
+@../AGENTS.md
+<!-- Uncomment when you add rule files. See .claude/rules/README.md for the pattern. -->
+<!-- @./rules/*.md -->
+```
+
+becomes:
+
+```
+@../AGENTS.md
+@./rules/*.md
+```
+
+Note: the line stays commented out in this template repository. Downstream consumers uncomment it
+after authoring their first rule file.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule files must be derived from documented failures, not
+from intuition or generic advice. A checklist written in advance of any failure will drift into
+noise — the model will pattern-match the checklist language and satisfy it superficially. A
+checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the rule
+file is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen.md` rule file might look like for a downstream
+project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an ADR
+(ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual rule
+files belong in downstream repos, not in this template.
+
+```
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## What NOT to put in a rule file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Rule files are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the rule file is not ready to be written.

--- a/.copilot/README.md
+++ b/.copilot/README.md
@@ -24,10 +24,25 @@ The `implement-worker` subagent used by `/implement` is defined in `.claude/agen
 
 Agents must write temporary files to `tmp/agents/copilot/` (not `/tmp/`). Include a context identifier (issue number, PR number, or task ID) in the filename to avoid collisions.
 
+## Per-Stack Instructions
+
+GitHub Copilot natively discovers instruction files placed in `.github/instructions/` and named
+`NAME.instructions.md`. Each file begins with YAML frontmatter (`applyTo: '<glob>'`) that gates
+it to a specific path scope, followed by a skill-gated, numbered self-check body (≤30 lines) and
+an `Observed failures:` footer.
+
+This is the Copilot equivalent of `.claude/rules/` (loaded via `@import` in `.claude/CLAUDE.md`)
+and `.gemini/rules/` (loaded via `@` directive in `GEMINI.md`). The discipline — build from
+observed failures, not generic advice — is shared across all three CLIs.
+
+See [`.github/instructions/README.md`](../.github/instructions/README.md) for the full pattern,
+file structure, and a worked example.
+
 ## See Also
 
 - `.claude/commands/` — slash command definitions (auto-discovered by Copilot CLI)
 - `.claude/agents/implement-worker.md` — implement-worker subagent definition
 - `.github/hooks/copilot-hooks.json` — dangerous command hook wiring
+- `.github/instructions/README.md` — per-stack instruction file pattern for Copilot
 - `docs/development/ai/slash-commands.md` — full workflow and command reference
 - `docs/development/ai/command-blocking.md` — hook documentation

--- a/.gemini/rules/README.md
+++ b/.gemini/rules/README.md
@@ -1,0 +1,93 @@
+# Per-Stack Rule Files (Gemini)
+
+## Purpose
+
+Rule files in this directory capture **narrow, recurring footguns** that Gemini CLI keeps getting
+wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md` carries
+broad workflow and architectural rules for the whole project. A rule file carries three to ten
+numbered self-checks for one specific failure mode — small enough to survive a context window, sharp
+enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+## When to author a rule file
+
+Write a rule file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File structure
+
+Each rule file must have three parts:
+
+```
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+- **`Skill: <name>`** — the first line, no heading. Names the capability gate so the model can
+  self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, split it.
+
+## How to load
+
+When you author a rule file (e.g., `codegen.md`), add a literal `@`-import for it to `GEMINI.md`:
+
+```markdown
+@./AGENTS.md
+@./.gemini/rules/codegen.md
+
+# Gemini CLI Instructions
+...
+```
+
+Add one line per rule file. Do **not** use a glob like `@./.gemini/rules/*.md` — Gemini CLI's
+[Memory Import Processor](https://geminicli.com/docs/reference/memport/) only supports literal
+relative or absolute paths to specific files. Globs work in practice via undocumented behavior but
+emit a spurious `[ERROR] [ImportProcessor] Failed to import .../*.md: ENOENT` log on every run
+(the processor calls `access()` on the literal pattern before expanding it).
+
+This is the inverse of Claude Code's `.claude/CLAUDE.md`, which does support glob imports — the two
+CLIs differ here despite using the same `@`-import syntax.
+
+Note: this template ships with no import line in `GEMINI.md`. Add the first line when you author
+your first rule file.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule files must be derived from documented failures, not
+from intuition or generic advice. A checklist written in advance of any failure will drift into
+noise — the model will pattern-match the checklist language and satisfy it superficially. A
+checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the rule
+file is not ready to be written yet.
+
+## What NOT to put in a rule file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Rule files are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the rule file is not ready to be written.

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -1,0 +1,135 @@
+# Per-Stack Instruction Files (GitHub Copilot)
+
+## Purpose
+
+Instruction files in this directory capture **narrow, recurring footguns** that GitHub Copilot
+keeps getting wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`.
+`AGENTS.md` carries broad workflow and architectural rules for the whole project. An instruction
+file carries three to ten numbered self-checks for one specific failure mode — small enough to
+survive a context window, sharp enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+> **Copilot-native format:** Files in this directory are consumed by GitHub Copilot via its native
+> auto-discovery mechanism. Claude Code and Gemini CLI **cannot** read `.github/instructions/`
+> files. For the Claude equivalent use `.claude/rules/`; for the Gemini equivalent use
+> `.gemini/rules/`.
+
+## When to author an instruction file
+
+Write an instruction file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File naming and location
+
+Files must be placed directly in `.github/instructions/` and named `NAME.instructions.md`.
+Copilot auto-discovers all `*.instructions.md` files in this directory — no explicit import or
+directive is required.
+
+## File structure
+
+Each instruction file must begin with YAML frontmatter that gates the file to a path scope,
+followed by three required sections:
+
+```
+---
+applyTo: 'src/**/*.py'
+---
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+### `applyTo:` frontmatter
+
+The `applyTo:` field is **required**. It is a glob pattern that gates the file to specific paths:
+
+- `applyTo: '**'` — applies repo-wide (equivalent to Claude's `@./rules/*.md` with no path filter)
+- `applyTo: 'src/**/*.py'` — scopes to Python source files only
+- `applyTo: 'tests/**'` — scopes to test files only
+
+Use a narrow glob when the self-checks are only relevant for a specific subtree.
+
+### Body sections
+
+- **`Skill: <name>`** — the first line after frontmatter, no heading. Names the capability gate so
+  the model can self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per instruction file (excluding frontmatter). If a file grows past
+30 lines, split it.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that instruction files must be derived from documented
+failures, not from intuition or generic advice. A checklist written in advance of any failure will
+drift into noise — the model will pattern-match the checklist language and satisfy it
+superficially. A checklist written because a specific PR broke a specific invariant three times is
+sharp enough to change behavior. If you cannot fill in the `Observed failures:` footer with real
+links, the instruction file is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen.instructions.md` file might look like for a
+downstream project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an
+ADR (ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual
+instruction files belong in downstream repos, not in this template.
+
+```
+---
+applyTo: 'src/**/*.py'
+---
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## Shared discipline across CLIs
+
+The **discipline** (≤30 lines, numbered self-checks, observed-failures footer) is shared across
+Claude Code, Gemini CLI, and GitHub Copilot even though the file format differs:
+
+| CLI | Directory | Load mechanism |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
+| Gemini CLI | `.gemini/rules/` | One `@./.gemini/rules/<name>.md` line per rule file in `GEMINI.md` (literal paths only) |
+| GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+
+See [`.claude/rules/README.md`](../../.claude/rules/README.md) and
+[`.gemini/rules/README.md`](../../.gemini/rules/README.md) for the Claude and Gemini variants.
+
+## What NOT to put in an instruction file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Instruction files are for stack-specific self-checks, not
+  universal workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the instruction file is not ready to be written.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,10 +432,10 @@ Each supported AI CLI has a dedicated config directory at the repo root:
 
 | CLI | Config Directory | Notes |
 | :--- | :--- | :--- |
-| Claude Code | `.claude/` | Commands, agents, settings. Primary source of slash commands. |
-| Gemini CLI | `.gemini/` | Commands and settings. Output-only commands (orchestrated by Claude). |
-| GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
-| Codex CLI | `.codex/` | `config.toml` only (command approval policies). No slash commands. |
+| Claude Code | `.claude/` | Commands, agents, rules, settings. Primary source of slash commands. |
+| Gemini CLI | `.gemini/` | Commands, settings, and `rules/` subdirectory for per-stack rule files. Output-only commands (orchestrated by Claude). |
+| GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. Per-stack instruction files live in `.github/instructions/` (Copilot-native; Claude/Gemini cannot read them). See `.github/instructions/README.md`. |
+| Codex CLI | `.codex/`, `.agents/skills/` | `config.toml` for approvals/hooks plus repo-scoped skills for the Codex workflow. No custom slash commands. Rule-shaped skills live in `.agents/skills/<name>/SKILL.md`; the `description:` frontmatter is the skill-gate trigger. See `.agents/skills/README.md`. |
 
 Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/plan-issue`, `/implement`, `/finalize`, etc.) works out of the box.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,5 @@
+@./AGENTS.md
+
 # Gemini CLI Instructions
 
 ## Context

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -146,5 +146,9 @@ Run `/where-am-i`. It is read-only, has no side effects, and will tell you the c
 - [AI Agent Setup](../AI_SETUP.md) — per-CLI configuration, permissions, and hooks.
 - [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
 - [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.
+- [`.claude/rules/` scaffold](../../../.claude/rules/README.md) — per-stack rule-file pattern for downstream consumers who need narrow, skill-gated self-checks beyond what `AGENTS.md` covers.
+- [`.gemini/rules/` scaffold](../../../.gemini/rules/README.md) — per-stack rule-file pattern for Gemini CLI (mirrors `.claude/rules/`).
+- [`.github/instructions/` scaffold](../../../.github/instructions/README.md) — per-stack instruction-file pattern for GitHub Copilot CLI.
+- [`.agents/skills/` scaffold](../../../.agents/skills/README.md) — per-stack skill-file pattern for Codex CLI.
 - <!-- TODO: wire this link up properly when #342 lands -->
   For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).


### PR DESCRIPTION
## Description

Establishes a parallel "rules-as-imports" scaffold across all four supported AI CLIs. Each CLI gets a `README.md` documenting its native pattern for narrow, skill-gated, per-stack rule/instruction files that sit *alongside* `AGENTS.md` rather than duplicating it.

Ports five upstream pyproject-template PRs together because they're tightly coupled (one establishes a pattern; the next four mirror/refine it across the other CLIs):

| CLI | Native mechanism | Upstream PR | Resulting file |
| :--- | :--- | :--- | :--- |
| Claude Code | `@-import` glob in `.claude/CLAUDE.md` | [#525](https://github.com/endavis/pyproject-template/pull/525) | `.claude/rules/README.md` |
| Gemini CLI | per-file `@-import` from `GEMINI.md` | [#543](https://github.com/endavis/pyproject-template/pull/543), [#553](https://github.com/endavis/pyproject-template/pull/553) | `.gemini/rules/README.md` |
| GitHub Copilot CLI | native auto-discovery of `*.instructions.md` | [#546](https://github.com/endavis/pyproject-template/pull/546) | `.github/instructions/README.md` |
| Codex CLI | `description:` frontmatter as skill-gate trigger | [#547](https://github.com/endavis/pyproject-template/pull/547) | `.agents/skills/README.md` |

`#553` then unifies the four READMEs around the same per-file `@-import` / skill-gate discipline.

### Scope deviation flagged

**Pulling #546 and #547 forward from Phase E.** They're listed in Phase E of #823 as docs PRs, but `#553` (Phase C) modifies the READMEs they introduce — so they're prerequisites for `#553` and belong in Phase C. Sync issue will mark them done as part of this PR.

### Skipped from upstream's PRs

- **`docs/development/AI_SETUP.md`** updates — reference `/ghissue-*` commands we won't have until C.5 (where they get renamed to `/ghi-*` anyway). Cleaner to land that doc churn once command names settle in C.5.
- **`docs/development/ai/token-efficiency-add-ons.md`** — file doesn't exist locally yet; lands with #520 in Phase E.

### Notable judgment calls

- **Used post-#553 state, not latest, for all four READMEs.** Two lines in `.agents/skills/README.md` get updated by #564 (C.5) — using "latest" would pull forward `codex-plan`/`codex-implement` example references before the underlying skills exist.
- **AGENTS.md table preserved our wording around commands** (kept "Output-only commands" for Gemini, didn't add upstream's `ghissue-*` workflow names). Only added the structural references to rules/, instructions/, and skills/ directories.

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

| File | Type | Lines |
| :--- | :--- | :--- |
| `.claude/rules/README.md` | new | 110 |
| `.gemini/rules/README.md` | new | ~93 |
| `.github/instructions/README.md` | new | ~135 |
| `.agents/skills/README.md` | new | 151 |
| `.claude/CLAUDE.md` | modified | +2/-0 |
| `GEMINI.md` | modified | +2/-0 |
| `AGENTS.md` | modified | 1 hunk |
| `.copilot/README.md` | modified | +18/-0 |
| `docs/development/ai/first-5-minutes.md` | modified | +4/-0 |

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality (N/A — scaffold-only PR; no executable code added)
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type-check, security, spell-check, full test suite).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my feature works (N/A — scaffold-only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase C.1a of the pyproject-template sync (#823). Phase C.1b (Codex workflow skills under `.agents/skills/`, upstream #482) depends on `.agents/skills/README.md` existing and lands next.
