### PR TITLE
docs: clarify GitHub App vs PAT setup and credential scope in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -473,7 +473,44 @@ protection rules cover tag pushes, configure a bypass for the tagging step.
 The release PR itself is reviewed and merged through the normal PR flow, so
 no bypass is required for the commit and changelog changes.
 
-#### Organization Repositories: GitHub App (Recommended)
+#### Which path should I use?
+
+The two paths below are not "personal vs. organization" — a GitHub App
+works just as well on a personal account. The real distinction is **where
+your release runs from** and **whether you want full dependabot
+auto-merge automation**:
+
+| Use case | Recommended |
+| :--- | :--- |
+| CI-driven releases (workflow publishes from GitHub Actions) | **GitHub App** |
+| Dependabot auto-merge end-to-end automation | **GitHub App** (required) |
+| Org policy disallows PATs | **GitHub App** |
+| Solo / hobby repo, releasing only from your laptop, no CI release | **Fine-grained PAT** |
+
+> [!IMPORTANT]
+> The dependabot auto-merge workflow at
+> `.github/workflows/dependabot-automerge.yml` **requires a GitHub App**. A
+> PAT does not substitute, because the workflow needs the bot's `labeled`
+> event to trigger the Merge Gate — see
+> [Dependabot Auto-merge → Required GitHub App configuration](../docs/development/dependabot-automerge.md#required-github-app-configuration).
+
+#### Recommended: GitHub App
+
+A dedicated GitHub App is the modern, audit-friendly identity for release
+automation. It works for both personal-account repositories and
+organization repositories. Use this path if you want:
+
+- The dependabot auto-merge workflow to be fully automated end-to-end
+- A clean bot identity in the audit log instead of human attribution
+- Automatic short-lived token rotation (no manual PAT renewals)
+- A bypass-listed actor for any CI-driven tag-push flow you add later
+
+> [!NOTE]
+> The publish workflow at `.github/workflows/release.yml` uses **PyPI
+> trusted publishing (OIDC)** and the built-in `GITHUB_TOKEN`. It does not
+> consume `RELEASE_APP_ID` or `RELEASE_APP_PRIVATE_KEY`. Those credentials
+> exist for the dependabot auto-merge workflow and for any CI-driven
+> tag-push extension you might add — see step 5 below.
 
 Create a dedicated GitHub App that can bypass branch protection:
 
@@ -509,14 +546,39 @@ Create a dedicated GitHub App that can bypass branch protection:
 3. Select your release app from the list
 4. Save the ruleset
 
-**4. Store Secrets:**
+**4. Store Credentials at the Repository Scope:**
 
-In your repo **Settings** → **Secrets and variables** → **Actions**:
+In your repo **Settings** → **Secrets and variables** → **Actions** — store
+both at the **repository** scope, not in an environment:
 
-- Add **Secret:** `RELEASE_APP_PRIVATE_KEY` = contents of the `.pem` file
-- Add **Variable:** `RELEASE_APP_ID` = the App ID from step 1
+- **Secrets** tab → **New repository secret:**
+  `RELEASE_APP_PRIVATE_KEY` = contents of the `.pem` file
+- **Variables** tab → **New repository variable:**
+  `RELEASE_APP_ID` = the App ID from step 1
 
-**5. Update Workflows (if using CI-based releases):**
+> [!WARNING]
+> Use the repository scope, not an environment scope. The `enable-automerge`
+> job in `.github/workflows/dependabot-automerge.yml` does not declare an
+> `environment:`, so `${{ vars.RELEASE_APP_ID }}` and
+> `${{ secrets.RELEASE_APP_PRIVATE_KEY }}` only resolve at the repository (or
+> organization) scope. Storing either as an environment secret/variable makes
+> them silently resolve to an empty string at runtime — the workflow's
+> `if: vars.RELEASE_APP_ID != ''` guard fails closed and the label is applied
+> with `GITHUB_TOKEN`, which leaves the Merge Gate's `require-label` check
+> stuck at `FAILURE`.
+
+**5. Optional: CI-Driven Tag-Push Flow (not used by this template's `release.yml`):**
+
+This template's `release.yml` is triggered by a tag push that the
+maintainer makes locally with `doit release_tag`, and the publish step
+itself uses OIDC + `GITHUB_TOKEN` — so no App credentials are consumed by
+the workflow as shipped.
+
+If you later add a CI-driven flow that needs to push commits or tags from
+inside Actions (for example, a `workflow_dispatch` job that runs `cz
+bump`, commits the changelog, and pushes the tag), mint an App
+installation token and check out with it so the push uses the App's
+identity:
 
 ```yaml
 - name: Generate release token
@@ -533,9 +595,21 @@ In your repo **Settings** → **Secrets and variables** → **Actions**:
     fetch-depth: 0
 ```
 
-#### Personal Repositories: Personal Access Token (PAT)
+Because the App is on the Ruleset bypass list (step 3), pushes signed by
+its installation token can land on `main` and on protected tag refs
+without rule violations.
 
-For personal (non-organization) repositories, use a fine-grained PAT:
+#### Alternative: Fine-Grained PAT (local-only releases)
+
+Use this path **only** if all of the following apply:
+
+- You release from a maintainer's laptop with `doit release_tag` (no CI)
+- You don't need the dependabot auto-merge workflow's full automation
+- You're comfortable rotating the PAT before its expiration
+
+For any other case, use the [GitHub App path](#recommended-github-app)
+above. CI-driven releases or dependabot auto-merge automation should not
+use a PAT.
 
 **1. Create a Fine-Grained PAT:**
 
@@ -561,22 +635,6 @@ git config --global credential.helper store
 
 # Option 2: Include token in remote URL (less secure)
 git remote set-url origin https://<token>@github.com/username/repo.git
-```
-
-**3. Store as Secret (for CI-based releases):**
-
-In your repo **Settings** → **Secrets and variables** → **Actions**:
-
-- Add **Secret:** `RELEASE_PAT` = your PAT
-
-**4. Update Workflows:**
-
-```yaml
-- name: Checkout with PAT
-  uses: actions/checkout@v4
-  with:
-    token: ${{ secrets.RELEASE_PAT }}
-    fetch-depth: 0
 ```
 
 ### Release Checklist


### PR DESCRIPTION
## Description

Phase E.1 of the [pyproject-template sync (#823)](https://github.com/endavis/infrafoundry/issues/823). Adopts upstream [endavis/pyproject-template#499](https://github.com/endavis/pyproject-template/pull/499): clarifies GitHub App vs PAT setup and credential scope in `CONTRIBUTING.md`.

Restructures the **Setting Up Release Permissions** section to fix three confusions in the previous copy:

1. The "personal vs. organization" framing was misleading — a GitHub App works equally well on a personal account. The real decision axis is *CI-driven vs local-only releases* and *whether you want full dependabot auto-merge automation*.
2. There was no guidance on credential storage scope — storing `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` at the **environment** scope (rather than at the repository scope) silently breaks the `enable-automerge` job.
3. Step 5 ("Update Workflows (if using CI-based releases)") implied the App credentials were required for CI releases, but `release.yml` uses PyPI OIDC + `GITHUB_TOKEN`. The App credentials are only consumed by the dependabot auto-merge workflow today.

## Related Issue

Addresses #823

## Type of Change

- [x] Documentation update.

## Changes Made

`.github/CONTRIBUTING.md` — restructured "Setting Up Release Permissions":

- New `#### Which path should I use?` subsection with a 4-row decision table and an `> [!IMPORTANT]` callout naming the dependabot-automerge workflow as the App-required case.
- Renamed `#### Organization Repositories: GitHub App (Recommended)` → `#### Recommended: GitHub App` with a "use this if you want…" bullet list and a `> [!NOTE]` callout clarifying that `release.yml` uses OIDC + `GITHUB_TOKEN`, not the App credentials.
- Step 4: `Store Secrets` → `Store Credentials at the Repository Scope` with a `> [!WARNING]` callout describing the silent empty-string env-scope failure mode (`if: vars.RELEASE_APP_ID != ''` fails closed → label applied with `GITHUB_TOKEN` → `require-label` stuck at FAILURE).
- Step 5: `Update Workflows (if using CI-based releases)` → `Optional: CI-Driven Tag-Push Flow (not used by this template's release.yml)` with two new context paragraphs and a closing paragraph about Ruleset bypass.
- Renamed `#### Personal Repositories: Personal Access Token (PAT)` → `#### Alternative: Fine-Grained PAT (local-only releases)` with an explicit "use this **only** if all of the following apply" gate.
- Removed obsolete `**3. Store as Secret (for CI-based releases):**` and `**4. Update Workflows:**` PAT-in-CI subsections (the App path supersedes these).

## Hand-merge spot-check (per `docs/development/pyproject-template-divergences.md` category 3)

- ✅ The "Setting Up Release Permissions" section was verbatim-identical to upstream pre-patch — no InfraFoundry-specific divergence to preserve here. The InfraFoundry-specific branching/commit/workflow content elsewhere in `CONTRIBUTING.md` is untouched.

## Skipped / deferred

- **`docs/development/dependabot-automerge.md`** 1-line anchor update from upstream #499 — file doesn't exist locally (category-1 skip-list per `pyproject-template-divergences.md`).

## Pre-existing cross-link to flag (not in scope to fix here)

Line 493 already pointed to `../docs/development/dependabot-automerge.md#required-github-app-configuration`, and the new `> [!IMPORTANT]` callout reinforces that pointer. Both target a file that's currently in our category-1 skip-list.

Two later options for handling this:

1. Drop `docs/development/dependabot-automerge.md` from the category-1 skip-list and adopt it (now that we actively run the dependabot-automerge workflow per Phase D.1).
2. Inline the necessary callouts directly in `CONTRIBUTING.md` and drop the cross-links.

Either way, that's a separate decision — out of scope for E.1.

## Testing

- [x] `doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [x] Diff stat (+82/-24) matches upstream patch exactly.
- [ ] No new tests added — documentation-only change.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective — N/A: documentation-only.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — this PR *is* the documentation update.
- [ ] I have updated the CHANGELOG.md (n/a — sync-tracker PR; CHANGELOG updated at sync wrap-up)
- [x] My changes generate no new warnings
