### PR TITLE
docs: add AI agent token-efficiency add-ons walkthrough and LSP guide

### DIFF
--- a/.claude/lsp-setup.md
+++ b/.claude/lsp-setup.md
@@ -1,208 +1,71 @@
-# Claude LSP Setup Guide
+# Claude LSP Setup
 
-This guide explains how to set up Language Server Protocol (LSP) support for Claude Code, enabling fast code navigation and intelligent code understanding.
+This project ships LSP support for Claude Code via the `pyright-lsp@claude-plugins-official` plugin. The LSP server (pyright) gives AI agents go-to-definition, find-references, hover, and workspace symbol search.
 
-## ⚠️ Known Issues
-
-**LSP requests currently hang and do not return responses.** The pyright language server starts successfully but does not respond to LSP protocol requests from Claude Code. This appears to be a bug in the Claude Code LSP integration (released December 2025) or the pyright-lsp plugin.
-
-- ✅ Pyright CLI works perfectly (tested and confirmed)
-- ✅ Configuration is correct and validated
-- ✅ Language server starts successfully
-- ❌ LSP requests hang indefinitely (e.g., `textDocument/definition`)
-
-**Status:** Configuration is ready for when this issue is resolved. For now, use traditional file reading/searching.
-
-If you find that LSP works for you, please report your setup!
-
-## What is LSP?
-
-LSP (Language Server Protocol) provides Claude with semantic code understanding:
-- **Jump to definitions** - Navigate directly to function/class definitions
-- **Find references** - See where symbols are used across the codebase
-- **Type information** - Get instant type hints and signatures
-- **Error detection** - See type errors and diagnostics
-
-With LSP, Claude can navigate code in ~50ms instead of ~45 seconds using traditional text search.
+This file covers **installation only**. For what the `LSP` tool actually exposes, where the noisy stale "errors" after edits come from, and the two opt-ins an agent can flip on itself, see [`docs/development/ai/lsp-tool.md`](../docs/development/ai/lsp-tool.md).
 
 ## Prerequisites
 
-- Claude Code version 2.0.74 or later
-- Python 3.12+ environment
-- This project installed with dev dependencies
+- Claude Code 2.0.74 or later (LSP is enabled by default in 2.0.74+; older versions need `ENABLE_LSP_TOOL=1`)
+- Python 3.12+
+- This project installed with dev dependencies (`uv sync`) — pyright comes in via the dev group
 
-## Installation Steps
+## Install Steps
 
-### 1. Enable LSP Tool
+### 1. Install the plugin
 
-**Option A: Using .envrc.local (Recommended)**
-
-This project uses direnv for environment management:
-
-```bash
-# Copy the example file if you haven't already
-cp .envrc.local.example .envrc.local
-
-# Uncomment the ENABLE_LSP_TOOL line in .envrc.local
-# Change: # export ENABLE_LSP_TOOL=1
-# To:     export ENABLE_LSP_TOOL=1
-
-# direnv will automatically load it when you cd into the project
-```
-
-**Option B: Global Shell Profile**
-
-Alternatively, add this to your shell profile (`~/.bashrc`, `~/.zshrc`, or `~/.profile`):
-
-```bash
-export ENABLE_LSP_TOOL=1
-```
-
-Then reload your shell:
-
-```bash
-source ~/.bashrc  # or ~/.zshrc
-```
-
-### 2. Install Pyright LSP Plugin
-
-In Claude Code, run:
+In Claude Code:
 
 ```
 /plugin install pyright-lsp@claude-plugins-official
 ```
 
-### 3. Install Pyright Language Server
+### 2. Confirm `pyright-langserver` is on PATH
 
-Choose one installation method:
-
-**Via pip (recommended for Python projects):**
-```bash
-pip install pyright
-```
-
-**Via npm:**
-```bash
-npm install -g pyright
-```
-
-**Via Homebrew (macOS):**
-```bash
-brew install pyright
-```
-
-### 4. Verify Installation
-
-Check that pyright is in your PATH:
+`uv sync` installs pyright into `.venv/bin/`. Verify:
 
 ```bash
-pyright --version
+uv run pyright --version
+# → pyright 1.1.x
 ```
 
-Expected output:
+If running outside `uv run`, make sure the venv is on PATH (this project uses direnv).
+
+### 3. (Optional, Claude Code < 2.0.74) Enable the LSP tool
+
+Older Claude Code releases gate the LSP tool behind an env var. Add to `.envrc.local`:
+
+```bash
+export ENABLE_LSP_TOOL=1
 ```
-pyright 1.1.x
-```
+
+Or your shell profile. **Skip this step on 2.0.74+** — the tool is enabled by default.
 
 ## Configuration
 
-This project is already configured for LSP via `pyproject.toml`:
+Already done — `[tool.pyright]` in `pyproject.toml` sets `include`, `exclude`, `pythonVersion`, and the venv path. No additional setup needed.
 
-```toml
-[tool.pyright]
-include = ["src", "tests", "*.py", "tools", ".github"]
-exclude = ["**/__pycache__", "**/.venv", "**/tmp", ...]
-pythonVersion = "3.12"
-typeCheckingMode = "basic"
+## Verifying It Works
+
+Ask an agent to use the `LSP` tool against a known symbol:
+
+```
+Use the LSP tool's goToDefinition on the `greet` symbol in src/.
 ```
 
-No additional configuration needed!
-
-## Testing LSP
-
-Ask Claude to test LSP functionality:
-
-1. **Jump to definition:**
-   ```
-   Jump to the definition of the greet function
-   ```
-
-2. **Find references:**
-   ```
-   Find all references to the __version__ variable
-   ```
-
-3. **Type information:**
-   ```
-   What's the return type of the greet function?
-   ```
-
-If LSP is working, Claude will provide instant, accurate responses with file paths and line numbers.
+A working setup returns the file path and line number near-instantly. A broken setup falls back to `Grep`.
 
 ## Troubleshooting
 
-### "No LSP server available"
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `No LSP server available` | `pyright-langserver` not on PATH | `uv sync`; or `pip install pyright`; or `npm install -g pyright` |
+| `Executable not found in $PATH` | Plugin installed but binary missing | Same as above |
+| Plugin not loading at all | Plugin not installed at user scope | `/plugin install pyright-lsp@claude-plugins-official` then restart Claude Code |
+| Noisy or stale "errors" after every edit | Pyright diagnostic side-channel staleness — working as designed | See [`docs/development/ai/lsp-tool.md`](../docs/development/ai/lsp-tool.md) for the two documented opt-ins |
 
-**Cause:** Pyright binary not found in PATH
+## Related
 
-**Solution:**
-```bash
-# Check if pyright is installed
-which pyright
-
-# If not found, install it
-pip install pyright
-```
-
-### "Executable not found in $PATH"
-
-**Cause:** Pyright language server not installed
-
-**Solution:** Follow step 3 above to install the pyright binary
-
-### LSP not responding
-
-**Cause:** Plugin not installed or ENABLE_LSP_TOOL not set
-
-**Solution:**
-1. Verify environment variable: `echo $ENABLE_LSP_TOOL` (should output "1")
-2. Reinstall plugin: `/plugin install pyright-lsp@claude-plugins-official`
-3. Restart Claude Code
-
-### "pyright-langserver not found"
-
-**Cause:** Some installations use different binary names
-
-**Solution:**
-```bash
-# If installed via npm, it might be:
-which pyright-langserver
-
-# Or try reinstalling via pip
-pip install --force-reinstall pyright
-```
-
-## Performance Benefits
-
-Without LSP:
-- Code navigation: ~45 seconds (requires reading multiple files)
-- High token usage for exploration
-
-With LSP:
-- Code navigation: ~50ms (direct symbol lookup)
-- Minimal token usage for navigation
-- Better type understanding
-- Faster development iterations
-
-## Related Documentation
-
-- [AI_SETUP.md](../docs/development/AI_SETUP.md) - Complete AI development setup
+- [LSP Tool and Diagnostic Noise](../docs/development/ai/lsp-tool.md) — what agents see, why diagnostics arrive stale, and how to opt out
+- [AI Setup](../docs/development/AI_SETUP.md) — broader AI agent setup for this template
 - [Pyright Documentation](https://microsoft.github.io/pyright/)
-- [Claude Code Plugin Docs](https://code.claude.com/docs/en/discover-plugins)
-
-## Need Help?
-
-If you encounter issues:
-1. Check the troubleshooting section above
-2. Verify all prerequisites are met
-3. Open an issue at: https://github.com/username/package_name/issues

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -201,7 +201,7 @@ To opt out or tune values for your local environment, override them in `.claude/
 **Cross-references:**
 
 - The 50% autocompact threshold is paired with the PreCompact handoff hook (`tools/hooks/ai/precompact-checkpoint.py`), which serializes session state on compaction so the post-compact continuation can rehydrate it. Both pieces are now active.
-<!-- TBD: link to add-ons walkthrough doc when Phase E.2 of pyproject-template sync (#823) lands the upstream walkthrough. -->
+- For operators who need more aggressive token reduction, see [AI Agent Token-Efficiency Add-Ons](ai/token-efficiency-add-ons.md) — a catalogue of opt-in external tools (RTK, Headroom, Caveman) with tipping-point guidance and trust caveats.
 
 ### 4. GitHub Copilot CLI
 

--- a/docs/development/ai/lsp-tool.md
+++ b/docs/development/ai/lsp-tool.md
@@ -1,0 +1,116 @@
+---
+title: LSP Tool and Diagnostic Noise
+description: What the LSP tool gives an AI agent, why pyright diagnostics arrive stale, and the two opt-outs agents can flip on themselves
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - lsp
+  - pyright
+---
+
+# LSP Tool and Diagnostic Noise
+
+Claude Code (v2.0.74+) ships an `LSP` tool backed by the `pyright-lsp@claude-plugins-official` plugin. The tool itself is a navigation aid; the plugin layered on top of it is also responsible for a *separate* side channel that auto-injects pyright diagnostics into conversation context after edits. The two flows have very different cost profiles, and conflating them is what produces the "agent keeps chasing errors that aren't really errors" pattern.
+
+## What the `LSP` Tool Actually Exposes
+
+The `LSP` tool surfaces nine operations. **None of them return diagnostics.**
+
+| Operation | Use |
+|---|---|
+| `goToDefinition` | Jump to the file/line where a symbol is defined |
+| `findReferences` | Find every reference to a symbol across the workspace |
+| `hover` | Get the type signature and docstring at a position |
+| `documentSymbol` | List every symbol declared in a file |
+| `workspaceSymbol` | Search the entire workspace by symbol name |
+| `goToImplementation` | Jump from an interface/abstract member to its implementations |
+| `prepareCallHierarchy` | Anchor a call-hierarchy query at a position |
+| `incomingCalls` | List functions that call the anchored target |
+| `outgoingCalls` | List functions called by the anchored target |
+
+Every one of these answers from pyright's symbol index in milliseconds. The index is updated lazily but always responds with whatever it currently has. **Navigation is not where the slowness comes from.**
+
+## Where the Slow / Stale Errors Come From
+
+Diagnostics (type errors, lint warnings) are *not* an `LSP` tool operation. They reach the model through a separate side channel: the pyright-lsp plugin pushes pyright's `publishDiagnostics` output into conversation context after `Edit`/`Write` tool calls. This is the source of the noise:
+
+- **Stale diagnostics** — pyright re-analyzes the file (and its dependents) after every change. On a non-trivial graph this takes 1–4 seconds. The diagnostic snapshot is taken before re-analysis settles, so the model sees errors against line numbers that no longer exist or symbols that were just renamed. Tracked upstream as [anthropics/claude-code#17979](https://github.com/anthropics/claude-code/issues/17979) and [#21297](https://github.com/anthropics/claude-code/issues/21297).
+- **Hint-level noise promoted to errors** — pyright emits `DiagnosticTag.Unnecessary` (e.g., a never-used parameter) at *hint* severity. The plugin currently surfaces these as if they were diagnostics worth acting on. Tracked as [anthropics/claude-code#26634](https://github.com/anthropics/claude-code/issues/26634).
+
+mypy via `doit check` is the authoritative type checker for this repo. Pyright's role is purely to back the LSP tool — its diagnostics are advisory, and they are cheap to ignore by default.
+
+## Default Stance
+
+LSP stays on. The navigation operations are valuable, and the diagnostic noise is something an agent can tune out once it knows the shape of the problem (symptom: errors against line numbers that don't match the just-edited file; cure: re-read the file or run `doit check` rather than chase the diagnostic).
+
+If an agent (or the human running it) wants to silence the noise more aggressively, two opt-outs are below. Pick one or the other — running both is redundant.
+
+## Opt-Out A: Make Diagnostics Wait Until Pyright Catches Up
+
+Add a `PostToolUse` sleep hook to `.claude/settings.local.json` (gitignored, per-clone):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sleep 3",
+            "statusMessage": "Letting pyright catch up to prevent stale diagnostics"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+| | |
+|---|---|
+| **What it does** | Delays the next tool call by 3 seconds, giving pyright time to settle before the diagnostic snapshot fires. |
+| **Keeps diagnostics?** | Yes — the goal is fresher diagnostics, not fewer. |
+| **Cost** | ~3 s of pure wait per `Edit`/`Write`/`MultiEdit`. A 30-edit session pays ~90 s of dead time. |
+| **Caveats** | 1 s is often not enough on real codebases; 3 s is a safer floor but still won't survive a cold cache or a large refactor. The hook fires on every edit regardless of whether diagnostics would have been stale. Whether Claude Code reads diagnostics synchronously with PostToolUse return is undocumented — the hook is a community-known workaround, not a guaranteed fix. |
+| **Pick this when** | You actively use pyright's diagnostics and just want them to be correct. |
+
+## Opt-Out B: Turn Off Pyright Diagnostics Entirely
+
+Edit `pyproject.toml`:
+
+```toml
+[tool.pyright]
+typeCheckingMode = "off"   # was "basic"
+```
+
+| | |
+|---|---|
+| **What it does** | Pyright still indexes the workspace (so navigation works) but emits no type-check diagnostics, so there is nothing for the side channel to push into context. |
+| **Keeps diagnostics?** | No — pyright's diagnostics go silent. mypy via `doit check` remains authoritative. |
+| **Cost** | Zero runtime overhead. |
+| **Caveats** | You lose pyright's interactive view of type errors. If you were using pyright as a second opinion against mypy, you'd lose that signal until you flip it back. |
+| **Pick this when** | mypy via `doit check` is already your source of truth and pyright's running commentary is noise you'd rather not have. |
+
+## Future Direction
+
+Both [pyrefly (Meta)](https://pyrefly.org/) and [ty (Astral)](https://astral.sh/blog/ty) ship full LSP implementations backed by Rust analyzers, with re-analysis times measured in milliseconds rather than seconds. Either would collapse the staleness window enough that neither opt-out above would be necessary. Both are still beta as of May 2026; pyrefly is further along on Python typing conformance, ty is closer aligned with this repo's `uv`/`ruff` toolchain.
+
+A future migration would replace the `pyright-lsp@claude-plugins-official` plugin with a local plugin pointing `lspServers.<name>.command` at `pyrefly lsp` or `ty server`. No such plugin is in the official Claude Code marketplace yet; a local one is straightforward to author when the time is right.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`.claude/lsp-setup.md`](../../../.claude/lsp-setup.md) | Earlier pyright-lsp installation notes (now partially superseded — LSP requests no longer hang) |
+| [`pyproject.toml`](../../../pyproject.toml) | `[tool.pyright]` block; flip `typeCheckingMode` here for opt-out B |
+| `.claude/settings.local.json` | Per-clone Claude settings; wire opt-out A here |
+
+## Related
+
+- [Ruff Auto-Fix on Edit Hook](ruff-fix-hook.md) — sibling `PostToolUse` hook that runs ruff `--fix` on edited Python files
+- [AI Command Blocking](command-blocking.md) — `PreToolUse` hook reference
+- [AI Architectural Conventions](architectural-conventions.md)

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -1,0 +1,254 @@
+---
+title: AI Agent Token-Efficiency Add-Ons
+description: Opt-in catalogue of external tools for reducing token usage in Claude Code sessions
+audience:
+  - contributors
+  - ai-agents
+  - operators
+tags:
+  - ai
+  - token-efficiency
+  - add-ons
+---
+
+# AI Agent Token-Efficiency Add-Ons
+
+## Purpose
+
+This page is an **opt-in menu** for operators of larger downstream projects who hit token-cost or
+session-length pain points. The baseline defaults (env-var settings, autocompact threshold) are
+already on for everyone — see [AI Agent Setup: Environment Variables](../AI_SETUP.md#environment-variables).
+Add-ons here are additional investments: each has setup cost, operational burden, and in some cases
+a trust trade-off. Read the tipping-point guidance before adopting any of them.
+
+Most projects built on this template do not need these. The audience is operators running
+multi-hour sessions against large codebases where the baseline defaults are not enough.
+
+## When to consider an add-on
+
+Adopt an add-on when one or more of the following apply:
+
+- Sessions end in autocompact more than once per workday.
+- Shell command output (test runs, `find` output, diff blobs) dominates context billing.
+- AGENTS.md rules drift noticeably in long sessions — the agent ignores a documented rule late
+  in a conversation that it respected at the start.
+- You are running concurrent agents on a shared API key and token-rate costs are measurable.
+- You are working in a regulated environment and want auditable compression before tokens leave
+  the machine.
+
+## RTK (Rust Token Killer)
+
+**Repo:** [github.com/rtk-ai/rtk](https://github.com/rtk-ai/rtk)
+
+RTK is a shell-output compressor. It intercepts the stdout of commands you run through the
+Claude Code terminal, strips redundant whitespace and repeated lines, and injects a compact
+representation into the context instead of the raw output. It is written in Rust for low-overhead
+interception and ships as a standalone binary as well as bundled inside Headroom (see below).
+
+**Tipping-point:** adopt RTK when test-suite output, build logs, or `find`/`grep` results are a
+visible fraction of your context bills. If `pytest` output is 200 lines per run and you run tests
+frequently in a session, RTK compresses that cost significantly.
+
+**Per-CLI applicability:**
+
+| CLI | Works? |
+| :--- | :--- |
+| Claude Code | Yes |
+| Gemini CLI | Yes (shell interception is CLI-agnostic) |
+| GitHub Copilot CLI | Yes |
+| Codex CLI | Yes |
+
+**Install (standalone):**
+
+```bash
+# Install the Rust binary
+cargo install rtk
+
+# Wrap your shell session
+rtk -- bash
+```
+
+Once the shell is wrapped, every command Claude Code (or you) runs through the terminal has its
+output compressed automatically. No changes to `.claude/settings.local.json` are required.
+
+**Trust caveat:** RTK operates entirely on your machine and does not proxy the API — it rewrites
+the text that ends up in the context, but it never reads or forwards your API key. No significant
+trust concern beyond normal Rust binary installation hygiene.
+
+## Headroom
+
+**Repo:** [github.com/chopratejas/headroom](https://github.com/chopratejas/headroom)
+
+Headroom is a local proxy that sits between Claude Code and the Anthropic API. It intercepts
+outbound API requests and compresses conversation history, system prompts, `CLAUDE.md` content,
+and tool-call outputs **before they leave the machine**, reducing the token count sent upstream.
+It also ships RTK as a bundled dependency so you get both tools in one install.
+
+**Tipping-point:** adopt Headroom when context bills are high across the board — not just shell
+output but also system prompts and conversation history. It is the most aggressive compression
+option and gives you the broadest reduction.
+
+> **Trust caveat:** Headroom is a **MITM proxy** in your API path. All requests to the Anthropic
+> API, including your API key and full conversation content, pass through Headroom's local process.
+> **Read the source before adopting Headroom on shared or employer-owned codebases.** Confirm that
+> the binary you run matches the source at the tagged version and that no network forwarding is
+> configured. This is not a warning against Headroom itself — it is a standard due-diligence step
+> for any tool that sits in the API path.
+
+**Per-CLI applicability:**
+
+| CLI | Works? |
+| :--- | :--- |
+| Claude Code | Yes |
+| Gemini CLI | No (Gemini API endpoint differs; not tested) |
+| GitHub Copilot CLI | No (uses GitHub's Copilot endpoint, not Anthropic) |
+| Codex CLI | No (uses OpenAI endpoint) |
+
+**Install:**
+
+```bash
+# Install Headroom (bundles RTK)
+cargo install headroom
+
+# Start the local proxy (default port 8082)
+headroom proxy
+
+# Configure Claude Code to route through it
+```
+
+**`.claude/settings.local.json` snippet:**
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://localhost:8082"
+  }
+}
+```
+
+This is a **local-only** settings file (not committed). The
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var documented in
+[AI Agent Setup: Environment Variables](../AI_SETUP.md#environment-variables) continues to work alongside Headroom —
+Headroom compresses tokens in flight while autocompact still triggers at your configured threshold.
+
+## Caveman
+
+**Repo:** [github.com/JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)
+
+Caveman is a Claude Code plugin that injects terse-style instructions at `SessionStart` and on
+**every `UserPromptSubmit` event**. It tells the model to prefer brevity: shorter responses,
+minimal prose, table-first formatting. Because it fires every turn, injected style survives
+autocompact and context drift — the model is reminded on each prompt, not just at session start.
+
+**Tipping-point:** adopt Caveman when you observe that Claude's response verbosity increases over
+a long session, or when you want a consistent terse baseline across all sessions without relying
+on ad-hoc prompting.
+
+**Caveman is complementary to `AGENTS.md`, not a replacement.** `AGENTS.md` is rich
+project-specific content (workflows, architecture, tooling rules) that is auto-loaded once per
+session. Caveman injects narrow style instructions on every turn. They target different things.
+Stacking is reasonable — but read the intensity trade-off table below before choosing a level.
+
+### Intensity levels
+
+| Level | What it enforces | Risk with project rules |
+| :--- | :--- | :--- |
+| `lite` | Terse phrasing, concise bullet points | Low — plays well with AGENTS.md; prose in issue bodies and PR descriptions is unaffected |
+| `full` | Short answers, table-first, minimal explanation | Medium — may shorten ADR rationale, PR descriptions, commit messages below template minimums |
+| `ultra` | Extreme brevity, single-sentence answers | High — likely to conflict with rules requiring structured long-form artefacts (issue bodies, ADR decisions) |
+
+**Recommendation: start with `lite`.** It reduces verbosity in conversational turns without
+clashing with template rules that require structured prose in artefacts. Move to `full` only
+after confirming your workload does not produce artefacts that need to meet a length standard.
+
+**Per-CLI applicability:**
+
+| CLI | Works? |
+| :--- | :--- |
+| Claude Code | Yes (native plugin system) |
+| Gemini CLI | No |
+| GitHub Copilot CLI | No |
+| Codex CLI | No |
+
+**Install and enable:**
+
+Follow the installation steps in the Caveman repo. Once installed, enable it at `lite` intensity
+in your local Claude Code settings:
+
+**`.claude/settings.local.json` snippet:**
+
+```json
+{
+  "plugins": {
+    "caveman": {
+      "intensity": "lite"
+    }
+  }
+}
+```
+
+This is a **local-only** file (not committed). Do not commit Caveman plugin config — intensity
+preference varies by operator and can conflict with other contributors' expectations.
+
+## Session-survival of project rules
+
+This section documents the **pattern** that Caveman uses, so you can apply it to any narrow rule
+that needs to survive long sessions — not just terse style.
+
+### The two injection mechanisms
+
+Claude Code offers two ways to get instructions in front of the model:
+
+| | Auto-load (`CLAUDE.md` / `AGENTS.md`) | Per-turn injection (`UserPromptSubmit` hook) |
+| :--- | :--- | :--- |
+| Loaded | Once at session start | Every user message |
+| Survives autocompact / context drift | No | Yes |
+| Best for | Rich, project-specific content | Narrow rules that "the model knows but forgets" |
+
+**Auto-load** is how this template ships `AGENTS.md` — comprehensive project context loaded once
+per session. It works well for the bulk of project rules. **The failure mode is drift**: after an
+autocompact event, or deep in a long conversation, the model may stop honoring a specific rule
+even though `AGENTS.md` is still nominally in context.
+
+**Per-turn injection** fires on every `UserPromptSubmit` event. It adds a small amount of text to
+every message, but that text is always present, always current, and always wins against drift.
+Caveman uses this mechanism for terse style.
+
+### When to use this pattern yourself
+
+The `UserPromptSubmit` hook is a reusable technique. If you have a narrow rule that you observe
+the model forgetting mid-session, wrapping it in a `UserPromptSubmit` hook is often more reliable
+than repeating it in `AGENTS.md`. Good candidates:
+
+- A naming convention the model tends to ignore late in sessions.
+- A formatting rule for a specific artefact type.
+- A reminder to use `doit` instead of raw `git`/`gh` for a particular class of operation.
+
+The hook lives in `.claude/settings.json` (committed) or `.claude/settings.local.json`
+(local-only). Keep injected text short — per-turn injection costs tokens on every message, so
+verbosity here works against the goal.
+
+## Related primitives in this template
+
+These are not add-ons (they ship with the template) but they interact with the tools above:
+
+- **`/checkpoint` and `/restore`** — session-state preservation commands. When a session is
+  about to hit its context limit, `/checkpoint` writes a portable state file and `/restore`
+  reconstructs context in a new session. Complements all three add-ons above. See
+  [Slash Commands and Workflows](slash-commands.md).
+- **Env-var defaults** — `ENABLE_PROMPT_CACHING_1H`, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, and
+  `CLAUDE_CODE_SUBAGENT_MODEL` are already set via `.claude/settings.json`. Headroom and Caveman
+  layer on top of these defaults, not instead of them. See
+  [AI Agent Setup: Environment Variables](../AI_SETUP.md#environment-variables).
+- **PreCompact handoff hook** — `tools/hooks/ai/precompact-checkpoint.py` (shipped in PR #828).
+  Autocompact events serialize session state via the hook, so the post-compact continuation
+  rehydrates more context automatically — reducing the frequency of sessions that need
+  `/checkpoint` or Headroom.
+
+## Out of scope
+
+- No code is shipped here. All three tools are external; install them from their respective repos.
+- Equivalent add-ons for Gemini CLI, Codex CLI, and GitHub Copilot CLI. Most of these tools are
+  Claude Code-specific. If equivalents exist for other CLIs, that is a separate doc.
+- Shipping tool configuration in this template's committed files. All snippets above go into
+  `.claude/settings.local.json` (not committed) to keep individual operator preferences local.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,8 @@ nav:
         - Architectural Conventions: development/ai/architectural-conventions.md
         - Enforcement Principles: development/ai/enforcement-principles.md
         - Command Blocking: development/ai/command-blocking.md
+        - LSP Tool and Diagnostics: development/ai/lsp-tool.md
+        - Token-Efficiency Add-Ons: development/ai/token-efficiency-add-ons.md
         - Ruff-fix Hook: development/ai/ruff-fix-hook.md
         - Statusline: development/ai/statusline.md
     - pyproject-template Divergences: development/pyproject-template-divergences.md


### PR DESCRIPTION
## Description

Phase E.2 of the [pyproject-template sync (#823)](https://github.com/endavis/infrafoundry/issues/823). Bundles two upstream PRs:

- **endavis/pyproject-template#520** — token-efficiency add-ons walkthrough. New `docs/development/ai/token-efficiency-add-ons.md` covering RTK (shell-output compression), Headroom (MITM proxy), and Caveman (per-turn style injection). Tipping-point heuristics, per-CLI applicability, install snippets, trust caveats.
- **endavis/pyproject-template#567** — AI agent LSP guide. New `docs/development/ai/lsp-tool.md` documenting the nine `LSP` tool operations, the separate pyright diagnostic side channel, and two opt-outs. Plus `.claude/lsp-setup.md` upstream rewrite that replaces the stale "Known Issues: LSP requests currently hang" section.

## Related Issue

Addresses #823

## Type of Change

- [x] Documentation update.

## Changes Made

| File | Change |
|:--|:--|
| `docs/development/ai/token-efficiency-add-ons.md` (NEW) | Adopted from #520 with two local edits (see below). |
| `docs/development/ai/lsp-tool.md` (NEW) | Adopted verbatim from #567. |
| `docs/development/AI_SETUP.md` | Replaced D.4's TBD comment with the upstream cross-link. |
| `mkdocs.yml` | Inserted 2 nav entries under `AI:` block after `Command Blocking`. |
| `.claude/lsp-setup.md` | Adopted upstream rewrite (-170/+33) — replaces stale "LSP requests currently hang" claim with install-only content + cross-link to `lsp-tool.md`. |

## Local edits to upstream content

Two edits to `token-efficiency-add-ons.md`, both per #823 directive or local-reality fixes:

1. **One-sentence `cbm-session-reminder` mention removed** from the "Session-survival of project rules" section. The CBM and context-mode hook plumbing tracks separately in evaluation issue #824 and is excluded from this sync per the #823 skip-list policy.
2. **Cross-reference to upstream `#513`** (PreCompact handoff hook tracker) rewritten to point at our actual local hook `tools/hooks/ai/precompact-checkpoint.py` shipped via PR #828. Bare `#513` in our markdown would auto-link to InfraFoundry's unrelated PR #513 (aiqum blueprint refactor) — same fix pattern applied in D.4 (PR #842).

## Hand-merge spot-check (per `docs/development/pyproject-template-divergences.md` category 3)

- ✅ `mkdocs.yml` preserves the InfraFoundry nav tree (Providers, Runners, Configuration, etc.) — only inserting 2 lines inside the `AI:` subblock between existing entries.

## Skipped / deferred

- **`docs/TABLE_OF_CONTENTS.md`** (3-line additions from both upstream PRs) — category-1 skeleton TOC; mkdocs nav supersedes.

## Notes

- **`.claude/lsp-setup.md` is not in any divergences-doc category** — adopt-by-omission. Our local file had diverged from upstream's pre-rewrite version (added a "Known Issues: LSP requests hang" section, plus a `username/package_name/issues` template-placeholder link at the bottom). The upstream rewrite addresses both stale-content issues while making the file install-only — net cleanup. The upstream PR #567 body itself flagged the supersession; adopting the rewrite resolves it in one shot.

## Testing

- [x] `doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [ ] No new tests added — documentation-only change.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective — N/A: documentation-only.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — this PR *is* the documentation update.
- [ ] I have updated the CHANGELOG.md (n/a — sync-tracker PR; CHANGELOG updated at sync wrap-up)
- [x] My changes generate no new warnings
