### PR TITLE
chore: add Claude Code env-var defaults for token efficiency

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "env": {
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6"
+  },
   "statusLine": {
     "type": "command",
     "command": "bash $CLAUDE_PROJECT_DIR/.claude/statusline-command.sh"

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -163,6 +163,46 @@ claude
 
 For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` in the repository root.
 
+#### Environment Variables
+
+`.claude/settings.json` ships an `env` block with three Claude Code defaults aimed at token efficiency and session survival on long-running work. These propagate to downstream consumers via the template-sync mechanism, so all projects derived from this template inherit the same defaults.
+
+| Var | Value | Effect | Risk |
+| :--- | :--- | :--- | :--- |
+| `ENABLE_PROMPT_CACHING_1H` | `1` | Extends prompt cache TTL from 5 minutes to 1 hour. Cuts cost on repeated reads of the same context within a session. | None — pure efficiency flag. |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `50` | Auto-compaction triggers at 50% of the context window instead of the default (~92%). Sessions compact earlier, leaving more headroom for the post-compact continuation. | Mitigated by the PreCompact handoff hook (already enabled — see PR #828). |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | `claude-sonnet-4-6` | Subagents (e.g. those spawned by `/implement`) default to Sonnet 4.6 instead of inheriting the parent's Opus model. | Subagent output quality drops below Opus on hard reasoning tasks. Mitigate per-agent (see below). |
+
+**Per-agent model overrides:**
+
+`CLAUDE_CODE_SUBAGENT_MODEL` is a default. Any agent file under `.claude/agents/` that declares an explicit `model:` in its YAML frontmatter wins:
+
+```yaml
+---
+name: high-stakes-reviewer
+model: claude-opus-4-7   # overrides the env-var default for this agent only
+---
+```
+
+Agents without a `model:` line inherit the env-var default. This template's `.claude/agents/implement-worker.md` deliberately does not override — implement-worker runs on Sonnet 4.6 as an explicit cost/quality trade-off. Future high-stakes subagents (e.g. design review, security review) can opt into Opus on a per-file basis.
+
+**Per-developer overrides:**
+
+To opt out or tune values for your local environment, override them in `.claude/settings.local.json` (already gitignored, used elsewhere in this template for personal config). Example:
+
+```json
+{
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"
+  }
+}
+```
+
+**Cross-references:**
+
+- The 50% autocompact threshold is paired with the PreCompact handoff hook (`tools/hooks/ai/precompact-checkpoint.py`), which serializes session state on compaction so the post-compact continuation can rehydrate it. Both pieces are now active.
+<!-- TBD: link to add-ons walkthrough doc when Phase E.2 of pyproject-template sync (#823) lands the upstream walkthrough. -->
+
 ### 4. GitHub Copilot CLI
 
 **Configuration:** `.copilot/` directory


### PR DESCRIPTION
## Description

Phase D.4 of the [pyproject-template sync (#823)](https://github.com/endavis/infrafoundry/issues/823). Adopts upstream [endavis/pyproject-template#519](https://github.com/endavis/pyproject-template/pull/519): Claude Code env-var defaults for token efficiency.

Adds an `env` block to `.claude/settings.json` with three keys:

| Var | Value | Effect |
| :--- | :--- | :--- |
| `ENABLE_PROMPT_CACHING_1H` | `1` | Extends prompt cache TTL from 5 min to 1 hour. Pure efficiency, no behaviour change. |
| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `50` | Auto-compact triggers at 50% of the context window instead of ~92%. Pairs with the PreCompact handoff hook we already enabled in PR #828. |
| `CLAUDE_CODE_SUBAGENT_MODEL` | `claude-sonnet-4-6` | Subagents (`Agent` tool, including `implement-worker`) default to Sonnet 4.6 instead of inheriting Opus from the parent. Per-agent `model:` frontmatter still wins. Our only local agent (`implement-worker`) has no override — runs on Sonnet 4.6 as the explicit cost/quality trade-off documented upstream. |

Adds a `#### Environment Variables` subsection to `docs/development/AI_SETUP.md` covering the three vars, per-agent overrides, per-developer overrides via `.claude/settings.local.json`, and cross-references.

## Related Issue

Addresses #823

## Type of Change

- [x] Documentation update.
- [x] Configuration / project-defaults change (no code path affected; behavior change is via Claude Code reading the new env vars).

## Changes Made

- `.claude/settings.json` — top-level `env` block (5 lines) inserted before `statusLine`.
- `docs/development/AI_SETUP.md` — new `#### Environment Variables` subsection in Section 3 (Claude Code), inserted between the LSP setup pointer and `### 4. GitHub Copilot CLI`.

## Hand-merge spot-check (per `docs/development/pyproject-template-divergences.md` category 3)

- ✅ `.claude/settings.json` preserves all five hook configs (`PreToolUse: Bash` → `block-dangerous-commands` + `bash-ban-raw-tools`; `PostToolUse: Edit|Write|MultiEdit` → `ruff-fix-on-edit`; `PreCompact` → `precompact-checkpoint`; `SessionStart: compact|resume` → `session-resume-restore`) and the `statusLine`.

## Local divergence from upstream text

The upstream subsection cross-references bare `#513` (the upstream PreCompact hook tracker) and `#514` (the upstream add-ons walkthrough). Bare `#NNN` in our markdown would auto-link to InfraFoundry's unrelated local PRs (`#513` is aiqum blueprint refactor; `#514` is k3s blueprint refactor). Two edits to keep the doc accurate:

- The PreCompact reference now points to **PR #828** (where we shipped the hook locally during Phase B) plus a sentence describing what `precompact-checkpoint.py` does. Truthful and unambiguous.
- The TBD-link comment for #514 now points at **Phase E.2 of #823** as the placeholder context, so a future reader knows what will fill it in.

## Skipped / deferred

None. Both upstream files are adopted in full.

## Behavior changes after merge

- Subagents (the `Agent` tool, including `implement-worker`) default to **Sonnet 4.6** instead of Opus 4.7 — significant cost reduction with documented per-agent escape hatch.
- Auto-compaction fires at 50% of the context window — earlier compaction, more headroom for the post-compact continuation, paired with the PreCompact handoff hook (PR #828).
- Prompt cache TTL extends to 1h — pure cost win.

## Testing

- [x] `doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [x] `.claude/settings.json` parses as valid JSON (covered by `check-yaml`/`check-json` in pre-commit and CI).
- [ ] No new tests added — config + markdown only; nothing pytest-testable.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective — N/A: config + markdown only.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (n/a — sync-tracker PR; CHANGELOG updated at sync wrap-up)
- [x] My changes generate no new warnings
