### PR TITLE
fix: firewall_rule statetype + silent addRule failures on newer os-firewall

### DIFF
--- a/src/infrafoundry/providers/opnsense/services/firewall_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/firewall_rule.py
@@ -80,14 +80,28 @@ ACTION_CHOICES: tuple[str, ...] = ("pass", "block", "reject")
 DIRECTION_CHOICES: tuple[str, ...] = ("in", "out", "any")
 IPPROTOCOL_CHOICES: tuple[str, ...] = ("inet", "inet6", "inet46")
 STATE_POLICY_CHOICES: tuple[str, ...] = ("", "default", "if-bound", "floating")
-STATETYPE_CHOICES: tuple[str, ...] = (
-    "",
-    "keep state",
-    "sloppy state",
-    "modulate state",
-    "synproxy state",
-    "none",
-)
+# os-firewall's ``statetype`` is an OptionField whose WIRE value is the option
+# KEY (``keep`` / ``sloppy`` / ``modulate`` / ``synproxy`` / ``none``). Newer
+# os-firewall versions REQUIRE a non-empty value and reject the display labels;
+# older versions tolerated ``""`` and the labels. Map every accepted operator
+# input — option keys, legacy display labels, and empty — to the wire key;
+# empty / unspecified defaults to ``keep`` (the OPNsense model default). See #882.
+_STATETYPE_TO_KEY: dict[str, str] = {
+    "": "keep",
+    "keep": "keep",
+    "keep state": "keep",
+    "sloppy": "sloppy",
+    "sloppy state": "sloppy",
+    "modulate": "modulate",
+    "modulate state": "modulate",
+    "synproxy": "synproxy",
+    "synproxy state": "synproxy",
+    "none": "none",
+    "no state": "none",
+}
+# Accepted operator inputs for ``statetype`` (option keys + legacy labels +
+# empty); validated before normalization to the wire key.
+STATETYPE_CHOICES: tuple[str, ...] = tuple(_STATETYPE_TO_KEY)
 
 # Wire-key serialization kinds for ``_PAYLOAD_FIELD_MAP`` entries. ``str``
 # fields pass through; ``bool`` fields become ``"0"``/``"1"``; ``int``
@@ -271,8 +285,11 @@ class FirewallRuleConfig:
             destination_port: Port (or empty).
 
         State:
-            statetype: ``""`` / ``"keep state"`` / ``"sloppy state"`` /
-                ``"modulate state"`` / ``"synproxy state"`` / ``"none"``.
+            statetype: pf state-tracking mode. Accepts the os-firewall option
+                key (``keep`` / ``sloppy`` / ``modulate`` / ``synproxy`` /
+                ``none``) or the legacy display label (``"keep state"`` …);
+                empty / unspecified defaults to ``keep``. Always serialized as
+                the option key on the wire (#882).
             state_policy: ``""`` / ``"default"`` / ``"if-bound"`` /
                 ``"floating"``. Wire key is ``state-policy``.
             statetimeout: Custom state timeout (string).
@@ -422,6 +439,11 @@ class FirewallRuleConfig:
             value: Any = getattr(self, attr)
             if attr == "description":
                 value = self.encoded_description()
+            if attr == "statetype":
+                # Emit the os-firewall OptionField KEY (required, non-empty on
+                # newer versions); map legacy labels / empty to the key (#882).
+                inner[wire_key] = _STATETYPE_TO_KEY.get(str(value), "keep")
+                continue
             if kind == "bool":
                 inner[wire_key] = _bool_str(bool(value))
             elif kind == "int":
@@ -560,6 +582,37 @@ def _normalize_field(value: Any) -> str:
                 return str(option_key)
         return ""
     return str(value)
+
+
+def _ensure_api_ok(response: dict[str, Any], *, op: str, name: str) -> None:
+    """Raise if an os-firewall ``firewall/filter`` write was rejected.
+
+    OPNsense returns HTTP 200 with ``{"result": "failed", "validations":
+    {...}}`` when a rule payload is rejected (e.g. an invalid ``statetype``).
+    The diff dispatcher must surface that instead of counting a phantom
+    mutation — the silent failure that masked #882 (apply reported
+    ``applied 1 adds`` while ``searchRule`` stayed empty). Success values
+    differ per verb (``addRule``/``setRule`` → ``"saved"``; ``delRule`` →
+    ``"deleted"``), so we treat anything other than an explicit ``"failed"``
+    as success rather than matching exact success strings.
+
+    Args:
+        response: Raw ``addRule`` / ``setRule`` / ``delRule`` response.
+        op: Operation name for the error message (``add`` / ``update`` / ``delete``).
+        name: Rule name (or uuid) for the error message.
+
+    Raises:
+        APIError: If ``response["result"] == "failed"``.
+    """
+    if response.get("result") != "failed":
+        return
+    validations = response.get("validations")
+    detail = f" validations={validations}" if validations else ""
+    raise APIError(
+        f"firewall_rule {op} for {name!r} did not persist: result='failed'{detail}",
+        response=str(response),
+        provider="opnsense",
+    )
 
 
 def _normalize_categories(value: Any) -> set[str]:
@@ -1004,15 +1057,19 @@ class FirewallRuleService(BaseService):
         deleted = 0
 
         for rule in diff.adds:
-            self.add(rule)
+            _ensure_api_ok(self.add(rule), op="add", name=rule.name)
             created += 1
 
         for live_rule, want in diff.updates:
-            self.update(live_rule.uuid, want)
+            _ensure_api_ok(self.update(live_rule.uuid, want), op="update", name=want.name)
             updated += 1
 
         for live_rule in diff.deletes:
-            self.delete(live_rule.uuid)
+            _ensure_api_ok(
+                self.delete(live_rule.uuid),
+                op="delete",
+                name=live_rule.managed_name or live_rule.uuid,
+            )
             deleted += 1
 
         if created or updated or deleted:

--- a/tests/unit/providers/opnsense/test_firewall_rule_service.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_service.py
@@ -1240,3 +1240,73 @@ class TestExportToYaml:
         # Hyphenated wire keys must NOT leak into the YAML output.
         assert "state-policy:" not in text
         assert "max-src-conn:" not in text
+
+
+class TestStatetypeWireKey:
+    """``statetype`` serializes to the os-firewall option KEY (#882)."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("", "keep"),
+            ("keep", "keep"),
+            ("keep state", "keep"),
+            ("sloppy", "sloppy"),
+            ("sloppy state", "sloppy"),
+            ("modulate state", "modulate"),
+            ("synproxy state", "synproxy"),
+            ("none", "none"),
+            ("no state", "none"),
+        ],
+    )
+    def test_statetype_serialized_as_option_key(self, value: str, expected: str) -> None:
+        inner = _rule("r", statetype=value).to_payload()["rule"]
+        assert inner["statetype"] == expected
+
+    def test_empty_statetype_defaults_to_keep(self) -> None:
+        # Newer os-firewall requires a non-empty statetype; an unspecified
+        # value must still serialize to a valid option key.
+        assert _rule("r").to_payload()["rule"]["statetype"] == "keep"
+
+    def test_loader_accepts_option_keys_and_labels(self) -> None:
+        cfgs = firewall_rule_configs_from_resources(
+            [
+                _resource("by_key", {"interface": "lan", "statetype": "keep"}),
+                _resource("by_label", {"interface": "lan", "statetype": "keep state"}),
+            ]
+        )
+        assert [c.to_payload()["rule"]["statetype"] for c in cfgs] == ["keep", "keep"]
+
+
+class TestApplyDiffSurfacesFailures:
+    """``apply_diff`` raises on a failed write instead of counting a phantom (#882)."""
+
+    def test_failed_add_raises_apierror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        svc = FirewallRuleService(MagicMock())
+        monkeypatch.setattr(
+            svc,
+            "add",
+            MagicMock(
+                return_value={
+                    "result": "failed",
+                    "validations": {"rule.statetype": "A value is required."},
+                }
+            ),
+        )
+        with pytest.raises(APIError, match="did not persist"):
+            svc.apply_diff(Diff(adds=[_rule("r")]))
+
+    def test_failed_delete_raises_apierror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        svc = FirewallRuleService(MagicMock())
+        monkeypatch.setattr(svc, "delete", MagicMock(return_value={"result": "failed"}))
+        with pytest.raises(APIError, match="did not persist"):
+            svc.apply_diff(Diff(deletes=[_live("u1", "r")]))
+
+    def test_saved_add_succeeds_and_applies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        svc = FirewallRuleService(MagicMock())
+        monkeypatch.setattr(svc, "add", MagicMock(return_value={"result": "saved", "uuid": "u1"}))
+        apply_changes = MagicMock(return_value={"status": "ok"})
+        monkeypatch.setattr(svc, "apply_changes", apply_changes)
+        counts = svc.apply_diff(Diff(adds=[_rule("r")]))
+        assert counts == {"created": 1, "updated": 0, "deleted": 0}
+        apply_changes.assert_called_once()


### PR DESCRIPTION
## Description

`firewall_rule` could not create rules on newer OPNsense os-firewall versions (observed on opnsense-a, 26.1.x), and failed **silently**:

- os-firewall's `statetype` is an `OptionField` whose wire value is the option **key** (`keep` / `sloppy` / `modulate` / `synproxy` / `none`), and the newer version **requires** a non-empty value. InfraFoundry defaulted `statetype` to `""` and serialized the display **labels** (`"keep state"`) verbatim, so `addRule` was rejected (`"A value is required."` / `"Option [] not in list."`).
- `apply_diff` counted desired adds without checking the `addRule` result, so a failed apply printed `applied 1 adds` while `searchRule` returned 0 rows — masking the problem.

The older os-firewall on the prod box tolerates the empty/label form, which is why the existing RFC4890 rule works there and this never surfaced.

## Related Issue

Addresses #882

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `to_payload` maps every accepted `statetype` input (option keys, legacy labels, empty) to the wire option key; empty/unspecified → `keep`. `_normalize_field` already collapses live `OptionField` values to their key, so desired == live stays churn-free.
- `STATETYPE_CHOICES` accepts both option keys and the legacy labels (backward compatible — existing YAML keeps validating).
- `apply_diff` raises `APIError` (surfacing `validations`) when an `add`/`update`/`delete` returns `result="failed"`, instead of counting a phantom mutation.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green (format, lint, type-check, bandit, audit). Added `TestStatetypeWireKey` (key/label/empty → wire key) and `TestApplyDiffSurfacesFailures` (raises on `result="failed"`). All 211 firewall_rule tests pass; full suite 5921 passed (the lone failure is the unrelated, pre-existing `test_export_proxmox_success` xdist line-wrap flake — passes when run alone / in CI). Verified live against opnsense-a's os-firewall API: a rule with the option-key `statetype` is accepted (`result: saved`).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (the `statetype` docstring documents the accepted inputs + wire-key contract)
- [ ] I have updated the CHANGELOG.md — generated from conventional commits at release
- [x] My changes generate no new warnings

## Additional Notes

Prod safety: empty `statetype` (the only state the existing managed RFC4890 rule uses) now serializes to `keep`; since the prod box's older os-firewall also exposes key-based options, the next prod apply shows a one-time, behaviorally-identical `statetype` reconciliation and no churn thereafter.

Discovered while restoring opnsense-a's GUI over the new `OPNSENSE_PROXY` support (#878/#879). The same swallowed-result pattern may exist in `nat_rules` (same `firewall/filter`-style flow) — worth a follow-up audit.
