### PR TITLE
test: isolate test_bash_ban_raw_tools from the global unlock file

### DIFF
--- a/tests/test_bash_ban_raw_tools.py
+++ b/tests/test_bash_ban_raw_tools.py
@@ -45,6 +45,22 @@ def hook() -> Iterator[types.ModuleType]:
         sys.modules.pop("bash_ban_raw_tools", None)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_unlock_file(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Neutralize the global /tmp/bash-raw-unlock escape hatch for every test.
+
+    Points UNLOCK_FILE at a nonexistent path so is_unlocked() is deterministically
+    False regardless of developer-machine state (#905). Tests that exercise the
+    escape hatch re-point UNLOCK_FILE explicitly; their monkeypatch runs after this
+    fixture and takes precedence.
+    """
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(tmp_path / "nonexistent-unlock"))
+
+
 def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
     """Replace ``sys.stdin`` with a StringIO containing *payload*."""
     monkeypatch.setattr(sys, "stdin", io.StringIO(payload))


### PR DESCRIPTION
## Description

`tests/test_bash_ban_raw_tools.py::test_banned_leading_command_exits_2` (7 parametrized cases) was not hermetic. It invoked the hook's `main()` without neutralizing `UNLOCK_FILE`, so `is_unlocked()` read the real global escape-hatch file `/tmp/bash-raw-unlock`. When an operator had touched that file to unlock their shell (it stays fresh for 10 minutes), the hook returned `0` (allow) instead of `2` (block) and all 7 cases failed with `assert 0 == 2`. The suite passed in CI (clean runner, no file) but failed locally whenever the unlock file was fresh — the result depended on developer-machine state.

This adds a single module-wide `autouse` fixture (`_isolate_unlock_file`) that points `hook.UNLOCK_FILE` at a nonexistent `tmp_path` for every test, so `is_unlocked()` is deterministically `False`. The whole module is now hermetic by default, and any future test added to it is automatically protected. The existing escape-hatch tests set their own `UNLOCK_FILE` via `monkeypatch.setattr`, which runs after the fixture and takes precedence, so they are unaffected. The production hook (`tools/hooks/ai/bash-ban-raw-tools.py`) is not modified.

## Related Issue

Addresses #905

## Type of Change

- [x] Test improvement

## Changes Made

- `tests/test_bash_ban_raw_tools.py`: added the `_isolate_unlock_file` autouse fixture (placed directly after the `hook` fixture). No production code changed; no test cases added or removed. `test_banned_leading_command_exits_2` is fixed transitively without being edited.

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes

**Hermeticity proof** — the suite was run in both unlock states and is green in each:
- `/tmp/bash-raw-unlock` **present** (the previously-failing condition): 19 passed (was 7 failing).
- `/tmp/bash-raw-unlock` **absent**: 19 passed.

**End-to-end:** `doit check` was run with a fresh `/tmp/bash-raw-unlock` present (the exact condition that made the old code fail) and is fully green, including the complete `pytest` suite.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

- **No documentation update:** production hook behavior is unchanged; this is a test-isolation fix only. The hook doc (`docs/development/ai/token-efficiency-add-ons.md`) describes the hook, not its tests.
- **No ADR:** `chore`, no `needs-adr` label, no architectural decision.
- **No CHANGELOG entry:** internal test-infrastructure reliability fix with no user-facing impact.
- Pyright may flag `_isolate_unlock_file` as "not accessed" — this is the standard false positive for `autouse` fixtures (pytest invokes them implicitly), matching the existing `_clear_category_marker_cache` fixture elsewhere in the suite. `mypy`/`doit check` are green.
- Surfaced while shipping PR #904 (issue #884); the 7 failures were unrelated to that change.
