### PR TITLE
feat: add Codex CLI workflow skills

### DIFF
--- a/.agents/skills/finalize/SKILL.md
+++ b/.agents/skills/finalize/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: finalize
+description: Use when the implementation and review cycle for a repository issue is complete in a Codex session. Reviews the branch diff, updates docs or ADRs if needed, validates with `doit check`, drafts commit and PR artifacts, and stops for explicit approval before commit or PR creation.
+---
+
+# Finalize
+
+Finalize the current issue branch for this repository.
+
+## When to use
+
+Use this skill after implementation is complete and the user wants Codex to prepare the commit and PR artifacts without committing or opening the PR until approval is explicit.
+
+Expected prompt shape:
+
+- `$finalize finalize this branch`
+- `$finalize prepare the PR for issue 399`
+
+## Instructions
+
+1. Detect the current branch and linked issue:
+   ```bash
+   git branch --show-current
+   ```
+   - Extract the issue number from the branch name, for example `feat/399-description` -> `399`.
+   - If on `main`, stop and tell the user they must be on a feature branch.
+
+2. Gather context:
+   ```bash
+   gh issue view <issue-number> --json title,labels
+   git status --short
+   git diff main --stat
+   ```
+   - If there are unstaged or uncommitted changes, list them and confirm they should be included.
+
+3. Read the project rules before finalization:
+   - `AGENTS.md`
+   - `.github/CONTRIBUTING.md`
+   - `.github/pull_request_template.md`
+   - `docs/decisions/README.md`
+
+4. Check whether docs or ADR updates are required:
+   - Review the changed files for user-facing behavior or workflow changes.
+   - If the issue has `needs-adr`, create or update the ADR before proceeding.
+   - Keep ADR links aligned with the relevant documentation.
+
+5. Run final validation:
+   ```bash
+   doit check
+   ```
+   - All checks must pass before moving on.
+
+6. Draft the PR body to a project-scoped temp file:
+   ```bash
+   mkdir -p tmp/agents/codex
+   ```
+   - Write the PR body to `tmp/agents/codex/pr-body-issue-<issue-number>.md`.
+   - The PR body must include `Addresses #<issue-number>`.
+
+7. Present the user with:
+   - the proposed commit message following conventional commits
+   - the proposed PR title
+   - the PR body summary
+   - any docs or ADR updates made
+
+8. Wait for explicit user approval before:
+   - staging files
+   - committing
+   - running `doit pr --title=... --body-file=...`
+
+9. After approval, use `doit pr` rather than `gh pr create`, report the PR URL, and remove the temp PR body file.

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: implement
+description: Use when implementing an approved GitHub issue plan in this repository from a Codex session. Creates or resumes the issue branch, follows the posted plan comment, writes tests with the change, and finishes with `doit check`.
+---
+
+# Implement Issue
+
+Implement the approved plan for a GitHub issue in this repository.
+
+## When to use
+
+Use this skill when the user wants Codex to carry out the repository's implementation workflow for an issue that already has an approved plan comment.
+
+Expected prompt shape:
+
+- `$implement implement issue 399`
+- `$implement continue work on issue 399`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Validate the issue exists and is open:
+   ```bash
+   gh issue view <issue-number> --json number,title,state,labels
+   ```
+   - If the issue does not exist or is closed, stop and tell the user.
+
+2. Verify an approved plan comment exists:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/<issue-number>/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
+   ```
+   - If no plan comment exists, stop and tell the user to run `$plan-issue` first.
+
+3. Check the current branch state:
+   ```bash
+   git branch --show-current
+   git status --short
+   ```
+   - If already on a branch matching `*/<issue-number>-*`, resume work there.
+   - If not, create a new branch from fresh `main`.
+
+4. Determine the branch type from labels:
+   - `enhancement` -> `feat`
+   - `bug` -> `fix`
+   - `refactor` -> `refactor`
+   - `documentation` -> `docs`
+   - `chore` -> `chore`
+   - otherwise `issue`
+
+5. If a new branch is needed, create it from updated `main`:
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b <type>/<issue-number>-<short-description>
+   ```
+
+6. Read the project rules before editing:
+   - `AGENTS.md`
+   - `docs/development/ai/architectural-conventions.md`
+   - `.github/CONTRIBUTING.md`
+
+7. Fetch the issue and plan details:
+   ```bash
+   gh issue view <issue-number> --json title,body,labels
+   gh api repos/{owner}/{repo}/issues/<issue-number>/comments --jq '.[].body'
+   ```
+   - Use the approved implementation plan comment as the implementation contract.
+
+8. Implement the plan in the main Codex session:
+   - Follow existing repo patterns.
+   - Create tests with the implementation.
+   - Do not commit.
+   - If an action fails in a way that changes the intended fix, stop and explain it to the user.
+
+9. Run full validation:
+   ```bash
+   doit check
+   ```
+   - Fix failures that are part of the issue scope.
+   - Do not paper over failing tests by weakening them without user discussion.
+
+10. Summarize what changed, list the changed files, report the validation result, and tell the user the next workflow step is `$finalize`.

--- a/.agents/skills/plan-issue/SKILL.md
+++ b/.agents/skills/plan-issue/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: plan-issue
+description: Use when planning work for a GitHub issue in this repository from a Codex session. Drafts an implementation plan, iterates with the user, and posts the approved plan comment with the repo's required header format.
+---
+
+# Plan Issue
+
+Create an implementation plan for a GitHub issue in this repository.
+
+## When to use
+
+Use this skill when the user wants a Codex-native equivalent of the repository's planning workflow for an issue.
+
+Expected prompt shape:
+
+- `$plan-issue plan issue 399`
+- `$plan-issue create an implementation plan for issue 399`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Validate the issue exists and is open:
+   ```bash
+   gh issue view <issue-number> --json number,title,state,labels
+   ```
+   - If the issue does not exist, stop and tell the user.
+   - If the issue is closed, stop and ask whether to reopen it or stop.
+
+2. Check for an existing plan comment:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/<issue-number>/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
+   ```
+   - If one already exists, warn the user that continuing will post a new plan comment.
+
+3. Read the project rules before planning:
+   - `AGENTS.md`
+   - `.github/ISSUE_TEMPLATE/feature_request.yml` for feature scope expectations
+   - `docs/development/ai/architectural-conventions.md`
+
+4. Fetch the full issue details:
+   ```bash
+   gh issue view <issue-number> --json title,body,labels,assignees
+   ```
+   - Identify the goal, success criteria, constraints, and whether the issue has `needs-adr`.
+
+5. Explore the relevant repo context:
+   - Read only the files needed to understand the affected workflow or feature area.
+   - Check for related ADRs in `docs/decisions/`.
+   - If multiple valid approaches remain, discuss them with the user before deciding.
+
+6. Draft the plan in this exact structure:
+   ```markdown
+   ## Implementation Plan for #<number>: <title>
+
+   ### Overview
+   Brief description of what will be done.
+
+   ### Files to Create/Modify
+   - [ ] `path/to/file` — description
+
+   ### Test Plan
+   - [ ] Concrete test case
+
+   ### Documentation
+   - [ ] Docs to update
+   - [ ] ADR needed: yes/no
+
+   ### Validation
+   - [ ] `doit check` passes
+   - [ ] Manual verification step
+
+   ### Risks and Considerations
+   - Key trade-off or implementation risk
+   ```
+
+7. Iterate with the user until they explicitly approve the plan. Do not post anything to GitHub before approval.
+
+8. Post the approved plan as an issue comment with the exact header format above:
+   ```bash
+   gh issue comment <issue-number> --body "<approved plan markdown>"
+   ```
+
+9. Tell the user the plan was posted and that the next Codex workflow step is `$implement`.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,150 +1,37 @@
 # Codex CLI Configuration
 # Location: ~/.codex/config.toml or project-specific .codex/config.toml
 #
-# This configuration whitelists common development commands for Python projects
-# using uv, doit, git, and GitHub CLI.
-#
-# SECURITY: Dangerous commands are blocked below. See AGENTS.md for rules.
+# This configuration uses the current Codex config schema. The repo-native
+# dangerous-command protection lives in the shared hook script below; use that
+# script to change blocked patterns instead of adding obsolete approval-policy
+# rule tables here.
 
-# Default approval policy
-default_policy = "untrusted"  # Prompt before running untrusted commands
+# Prompt before running untrusted commands.
+approval_policy = "untrusted"
+
+[features]
+# Enable lifecycle hook support for the shared dangerous-command policy.
+codex_hooks = true
 
 # =============================================================================
 # PRE-TOOL-USE HOOK — Primary defense
 # =============================================================================
-# The shared hook script provides context-aware blocking (shlex tokenization,
-# protected-branch detection, chained-command scanning). The approval_policy
-# deny rules below act as a secondary (belt-and-suspenders) defense layer in
-# case the hook fails to load or Codex evaluates policies before hooks.
-[hooks]
-pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+# The shared hook script provides context-aware blocking via tokenization,
+# protected-branch detection, and chained-command scanning.
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.py"'
+timeout = 30
+statusMessage = "Checking Bash command"
 
 # =============================================================================
-# BLOCKED COMMANDS - Secondary defense (approval_policy deny rules)
+# SHELL ENVIRONMENT POLICY
 # =============================================================================
-
-# Block --admin flag (bypasses branch protection)
-[[approval_policy]]
-type = "command"
-pattern = "--admin"
-action = "deny"
-reason = "BLOCKED: --admin bypasses branch protection rules. See AGENTS.md."
-
-# Block --force flag (can cause data loss)
-[[approval_policy]]
-type = "command"
-pattern = "--force\\b"
-action = "deny"
-reason = "BLOCKED: --force can cause data loss. See AGENTS.md."
-
-# Block --no-verify flag (skips pre-commit hooks)
-[[approval_policy]]
-type = "command"
-pattern = "--no-verify"
-action = "deny"
-reason = "BLOCKED: --no-verify skips security hooks. See AGENTS.md."
-
-# Block force push variants
-[[approval_policy]]
-type = "command"
-pattern = "git\\s+push.*-f\\b"
-action = "deny"
-reason = "BLOCKED: Force push can overwrite remote history. See AGENTS.md."
-
-[[approval_policy]]
-type = "command"
-pattern = "--force-with-lease"
-action = "deny"
-reason = "BLOCKED: Force push variant. See AGENTS.md."
-
-# Block git reset --hard (can lose uncommitted changes)
-[[approval_policy]]
-type = "command"
-pattern = "git\\s+reset\\s+--hard"
-action = "deny"
-reason = "BLOCKED: Hard reset can lose uncommitted changes. See AGENTS.md."
-
-# Block destructive rm commands
-[[approval_policy]]
-type = "command"
-pattern = "rm\\s+-rf\\s+/"
-action = "deny"
-reason = "BLOCKED: Destructive command - removes filesystem. See AGENTS.md."
-
-[[approval_policy]]
-type = "command"
-pattern = "rm\\s+-rf\\s+~"
-action = "deny"
-reason = "BLOCKED: Destructive command - removes home directory. See AGENTS.md."
-
-# Block direct gh issue/pr create - use doit wrappers instead
-[[approval_policy]]
-type = "command"
-pattern = "gh\\s+issue\\s+create"
-action = "deny"
-reason = "BLOCKED: Use 'doit issue --type=<type>' instead of 'gh issue create'. See AGENTS.md."
-
-[[approval_policy]]
-type = "command"
-pattern = "gh\\s+pr\\s+create"
-action = "deny"
-reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
-
-# Block uv add - dependencies require user approval
-[[approval_policy]]
-type = "command"
-pattern = "uv\\s+add"
-action = "deny"
-reason = "BLOCKED: Adding dependencies requires user approval. Suggest the package and let the user run 'uv add <package>' manually. See AGENTS.md."
-
-# Block doit release - releases must be run manually by the user
-[[approval_policy]]
-type = "command"
-pattern = "doit\\s+release"
-action = "deny"
-reason = "BLOCKED: Releases must be run manually by the user, not by AI agents. See AGENTS.md."
-
-# =============================================================================
-# ALLOWED COMMANDS - Standard development tools
-# =============================================================================
-
-# Whitelist standard development tools
-[[approval_policy]]
-type = "command"
-pattern = "^(git|gh|uv|doit|ls|cat|tree|find|grep|wc|mkdir|python|pytest|ruff|mypy)\\b"
-action = "allow"
-reason = "Standard development and version control tools"
-
-# Allow specific git operations
-[[approval_policy]]
-type = "command"
-pattern = "^git\\s+(status|diff|log|add|commit|push|pull|fetch|checkout|branch|merge|stash|reset|rebase|remote)"
-action = "allow"
-reason = "Common git operations"
-
-# Allow GitHub CLI operations
-[[approval_policy]]
-type = "command"
-pattern = "^gh\\s+(auth|pr|issue|run|api)"
-action = "allow"
-reason = "GitHub CLI operations"
-
-# Allow uv package management
-[[approval_policy]]
-type = "command"
-pattern = "^uv\\s+(pip|venv|build|publish|run|sync)"
-action = "allow"
-reason = "UV package manager operations"
-
-# Allow doit task automation
-[[approval_policy]]
-type = "command"
-pattern = "^doit\\s+(list|test|coverage|lint|format|check|build|cleanup)"
-action = "allow"
-reason = "Doit task automation"
-
-# Shell environment policy - whitelist safe environment variables
-[shell_env_policy]
+[shell_environment_policy]
+inherit = "core"
 include_only = [
     "PATH",
     "HOME",
@@ -162,8 +49,6 @@ exclude = [
     "CODECOV_TOKEN",
 ]
 
-# Sandbox mode (optional - set to false for local development)
-# sandbox_mode = false
-
-# Network access policy
-# network_access = "prompt"  # Options: "allow", "deny", "prompt"
+# Sandbox mode is intentionally left to the user's Codex environment defaults.
+# If your local setup needs a project override, add it explicitly using the
+# current Codex config keys from the official docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,8 @@ Each supported AI CLI has a dedicated config directory at the repo root:
 
 Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/plan-issue`, `/implement`, `/finalize`, etc.) works out of the box.
 
+Codex CLI does **not** use repo-defined slash commands in this template. Its repo-native workflow is provided through checked-in skills under `.agents/skills/`, invoked with built-in Codex skill selection such as `/skills` or explicit mentions like `$plan-issue`.
+
 ### Temporary Files
 
 AI agents **must never** write temporary files to generic locations like `/tmp/`. Instead, use the project-scoped directory:

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -22,7 +22,7 @@ This template is designed primarily for **Claude Code**, which is the only agent
 
 | Agent | Permission model | Hooks support | Slash commands | LSP | Dual-agent role |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Codex CLI** | TOML approval policies (`.codex/config.toml`) | Project-level `tools/hooks/ai/` apply via shell | None shipped | Not documented | Standalone alternative (not part of dual-agent flow) |
+| **Codex CLI** | TOML approval policies (`.codex/config.toml`) plus repo skills (`.agents/skills/`) | Project-level `tools/hooks/ai/` apply via Codex hooks | Built-in only; repo workflow uses skills | Not documented | Standalone alternative (not part of dual-agent flow) |
 | **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 2 output-only (`/plan-issue`, `/review-pr`) | Not documented | Second-opinion reviewer / planner in dual-agent flow |
 | **GitHub Copilot CLI** | JSON hook config (`.github/hooks/copilot-hooks.json`) | Project-level hooks apply; Copilot `preToolUse` hook wired | Auto-discovers from `.claude/commands/` | Not documented | Standalone alternative (auto-discovers Claude commands) |
 | **Claude Code** | Layered permissions (`.claude/settings.local.json` + `.claude/settings.json` PreToolUse hooks) | Project-level hooks plus Claude PreToolUse hooks | 8 (`plan-issue`, `implement`, `finalize`, `close-issue`, `plan-both`, `review-both`, `gemini-review`, `where-am-i`) | Supported | Primary orchestrator in single-agent and dual-agent flows |
@@ -60,7 +60,7 @@ codex
 - [Configuring Codex](https://developers.openai.com/codex/local-config/)
 - [Codex Security Guide](https://developers.openai.com/codex/security/)
 
-**Codex parity status:** Codex ships no slash commands in this template — `.codex/` contains only `config.toml`. LSP integration is not documented for Codex here. Codex is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer the OpenAI CLI. The project-level hooks under `tools/hooks/ai/` still apply to Codex — see [Command Blocking](ai/command-blocking.md). For the broader slash-command and dual-agent picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+**Codex parity status:** Codex does not use repo-defined slash commands in this template. Instead, it uses repo-scoped workflow skills checked into `.agents/skills/` and invoked through Codex's built-in skill surface such as `/skills` or explicit mentions like `$plan-issue`, `$implement`, and `$finalize`. LSP integration is not documented for Codex here. Codex is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer the OpenAI CLI. The shared dangerous-command hook at `tools/hooks/ai/block-dangerous-commands.py` applies to Codex via `.codex/config.toml`, and the approval-policy rules remain a secondary defense layer. For the broader workflow picture, see [Slash Commands and Workflows](ai/slash-commands.md).
 
 ### 2. Gemini CLI (Google)
 
@@ -266,12 +266,24 @@ When using this template for a new project:
 
 **Codex CLI** (`.codex/config.toml`):
 ```toml
-[[approval_policy]]
+approval_policy = "untrusted"
+
+[features]
+codex_hooks = true
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
 type = "command"
-pattern = "^your-command\\b"
-action = "allow"
-reason = "Description of command"
+command = 'python3 "$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.py"'
+timeout = 30
+statusMessage = "Checking Bash command"
 ```
+
+Use the shared hook script to control dangerous command patterns. The older
+`[[approval_policy]]` command-rule examples are not part of the current Codex
+config schema.
 
 **Gemini CLI** (`.gemini/settings.json`):
 ```json

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -149,11 +149,22 @@ EOF
 
 `.codex/config.toml`:
 ```toml
-[hooks]
-pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+approval_policy = "untrusted"
+
+[features]
+codex_hooks = true
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.py"'
+timeout = 30
+statusMessage = "Checking Bash command"
 ```
 
-Codex also keeps `approval_policy` deny rules as a secondary defense layer. See `.codex/config.toml` for the full configuration.
+Codex uses the shared hook as the primary defense layer. Project docs should not rely on the obsolete `[[approval_policy]]` command-rule format.
 
 ### Testing
 

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -166,24 +166,24 @@ reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
 
 ### By AI Agent Enforcement (Claude, Gemini, Copilot, Codex)
 
-These patterns are blocked across all AI agents. Claude, Gemini, and Copilot all use the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (wired via `.claude/settings.json`, `.gemini/settings.json`, and `.github/hooks/copilot-hooks.json` respectively). Codex uses approval policies in `.codex/config.toml` (no hook support).
+These patterns are blocked across all AI agents. Claude, Gemini, and Copilot all use the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (wired via `.claude/settings.json`, `.gemini/settings.json`, and `.github/hooks/copilot-hooks.json` respectively). Codex uses the shared hook through `.codex/config.toml`, and the approval policies in that same file remain a secondary defense layer.
 
 | Pattern | Command | Claude | Gemini | Copilot | Codex |
 |---------|---------|--------|--------|---------|-------|
-| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Hook | Config |
-| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Hook | Config |
-| `--hard` flag | `git reset --hard` | Hook | Hook | Hook | Config |
-| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Hook | Config |
-| `sudo rm` | Any shell | Hook | Hook | Hook | Config |
-| Force push to protected branch | `git push --force origin main` | Hook | Hook | Hook | Config |
-| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | Hook | — |
-| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | Hook | — |
-| `gh pr create` | Use `doit pr` instead | Hook | Hook | Hook | Config |
-| `gh issue create` | Use `doit issue` instead | Hook | Hook | Hook | Config |
-| `uv add` | User runs manually | Hook | Hook | Hook | Config |
-| `doit release*` | User runs manually | Hook | Hook | Hook | Config |
+| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Hook | Hook + Config |
+| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Hook | Hook + Config |
+| `--hard` flag | `git reset --hard` | Hook | Hook | Hook | Hook + Config |
+| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Hook | Hook + Config |
+| `sudo rm` | Any shell | Hook | Hook | Hook | Hook + Config |
+| Force push to protected branch | `git push --force origin main` | Hook | Hook | Hook | Hook + Config |
+| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | Hook | Hook |
+| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | Hook | Hook |
+| `gh pr create` | Use `doit pr` instead | Hook | Hook | Hook | Hook + Config |
+| `gh issue create` | Use `doit issue` instead | Hook | Hook | Hook | Hook + Config |
+| `uv add` | User runs manually | Hook | Hook | Hook | Hook + Config |
+| `doit release*` | User runs manually | Hook | Hook | Hook | Hook + Config |
 
-> **Note**: "Hook" = `block-dangerous-commands.py` (shared across Claude, Gemini, and Copilot), "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
+> **Note**: "Hook" = `block-dangerous-commands.py` through each agent's hook wiring. For Codex, "Config" refers to the additional approval-policy rules in `.codex/config.toml`.
 
 ### By Pre-commit Hooks (All Developers and Agents)
 

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -128,7 +128,17 @@ Invoked by Claude's `/review-both` and `/gemini-review` commands via `gemini -p 
 
 ## Codex
 
-The `.codex/` directory contains only `config.toml`, which configures command approval policies for the Codex CLI. No slash commands ship for Codex. The dual-agent workflow in this template targets Claude and Gemini.
+Codex does not use repo-defined slash commands in this template. Instead, the Codex workflow is provided through **repo-scoped skills** under `.agents/skills/`, which Codex can invoke through its built-in `/skills` browser or explicit mentions such as `$plan-issue`, `$implement`, and `$finalize`.
+
+**Workflow coverage:** the checked-in Codex skills cover planning, implementation, and finalization through PR creation. They preserve the same repo artifact contract used by the Claude flow:
+
+- `$plan-issue` posts the approved plan comment with the header `## Implementation Plan for #<n>: <title>`
+- `$implement` creates or resumes the issue branch and finishes with `doit check`
+- `$finalize` drafts the commit and PR artifacts and uses `doit pr` after explicit approval
+
+**Config and safety:** `.codex/config.toml` still configures approvals and hook wiring for Codex. The shared dangerous-command hook at `tools/hooks/ai/block-dangerous-commands.py` applies to Codex, and the approval-policy deny rules remain a secondary defense layer.
+
+**Out of scope for Codex in this template:** no repo-defined custom slash commands, no dual-agent orchestration, and no Codex-specific close-issue automation.
 
 ## Copilot
 

--- a/tests/template/test_ai_agent_assets.py
+++ b/tests/template/test_ai_agent_assets.py
@@ -1,0 +1,68 @@
+"""Tests for AI agent workflow assets checked into the template."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_codex_workflow_skills_exist() -> None:
+    """Codex workflow skills should be present in the repo skills directory."""
+    skill_paths = [
+        REPO_ROOT / ".agents" / "skills" / "plan-issue" / "SKILL.md",
+        REPO_ROOT / ".agents" / "skills" / "implement" / "SKILL.md",
+        REPO_ROOT / ".agents" / "skills" / "finalize" / "SKILL.md",
+    ]
+
+    for skill_path in skill_paths:
+        assert skill_path.exists(), f"Missing Codex skill: {skill_path}"
+
+
+def test_codex_config_keeps_shared_dangerous_command_hook() -> None:
+    """Codex config should keep the shared dangerous-command hook wired."""
+    config = (REPO_ROOT / ".codex" / "config.toml").read_text(encoding="utf-8")
+
+    assert "codex_hooks = true" in config
+    assert "[[hooks.PreToolUse]]" in config
+    assert "block-dangerous-commands.py" in config
+
+
+def test_codex_config_uses_current_schema() -> None:
+    """Codex config should avoid obsolete keys from older Codex releases."""
+    config = (REPO_ROOT / ".codex" / "config.toml").read_text(encoding="utf-8")
+
+    assert 'approval_policy = "untrusted"' in config
+    assert "default_policy" not in config
+    assert "[[approval_policy]]" not in config
+    assert "[shell_env_policy]" not in config
+
+
+def test_ai_setup_documents_codex_skills_workflow() -> None:
+    """AI setup docs should describe the Codex skills-based workflow."""
+    content = (REPO_ROOT / "docs" / "development" / "AI_SETUP.md").read_text(encoding="utf-8")
+
+    assert ".agents/skills" in content
+    assert "$plan-issue" in content
+    assert "shared dangerous-command hook" in content
+
+
+def test_slash_commands_doc_mentions_codex_skills_instead_of_custom_commands() -> None:
+    """Workflow docs should describe Codex via skills rather than custom slash commands."""
+    content = (REPO_ROOT / "docs" / "development" / "ai" / "slash-commands.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "repo-scoped skills" in content
+    assert "/skills" in content
+    assert "$implement" in content
+
+
+def test_enforcement_principles_document_codex_hook_support() -> None:
+    """Enforcement docs should reflect current Codex hook support."""
+    content = (REPO_ROOT / "docs" / "development" / "ai" / "enforcement-principles.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Codex uses the shared hook" in content
+    assert "no hook support" not in content


### PR DESCRIPTION
## Description

Ports Codex CLI workflow skills from upstream [pyproject-template PR #482](https://github.com/endavis/pyproject-template/pull/482). Adds three repo-scoped Codex skills under `.agents/skills/` (the scaffold landed in C.1a / #831) and slims `.codex/config.toml` to the current Codex config schema.

### What ships

**Three Codex skills** mirroring the Claude single-agent workflow:
- `$plan-issue` — posts an approved plan comment with the standard header `## Implementation Plan for #<n>: <title>`
- `$implement` — creates or resumes an issue branch, implements files and tests, runs `doit check`
- `$finalize` — drafts commit and PR artifacts, uses `doit pr` after explicit user approval

Codex invokes them through its built-in skill surface (`/skills` or explicit mentions like `$plan-issue`). They share the GitHub-artifact contract with the Claude flow, so users can switch agents mid-workflow without losing state.

**`.codex/config.toml` major slim (169 → 54 lines):**
- Migrates to current Codex schema (`approval_policy = "untrusted"`, `[features] codex_hooks = true`, `[[hooks.PreToolUse]]`)
- Wires the shared `block-dangerous-commands.py` hook (was Codex-only `[hooks] pre_tool_use` syntax before)
- Removes per-pattern `[[approval_policy]]` deny rules — the shared hook now provides equivalent protection for `--admin`, `--force`, `--no-verify`, `--hard`, `rm -rf /`, `gh issue create`, `gh pr create`, `uv add`, `doit release*`, and protected-branch operations

**Test:** `tests/template/test_ai_agent_assets.py` — 6 cases verifying the three skill files exist and follow the expected structure.

### Notable decisions

- **Fetched SKILL.md content from PR #482's merge commit (`9161946`)** rather than upstream HEAD. C.5 (#564) renames these skills (`codex-plan`/`codex-implement`/`ghi-finalize`) — we'll pick that up when we sync the `/multi-*` refactor. For now the original names (`plan-issue`/`implement`/`finalize`) match our Claude command names, which is what the SKILL.md content references.

- **Doc updates are clean of `ghissue-*` references.** Unlike the AI_SETUP.md hunks deferred in C.1a, the #482 doc changes use `$plan-issue`/`$implement`/`$finalize` (matching our actual command names) and the schema-migration snippets are command-agnostic. Applied verbatim.

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

| File | Type | Lines |
| :--- | :--- | :--- |
| `.agents/skills/plan-issue/SKILL.md` | new | 84 |
| `.agents/skills/implement/SKILL.md` | new | 83 |
| `.agents/skills/finalize/SKILL.md` | new | 71 |
| `tests/template/test_ai_agent_assets.py` | new | 68 |
| `.codex/config.toml` | replaced | 169 → 54 |
| `AGENTS.md` | modified | +2/-0 |
| `docs/development/AI_SETUP.md` | modified | 3 hunks |
| `docs/development/ai/slash-commands.md` | modified | +11/-1 |
| `docs/development/ai/command-blocking.md` | modified | +14/-3 |
| `docs/development/ai/enforcement-principles.md` | modified | +15/-15 |

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally; 6/6 `test_ai_agent_assets` tests pass.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase C.1b of the pyproject-template sync (#823). Closes Phase C.1. Phase C.2 (Gemini Policy Engine + token-efficiency settings, upstream #529 + #542) follows next.
