### PR TITLE
fix: exclude server-computed fields from firewall_rule diff

### DIFF
--- a/src/infrafoundry/providers/opnsense/services/firewall_rule.py
+++ b/src/infrafoundry/providers/opnsense/services/firewall_rule.py
@@ -176,6 +176,12 @@ _PAYLOAD_FIELD_MAP: tuple[tuple[str, str, _FieldKind], ...] = (
     ("allowopts", "allowopts", "bool"),
 )
 
+# Wire keys OPNsense auto-/server-computes (operator never sets them).
+# to_payload emits empty defaults for these, so they would otherwise force
+# a phantom update on every diff. Excluded from _needs_update only — they
+# are still sent on setRule (the box recomputes them harmlessly). See #884.
+_DIFF_IGNORED_FIELDS: frozenset[str] = frozenset({"sort_order", "prio_group"})
+
 
 class OpnsenseDriftError(InfraFoundryError):
     """A managed rule's identity tag is malformed on the live box.
@@ -556,9 +562,17 @@ def compute_diff(
 
 
 def _needs_update(have: LiveFirewallRule, want: FirewallRuleConfig) -> bool:
-    """Return True if the live row's fields differ from the desired payload."""
+    """Return True if the live row's fields differ from the desired payload.
+
+    Fields in ``_DIFF_IGNORED_FIELDS`` (``sort_order``, ``prio_group``) are
+    skipped: OPNsense auto-computes them on save, so comparing the live
+    server-assigned value against the empty default ``to_payload`` emits
+    would force a spurious update on every run (#884).
+    """
     payload = want.to_payload()["rule"]
     for key, want_value in payload.items():
+        if key in _DIFF_IGNORED_FIELDS:
+            continue
         have_value = _normalize_field(have.raw.get(key))
         if str(want_value) != have_value:
             return True

--- a/tests/unit/providers/opnsense/test_firewall_rule_service.py
+++ b/tests/unit/providers/opnsense/test_firewall_rule_service.py
@@ -470,6 +470,53 @@ class TestComputeDiffUpdates:
         diff = compute_diff([rule], [live])
         assert diff.is_empty
 
+    def test_no_update_when_only_server_computed_fields_differ(self) -> None:
+        # Regression for #884: sort_order and prio_group are server-computed by
+        # OPNsense. to_payload emits "" for both; the live row carries realistic
+        # server values. Without the _DIFF_IGNORED_FIELDS exclusion this forces
+        # a phantom update on every run.
+        rule = _rule("foo", interface="lan")
+        payload_inner = rule.to_payload()["rule"]
+        live_raw: dict[str, Any] = {
+            "uuid": "u1",
+            **payload_inner,
+            "sort_order": "200000.0000100",  # server-assigned
+            "prio_group": "200000",  # server-assigned
+        }
+        live = LiveFirewallRule(
+            uuid="u1",
+            managed_name="foo",
+            description="",
+            raw=live_raw,
+        )
+        diff = compute_diff([rule], [live])
+        assert diff.is_empty
+
+    def test_update_still_detected_with_server_computed_fields(self) -> None:
+        # Negative control: server-computed fields present in the live row but
+        # one real field (action) diverges from desired — exactly one update
+        # must be reported. Proves the exclusion is scoped to sort_order /
+        # prio_group and does not mask genuine changes.
+        rule = _rule("foo", interface="lan", action="pass")
+        payload_inner = rule.to_payload()["rule"]
+        live_raw: dict[str, Any] = {
+            "uuid": "u1",
+            **payload_inner,
+            "sort_order": "200000.0000100",
+            "prio_group": "200000",
+            "action": "block",  # diverges from desired "pass"
+        }
+        live = LiveFirewallRule(
+            uuid="u1",
+            managed_name="foo",
+            description="",
+            raw=live_raw,
+        )
+        diff = compute_diff([rule], [live])
+        assert len(diff.updates) == 1
+        assert len(diff.adds) == 0
+        assert len(diff.deletes) == 0
+
 
 class TestComputeDiffDeletes:
     def test_managed_live_with_no_desired_is_deleted(self) -> None:


### PR DESCRIPTION
## Description

`foundry infra plan` reported `1 to update` on every run for unchanged firewall rules, even when no
operator YAML had changed. The churn was caused by `_needs_update` comparing two server-computed
fields — `sort_order` and `prio_group` — against the empty defaults that `to_payload` emits for
them. OPNsense assigns these values automatically on save; the operator never sets them, and
InfraFoundry's YAML schema has no fields for them.

The fix adds `_DIFF_IGNORED_FIELDS = frozenset({"sort_order", "prio_group"})` and a skip guard at
the top of the `_needs_update` loop. This mirrors the same principle used for write-only or
server-managed fields across other services: excluded from diff, still sent on `setRule` (the box
recomputes them harmlessly). The `to_payload` output is unchanged — only the comparison step skips
these two keys.

## Related Issue

Addresses #884

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/infrafoundry/providers/opnsense/services/firewall_rule.py`: added `_DIFF_IGNORED_FIELDS`
  constant (`sort_order`, `prio_group`) and a `continue` guard in `_needs_update` to skip
  server-computed fields during diff comparison. Docstring updated to explain the exclusion and
  link to the issue.
- `tests/unit/providers/opnsense/test_firewall_rule_service.py`: added two tests to
  `TestComputeDiffUpdates`:
  - `test_no_update_when_only_server_computed_fields_differ` — regression test: live row carries
    realistic server-assigned `sort_order`/`prio_group` values; desired YAML is unchanged;
    `compute_diff` must return empty (no phantom update).
  - `test_update_still_detected_with_server_computed_fields` — negative control: server-computed
    fields present in the live row, but `action` diverges from desired; exactly one update must
    be reported, proving the exclusion does not mask genuine changes.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Regression verification:** the regression test (`test_no_update_when_only_server_computed_fields_differ`)
fails on main (before the fix) and passes on this branch (after the fix), confirming the guard
eliminates the phantom update.

**NAT rules checked:** `nat_rules` service (`nat_rule.py`) was reviewed — it does not emit
`sort_order` or `prio_group` in its payload, so it is unaffected by this change.

**`doit check` result:** format, lint, type-check, security, and spell all pass; every new and
existing `firewall_rule` test passes. This branch adds 2 new passing tests (5917 passed vs 5915 on
`main`). The only local test failures are 7 pre-existing `test_bash_ban_raw_tools` cases that fail
**solely because the developer machine has a fresh `/tmp/bash-raw-unlock` escape-hatch file**, which
makes the command-blocking hook allow commands the test expects it to block. They fail identically
on `main`, are unrelated to this change, and do not occur in CI (a clean runner has no unlock file).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

No documentation update was needed. The existing docs (`docs/development/opnsense-resource-coverage.md`
and `docs/decisions/0015-opnsense-firewall-rules-direct-api-via-mvc-controller.md`) describe field
coverage and identity scheme but do not document diff behavior or server-computed field handling.
No ADR update is required — this is a bug fix, not an architectural decision, and the issue carries
no `needs-adr` label.
