### PR TITLE
chore(deps): bump pyjwt to 2.13.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2165,11 +2165,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Description

`pyjwt 2.12.1` (transitive via `azure-identity → msal[crypto]`) carries 4 known advisories (PYSEC-2026-175/177/178/179), fixed in 2.13.0. `doit audit` runs as a step in the CI `lint` job, so these turned the `lint` check red on `main` and every open PR (e.g. #879, #869) regardless of each PR's own changes. This bumps the locked `pyjwt` to 2.13.0.

## Related Issue

Addresses #880

## Type of Change

- [x] Other — dependency / security maintenance (lock-only transitive bump)

## Changes Made

- `uv lock --upgrade-package pyjwt` → `pyjwt 2.12.1` → `2.13.0`.
- **`uv.lock` is the only changed file** — no `pyproject.toml` change and no new direct dependency (`msal`'s `<3` constraint already permits 2.13.0).

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes

`doit audit` now reports **"No known vulnerabilities found"** (was failing on the 4 pyjwt advisories). Full suite: 5898 passed (the single failure is the unrelated, pre-existing `test_export_proxmox_success` xdist line-wrap flake, which passes when run alone).

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint` / `doit audit`)
- [ ] I have run type checking — N/A (no source changes; lock-only)
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — N/A
- [ ] I have updated the CHANGELOG.md — generated from conventional commits at release
- [x] My changes generate no new warnings

## Additional Notes

Lock-only fix that unblocks the `lint`/`audit` check for `main` and all open PRs (incl. #879, #869). Filing now rather than waiting for dependabot because the advisory is currently breaking CI repo-wide.
