### PR TITLE
chore: bump pyproject-template pin to ba12770 (2026-05-14)

### DIFF
--- a/.config/pyproject_template/settings.toml
+++ b/.config/pyproject_template/settings.toml
@@ -1,3 +1,3 @@
 [template]
-commit = "7a13c9384b1b94446836eabaa20ca0800d185369"
-commit_date = "2026-04-23"
+commit = "ba1277055360eb23533ccd7bb9f9fe4a9e46e24d"
+commit_date = "2026-05-14"


### PR DESCRIPTION
## Description

Final phase of the [pyproject-template sync (#823)](https://github.com/endavis/infrafoundry/issues/823). Bumps the template pin from `7a13c9384b1b94446836eabaa20ca0800d185369` (2026-04-23) to `ba1277055360eb23533ccd7bb9f9fe4a9e46e24d` (2026-05-14 — current upstream HEAD).

All upstream commits in the interval have been adopted in earlier phase PRs.

## Related Issue

Addresses #823

This PR is the final acceptance step for #823. Once merged, #823 can be closed manually with the standard "Addressed in PR #849" comment.

## Type of Change

- [x] Configuration update (pin marker only).

## Changes Made

`.config/pyproject_template/settings.toml`:
- `commit`: `7a13c938…` → `ba127705…`
- `commit_date`: `2026-04-23` → `2026-05-14`

## Sync record (all phases of #823)

| Phase | PRs | Description |
|:--|:--|:--|
| A | #825, #826 | Sync-exclude mechanism + `Addresses` regex anchor |
| B | #828, #829, #830 | PreCompact/SessionStart hooks; bash-ban-raw-tools; Claude Max usage helper |
| C | #831, #832, #833, #834, #835 | AI-agent workflow refactor (rules scaffolds, Policy Engine, multi-agent + final-state) |
| D | #836, #837, #840, #842 | Tooling and CI improvements |
| E | #843, #844 | CONTRIBUTING.md restructure; token-efficiency walkthrough + LSP guide |
| F.1 | #845 | urllib3 2.6.3 → 2.7.0 (upstream #577) |
| F.2 | #846 | bash-ban-raw-tools piped-truncator removal (upstream #579) |
| F.3a | #847 | Statusline bucket end times + semantic colors (upstream #581 + #582) |
| F.3 | #848 | `ALLOW_AI_READY_TO_MERGE` governance opt-in (upstream #575) |
| **F.4** | **this PR** | **Pin bump** |

## Outstanding follow-ups (filed as separate issues, not blocking sync closure)

- **#822** — `-h` short alias for `foundry` CLI (upstream pattern good; standalone issue).
- **#824** — evaluate enabling CBM and context-mode hooks (upstream `#537` and `#538` skipped per #823 decision).
- **#838** — port upstream tooling test coverage (`mock_subprocess` fixture + 7 deferred test files).
- **#839** — bump remaining 7 CVE-affected transitive deps + add audit gate to `doit check`. Urllib3 already addressed in F.1; remaining CVEs in cryptography, lxml, paramiko, pygments, pyjwt.
- **#841** — reconcile pre-commit-hook table divergence in `ci-cd-testing.md` and `doit-tasks-reference.md`.

## Hand-merge spot-check

N/A — pin marker file is a 2-line metadata bump; no divergence concerns.

## Skipped / deferred

The two-PR Phase F.2 (separate `docs:` PR for new divergences) is **skipped** per the F-phase decision earlier in this session: no new divergences are ready to commit. Both pending divergence questions (#841 outcome + dependabot-automerge.md cross-link decision) require user input before they can land in `pyproject-template-divergences.md`.

## Testing

- [x] `doit check` passes locally.
- [ ] No new tests added — pin marker only.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective — N/A: pin metadata bump.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — N/A.
- [ ] I have updated the CHANGELOG.md — N/A: pin marker, no user-visible behavior change.
- [x] My changes generate no new warnings
