### PR TITLE
feat: cross-agent delegation matrix (plan/implement/review across all 4 CLIs)

### DIFF
--- a/.agents/skills/delegate-claude-adversarial-review/SKILL.md
+++ b/.agents/skills/delegate-claude-adversarial-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-claude-adversarial-review
+description: Delegate a steerable adversarial review of current changes from a Codex session to Claude Code. Hands an adversarial-review to Claude via `claude -p` and returns the challenge to Codex.
+---
+
+# Delegate Adversarial Review to Claude
+
+Hand off a steerable adversarial review to Claude Code from a Codex session — pressure-tests design choices, assumptions, and alternative approaches.
+
+## When to use
+
+Use this skill when the user explicitly wants an adversarial / challenge review done by Claude (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-claude-adversarial-review challenge the design of the current changes`
+- `$delegate-claude-adversarial-review have Claude pressure-test this branch`
+
+The user may include focus text after the trigger.
+
+## Instructions
+
+1. Capture any focus text from the user's request.
+2. Run Claude Code non-interactively. Adversarial review challenges direction, not just code details.
+
+   ```bash
+   claude -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): <focus>'
+   ```
+
+3. Capture stdout and summarize the adversarial findings.
+4. This is a *challenge* — the user decides whether to accept, defer, or push back.
+5. Do NOT auto-apply suggestions.

--- a/.agents/skills/delegate-claude-implement/SKILL.md
+++ b/.agents/skills/delegate-claude-implement/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-claude-implement
+description: Delegate implementation of a GitHub issue from a Codex session to Claude Code. Hands implementation work to Claude via `claude -p` and returns the result to Codex.
+---
+
+# Delegate Implement to Claude
+
+Hand off implementation work for a GitHub issue to Claude Code from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants implementation done by Claude (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-claude-implement implement issue 399`
+- `$delegate-claude-implement delegate implementation of #399 to Claude`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Confirm the issue number from the user's request.
+2. Run Claude Code non-interactively. Hybrid C: prefer the existing `/claude:implement` command if available, otherwise inline workflow.
+
+   ```bash
+   claude -p 'Implement GitHub issue #<n> in the current repository. If the /claude:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #<n> via `gh issue view <n> --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/<n>-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+   ```
+
+3. Capture stdout and summarize what was implemented and the `doit check` result.
+4. Show the user the changed files (`git status`, `git diff --stat`).
+5. Do NOT push or open a PR yourself.

--- a/.agents/skills/delegate-claude-plan/SKILL.md
+++ b/.agents/skills/delegate-claude-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-claude-plan
+description: Delegate planning for a GitHub issue from a Codex session to Claude Code. Hands the planning work to Claude via `claude -p` and returns the plan to Codex.
+---
+
+# Delegate Plan to Claude
+
+Hand off planning work for a GitHub issue to Claude Code from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants planning done by Claude (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-claude-plan plan issue 399`
+- `$delegate-claude-plan delegate planning for #399 to Claude`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Confirm the issue number from the user's request.
+2. Run Claude Code non-interactively. Hybrid C: prefer the existing `/claude:plan` command if available, otherwise inline workflow.
+
+   ```bash
+   claude -p 'Plan the implementation for GitHub issue #<n> in the current repository. If the /claude:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view <n> --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+   ```
+
+3. Capture stdout and summarize the plan to the user.
+4. If the user wants revisions, invoke Claude again with their feedback appended.
+5. Do NOT post the plan as a comment yourself — the user owns that step.

--- a/.agents/skills/delegate-claude-review/SKILL.md
+++ b/.agents/skills/delegate-claude-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-claude-review
+description: Delegate a read-only code review of current changes from a Codex session to Claude Code. Hands the review to Claude via `claude -p` and returns findings to Codex.
+---
+
+# Delegate Review to Claude
+
+Hand off a read-only code review of current changes to Claude Code from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants a review done by Claude (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-claude-review review the current changes`
+- `$delegate-claude-review have Claude review this branch`
+
+The user may include optional focus text after the trigger.
+
+## Instructions
+
+1. Capture any focus text from the user's request.
+2. Run Claude Code non-interactively. Hybrid C: prefer the existing `/claude:review` command if available, otherwise the prompt is fully inlined.
+
+   ```bash
+   claude -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): <focus>'
+   ```
+
+3. Capture stdout and summarize the review findings.
+4. Highlight blocking issues vs nits.
+5. Do NOT auto-apply suggestions — the user decides what to act on.

--- a/.agents/skills/delegate-copilot-adversarial-review/SKILL.md
+++ b/.agents/skills/delegate-copilot-adversarial-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-copilot-adversarial-review
+description: Delegate a steerable adversarial review of current changes from a Codex session to GitHub Copilot CLI. Hands the challenge to Copilot via `copilot --allow-all -p` and returns it to Codex.
+---
+
+# Delegate Adversarial Review to Copilot
+
+Hand off a steerable adversarial review to GitHub Copilot CLI from a Codex session — pressure-tests design choices, assumptions, and alternative approaches.
+
+## When to use
+
+Use this skill when the user explicitly wants an adversarial / challenge review done by Copilot (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-copilot-adversarial-review challenge the design of the current changes`
+- `$delegate-copilot-adversarial-review have Copilot pressure-test this branch`
+
+The user may include focus text after the trigger.
+
+## Instructions
+
+1. Capture any focus text from the user's request.
+2. Run Copilot CLI non-interactively. Copilot requires `--allow-all` for non-interactive mode. Adversarial review challenges direction, not just code details.
+
+   ```bash
+   copilot --allow-all -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): <focus>'
+   ```
+
+3. Capture stdout and summarize the adversarial findings.
+4. This is a *challenge* — the user decides whether to accept, defer, or push back.
+5. Do NOT auto-apply suggestions.

--- a/.agents/skills/delegate-copilot-implement/SKILL.md
+++ b/.agents/skills/delegate-copilot-implement/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-copilot-implement
+description: Delegate implementation of a GitHub issue from a Codex session to GitHub Copilot CLI. Hands implementation work to Copilot via `copilot --allow-all -p` and returns the result to Codex.
+---
+
+# Delegate Implement to Copilot
+
+Hand off implementation work for a GitHub issue to GitHub Copilot CLI from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants implementation done by Copilot (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-copilot-implement implement issue 399`
+- `$delegate-copilot-implement delegate implementation of #399 to Copilot`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Confirm the issue number from the user's request.
+2. Run Copilot CLI non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:implement` command if available, otherwise inline workflow.
+
+   ```bash
+   copilot --allow-all -p 'Implement GitHub issue #<n> in the current repository. If the /copilot:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #<n> via `gh issue view <n> --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/<n>-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+   ```
+
+3. Capture stdout and summarize what was implemented and the `doit check` result.
+4. Show the user the changed files (`git status`, `git diff --stat`).
+5. Do NOT push or open a PR yourself.

--- a/.agents/skills/delegate-copilot-plan/SKILL.md
+++ b/.agents/skills/delegate-copilot-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-copilot-plan
+description: Delegate planning for a GitHub issue from a Codex session to GitHub Copilot CLI. Hands the planning work to Copilot via `copilot --allow-all -p` and returns the plan to Codex.
+---
+
+# Delegate Plan to Copilot
+
+Hand off planning work for a GitHub issue to GitHub Copilot CLI from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants planning done by Copilot (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-copilot-plan plan issue 399`
+- `$delegate-copilot-plan delegate planning for #399 to Copilot`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Confirm the issue number from the user's request.
+2. Run Copilot CLI non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:plan` command if available, otherwise inline workflow.
+
+   ```bash
+   copilot --allow-all -p 'Plan the implementation for GitHub issue #<n> in the current repository. If the /copilot:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view <n> --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+   ```
+
+3. Capture stdout and summarize the plan to the user.
+4. If the user wants revisions, invoke Copilot again with their feedback appended.
+5. Do NOT post the plan as a comment yourself — the user owns that step.

--- a/.agents/skills/delegate-copilot-review/SKILL.md
+++ b/.agents/skills/delegate-copilot-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-copilot-review
+description: Delegate a read-only code review of current changes from a Codex session to GitHub Copilot CLI. Hands the review to Copilot via `copilot --allow-all -p` and returns findings to Codex.
+---
+
+# Delegate Review to Copilot
+
+Hand off a read-only code review of current changes to GitHub Copilot CLI from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants a review done by Copilot (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-copilot-review review the current changes`
+- `$delegate-copilot-review have Copilot review this branch`
+
+The user may include optional focus text after the trigger.
+
+## Instructions
+
+1. Capture any focus text from the user's request.
+2. Run Copilot CLI non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:review` command if available, otherwise the prompt is fully inlined.
+
+   ```bash
+   copilot --allow-all -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): <focus>'
+   ```
+
+3. Capture stdout and summarize the review findings.
+4. Highlight blocking issues vs nits.
+5. Do NOT auto-apply suggestions — the user decides what to act on.

--- a/.agents/skills/delegate-gemini-adversarial-review/SKILL.md
+++ b/.agents/skills/delegate-gemini-adversarial-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-gemini-adversarial-review
+description: Delegate a steerable adversarial review of current changes from a Codex session to Gemini CLI. Hands the challenge to Gemini via `gemini -p` and returns it to Codex.
+---
+
+# Delegate Adversarial Review to Gemini
+
+Hand off a steerable adversarial review to Gemini CLI from a Codex session — pressure-tests design choices, assumptions, and alternative approaches.
+
+## When to use
+
+Use this skill when the user explicitly wants an adversarial / challenge review done by Gemini (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-gemini-adversarial-review challenge the design of the current changes`
+- `$delegate-gemini-adversarial-review have Gemini pressure-test this branch`
+
+The user may include focus text after the trigger.
+
+## Instructions
+
+1. Capture any focus text from the user's request.
+2. Run Gemini CLI non-interactively. Adversarial review challenges direction, not just code details.
+
+   ```bash
+   gemini -y -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): <focus>'
+   ```
+
+3. Capture stdout and summarize the adversarial findings.
+4. This is a *challenge* — the user decides whether to accept, defer, or push back.
+5. Do NOT auto-apply suggestions.

--- a/.agents/skills/delegate-gemini-implement/SKILL.md
+++ b/.agents/skills/delegate-gemini-implement/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-gemini-implement
+description: Delegate implementation of a GitHub issue from a Codex session to Gemini CLI. Hands implementation work to Gemini via `gemini -p` and returns the result to Codex.
+---
+
+# Delegate Implement to Gemini
+
+Hand off implementation work for a GitHub issue to Gemini CLI from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants implementation done by Gemini (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-gemini-implement implement issue 399`
+- `$delegate-gemini-implement delegate implementation of #399 to Gemini`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Confirm the issue number from the user's request.
+2. Run Gemini CLI non-interactively. Hybrid C: prefer the existing `/gemini:implement` command if available, otherwise inline workflow.
+
+   ```bash
+   gemini -y -p 'Implement GitHub issue #<n> in the current repository. If the /gemini:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #<n> via `gh issue view <n> --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/<n>-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+   ```
+
+3. Capture stdout and summarize what was implemented and the `doit check` result.
+4. Show the user the changed files (`git status`, `git diff --stat`).
+5. Do NOT push or open a PR yourself.

--- a/.agents/skills/delegate-gemini-plan/SKILL.md
+++ b/.agents/skills/delegate-gemini-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-gemini-plan
+description: Delegate planning for a GitHub issue from a Codex session to Gemini CLI. Hands the planning work to Gemini via `gemini -p` and returns the plan to Codex.
+---
+
+# Delegate Plan to Gemini
+
+Hand off planning work for a GitHub issue to Gemini CLI from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants planning done by Gemini (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-gemini-plan plan issue 399`
+- `$delegate-gemini-plan delegate planning for #399 to Gemini`
+
+If the issue number is missing, ask for it before continuing.
+
+## Instructions
+
+1. Confirm the issue number from the user's request.
+2. Run Gemini CLI non-interactively. Hybrid C: prefer the existing `/gemini:plan` command if available, otherwise inline workflow.
+
+   ```bash
+   gemini -y -p 'Plan the implementation for GitHub issue #<n> in the current repository. If the /gemini:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view <n> --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+   ```
+
+3. Capture stdout and summarize the plan to the user.
+4. If the user wants revisions, invoke Gemini again with their feedback appended.
+5. Do NOT post the plan as a comment yourself — the user owns that step.

--- a/.agents/skills/delegate-gemini-review/SKILL.md
+++ b/.agents/skills/delegate-gemini-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: delegate-gemini-review
+description: Delegate a read-only code review of current changes from a Codex session to Gemini CLI. Hands the review to Gemini via `gemini -p` and returns findings to Codex.
+---
+
+# Delegate Review to Gemini
+
+Hand off a read-only code review of current changes to Gemini CLI from a Codex session.
+
+## When to use
+
+Use this skill when the user explicitly wants a review done by Gemini (not Codex itself).
+
+Expected prompt shape:
+
+- `$delegate-gemini-review review the current changes`
+- `$delegate-gemini-review have Gemini review this branch`
+
+The user may include optional focus text after the trigger.
+
+## Instructions
+
+1. Capture any focus text from the user's request.
+2. Run Gemini CLI non-interactively. Hybrid C: prefer the existing `/gemini:review` command if available, otherwise the prompt is fully inlined.
+
+   ```bash
+   gemini -y -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): <focus>'
+   ```
+
+3. Capture stdout and summarize the review findings.
+4. Highlight blocking issues vs nits.
+5. Do NOT auto-apply suggestions — the user decides what to act on.

--- a/.claude/commands/codex/adversarial-review.md
+++ b/.claude/commands/codex/adversarial-review.md
@@ -1,0 +1,16 @@
+# Adversarial Review via Codex
+
+Delegate a steerable adversarial review to Codex CLI — pressure-tests design choices, assumptions, and alternative approaches. Optional focus: $ARGUMENTS.
+
+## Instructions
+
+Use the Bash tool to invoke Codex non-interactively. Adversarial review challenges direction, not just code details.
+
+```bash
+codex -a never exec 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Codex returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.

--- a/.claude/commands/codex/implement.md
+++ b/.claude/commands/codex/implement.md
@@ -1,0 +1,16 @@
+# Implement via Codex
+
+Delegate implementation of GitHub issue #$ARGUMENTS to Codex CLI.
+
+## Instructions
+
+Use the Bash tool to invoke Codex non-interactively. Hybrid C: prefer the existing `$codex-implement` skill if available, otherwise inline workflow.
+
+```bash
+codex -a never exec 'Implement GitHub issue #$ARGUMENTS in the current repository. If the $codex-implement skill is available, activate it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #$ARGUMENTS via `gh issue view $ARGUMENTS --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/$ARGUMENTS-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Codex returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.

--- a/.claude/commands/codex/plan.md
+++ b/.claude/commands/codex/plan.md
@@ -1,0 +1,16 @@
+# Plan via Codex
+
+Delegate planning for GitHub issue #$ARGUMENTS to Codex CLI.
+
+## Instructions
+
+Use the Bash tool to invoke Codex non-interactively. The prompt below uses Hybrid C: it asks Codex to activate its existing `$codex-plan` skill if available, otherwise to follow the equivalent inline workflow. Single-quote the prompt so the literal `$codex-plan` reaches Codex (not the shell).
+
+```bash
+codex -a never exec 'Plan the implementation for GitHub issue #$ARGUMENTS in the current repository. If the $codex-plan skill is available, activate it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view $ARGUMENTS --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Codex returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Codex again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.

--- a/.claude/commands/codex/review.md
+++ b/.claude/commands/codex/review.md
@@ -1,0 +1,16 @@
+# Review via Codex
+
+Delegate a read-only code review of the current changes to Codex CLI. Optional focus area: $ARGUMENTS.
+
+## Instructions
+
+Use the Bash tool to invoke Codex non-interactively. Hybrid C: prefer the existing `$codex-review` skill if available, otherwise the prompt is fully inlined.
+
+```bash
+codex -a never exec 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Codex returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.

--- a/.claude/commands/copilot/adversarial-review.md
+++ b/.claude/commands/copilot/adversarial-review.md
@@ -1,0 +1,16 @@
+# Adversarial Review via Copilot
+
+Delegate a steerable adversarial review to GitHub Copilot CLI — pressure-tests design choices, assumptions, and alternative approaches. Optional focus: $ARGUMENTS.
+
+## Instructions
+
+Use the Bash tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. Adversarial review challenges direction, not just code details.
+
+```bash
+copilot --allow-all -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Copilot returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.

--- a/.claude/commands/copilot/implement.md
+++ b/.claude/commands/copilot/implement.md
@@ -1,0 +1,16 @@
+# Implement via Copilot
+
+Delegate implementation of GitHub issue #$ARGUMENTS to GitHub Copilot CLI.
+
+## Instructions
+
+Use the Bash tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:implement` command if available, otherwise inline workflow.
+
+```bash
+copilot --allow-all -p 'Implement GitHub issue #$ARGUMENTS in the current repository. If the /copilot:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #$ARGUMENTS via `gh issue view $ARGUMENTS --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/$ARGUMENTS-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Copilot returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.

--- a/.claude/commands/copilot/plan.md
+++ b/.claude/commands/copilot/plan.md
@@ -1,0 +1,16 @@
+# Plan via Copilot
+
+Delegate planning for GitHub issue #$ARGUMENTS to GitHub Copilot CLI.
+
+## Instructions
+
+Use the Bash tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:plan` command if available, otherwise inline workflow.
+
+```bash
+copilot --allow-all -p 'Plan the implementation for GitHub issue #$ARGUMENTS in the current repository. If the /copilot:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view $ARGUMENTS --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Copilot returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Copilot again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.

--- a/.claude/commands/copilot/review.md
+++ b/.claude/commands/copilot/review.md
@@ -1,0 +1,16 @@
+# Review via Copilot
+
+Delegate a read-only code review of the current changes to GitHub Copilot CLI. Optional focus area: $ARGUMENTS.
+
+## Instructions
+
+Use the Bash tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. The review prompt is inlined directly.
+
+```bash
+copilot --allow-all -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Copilot returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.

--- a/.claude/commands/gemini/adversarial-review.md
+++ b/.claude/commands/gemini/adversarial-review.md
@@ -1,0 +1,16 @@
+# Adversarial Review via Gemini
+
+Delegate a steerable adversarial review to Gemini CLI — pressure-tests design choices, assumptions, and alternative approaches. Optional focus: $ARGUMENTS.
+
+## Instructions
+
+Use the Bash tool to invoke Gemini non-interactively. Adversarial review challenges direction, not just code details.
+
+```bash
+gemini -y -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Gemini returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.

--- a/.claude/commands/gemini/implement.md
+++ b/.claude/commands/gemini/implement.md
@@ -1,0 +1,16 @@
+# Implement via Gemini
+
+Delegate implementation of GitHub issue #$ARGUMENTS to Gemini CLI.
+
+## Instructions
+
+Use the Bash tool to invoke Gemini non-interactively. Hybrid C: prefer the existing `/gemini:implement` command if available, otherwise inline workflow.
+
+```bash
+gemini -y -p 'Implement GitHub issue #$ARGUMENTS in the current repository. If the /gemini:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #$ARGUMENTS via `gh issue view $ARGUMENTS --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/$ARGUMENTS-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Gemini returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.

--- a/.claude/commands/gemini/plan.md
+++ b/.claude/commands/gemini/plan.md
@@ -1,0 +1,16 @@
+# Plan via Gemini
+
+Delegate planning for GitHub issue #$ARGUMENTS to Gemini CLI.
+
+## Instructions
+
+Use the Bash tool to invoke Gemini non-interactively. Hybrid C: prefer the existing `/gemini:plan` command if available, otherwise inline workflow.
+
+```bash
+gemini -y -p 'Plan the implementation for GitHub issue #$ARGUMENTS in the current repository. If the /gemini:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view $ARGUMENTS --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Gemini returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Gemini again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.

--- a/.claude/commands/gemini/review.md
+++ b/.claude/commands/gemini/review.md
@@ -1,0 +1,16 @@
+# Review via Gemini
+
+Delegate a read-only code review of the current changes to Gemini CLI. Optional focus area: $ARGUMENTS.
+
+## Instructions
+
+Use the Bash tool to invoke Gemini non-interactively. The review prompt is inlined directly.
+
+```bash
+gemini -y -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Gemini returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.

--- a/.copilot/commands/claude/adversarial-review.md
+++ b/.copilot/commands/claude/adversarial-review.md
@@ -1,0 +1,16 @@
+# Adversarial Review via Claude
+
+Delegate a steerable adversarial review to Claude Code — pressure-tests design choices, assumptions, and alternative approaches. Optional focus: $ARGUMENTS.
+
+## Instructions
+
+Run Claude Code non-interactively via shell. Adversarial review challenges direction, not just code details.
+
+```bash
+claude -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Claude returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.

--- a/.copilot/commands/claude/implement.md
+++ b/.copilot/commands/claude/implement.md
@@ -1,0 +1,16 @@
+# Implement via Claude
+
+Delegate implementation of GitHub issue #$ARGUMENTS to Claude Code.
+
+## Instructions
+
+Run Claude Code non-interactively via shell. Hybrid C: prefer the existing `/claude:implement` command if available, otherwise inline workflow.
+
+```bash
+claude -p 'Implement GitHub issue #$ARGUMENTS in the current repository. If the /claude:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #$ARGUMENTS via `gh issue view $ARGUMENTS --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/$ARGUMENTS-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Claude returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.

--- a/.copilot/commands/claude/plan.md
+++ b/.copilot/commands/claude/plan.md
@@ -1,0 +1,16 @@
+# Plan via Claude
+
+Delegate planning for GitHub issue #$ARGUMENTS to Claude Code.
+
+## Instructions
+
+Run Claude Code non-interactively via shell. Hybrid C: prefer the existing `/claude:plan` command if available, otherwise inline workflow.
+
+```bash
+claude -p 'Plan the implementation for GitHub issue #$ARGUMENTS in the current repository. If the /claude:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view $ARGUMENTS --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Claude returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Claude again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.

--- a/.copilot/commands/claude/review.md
+++ b/.copilot/commands/claude/review.md
@@ -1,0 +1,16 @@
+# Review via Claude
+
+Delegate a read-only code review of the current changes to Claude Code. Optional focus area: $ARGUMENTS.
+
+## Instructions
+
+Run Claude Code non-interactively via shell. Hybrid C: prefer the existing `/claude:review` command if available, otherwise the prompt is fully inlined.
+
+```bash
+claude -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Claude returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.

--- a/.copilot/commands/codex/adversarial-review.md
+++ b/.copilot/commands/codex/adversarial-review.md
@@ -1,0 +1,16 @@
+# Adversarial Review via Codex
+
+Delegate a steerable adversarial review to Codex CLI — pressure-tests design choices, assumptions, and alternative approaches. Optional focus: $ARGUMENTS.
+
+## Instructions
+
+Run Codex non-interactively via shell. Adversarial review challenges direction, not just code details.
+
+```bash
+codex -a never exec 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Codex returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.

--- a/.copilot/commands/codex/implement.md
+++ b/.copilot/commands/codex/implement.md
@@ -1,0 +1,16 @@
+# Implement via Codex
+
+Delegate implementation of GitHub issue #$ARGUMENTS to Codex CLI.
+
+## Instructions
+
+Run Codex non-interactively via shell. Hybrid C: prefer the existing `$codex-implement` skill if available, otherwise inline workflow.
+
+```bash
+codex -a never exec 'Implement GitHub issue #$ARGUMENTS in the current repository. If the $codex-implement skill is available, activate it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #$ARGUMENTS via `gh issue view $ARGUMENTS --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/$ARGUMENTS-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Codex returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.

--- a/.copilot/commands/codex/plan.md
+++ b/.copilot/commands/codex/plan.md
@@ -1,0 +1,16 @@
+# Plan via Codex
+
+Delegate planning for GitHub issue #$ARGUMENTS to Codex CLI.
+
+## Instructions
+
+Run Codex non-interactively via shell. Hybrid C: prefer the existing `$codex-plan` skill if available, otherwise inline workflow. Single-quote the prompt so the literal `$codex-plan` reaches Codex (not the shell).
+
+```bash
+codex -a never exec 'Plan the implementation for GitHub issue #$ARGUMENTS in the current repository. If the $codex-plan skill is available, activate it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view $ARGUMENTS --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Codex returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Codex again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.

--- a/.copilot/commands/codex/review.md
+++ b/.copilot/commands/codex/review.md
@@ -1,0 +1,16 @@
+# Review via Codex
+
+Delegate a read-only code review of the current changes to Codex CLI. Optional focus area: $ARGUMENTS.
+
+## Instructions
+
+Run Codex non-interactively via shell. Hybrid C: prefer the existing `$codex-review` skill if available, otherwise the prompt is fully inlined.
+
+```bash
+codex -a never exec 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Codex returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.

--- a/.copilot/commands/gemini/adversarial-review.md
+++ b/.copilot/commands/gemini/adversarial-review.md
@@ -1,0 +1,16 @@
+# Adversarial Review via Gemini
+
+Delegate a steerable adversarial review to Gemini CLI — pressure-tests design choices, assumptions, and alternative approaches. Optional focus: $ARGUMENTS.
+
+## Instructions
+
+Run Gemini non-interactively via shell. Adversarial review challenges direction, not just code details.
+
+```bash
+gemini -y -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Gemini returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.

--- a/.copilot/commands/gemini/implement.md
+++ b/.copilot/commands/gemini/implement.md
@@ -1,0 +1,16 @@
+# Implement via Gemini
+
+Delegate implementation of GitHub issue #$ARGUMENTS to Gemini CLI.
+
+## Instructions
+
+Run Gemini non-interactively via shell. Hybrid C: prefer the existing `/gemini:implement` command if available, otherwise inline workflow.
+
+```bash
+gemini -y -p 'Implement GitHub issue #$ARGUMENTS in the current repository. If the /gemini:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #$ARGUMENTS via `gh issue view $ARGUMENTS --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/$ARGUMENTS-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Gemini returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.

--- a/.copilot/commands/gemini/plan.md
+++ b/.copilot/commands/gemini/plan.md
@@ -1,0 +1,16 @@
+# Plan via Gemini
+
+Delegate planning for GitHub issue #$ARGUMENTS to Gemini CLI.
+
+## Instructions
+
+Run Gemini non-interactively via shell. Hybrid C: prefer the existing `/gemini:plan` command if available, otherwise inline workflow.
+
+```bash
+gemini -y -p 'Plan the implementation for GitHub issue #$ARGUMENTS in the current repository. If the /gemini:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view $ARGUMENTS --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Gemini returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Gemini again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.

--- a/.copilot/commands/gemini/review.md
+++ b/.copilot/commands/gemini/review.md
@@ -1,0 +1,16 @@
+# Review via Gemini
+
+Delegate a read-only code review of the current changes to Gemini CLI. Optional focus area: $ARGUMENTS.
+
+## Instructions
+
+Run Gemini non-interactively via shell. Hybrid C: prefer the existing `/gemini:review` command if available, otherwise the prompt is fully inlined.
+
+```bash
+gemini -y -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): $ARGUMENTS'
+```
+
+After Gemini returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.

--- a/.gemini/commands/claude/adversarial-review.toml
+++ b/.gemini/commands/claude/adversarial-review.toml
@@ -1,0 +1,15 @@
+description = "Delegate a steerable adversarial review to Claude Code. Optional focus: {{args}}."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Claude Code non-interactively. Adversarial review challenges direction, not just code details.
+
+```bash
+claude -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): {{args}}'
+```
+
+After Claude returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.
+"""

--- a/.gemini/commands/claude/implement.toml
+++ b/.gemini/commands/claude/implement.toml
@@ -1,0 +1,15 @@
+description = "Delegate implementation of GitHub issue {{args}} to Claude Code."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Claude Code non-interactively. Hybrid C: prefer the existing `/claude:implement` command if available, otherwise inline workflow.
+
+```bash
+claude -p 'Implement GitHub issue #{{args}} in the current repository. If the /claude:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #{{args}} via `gh issue view {{args}} --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/{{args}}-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Claude returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.
+"""

--- a/.gemini/commands/claude/plan.toml
+++ b/.gemini/commands/claude/plan.toml
@@ -1,0 +1,15 @@
+description = "Delegate planning for GitHub issue {{args}} to Claude Code."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Claude Code non-interactively. Hybrid C: prefer the existing `/claude:plan` command if available, otherwise inline workflow.
+
+```bash
+claude -p 'Plan the implementation for GitHub issue #{{args}} in the current repository. If the /claude:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view {{args}} --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Claude returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Claude again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.
+"""

--- a/.gemini/commands/claude/review.toml
+++ b/.gemini/commands/claude/review.toml
@@ -1,0 +1,15 @@
+description = "Delegate a read-only review of current changes to Claude Code. Optional focus area: {{args}}."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Claude Code non-interactively. Hybrid C: prefer the existing `/claude:review` command if available, otherwise the prompt is fully inlined.
+
+```bash
+claude -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): {{args}}'
+```
+
+After Claude returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.
+"""

--- a/.gemini/commands/codex/adversarial-review.toml
+++ b/.gemini/commands/codex/adversarial-review.toml
@@ -1,0 +1,15 @@
+description = "Delegate a steerable adversarial review to Codex CLI. Optional focus: {{args}}."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Codex non-interactively. Adversarial review challenges direction, not just code details.
+
+```bash
+codex -a never exec 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): {{args}}'
+```
+
+After Codex returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.
+"""

--- a/.gemini/commands/codex/implement.toml
+++ b/.gemini/commands/codex/implement.toml
@@ -1,0 +1,15 @@
+description = "Delegate implementation of GitHub issue {{args}} to Codex CLI."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Codex non-interactively. Hybrid C: prefer the existing `$codex-implement` skill if available, otherwise inline workflow.
+
+```bash
+codex -a never exec 'Implement GitHub issue #{{args}} in the current repository. If the $codex-implement skill is available, activate it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #{{args}} via `gh issue view {{args}} --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/{{args}}-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Codex returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.
+"""

--- a/.gemini/commands/codex/plan.toml
+++ b/.gemini/commands/codex/plan.toml
@@ -1,0 +1,15 @@
+description = "Delegate planning for GitHub issue {{args}} to Codex CLI."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Codex non-interactively. Hybrid C: prefer the existing `$codex-plan` skill if available, otherwise inline workflow. Single-quote the prompt so the literal `$codex-plan` reaches Codex (not the shell).
+
+```bash
+codex -a never exec 'Plan the implementation for GitHub issue #{{args}} in the current repository. If the $codex-plan skill is available, activate it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view {{args}} --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Codex returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Codex again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.
+"""

--- a/.gemini/commands/codex/review.toml
+++ b/.gemini/commands/codex/review.toml
@@ -1,0 +1,15 @@
+description = "Delegate a read-only review of current changes to Codex CLI. Optional focus area: {{args}}."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Codex non-interactively. Hybrid C: prefer the existing `$codex-review` skill if available, otherwise the prompt is fully inlined.
+
+```bash
+codex -a never exec 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): {{args}}'
+```
+
+After Codex returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.
+"""

--- a/.gemini/commands/copilot/adversarial-review.toml
+++ b/.gemini/commands/copilot/adversarial-review.toml
@@ -1,0 +1,15 @@
+description = "Delegate a steerable adversarial review to GitHub Copilot CLI. Optional focus: {{args}}."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. Adversarial review challenges direction, not just code details.
+
+```bash
+copilot --allow-all -p 'Run an adversarial review of the current uncommitted changes and the current branch vs main. Read-only. Be skeptical and steerable: pressure-test design choices, hidden assumptions, tradeoffs, alternative approaches, failure modes (auth, data loss, races, rollback, reliability). 1) Run `git status`, `git diff`, `git log main..HEAD`. 2) Read AGENTS.md and related ADRs. 3) Ask: was this the right approach? Would a different design be safer or simpler? What edge cases are missed? What hidden coupling exists? 4) Print findings to stdout in a structured format (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering). Do NOT modify any files. Focus area (optional): {{args}}'
+```
+
+After Copilot returns:
+- Summarize the adversarial findings to the user.
+- This is a *challenge* — the user decides whether to accept, defer, or push back.
+- Do not auto-apply suggestions.
+"""

--- a/.gemini/commands/copilot/implement.toml
+++ b/.gemini/commands/copilot/implement.toml
@@ -1,0 +1,15 @@
+description = "Delegate implementation of GitHub issue {{args}} to GitHub Copilot CLI."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:implement` command if available, otherwise inline workflow.
+
+```bash
+copilot --allow-all -p 'Implement GitHub issue #{{args}} in the current repository. If the /copilot:implement command is available, run it for this issue. Otherwise, follow this workflow: 1) Read the plan comment from issue #{{args}} via `gh issue view {{args}} --json comments`. 2) Read AGENTS.md for branch naming and commit conventions. 3) Create or check out the branch `<type>/{{args}}-<slug>` (do not commit to main). 4) Implement the changes per the plan. 5) Run `doit check` to validate. Do NOT push the branch or open a PR — the user reviews first.'
+```
+
+After Copilot returns:
+- Summarize what was implemented and the `doit check` result.
+- Show the user the changed files (`git status`, `git diff --stat`) so they can review.
+- Do not push or open a PR yourself.
+"""

--- a/.gemini/commands/copilot/plan.toml
+++ b/.gemini/commands/copilot/plan.toml
@@ -1,0 +1,15 @@
+description = "Delegate planning for GitHub issue {{args}} to GitHub Copilot CLI."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:plan` command if available, otherwise inline workflow.
+
+```bash
+copilot --allow-all -p 'Plan the implementation for GitHub issue #{{args}} in the current repository. If the /copilot:plan command is available, run it for this issue. Otherwise, follow this workflow: 1) Run `gh issue view {{args}} --json title,body,labels` to read the issue. 2) Read AGENTS.md to understand the workflow and conventions. 3) Explore the relevant files. 4) Draft a plan with three sections: Implementation Plan, Test Plan, Validation Plan. 5) Print the full plan to stdout. Do NOT post a comment to the issue — the user reviews and posts.'
+```
+
+After Copilot returns:
+- Summarize the plan to the user.
+- If the user wants revisions, invoke Copilot again with their feedback appended to the prompt.
+- Do not post the plan as a comment yourself — the user owns that step.
+"""

--- a/.gemini/commands/copilot/review.toml
+++ b/.gemini/commands/copilot/review.toml
@@ -1,0 +1,15 @@
+description = "Delegate a read-only review of current changes to GitHub Copilot CLI. Optional focus area: {{args}}."
+prompt = """
+## Instructions
+
+Use the `run_shell_command` tool to invoke Copilot non-interactively. Copilot requires `--allow-all` for non-interactive mode. Hybrid C: prefer the existing `/copilot:review` command if available, otherwise the prompt is fully inlined.
+
+```bash
+copilot --allow-all -p 'Review the current uncommitted changes and the current branch vs main, read-only. 1) Run `git status` and `git diff` to see what changed. 2) Run `git log main..HEAD --oneline` for branch context. 3) Read AGENTS.md and any relevant ADRs in docs/decisions/. 4) Identify correctness issues, risks, missing tests, style/convention violations, and concrete suggestions. 5) Print findings to stdout in a structured format (Summary / Issues / Suggestions). Do NOT modify any files. Focus area (optional): {{args}}'
+```
+
+After Copilot returns:
+- Summarize the review findings to the user.
+- Highlight any blocking issues vs nits.
+- The user decides what to act on; do not auto-apply suggestions.
+"""

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -24,5 +24,21 @@
   },
   "context": {
     "files": ["AGENTS.md", "GEMINI.md"]
+  },
+  "skills": {
+    "disabled": [
+      "delegate-claude-plan",
+      "delegate-claude-implement",
+      "delegate-claude-review",
+      "delegate-claude-adversarial-review",
+      "delegate-gemini-plan",
+      "delegate-gemini-implement",
+      "delegate-gemini-review",
+      "delegate-gemini-adversarial-review",
+      "delegate-copilot-plan",
+      "delegate-copilot-implement",
+      "delegate-copilot-review",
+      "delegate-copilot-adversarial-review"
+    ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,8 @@ Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills fr
 
 Codex CLI does **not** use repo-defined slash commands in this template. Its repo-native workflow is provided through checked-in skills under `.agents/skills/`, invoked with built-in Codex skill selection such as `/skills` or explicit mentions like `$plan-issue`.
 
+**Cross-agent delegation matrix:** in addition to self-action commands, every agent can delegate `plan`, `implement`, `review`, and `adversarial-review` to any of the other three via `<target>:<action>` commands (`/codex:plan 42` from Claude, `$delegate-gemini-implement 42` from Codex, etc.). Bridge files live under `.claude/commands/<target>/`, `.gemini/commands/<target>/`, `.copilot/commands/<target>/`, and `.agents/skills/delegate-<target>-<action>/`. See [Cross-Agent Delegation Matrix](docs/development/ai/cross-agent-delegation.md).
+
 ### Temporary Files
 
 AI agents **must never** write temporary files to generic locations like `/tmp/`. Instead, use the project-scoped directory:

--- a/docs/development/ai/cross-agent-delegation.md
+++ b/docs/development/ai/cross-agent-delegation.md
@@ -1,0 +1,161 @@
+# Cross-Agent Delegation Matrix
+
+A consistent, explicit-invocation interface that lets any of the four supported AI CLIs (Claude Code, Codex CLI, Gemini CLI, Copilot CLI) hand a task — `plan`, `implement`, `review`, or `adversarial-review` — to any of the other three.
+
+## Why this exists
+
+Each agent already drives *itself* through the issue-driven workflow (`/<ai>:plan`, `/<ai>:implement`, `/ghi-finalize`). This matrix adds the missing piece: deliberate, user-invoked handoff *between* agents, without depending on third-party plugins like `openai/codex-plugin-cc` or community Gemini/Copilot forks.
+
+The matrix replaces what would otherwise be a patchwork of inconsistent third-party plugins. It runs on top of the CLIs' existing non-interactive modes (`-p` / `exec`) and uses the same command names across all hosts, so users learn the surface once.
+
+## Convention
+
+`<prefix><target>:<action>` where:
+
+- **Prefix:** `/` on Claude Code, Gemini CLI, and Copilot CLI; `$` on Codex CLI (Codex's repo-defined commands are skills, not slash commands; OpenAI deprecated `~/.codex/prompts/`).
+- **Target:** `claude`, `codex`, `gemini`, `copilot` — the agent to invoke. Can be the **same** agent (self-action) or one of the other three (cross-agent delegation).
+- **Action:** `plan`, `implement`, `review`, `adversarial-review`.
+
+Self-action (`/claude:plan`, `/gemini:implement`, `$codex-review`, etc.) and cross-agent delegation (`/gemini:plan` from Claude, `/claude:plan` from Gemini, etc.) share the same naming convention. For self-action the command body runs the work natively in the host agent; for cross-agent delegation it shells out to the target CLI.
+
+| Action | Argument | Notes |
+| :--- | :--- | :--- |
+| `plan` | issue number (required) | Prefers the target's existing `/<target>:plan` or `$<target>-plan` if available; otherwise inline workflow. |
+| `implement` | issue number (required) | Prefers the target's existing `/<target>:implement` or `$<target>-implement` if available; otherwise inline workflow. |
+| `review` | optional focus area | Reviews current PR or branch-vs-main changes. |
+| `adversarial-review` | optional focus | Steerable challenge review — pressure-tests design, hidden assumptions, alternatives, failure modes. |
+
+## Matrix
+
+The 4 sources × 4 targets × 4 actions = 64 cells (including self-action). Cross-agent delegation is 4 × 3 × 4 = 48 cells.
+
+| Source ↓ / Target → | claude (self) | codex | gemini | copilot |
+| :--- | :--- | :--- | :--- | :--- |
+| **claude** (`.claude/commands/`) | `/claude:{plan,implement,review,adversarial-review}` | `/codex:{...}` | `/gemini:{...}` | `/copilot:{...}` |
+| **codex** (`.agents/skills/`) | `$delegate-claude-{...}` | `$codex-{plan,implement,review,adversarial-review}` | `$delegate-gemini-{...}` | `$delegate-copilot-{...}` |
+| **gemini** (`.gemini/commands/`) | `/claude:{...}` | `/codex:{...}` | `/gemini:{plan,implement,review,adversarial-review}` | `/copilot:{...}` |
+| **copilot** (`.copilot/commands/`) | `/claude:{...}` | `/codex:{...}` | `/gemini:{...}` | `/copilot:{plan,implement,review,adversarial-review}` |
+
+Each cell expands to `{plan, implement, review, adversarial-review}`. The diagonal (self-action) cells use the same `<ai>:<action>` naming convention; they run natively in the host agent rather than shelling out.
+
+## Non-interactive flags per CLI
+
+Each bridge invokes the target CLI in headless mode. Each CLI requires a flag to skip the interactive approval prompts that would otherwise block tool calls when no human is at the terminal:
+
+| Target | Invocation | Why |
+| :--- | :--- | :--- |
+| Claude Code | `claude -p '<prompt>'` | `-p` runs headless. No additional approval-bypass flag needed for the typical tool surface. |
+| Codex CLI | `codex -a never exec '<prompt>'` | `-a never` (`--ask-for-approval never`) prevents Codex from asking the (absent) user before running shell commands. Without it, every tool call in the delegated session is denied. |
+| Gemini CLI | `gemini -y -p '<prompt>'` | `-y` (`--yolo`) auto-accepts all tool calls. Without it, `run_shell_command` calls are denied by policy in non-interactive mode. |
+| Copilot CLI | `copilot --allow-all -p '<prompt>'` | `--allow-all` enables all permissions (equivalent to `--allow-all-tools --allow-all-paths --allow-all-urls`). Without it, Copilot prompts for path or URL access mid-session, which the absent user can't answer. **Order matters:** `--allow-all` must precede `-p`, since `-p <text>` consumes its argument and would otherwise grab the next flag. |
+
+These flags are intentional: in delegated invocations, the human is at the *source* agent and not at the target's prompt. Approval prompts in the target session can never be answered, so they must be bypassed. The source agent retains full visibility through captured stdout and can stop the chain at any point.
+
+## Hybrid C: how a delegation actually executes
+
+Each command body is a prompt that the source agent reads. The body tells the source agent to invoke the target's CLI in non-interactive mode via the source's tool layer (Bash/exec) and pass a prompt that:
+
+1. **Asks the target to activate its existing self-action command if available** (`/claude:plan`, `$codex-implement`, etc.).
+2. **Falls back to an inline workflow** (steps the target should follow if the self-action command isn't available or doesn't activate in non-interactive mode).
+
+This dual-path design — Hybrid C — works regardless of whether each CLI's non-interactive mode resolves slash commands or skill mentions. If resolution works, the target uses its existing solo command and stays consistent with self-action behavior. If it doesn't, the target falls through to the inline steps and still does the right thing.
+
+The output of the target CLI is captured by the source agent's tool layer (e.g., Bash) and re-injected into the source's conversation context, so the source can iterate on the result.
+
+## Per-host invocation examples
+
+```text
+# In Claude Code
+/codex:plan 42                 # Claude delegates planning of issue 42 to Codex
+/gemini:adversarial-review     # Claude delegates an adversarial review of current changes to Gemini
+
+# In Codex CLI
+$delegate-claude-implement 42  # Codex delegates implementation of issue 42 to Claude
+$delegate-gemini-review        # Codex delegates a review of current changes to Gemini
+
+# In Gemini CLI
+/claude:plan 42                # Gemini delegates planning of issue 42 to Claude
+/copilot:review                # Gemini delegates a review of current changes to Copilot
+
+# In Copilot CLI
+/codex:adversarial-review      # Copilot delegates an adversarial review to Codex
+/gemini:implement 42           # Copilot delegates implementation of issue 42 to Gemini
+```
+
+## Payload schema
+
+| Action | Required | Optional |
+| :--- | :--- | :--- |
+| `plan` | issue number | — |
+| `implement` | issue number | — |
+| `review` | — | focus area / file scope |
+| `adversarial-review` | — | focus area / risk dimension |
+
+All cells receive a single freeform string argument that the source agent interpolates into the prompt. Issue numbers map to `$ARGUMENTS` (Claude/Copilot markdown commands), `{{args}}` (Gemini TOML commands), or are extracted from the user's natural language (Codex skills).
+
+## Path conflict between Codex and Gemini
+
+Per OpenAI's Codex skills docs, the only repo-local skill path is `.agents/skills/` (no `.codex/skills/` variant). Per Gemini CLI's docs, Gemini also loads skills from `.agents/skills/` — the path is documented as "an interoperable path for managing agent-specific expertise that remains compatible across different AI tools."
+
+This means the 12 Codex-source delegation skills under `.agents/skills/delegate-*` would be auto-loaded by Gemini and could be mis-activated by Gemini's model.
+
+**Mitigation:** `.gemini/settings.json` has a `skills.disabled` list that excludes specific skill names from Gemini's loading. All 12 `delegate-*` skill names are added there:
+
+```json
+"skills": {
+  "disabled": [
+    "delegate-claude-plan",
+    "delegate-claude-implement",
+    "delegate-claude-review",
+    "delegate-claude-adversarial-review",
+    "delegate-gemini-plan",
+    "delegate-gemini-implement",
+    "delegate-gemini-review",
+    "delegate-gemini-adversarial-review",
+    "delegate-copilot-plan",
+    "delegate-copilot-implement",
+    "delegate-copilot-review",
+    "delegate-copilot-adversarial-review"
+  ]
+}
+```
+
+Inverse directions are clean by construction: Codex does not read `.gemini/commands/`, `.claude/commands/`, or `.copilot/commands/`; Claude and Copilot do not read `.agents/skills/`. Only the Gemini ↔ Codex pair shares a path.
+
+## Multi-agent orchestration (`/multi-*`)
+
+In addition to the 1-to-1 delegation matrix above, this template ships three N-to-1 orchestrators that let any host agent run **any combination** of agents in parallel and synthesize the results:
+
+| Command | Args | Description |
+| :--- | :--- | :--- |
+| `/multi-plan <ais...> <issue#>` | agent list + issue number | Each listed agent independently plans the issue; plans posted as separate comments; synthesized plan posted after user approval. |
+| `/multi-review <ais...>` | agent list | Each listed agent independently reviews the current PR; reviews posted as separate comments; synthesis posted after user approval. |
+| `/multi-adversarial-review <ais...>` | agent list | Each listed agent independently challenges the current changes; synthesis posted to PR (if exists) after user approval. |
+
+Each command is available for all four hosts:
+- Claude: `.claude/commands/multi-{plan,review,adversarial-review}.md`
+- Gemini: `.gemini/commands/multi-{plan,review,adversarial-review}.toml`
+- Copilot: `.copilot/commands/multi-{plan,review,adversarial-review}.md`
+- Codex: `.agents/skills/multi-{plan,review,adversarial-review}/SKILL.md`
+
+## Out of scope (v1)
+
+- Background jobs (`status`, `result`, `cancel` analogues)
+- Session resume across delegations
+- ACP-style brokering for long-running tasks
+- Streaming output
+
+These are deliberate omissions to keep v1 small. Synchronous-only invocation only.
+
+## Relationship to existing artifacts
+
+- `/<ai>:plan`, `/<ai>:implement`, `/<ai>:review`, `/<ai>:adversarial-review` — self-action and cross-agent delegation share the same naming convention. Self-action files live in `.<ai>/commands/<ai>/` (or `.agents/skills/codex-<action>/` for Codex).
+- `ghi-finalize`, `ghi-status` — these cover the post-implementation steps (commit, PR creation, status reporting).
+- `/multi-plan`, `/multi-review`, `/multi-adversarial-review` — N-to-1 orchestrators that dispatch to any combination of agents. See [Multi-agent orchestration](#multi-agent-orchestration-multi-) above.
+- `.claude/commands/`, `.gemini/commands/`, `.copilot/commands/`, `.agents/skills/` — established per-agent config directories. Self-action commands are in `<dir>/<ai>/` subdirectories; cross-agent bridges are in `<dir>/<target>/` subdirectories.
+- `.gemini/settings.json` `skills.disabled` — existing pattern, extended with 12 delegation entries and 3 multi-orchestrator entries (to prevent `.agents/skills/multi-*` from conflicting with Gemini's native TOML variants).
+
+## See also
+
+- [Slash Commands & Workflows](slash-commands.md) — reference for the underlying workflow commands.
+- [First 5 Minutes with an AI Agent](first-5-minutes.md) — narrative onboarding for the issue-driven flow this matrix complements.

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -160,8 +160,25 @@ GitHub Copilot CLI automatically discovers project skills from `.claude/commands
 4. **Decide: subagent or main context?** Delegate to a general-purpose subagent via the Task tool when the command does heavy codebase exploration, writes files, or runs long commands whose output would bloat the main conversation — `.claude/commands/implement.md` is the canonical example. Run in the main context when the user needs to interact step by step (plan mode, iteration, explicit approvals) — `.claude/commands/plan-issue.md` is the canonical example.
 5. **Update this document** when you add or remove a command. The command reference section should list every file under `.claude/commands/` and `.gemini/commands/`.
 
+## Cross-agent delegation matrix
+
+In addition to the self-action commands above, this template ships a `<target>:<action>` matrix that lets any source agent delegate `plan`, `implement`, `review`, or `adversarial-review` to any of the other three. The full design — convention, file layout, prefix mapping (`/foo` vs `$foo` for Codex), Hybrid C runtime behavior, and the `.agents/skills/` ↔ Gemini conflict mitigation — is documented separately:
+
+→ See [Cross-Agent Delegation Matrix](cross-agent-delegation.md).
+
+Quick reference:
+
+```text
+# In Claude Code / Gemini CLI / Copilot CLI:
+/<target>:<action> [args]      # e.g. /codex:plan 42, /gemini:adversarial-review
+
+# In Codex CLI (skills, not slash commands):
+$delegate-<target>-<action> [args]  # e.g. $delegate-claude-implement 42
+```
+
 ## See also
 
+- [Cross-Agent Delegation Matrix](cross-agent-delegation.md) — convention, matrix, and per-host invocation for the `<target>:<action>` family.
 - [First 5 Minutes with an AI Agent](first-5-minutes.md) — narrative onboarding walkthrough showing the workflow end to end.
 - [AI Agent Setup Guide](../AI_SETUP.md) — per-CLI configuration and whitelists.
 - [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.

--- a/tests/test_delegation_matrix.py
+++ b/tests/test_delegation_matrix.py
@@ -1,0 +1,91 @@
+"""Validate the cross-agent delegation matrix file layout.
+
+Static test only — no CLI or model invocations. Verifies that:
+
+- All 48 source x target x action command/skill files exist at the documented paths.
+- `.gemini/settings.json` `skills.disabled` contains all 12 Codex-source delegation
+  skill names (preventing Gemini from loading them).
+- The matrix documentation page exists.
+
+See `docs/development/ai/cross-agent-delegation.md` and issue #550.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+AGENTS = ("claude", "codex", "gemini", "copilot")
+ACTIONS = ("plan", "implement", "review", "adversarial-review")
+
+
+def _cross_pairs() -> list[tuple[str, str]]:
+    """Yield (source, target) pairs where source != target."""
+    return [(s, t) for s in AGENTS for t in AGENTS if s != t]
+
+
+def _expected_path(source: str, target: str, action: str) -> Path:
+    """Map a (source, target, action) cell to its on-disk location."""
+    if source == "claude":
+        return REPO_ROOT / ".claude" / "commands" / target / f"{action}.md"
+    if source == "gemini":
+        return REPO_ROOT / ".gemini" / "commands" / target / f"{action}.toml"
+    if source == "copilot":
+        return REPO_ROOT / ".copilot" / "commands" / target / f"{action}.md"
+    if source == "codex":
+        return REPO_ROOT / ".agents" / "skills" / f"delegate-{target}-{action}" / "SKILL.md"
+    raise ValueError(f"unknown source agent: {source}")
+
+
+@pytest.mark.parametrize(("source", "target"), _cross_pairs())
+@pytest.mark.parametrize("action", ACTIONS)
+def test_delegation_file_exists(source: str, target: str, action: str) -> None:
+    """Every (source, target, action) cell has a corresponding file."""
+    path = _expected_path(source, target, action)
+    assert path.is_file(), f"missing delegation file: {path.relative_to(REPO_ROOT)}"
+
+
+def test_total_file_count() -> None:
+    """4 sources x 3 targets x 4 actions = 48 files."""
+    paths = [_expected_path(s, t, a) for s, t in _cross_pairs() for a in ACTIONS]
+    existing = [p for p in paths if p.is_file()]
+    assert len(existing) == 48, (
+        f"expected 48 delegation files, found {len(existing)}; "
+        f"missing: {[str(p.relative_to(REPO_ROOT)) for p in paths if p not in existing]}"
+    )
+
+
+def test_gemini_disabled_list_contains_delegation_skills() -> None:
+    """All 12 Codex-source delegation skill names are disabled in .gemini/settings.json.
+
+    Without this, Gemini auto-loads the skills from .agents/skills/ (its docs document
+    that path as cross-agent interop) and may mis-activate them. See
+    docs/development/ai/cross-agent-delegation.md → "Path conflict between Codex and Gemini".
+    """
+    settings_path = REPO_ROOT / ".gemini" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+    disabled = set(settings["skills"]["disabled"])
+
+    expected_skills = {
+        f"delegate-{target}-{action}"
+        for target in AGENTS
+        if target != "codex"
+        for action in ACTIONS
+    }
+    assert len(expected_skills) == 12
+
+    missing = expected_skills - disabled
+    assert not missing, (
+        f"the following delegation skills must be added to "
+        f".gemini/settings.json skills.disabled: {sorted(missing)}"
+    )
+
+
+def test_matrix_doc_exists() -> None:
+    """The cross-agent delegation doc page exists."""
+    doc = REPO_ROOT / "docs" / "development" / "ai" / "cross-agent-delegation.md"
+    assert doc.is_file(), f"missing matrix doc: {doc.relative_to(REPO_ROOT)}"


### PR DESCRIPTION
## Description

Ports the cross-agent delegation matrix from upstream [pyproject-template PR #551](https://github.com/endavis/pyproject-template/pull/551). Establishes a `<target>:<action>` matrix so any source agent (Claude, Gemini, Copilot, Codex) can delegate `plan`, `implement`, `review`, or `adversarial-review` to any of the other three.

### What ships

**48 new bridge files** — every source-CLI × target-CLI × action cell (4 sources × 3 targets × 4 actions = 48):

| Source CLI | Path pattern | Format | Count |
| :--- | :--- | :--- | :--- |
| Claude | `.claude/commands/{codex,copilot,gemini}/<action>.md` | `.md` | 12 |
| Copilot | `.copilot/commands/{claude,codex,gemini}/<action>.md` | `.md` | 12 |
| Gemini | `.gemini/commands/{claude,codex,copilot}/<action>.toml` | `.toml` | 12 |
| Codex | `.agents/skills/delegate-{claude,copilot,gemini}-<action>/SKILL.md` | `SKILL.md` | 12 |

Where `<action>` ∈ {`plan`, `implement`, `review`, `adversarial-review`}.

**Per-host invocation:**

```text
# Claude Code / Gemini CLI / Copilot CLI:
/<target>:<action> [args]      # e.g. /codex:plan 42, /gemini:adversarial-review

# Codex CLI (skills, not slash commands):
$delegate-<target>-<action> [args]  # e.g. $delegate-claude-implement 42
```

**New supporting files:**
- `docs/development/ai/cross-agent-delegation.md` (new) — full design doc: convention, file layout, prefix mapping (`/foo` vs `$foo` for Codex), Hybrid C runtime behavior, and the `.agents/skills/` ↔ Gemini conflict mitigation.
- `tests/test_delegation_matrix.py` (new) — 51 tests verifying every cell of the matrix ships the expected bridge file in the expected format.

**Modified:**
- `.gemini/settings.json` — new `skills.disabled` block with 12 `delegate-*` entries so Gemini's built-in delegate skills don't conflict with the new TOML bridges. Notably this is the *first* time we add a `skills.disabled` block; C.3's `restore`/`checkpoint`/`ghissue-*` entries will join it when we fold C.3 into C.5.
- `AGENTS.md` — cross-agent delegation matrix paragraph appended after the AI Config Directories table.
- `docs/development/ai/slash-commands.md` — new "Cross-agent delegation matrix" section + see-also link.

### Notable decisions and deferrals

- **TOML format makes its first appearance under `.gemini/commands/`** (in the new bridge subdirs). Existing top-level `.gemini/commands/*.md` files stay as `.md` for now; C.5 will convert them.
- **`docs/development/AI_SETUP.md` updates from #551 deferred to C.5.** Upstream's hunks edit the agent comparison table to reference `ghissue-*` command names we don't have. C.5 (#564/#565) renames them to `ghi-*` anyway, so this PR doesn't touch them.
- **`docs/TABLE_OF_CONTENTS.md` update skipped** — file is in our divergences skip-list.
- **Bridges are already loaded in the active Claude Code session.** Skills like `codex:plan`, `gemini:implement`, `copilot:adversarial-review` now appear in the available-skills list (we noticed during implementation).

## Related Issue

Addresses #823

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

| Category | Count | Notes |
| :--- | :--- | :--- |
| New `.agents/skills/delegate-*/SKILL.md` | 12 | Codex bridges |
| New `.claude/commands/<target>/*.md` | 12 | Claude bridges |
| New `.copilot/commands/<target>/*.md` | 12 | Copilot bridges |
| New `.gemini/commands/<target>/*.toml` | 12 | Gemini bridges (TOML) |
| New `docs/development/ai/cross-agent-delegation.md` | 1 | Design doc |
| New `tests/test_delegation_matrix.py` | 1 | 51 tests |
| Modified `.gemini/settings.json` | 1 | skills.disabled block |
| Modified `AGENTS.md` | 1 | Matrix paragraph |
| Modified `docs/development/ai/slash-commands.md` | 1 | New section + see-also |

53 files total, 1235 insertions.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally; 51/51 delegation matrix tests pass. Bridge skills loaded successfully in the active Claude Code session during implementation.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release)
- [x] My changes generate no new warnings

## Scope

Phase C.4 of the pyproject-template sync (#823). Phase C.5a (upstream endavis/pyproject-template#563 — `/multi-*` orchestrators + folded-in C.3 pieces) follows next.
