### PR TITLE
feat: show usage bucket end times in statusline with semantic colors

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -8,6 +8,9 @@ COLOR="blue"
 C_RESET='\033[0m'
 C_GRAY='\033[38;5;245m'  # explicit gray for default text
 C_BAR_EMPTY='\033[38;5;238m'
+C_DIM="$C_BAR_EMPTY"  # semantic alias for dim separators (e.g., the `@` in usage segment)
+C_PCT='\033[38;5;71m'  # green: percentage values in usage segment (theme-independent)
+C_TIME='\033[38;5;136m'  # gold: reset-time values in usage segment (theme-independent)
 case "$COLOR" in
     orange)   C_ACCENT='\033[38;5;173m' ;;
     blue)     C_ACCENT='\033[38;5;74m' ;;
@@ -195,7 +198,23 @@ output+="\n${C_ACCENT}${model}${C_GRAY} | ${ctx}${C_RESET}"
 # See docs/development/ai/statusline.md#opt-in-claude-max-usage-display
 if [[ -n "$CLAUDE_USAGE_STATUSLINE" ]]; then
     usage=$(bash "$CLAUDE_PROJECT_DIR/tools/statusline/claude-usage.sh" 2>/dev/null)
-    [[ -n "$usage" && "$usage" != "?" ]] && output+="${C_GRAY} | ${usage}${C_RESET}"
+    if [[ -n "$usage" && "$usage" != "?" ]]; then
+        # Parse the helper's plain-text output (5h:N%@HHMM wk:N%@aaa-HHMM) and
+        # rebuild it with per-field colors: labels accent, percent green,
+        # `@` dim, time gold. Middle-dot separator between gauges.
+        if [[ "$usage" =~ ^5h:([0-9]+)%@([^ ]+)\ wk:([0-9]+)%@(.+)$ ]]; then
+            fh_pct="${BASH_REMATCH[1]}"
+            fh_time="${BASH_REMATCH[2]}"
+            wk_pct="${BASH_REMATCH[3]}"
+            wk_time="${BASH_REMATCH[4]}"
+            colored="${C_ACCENT}5h:${C_PCT}${fh_pct}%${C_DIM}@${C_TIME}${fh_time}"
+            colored+="${C_GRAY} · ${C_ACCENT}wk:${C_PCT}${wk_pct}%${C_DIM}@${C_TIME}${wk_time}"
+            output+="${C_GRAY} | ${colored}${C_RESET}"
+        else
+            # Unexpected format from the helper — emit uncolored as a safe fallback.
+            output+="${C_GRAY} | ${usage}${C_RESET}"
+        fi
+    fi
 fi
 
 printf '%b\n' "$output"

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -72,6 +72,17 @@ COLOR="blue"
 | slate    | 60        | Dark blue-gray |
 | cyan     | 37        | Bright, tech |
 
+The usage segment (opt-in, see below) uses three additional fixed colors that are independent
+of the `COLOR` theme:
+
+| Field | Variable | ANSI Code | Description |
+|-------|----------|-----------|-------------|
+| Percent value | `C_PCT` | 71 (green) | "value" semantics — current consumption |
+| `@` separator | `C_DIM` | 238 (dark gray) | dim join between percent and time |
+| Reset time | `C_TIME` | 136 (gold) | "schedule" semantics — when the bucket ends |
+
+Edit `.claude/statusline-command.sh` to change these.
+
 ### Removing Features
 
 Comment out or remove lines in the "Build output" section of the script:
@@ -106,7 +117,8 @@ Set `CLAUDE_USAGE_STATUSLINE=1` in your shell environment:
 export CLAUDE_USAGE_STATUSLINE=1
 ```
 
-Restart Claude Code. The statusline appends `5h:N% 7d:N%` to the model/context line.
+Restart Claude Code. The statusline appends `5h:N%@HHMM wk:N%@aaa-HHMM` to the model/context line.
+Times are shown in your local timezone.
 To disable temporarily: `unset CLAUDE_USAGE_STATUSLINE` and restart Claude Code.
 
 Example output (helper segment is the trailing portion of the third line):
@@ -114,7 +126,7 @@ Example output (helper segment is the trailing portion of the third line):
 ```
 📁 project | 🐍 .venv | Python: 3.12.12
 @username | 🔀 main (0 files uncommitted, synced 5m ago)
-Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens | 5h:25% 7d:6%
+Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens | 5h:25%@1800 · wk:6%@Mon-2000
 ```
 
 ### Cache behavior
@@ -127,6 +139,7 @@ Adjust `MAX_AGE` at the top of the script. To force a refresh: `rm ~/.cache/clau
 - Active Claude Code OAuth login (`${CLAUDE_CONFIG_DIR:-~/.claude}/.credentials.json`)
 - `curl` for HTTPS
 - `jq` (already required by base statusline)
+- `python3` for ISO-8601 timestamp formatting (already a project dev dependency)
 
 ### Helper troubleshooting
 

--- a/tests/test_statusline_claude_usage.py
+++ b/tests/test_statusline_claude_usage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -31,6 +32,11 @@ _STATUSLINE_INPUT = json.dumps(
         "context_window": {"context_window_size": 200000},
     }
 )
+
+# ISO timestamps far in the future so the test is timezone-agnostic for the date
+# part; only HHMM can vary by local TZ offset and that is accepted by the regex.
+_FH_RESETS_AT = "2099-06-15T18:00:00+00:00"
+_WK_RESETS_AT = "2099-06-16T20:00:00+00:00"
 
 
 def _make_env(tmp_path: Path) -> dict[str, str]:
@@ -82,7 +88,10 @@ def test_uses_fresh_cache_skips_network(tmp_path: Path) -> None:
     """Pre-seeded fresh cache is parsed and returned without hitting the network."""
     env = _make_env(tmp_path)
     cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
-    payload = {"five_hour": {"utilization": 42.7}, "seven_day": {"utilization": 7.3}}
+    payload = {
+        "five_hour": {"utilization": 42.7, "resets_at": _FH_RESETS_AT},
+        "seven_day": {"utilization": 7.3, "resets_at": _WK_RESETS_AT},
+    }
     cache_file.write_text(json.dumps(payload), encoding="utf-8")
     # Ensure mtime is current (fresh cache)
     now = time.time()
@@ -96,7 +105,11 @@ def test_uses_fresh_cache_skips_network(tmp_path: Path) -> None:
         timeout=5,
     )
     assert result.returncode == 0
-    assert result.stdout.strip() == "5h:42% 7d:7%"
+    output = result.stdout.strip()
+    # Format: 5h:42%@HHMM wk:7%@aaa-HHMM  (HHMM and aaa vary by runner TZ)
+    assert re.search(r"5h:42%@\d{4} wk:7%@[A-Za-z]{3}-\d{4}", output), (
+        f"Unexpected output: {output!r}"
+    )
 
 
 def test_emits_fallback_on_malformed_cache(tmp_path: Path) -> None:
@@ -136,10 +149,59 @@ def test_emits_fallback_when_token_field_missing(tmp_path: Path) -> None:
     assert result.stdout.strip() == "?"
 
 
+def test_emits_fallback_when_resets_at_missing(tmp_path: Path) -> None:
+    """Fresh cache with utilization but no resets_at fields emits '?'."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {
+        "five_hour": {"utilization": 42.7},
+        "seven_day": {"utilization": 7.3},
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_emits_fallback_when_resets_at_malformed(tmp_path: Path) -> None:
+    """Fresh cache with unparsable resets_at string emits '?'."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {
+        "five_hour": {"utilization": 42.7, "resets_at": "not-a-date"},
+        "seven_day": {"utilization": 7.3, "resets_at": "also-not-a-date"},
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
 def _seed_fresh_cache(env: dict[str, str]) -> None:
     """Pre-write a parseable, fresh cache so the helper short-circuits curl."""
     cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
-    payload = {"five_hour": {"utilization": 42.7}, "seven_day": {"utilization": 7.3}}
+    payload = {
+        "five_hour": {"utilization": 42.7, "resets_at": _FH_RESETS_AT},
+        "seven_day": {"utilization": 7.3, "resets_at": _WK_RESETS_AT},
+    }
     cache_file.write_text(json.dumps(payload), encoding="utf-8")
     now = time.time()
     os.utime(cache_file, (now, now))
@@ -161,7 +223,12 @@ def test_statusline_invokes_helper_when_env_set(tmp_path: Path) -> None:
         timeout=10,
     )
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "5h:42% 7d:7%" in result.stdout
+    # Both bucket labels must appear; exact times vary by runner TZ.
+    # The wrapper injects a middle-dot separator between gauges.
+    assert "5h:" in result.stdout
+    assert "wk:" in result.stdout
+    assert "7d:" not in result.stdout
+    assert " · " in result.stdout
 
 
 def test_statusline_skips_helper_when_env_unset(tmp_path: Path) -> None:
@@ -181,4 +248,4 @@ def test_statusline_skips_helper_when_env_unset(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "5h:" not in result.stdout
-    assert "7d:" not in result.stdout
+    assert "wk:" not in result.stdout

--- a/tools/statusline/claude-usage.sh
+++ b/tools/statusline/claude-usage.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Opt-in Claude Max usage helper for statusline display.
-# Outputs: 5h:N% 7d:N% on success, or literal ? on any failure.
+# Outputs: 5h:N%@HHMM wk:N%@aaa-HHMM on success, or literal ? on any failure.
 # Wire into .claude/statusline-command.sh manually — not called by default.
 #
-# Requirements: curl, jq, active Claude Code OAuth login
+# Requirements: curl, jq, python3, active Claude Code OAuth login
 # See: docs/development/ai/statusline.md#opt-in-claude-max-usage-display
 
 # Cache TTL in seconds
@@ -13,6 +13,68 @@ MAX_AGE=60
 CREDS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 CREDS_FILE="$CREDS_DIR/.credentials.json"
 CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/claude-usage.json"
+
+# Format a single ISO timestamp into local-timezone compact time.
+# Usage: _fmt_ts <iso_string> <strftime_format>
+# Returns empty string on failure.
+_fmt_ts() {
+    local iso="$1"
+    local fmt="$2"
+    python3 -c "
+from datetime import datetime
+import sys
+try:
+    dt = datetime.fromisoformat(sys.argv[1]).astimezone()
+    print(dt.strftime(sys.argv[2]))
+except Exception:
+    sys.exit(1)
+" "$iso" "$fmt" 2>/dev/null
+}
+
+# Parse a usage JSON file and emit the formatted statusline segment.
+# Usage: parse_usage <json_file>
+# On success: prints  5h:N%@HHMM wk:N%@aaa-HHMM  and returns 0.
+# On any failure: prints ? and returns 1.
+parse_usage() {
+    local file="$1"
+    # Extract the four fields as tab-separated; 'empty' if any field is missing.
+    local record
+    record=$(jq -r '
+        if (.five_hour.utilization != null) and (.five_hour.resets_at != null) and
+           (.seven_day.utilization != null) and (.seven_day.resets_at != null)
+        then [
+            (.five_hour.utilization | floor | tostring),
+            .five_hour.resets_at,
+            (.seven_day.utilization | floor | tostring),
+            .seven_day.resets_at
+        ] | join("\t")
+        else empty
+        end
+    ' "$file" 2>/dev/null)
+
+    if [[ -z "$record" ]]; then
+        echo "?"
+        return 1
+    fi
+
+    IFS=$'\t' read -r fh_pct fh_ts wk_pct wk_ts <<< "$record"
+
+    local fh_time wk_time
+    fh_time=$(_fmt_ts "$fh_ts" "%H%M")
+    if [[ -z "$fh_time" ]]; then
+        echo "?"
+        return 1
+    fi
+
+    wk_time=$(_fmt_ts "$wk_ts" "%a-%H%M")
+    if [[ -z "$wk_time" ]]; then
+        echo "?"
+        return 1
+    fi
+
+    echo "5h:${fh_pct}%@${fh_time} wk:${wk_pct}%@${wk_time}"
+    return 0
+}
 
 # Check cache freshness first — avoids a network call and a token read on every invocation
 if [[ -f "$CACHE" ]]; then
@@ -25,14 +87,7 @@ if [[ -f "$CACHE" ]]; then
         now=$(date +%s)
         age=$((now - cache_mtime))
         if [[ $age -lt $MAX_AGE ]]; then
-            # Try to parse the cached response
-            result=$(jq -r '"5h:\(.five_hour.utilization|floor)% 7d:\(.seven_day.utilization|floor)%"' "$CACHE" 2>/dev/null)
-            if [[ -n "$result" ]]; then
-                echo "$result"
-                exit 0
-            fi
-            # Cache parse failed — fall through to emit ? (no network attempt without a token)
-            echo "?"
+            parse_usage "$CACHE"
             exit 0
         fi
     fi
@@ -57,9 +112,4 @@ fi
 
 # Save to cache and parse
 echo "$response" > "$CACHE" 2>/dev/null
-result=$(jq -r '"5h:\(.five_hour.utilization|floor)% 7d:\(.seven_day.utilization|floor)%"' "$CACHE" 2>/dev/null)
-if [[ -n "$result" ]]; then
-    echo "$result"
-else
-    echo "?"
-fi
+parse_usage "$CACHE"


### PR DESCRIPTION
## Description

Phase F.3a of the [pyproject-template sync (#823)](https://github.com/endavis/infrafoundry/issues/823). Bundles two upstream PRs that together close upstream issue [endavis/pyproject-template#580](https://github.com/endavis/pyproject-template/issues/580):

- **endavis/pyproject-template#581** (`ef6b85d`) — bucket end times in the statusline. New output format `5h:N%@HHMM · wk:N%@aaa-HHMM`, showing both current consumption and when each bucket resets, in the user's local timezone. The `7d:` label is renamed to `wk:` to make room for the appended timestamp.
- **endavis/pyproject-template#582** (`ba12770`) — per-field semantic coloring (refinement to #581). The value portion is split into three theme-independent fixed colors: percent green (`C_PCT`, ANSI 71), `@` separator dim gray (`C_DIM`, ANSI 238), reset time gold (`C_TIME`, ANSI 136). Theme labels stay accent-colored. Graceful fallback if helper output does not match the expected pattern.

Bundled in one PR because #582 is a coloring refinement to #581's structure — splitting them would be artificial.

## Related Issue

Addresses #823

## Type of Change

- [x] New feature (enhanced statusline output, no behavior change for opt-out users).

## Changes Made

| File | Change |
|:--|:--|
| `tools/statusline/claude-usage.sh` | New `parse_usage()` function + `_fmt_ts()` python3 helper. Output format `5h:N%@HHMM wk:N%@aaa-HHMM`. Adds `python3` to runtime requirements (already a project dev dep). |
| `.claude/statusline-command.sh` | 3 new theme-independent color vars (`C_DIM`, `C_PCT`, `C_TIME`); bash-regex parse of helper output; per-field recoloring with `·` separator between gauges; graceful fallback to uncolored output if format unexpected. |
| `tests/test_statusline_claude_usage.py` | New test cases for the bucket-end-time parsing and malformed-timestamp fallback paths. |
| `docs/development/ai/statusline.md` | Per-field color table, updated output-format example, python3 prerequisite. |

## Hand-merge spot-check

None of the 4 files are in any `pyproject-template-divergences.md` category — adopt-by-omission. No InfraFoundry-specific divergences in any of them; we adopted these files in PR #830 (Phase B) verbatim from upstream and have not modified them locally. All four files replaced wholesale with upstream HEAD content.

## Skipped / deferred

None — both upstream PRs land in full.

## Testing

- [x] `doit check` passes locally (format, lint, lint_blueprints, type_check, security, spell_check, test).
- [ ] Manual verification of the statusline rendering requires a running Claude Code session with `CLAUDE_USAGE_STATUSLINE=1` and an active OAuth login. Out of scope for an automated check.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective — adopted upstream's new test cases.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (n/a — sync-tracker PR; CHANGELOG updated at sync wrap-up)
- [x] My changes generate no new warnings
