### PR TITLE
chore: bump urllib3 to 2.7.0 to clear pip-audit CVEs

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3015,11 +3015,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Phase F.1 of the [pyproject-template sync (#823)](https://github.com/endavis/infrafoundry/issues/823). Adopts upstream [endavis/pyproject-template#577](https://github.com/endavis/pyproject-template/pull/577): bump `urllib3` from 2.6.3 to 2.7.0 to clear pip-audit CVEs.

Run via `uv lock --upgrade-package urllib3` — diff matches upstream's `uv.lock` change exactly (+3/-3, the 2.6.3 → 2.7.0 hashes).

## Related Issue

Addresses #823

Partially advances #839 (CVE bumps + add audit gate). The remaining 7 CVEs in that issue (cryptography, lxml, paramiko, pygments, pyjwt) and the audit-gating work still need to be done in #839's eventual PR.

## Type of Change

- [x] Bug fix (security: clears the urllib3 CVE).

## Changes Made

- `uv.lock` — `urllib3` 2.6.3 → 2.7.0 (sdist + wheel hashes updated).

## Testing

- [x] `doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [ ] No new tests added — dependency-bump only.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective — N/A: dependency bump.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — n/a.
- [ ] I have updated the CHANGELOG.md (n/a — sync-tracker PR; CHANGELOG updated at sync wrap-up)
- [x] My changes generate no new warnings
