### PR TITLE
feat: migrate Gemini to Policy Engine + add token-efficiency settings

### DIFF
--- a/.gemini/policies/developer.toml
+++ b/.gemini/policies/developer.toml
@@ -1,0 +1,4 @@
+[[rule]]
+toolName = "*"
+decision = "ask_user"
+priority = 100

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -15,32 +15,8 @@
       }
     ]
   },
-  "tools": {
-    "allowed": [
-      "run_shell_command(git)",
-      "run_shell_command(gh)",
-      "run_shell_command(uv)",
-      "run_shell_command(doit)",
-      "run_shell_command(ls)",
-      "run_shell_command(cat)",
-      "run_shell_command(tree)",
-      "run_shell_command(find)",
-      "run_shell_command(grep)",
-      "run_shell_command(wc)",
-      "run_shell_command(mkdir)",
-      "run_shell_command(python)",
-      "run_shell_command(pytest)",
-      "run_shell_command(ruff)",
-      "run_shell_command(mypy)"
-    ],
-    "core": [
-      "ShellTool",
-      "ReadFileTool",
-      "WriteFileTool",
-      "LSTool",
-      "GrepTool"
-    ],
-    "sandbox": false
+  "chatCompression": {
+    "contextPercentageThreshold": 0.5
   },
   "ui": {
     "autoApprove": false,

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -80,6 +80,14 @@ Gemini CLI can read `AGENTS.md` (or `GEMINI.md`) from the project root. The conf
 - `ReadFileTool`, `WriteFileTool` - File operations
 - `LSTool`, `GrepTool` - File exploration
 
+#### Token Efficiency
+
+`.gemini/settings.json` ships with a compression default aimed at token efficiency in long sessions, mirroring the Claude tuning:
+
+| Setting | Value | Effect | Rationale |
+| :--- | :--- | :--- | :--- |
+| `chatCompression.contextPercentageThreshold` | `0.5` | Compression triggers at 50% of context window usage. | Reclaims token space earlier to avoid hitting hard context limits in long sessions. |
+
 **Setup:**
 ```bash
 # Gemini CLI automatically uses .gemini/settings.json if present


### PR DESCRIPTION
## Description

Ports the Gemini Policy Engine migration ([upstream #529](https://github.com/endavis/pyproject-template/pull/529)) and the token-efficiency settings ([upstream #542](https://github.com/endavis/pyproject-template/pull/542)). Both touch `.gemini/settings.json`; bundled into a single PR.

### Policy Engine migration (#529)

The old `.gemini/settings.json` shipped a `tools` block with a 15-entry `allowed` whitelist (`run_shell_command(git)`, `(gh)`, `(uv)`, `(doit)`, etc.) plus a fixed core-tool list and `sandbox = false`. Gemini auto-approved anything matching the whitelist.

The new approach lifts permission decisions out of `settings.json` into a dedicated `.gemini/policies/developer.toml` file:

```toml
[[rule]]
toolName = "*"
decision = "ask_user"
priority = 100
```

Net effect: Gemini sessions will prompt the user before each tool call rather than auto-allow a fixed whitelist. This is upstream's deliberate move from allowlist-driven autonomy to prompt-driven trust.

**Behavior change to be aware of:** sessions are more interactive. To restore allowlist-like behavior, add additive `[[rule]]` entries with `decision = "allow"` and `priority < 100` to `developer.toml`.

### Token-efficiency settings (#542)

Adds `chatCompression.contextPercentageThreshold = 0.5` to `.gemini/settings.json` so Gemini compresses chat history at 50% context utilization rather than waiting until later — reclaims token space earlier in long sessions. Mirrors the Claude tuning.

`docs/development/AI_SETUP.md` picks up a new "Token Efficiency" subsection with a setting/effect/rationale table.

### Skipped from upstream's PRs

- **`docs/development/ai/token-efficiency-add-ons.md`** update from #542 (3 lines). File doesn't exist locally yet; it lands with upstream #520 in Phase E along with the new section it introduces.

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

| File | Type | Lines |
| :--- | :--- | :--- |
| `.gemini/policies/developer.toml` | new | 4 |
| `.gemini/settings.json` | modified | -27 (#529) +3 (#542) = net -24 |
| `docs/development/AI_SETUP.md` | modified | +8/-0 |

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality (N/A — configuration-only PR)
- [x] Manually tested the changes

`doit check` passes locally. `.gemini/settings.json` validated as JSON; `.gemini/policies/developer.toml` validated with `tomllib`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my feature works (N/A — config-only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase C.2 of the pyproject-template sync (#823). Phase C.3 (Gemini TOML command conversion + Gemini-native `/implement` and `/finalize`, upstream #539 + #541 + #491) follows next.
