### PR TITLE
refactor: remove piped-truncator block from bash-ban-raw-tools hook

### DIFF
--- a/tests/test_bash_ban_raw_tools.py
+++ b/tests/test_bash_ban_raw_tools.py
@@ -109,6 +109,26 @@ def test_banned_word_as_non_leading_non_pipe_token_is_allowed(
     assert exc_info.value.code == 0
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls | head",
+        "ls | tail -100",
+        "cmd | head -n 5",
+    ],
+)
+def test_piped_truncator_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Piped truncators (``... | head``, ``... | tail``) are allowed — no native replacement."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
 # ---------------------------------------------------------------------------
 # Block: banned leading commands
 # ---------------------------------------------------------------------------
@@ -132,31 +152,6 @@ def test_banned_leading_command_exits_2(
     command: str,
 ) -> None:
     """Each banned leading command is blocked with exit code 2."""
-    _set_stdin(monkeypatch, _bash_payload(command))
-    with pytest.raises(SystemExit) as exc_info:
-        sys.exit(hook.main())
-    assert exc_info.value.code == 2
-
-
-# ---------------------------------------------------------------------------
-# Block: piped truncators
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "ls | head",
-        "ls | tail -100",
-        "cmd | head -n 5",
-    ],
-)
-def test_piped_truncator_exits_2(
-    hook: types.ModuleType,
-    monkeypatch: pytest.MonkeyPatch,
-    command: str,
-) -> None:
-    """Piped truncators (``... | head``, ``... | tail``) are blocked with exit code 2."""
     _set_stdin(monkeypatch, _bash_payload(command))
     with pytest.raises(SystemExit) as exc_info:
         sys.exit(hook.main())

--- a/tools/hooks/ai/bash-ban-raw-tools.py
+++ b/tools/hooks/ai/bash-ban-raw-tools.py
@@ -7,7 +7,6 @@ should be using native file tools for instead (Read, Grep, Glob, Edit, Write).
 
 Blocks:
   - Leading banned commands: cat, head, tail, find, grep, rg, wc
-  - Piped truncators: ... | head, ... | tail (regardless of args)
 
 Escape hatch:
   Touch /tmp/bash-raw-unlock (or the configured UNLOCK_FILE) to allow banned
@@ -31,9 +30,6 @@ from pathlib import Path
 
 # Commands that AI agents should never use via Bash when native tools are available
 BANNED_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "find", "grep", "rg", "wc"})
-
-# Commands that are banned when they appear after a pipe (regardless of arguments)
-PIPE_TRUNCATORS: frozenset[str] = frozenset({"head", "tail"})
 
 # Escape hatch: touch this file to allow banned commands for UNLOCK_WINDOW_SECONDS
 UNLOCK_FILE: str = "/tmp/bash-raw-unlock"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
@@ -86,18 +82,6 @@ def find_banned_leading(tokens: list[str]) -> str | None:
     return None
 
 
-def find_banned_pipe(tokens: list[str]) -> str | None:
-    """
-    Scan for a pipe token immediately followed by a PIPE_TRUNCATOR.
-
-    Returns the truncator name if found, else None.
-    """
-    for i, token in enumerate(tokens):
-        if token == "|" and i + 1 < len(tokens) and tokens[i + 1] in PIPE_TRUNCATORS:  # nosec B105 - "|" is the shell pipe character, not a credential.
-            return tokens[i + 1]
-    return None
-
-
 def _build_reason(offending: str) -> str:
     """Build a human-readable block reason for the given offending command."""
     suggestion = _SUGGESTIONS.get(offending, "a native tool")
@@ -139,12 +123,6 @@ def main() -> int:
 
     # Check for banned leading command
     offending = find_banned_leading(tokens)
-    if offending is not None:
-        print(_build_reason(offending), file=sys.stderr)
-        return 2
-
-    # Check for banned pipe-truncator
-    offending = find_banned_pipe(tokens)
     if offending is not None:
         print(_build_reason(offending), file=sys.stderr)
         return 2


### PR DESCRIPTION
## Description

Phase F.2 of the [pyproject-template sync (#823)](https://github.com/endavis/infrafoundry/issues/823). Adopts upstream [endavis/pyproject-template#579](https://github.com/endavis/pyproject-template/pull/579): removes the piped-truncator block from the `bash-ban-raw-tools` hook.

The piped-truncator block (`... | head`, `... | tail`) was over-blocking a legitimate shell pipeline pattern. There is no native-tool replacement for streaming a pipe through `head`/`tail` (e.g. `grep foo | head -20` to peek at the first matches without buffering the full result). Only file-read mode (leading `head`/`tail`) belongs in the ban — that case has a clear native replacement (`Read`).

Encountered this very pattern multiple times during the sync work (Phase D.3 onwards) and had to escape-hatch through `/tmp/bash-raw-unlock` for what was actually a legitimate command.

## Related Issue

Addresses #823

## Type of Change

- [x] Refactoring (relaxes hook over-block; same security boundary, fewer false positives).

## Changes Made

- `tools/hooks/ai/bash-ban-raw-tools.py` (-22 LOC): drop `PIPE_TRUNCATORS` frozenset, `find_banned_pipe()` function, and its `main()` invocation. Module docstring `Blocks:` list updated.
- `tests/test_bash_ban_raw_tools.py` (+16/-21): replace `test_piped_truncator_exits_2` with `test_piped_truncator_is_allowed` (same parametrize cases, exit code 0 instead of 2). Reorder section dividers accordingly.

## Skipped

The upstream patch also includes a 1-line removal in `docs/development/ai/token-efficiency-add-ons.md`. **That patch does not apply locally** — our copy of the doc was written in PR #844 (E.2) from upstream `#520`'s content (2026-05-03), which predates the addition of the bash-ban-raw-tools section to the doc. The full upstream HEAD version of `token-efficiency-add-ons.md` has three sections we don't have:

- **Bash raw-tool ban (opt-in)** — added upstream after #520; we ship the hook, would adopt the doc section.
- **Codebase Memory MCP gate (opt-in)** — explicitly omitted per #823 directive (CBM tracked in evaluation issue #824).
- **context-mode MCP wrappers (opt-in)** — explicitly omitted per #823 directive (context-mode tracked in #824).

Refreshing the doc to upstream HEAD with the bash-ban section restored and the CBM/context-mode sections still omitted is a separate scope, not bundled here. Worth a follow-up.

## Testing

- [x] `doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [x] `tests/test_bash_ban_raw_tools.py` parametrize cases now assert exit code 0 (allowed) instead of 2 (blocked) for piped truncators; banned-leading cases still assert exit code 2.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective — test reorientation is part of the patch.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — see "Skipped" above for the doc gap.
- [ ] I have updated the CHANGELOG.md (n/a — sync-tracker PR; CHANGELOG updated at sync wrap-up)
- [x] My changes generate no new warnings
