### PR TITLE
chore: sync per-platform extract_binaries + uv-lock-check pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,6 +191,24 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # Validate uv.lock is in sync with pyproject.toml when pyproject.toml is staged
+      - id: uv-lock-check
+        name: Validate uv.lock matches pyproject.toml
+        entry: |
+          bash -c '
+          uv lock --check || {
+            echo ""
+            echo "❌ ERROR: uv.lock is out of sync with pyproject.toml"
+            echo ""
+            echo "Run: uv lock"
+            echo "Then re-stage: git add uv.lock"
+            exit 1
+          }'
+        language: system
+        pass_filenames: false
+        files: ^pyproject\.toml$
+        stages: [pre-commit]
+
       # Auto-sync dependencies when uv.lock changes after git pull
       - id: uv-sync-on-pull
         name: Auto uv sync after pull (lock changed)

--- a/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
+++ b/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
@@ -18,6 +18,7 @@ Ensures bad code never enters the repository, provides fast feedback loop (secon
 - Issue #128: Align pre-commit, CI, and doit check to use consistent checks
 - Issue #19: Fix resolve pre-commit hook failures in template files
 - Issue #415: Add actionlint hook for GitHub Actions workflow validation
+- Issue #556: Validate uv.lock consistency on pyproject.toml changes
 
 ## Related Documentation
 

--- a/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
+++ b/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
@@ -14,6 +14,8 @@ Extend `tools/doit/install_tools.py` with three orthogonal capabilities while pr
 
 Supporting refactors: a private `_get_arch()` helper that maps `platform.machine()` to amd64/arm64 (passthrough for unknowns), and a private `_build_github_release_url()` so the binary path and the new archive path share URL construction.
 
+`extract_binaries` also accepts an optional per-platform `dict[str, list[str]]` keyed by `platform.system().lower()` (same convention as `asset_patterns`), for tools whose archive members differ per OS (e.g., `.exe` suffix on Windows).
+
 ## Rationale
 
 Downstream consumers (e.g., InfraFoundry) need to install five tools, but only direnv-style single binaries from GitHub releases work today. age and sops ship as multi-binary tar.gz archives; terraform and opentofu ship from non-GitHub URLs. Without these extensions every downstream consumer reinvents download/extract code with inconsistent (often missing) security handling.
@@ -41,6 +43,7 @@ The three capabilities are intentionally orthogonal so simple cases stay simple 
 ## Related Issues
 
 - Issue #326: install_tools framework: archive extraction and custom URLs
+- Issue #477: support per-platform `extract_binaries` in install_tool framework
 
 ## Related Documentation
 

--- a/tools/doit/install_tools.py
+++ b/tools/doit/install_tools.py
@@ -219,7 +219,7 @@ def install_tool(
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
-    extract_binaries: list[str] | None = None,
+    extract_binaries: list[str] | dict[str, list[str]] | None = None,
     url_template: str | None = None,
     prefer_brew: bool = True,
 ) -> None:
@@ -242,6 +242,21 @@ def install_tool(
             a downloaded archive (e.g. ``["age", "age-keygen"]``). When set,
             the download is treated as an archive (`.tar.gz`/`.tgz`/`.zip`)
             and binaries are extracted into the install dir.
+
+            Also accepts a per-platform mapping using the same key
+            convention as ``asset_patterns`` (``platform.system().lower()``
+            values such as ``"linux"``, ``"darwin"``, ``"windows"``).
+            Use this when archive members differ per OS — for example,
+            when Windows builds add a ``.exe`` suffix::
+
+                extract_binaries={
+                    "linux": ["age", "age-keygen"],
+                    "darwin": ["age", "age-keygen"],
+                    "windows": ["age.exe", "age-keygen.exe"],
+                }
+
+            On a platform missing from the dict, the install aborts with
+            the same ``Unsupported OS`` error used for ``asset_patterns``.
         url_template: Optional download URL template with ``{version}``,
             ``{os}``, and ``{arch}`` placeholders. When set, this is used
             instead of building a GitHub release URL from ``asset_patterns``.
@@ -281,7 +296,14 @@ def install_tool(
             sys.exit(1)
 
         if extract_binaries:
-            download_and_extract_archive(url, extract_binaries, get_install_dir())
+            if isinstance(extract_binaries, dict):
+                if system not in extract_binaries:
+                    print(f"Unsupported OS for {name}: {system}")
+                    sys.exit(1)
+                resolved_binaries = extract_binaries[system]
+            else:
+                resolved_binaries = extract_binaries
+            download_and_extract_archive(url, resolved_binaries, get_install_dir())
         else:
             if url_template is not None:
                 install_dir = get_install_dir()
@@ -308,7 +330,7 @@ def create_install_task(
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
-    extract_binaries: list[str] | None = None,
+    extract_binaries: list[str] | dict[str, list[str]] | None = None,
     url_template: str | None = None,
     prefer_brew: bool = True,
 ) -> dict[str, Any]:
@@ -325,7 +347,10 @@ def create_install_task(
         version_cmd: Command list for version check. Defaults to [name, "--version"].
         post_install_message: Optional message printed after installation.
         extract_binaries: Optional list of binary basenames to extract from
-            a downloaded archive. See :func:`install_tool`.
+            a downloaded archive, or a per-platform mapping keyed by
+            ``platform.system().lower()`` (e.g. ``{"linux": ["age"],
+            "windows": ["age.exe"]}``) when archive members differ per OS.
+            See :func:`install_tool`.
         url_template: Optional download URL template with ``{version}``,
             ``{os}``, ``{arch}`` placeholders. See :func:`install_tool`.
         prefer_brew: Use brew on macOS when True (default). See


### PR DESCRIPTION
## Description

Phase D.3 of the [pyproject-template sync](https://github.com/endavis/infrafoundry/issues/823). Bundles two upstream PRs:

- **endavis/pyproject-template#506** — per-platform `extract_binaries` in the `install_tool` framework. Widens `extract_binaries` on `install_tool()` and `create_install_task()` from `list[str] | None` to `list[str] | dict[str, list[str]] | None`. When a dict is passed, the current `platform.system().lower()` value selects the binary list; missing-platform aborts with the same `Unsupported OS` error used for `asset_patterns`. Backward compatible — list-form callers (every existing InfraFoundry call site) keep working unchanged. Docstring extended with example. ADR-9015 updated with the new shape and Issue #477 link.
- **endavis/pyproject-template#557** — `uv-lock-check` pre-commit hook. Runs `uv lock --check` only when `pyproject.toml` is staged (`files: ^pyproject\.toml$`), with a clear remediation message on failure. ADR-9009 updated with Issue #556 link.

## Related Issue

Addresses #823

## Type of Change

- [x] Code refactoring (tooling sync — no behavior change to InfraFoundry's installer call sites; new opt-in dict form for `extract_binaries`).
- [x] Documentation update (ADR-9009, ADR-9015 issue-link append).

## Changes Made

- `tools/doit/install_tools.py` — widen `extract_binaries` type on `install_tool()` and `create_install_task()`; add per-platform branching at the dispatch site; extend docstring with example.
- `docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md` — append per-platform paragraph + Issue #477 link.
- `.pre-commit-config.yaml` — insert `uv-lock-check` hook between `protect-dynamic-version` and `uv-sync-on-pull`.
- `docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md` — append Issue #556 link.

## Hand-merge spot-checks (per `docs/development/pyproject-template-divergences.md` category 3)

- ✅ `tools/doit/install_tools.py` preserves `_install_age`, `_install_terraform`, `_install_opentofu`, `_install_ansible`, `_install_hashicorp_zip`, the `# nosec B605` from PR #837, and all `task_install_*` definitions.
- ✅ `.pre-commit-config.yaml` preserves every InfraFoundry hook (`check-branch-name`, `no-commit-to-main`, `no-local-config`, `protect-dynamic-version`, `generate-doc-toc`, `uv-sync-on-pull`, `uv-sync-on-checkout`).

## Skipped / deferred

- **`tests/template/test_doit_install_tools.py`** (3 new tests in upstream #506) — file does not exist locally; depends on the upstream `mock_subprocess` fixture tracked in #838. Will be ported when that issue lands.
- **`docs/development/install-tools-framework.md`** (29 LOC in upstream #506) — category-1 skip-list per `pyproject-template-divergences.md`.
- **`docs/development/{ci-cd-testing,doit-tasks-reference}.md`** hook-table row updates from upstream #557 — our local versions of these docs diverged earlier and don't contain the upstream pre-commit-hook listing tables. A follow-up doc-parity issue should track bringing those tables in (separate `docs:` PR per the divergences-doc update rule).

## Testing

- [x] `doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [x] `tools/doit/install_tools.py` typed signature change verified by mypy.
- [x] `.pre-commit-config.yaml` parses (covered by `check-yaml` hook in CI).
- [ ] No new tests added in this PR — test additions deferred per the note above.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (deferred to #838)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (ADRs)
- [ ] I have updated the CHANGELOG.md (n/a — sync-tracker PR; CHANGELOG updated at sync wrap-up)
- [x] My changes generate no new warnings
